### PR TITLE
RDKAAMP-4002 : Display aamp branch commit id in logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ if(CMAKE_USE_SECMANAGER)
 	endif()
 endif()
 
-execute_process(COMMAND bash "-c" "${CMAKE_SOURCE_DIR}/buildinfo.sh" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE buildinfo)
+execute_process(COMMAND bash "-c" "${CMAKE_SOURCE_DIR}/buildinfo.sh" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE buildinfo)
 string(REGEX REPLACE "\n" "-" buildinfo "${buildinfo}")
 message("build: ${buildinfo}")
 set(LIBAAMP_DEFINES "${LIBAAMP_DEFINES} -DAAMP_VANILLA_AES_SUPPORT ${USE_MAC_FOR_RANDOM_GEN}")

--- a/buildinfo.sh
+++ b/buildinfo.sh
@@ -21,3 +21,8 @@ uname -o
 uname -m
 git branch --show-current
 git rev-parse --short HEAD
+if git describe --tags --exact-match HEAD > /dev/null 2>&1; then
+  git describe --tags --exact-match HEAD
+else
+  echo "No-Tag"
+fi


### PR DESCRIPTION
Reason for change: 
Test Procedure: Updated in ticket
Risks: Medium
Priority: P1