### PR TITLE
VPLAY-9732: Fix crash on retuning to AES-encrypted channel

### DIFF
--- a/drm/DrmInterface.cpp
+++ b/drm/DrmInterface.cpp
@@ -65,6 +65,13 @@ void registerCallback(DrmInterface *_this ,std::shared_ptr<AesDec> instance )
     });
 
 }
+/**
+ *@brief updates the PrivateInstanceAAMP instance
+ */
+void DrmInterface::UpdateAamp(PrivateInstanceAAMP* aamp)
+{
+	mpAamp = aamp;
+}
 
 /**
  * @brief registerCallbackForHls - register callback only for HLS

--- a/drm/DrmInterface.h
+++ b/drm/DrmInterface.h
@@ -117,6 +117,11 @@ public:
 	 */
 	ProfilerBucketType MapDrmToProfilerBucket(DrmProfilerBucketType drmType);
 
+	/*
+	 *@brief Updates the PrivateInstanceAAMP instance.
+	 */
+	void UpdateAamp(PrivateInstanceAAMP* aamp);
+
 };
 
 #endif // _DRM_INTERFACE_H_

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1903,6 +1903,7 @@ void TrackState::SetDrmContext()
 
 	if(mDrm)
 	{
+		mDrmInterface->UpdateAamp(aamp);
 		mDrm->SetDecryptInfo( &mDrmInfo,  aamp->mConfig->GetConfigValue(eAAMPConfig_LicenseKeyAcquireWaitTime) );
 	}
 }

--- a/test/utests/fakes/FakeDrmInterface.cpp
+++ b/test/utests/fakes/FakeDrmInterface.cpp
@@ -33,6 +33,10 @@ DrmInterface::DrmInterface(PrivateInstanceAAMP* aamp):mAesKeyBuf("aesKeyBuf")
 DrmInterface::~DrmInterface()
 {
 }
+
+void DrmInterface::UpdateAamp(PrivateInstanceAAMP*)
+{
+}
 void DrmInterface::TerminateCurlInstance(int mCurlInstance)
 {
 }


### PR DESCRIPTION
Fixes crash when retuning to AES-encrypted channels. Ensures DrmInterface singleton updates its internal pointer to the latest PrivateInstanceAAMP to avoid referencing deleted instances.