### PR TITLE
VPLAY-9716: Removal of WPEFrameworkSecurity Agent Utility

### DIFF
--- a/externals/rdk/PlayerThunderAccess.cpp
+++ b/externals/rdk/PlayerThunderAccess.cpp
@@ -23,7 +23,9 @@
  */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"
+#ifndef DISABLE_SECURITY_TOKEN
 #include <securityagent/SecurityTokenUtil.h>
+#endif
 #pragma GCC diagnostic pop
 #include "PlayerThunderAccess.h"
 
@@ -118,18 +120,23 @@ PlayerThunderAccess::PlayerThunderAccess(PlayerThunderAccessPlugin callsign)
     uint32_t status = Core::ERROR_NONE;
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
-
+    string sToken = "";
+#ifdef DISABLE_SECURITY_TOKEN
+     gPlayerSecurityData.securityToken = "token=" + sToken;
+     gPlayerSecurityData.tokenQueried = true;
+#else
     if(!gPlayerSecurityData.tokenQueried)
     {
         unsigned char buffer[MAX_LENGTH] = {0};
         gPlayerSecurityData.tokenStatus = GetSecurityToken(MAX_LENGTH,buffer);
         if(gPlayerSecurityData.tokenStatus > 0){
             // LOG_INFO( "[ThunderAccess] : GetSecurityToken success");
-            string sToken = (char*)buffer;
+            sToken = (char*)buffer;
             gPlayerSecurityData.securityToken = "token=" + sToken;
         }
         gPlayerSecurityData.tokenQueried = true;
     }
+#endif
 
     if (NULL == controllerObject) {
         /*Passing empty string instead of Controller callsign.This is assumed as controller plugin.*/


### PR DESCRIPTION
Reason for change: Added DISABLE_SECURITY_TOKEN Flag to disable the WPEFrameworkSecurity Token generation changes
Test Procedure: please referred from the ticket
Risks: Medium