### PR TITLE
VPLAY-9708 aamp not generating ala carte selectable schemes for indiv…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -892,11 +892,9 @@ install(FILES Accessibility.hpp AampEvent.h AampConfig.h AampCMCDCollector.h Aam
   middleware/PlayerUtils.h
   DESTINATION include)
 
-
-# Might need to bring back later. 
-#if (UTEST_ENABLED)
-#	add_subdirectory(test/utests EXCLUDE_FROM_ALL)
-#endif()
+if (UTEST_ENABLED)
+	add_subdirectory(test/utests EXCLUDE_FROM_ALL)
+endif()
 
 if (CMAKE_PLATFORM_UBUNTU OR CMAKE_SYSTEM_NAME STREQUAL Darwin )
     install(FILES build/aampcli-run-subtec.sh DESTINATION bin)


### PR DESCRIPTION
…idual l1 tests

Reason for change: allow utests to again be selectable in xcode
Test Procedure: select and run individual utests from xcode
Risks: Low