### PR TITLE
RDKEMW-2278: Removal of WPEFrameworkSecurity Agent Utility (#17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,12 @@ endif()
 endif()
 endif()
 
+option(DISABLE_SECURITY_TOKEN "Disable security token" OFF)
+
+if(DISABLE_SECURITY_TOKEN)
+  add_definitions(-DDISABLE_SECURITY_TOKEN)
+endif()
+
 if(CMAKE_WPEWEBKIT_JSBINDINGS)
 	message("CMAKE_WPEWEBKIT_JSBINDINGS is set, Finding JavaScriptCore")
 	pkg_search_module(PC_WPE_WEBKIT wpe-webkit-deprecated-0.1 wpe-webkit-1.0 wpe-webkit-1.1)

--- a/ThunderAccess.cpp
+++ b/ThunderAccess.cpp
@@ -25,7 +25,9 @@
 #include "priv_aamp.h"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"
+#ifndef DISABLE_SECURITY_TOKEN
 #include <securityagent/SecurityTokenUtil.h>
+#endif
 #pragma GCC diagnostic pop
 #include "ThunderAccess.h"
 
@@ -63,20 +65,25 @@ ThunderAccessAAMP::ThunderAccessAAMP(std::string callsign)
     uint32_t status = Core::ERROR_NONE;
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
-
+    string sToken = "";
+#ifdef DISABLE_SECURITY_TOKEN
+     gSecurityData.securityToken = "token=" + sToken;
+     gSecurityData.tokenQueried = true;
+#else
     if(!gSecurityData.tokenQueried)
     {
         unsigned char buffer[MAX_LENGTH] = {0};
         gSecurityData.tokenStatus = GetSecurityToken(MAX_LENGTH,buffer);
         if(gSecurityData.tokenStatus > 0){
             AAMPLOG_INFO( "[ThunderAccessAAMP] : GetSecurityToken success");
-            string sToken = (char*)buffer;
+            sToken = (char*)buffer;
             gSecurityData.securityToken = "token=" + sToken;
         }
         gSecurityData.tokenQueried = true;
 
         //AAMPLOG_WARN( "[ThunderAccessAAMP] securityToken : %s tokenStatus : %d tokenQueried : %s", gSecurityData.securityToken.c_str(), gSecurityData.tokenStatus, ((gSecurityData.tokenQueried)?"true":"false"));
     }
+#endif
 
     if (NULL == controllerObject) {
         /*Passing empty string instead of Controller callsign.This is assumed as controller plugin.*/

--- a/cmake/FindWPEFramework.cmake
+++ b/cmake/FindWPEFramework.cmake
@@ -47,10 +47,16 @@ if(PC_WPEFRAMEWORK_FOUND)
         HINTS ${PC_WPEFRAMEWORK_INCLUDEDIR} ${PC_WPEFRAMEWORK_INCLUDE_DIRS})
 
 if (USE_THUNDER_R4)
-       set(WPEFRAMEWORK_LIBS WPEFrameworkPlugins WPEFrameworkCore WPEFrameworkCOM WPEFrameworkSecurityUtil WPEFrameworkWebSocket)
+       set(WPEFRAMEWORK_LIBS WPEFrameworkPlugins WPEFrameworkCore WPEFrameworkCOM WPEFrameworkWebSocket)
 else()
-    set(WPEFRAMEWORK_LIBS WPEFrameworkPlugins WPEFrameworkCore WPEFrameworkTracing WPEFrameworkProtocols WPEFrameworkSecurityUtil)
+    set(WPEFRAMEWORK_LIBS WPEFrameworkPlugins WPEFrameworkCore WPEFrameworkTracing WPEFrameworkProtocols)
 endif()
+
+# Add WPEFrameworkSecurityUtil if DISABLE_SECURITY_TOKEN is not enabled
+if (NOT DISABLE_SECURITY_TOKEN)
+    list(APPEND WPEFRAMEWORK_LIBS WPEFrameworkSecurityUtil)
+endif()
+
     set(WPEFRAMEWORK_LIBRARY )
     foreach(LIB ${WPEFRAMEWORK_LIBS})
         find_library(WPEFRAMEWORK_LIBRARY_${LIB} NAMES ${LIB}


### PR DESCRIPTION
Reason for change: Added DISABLE_SECURITY_TOKEN Flag to disable the WPEFrameworkSecurity Token generation changes
Test Procedure:  please referred from the ticket
Risks: Medium