### PR TITLE
VPLAY-9710 aampcli kmp build failing to compile for older x86 Intel Mac

### DIFF
--- a/test/aampcli/aampcli_kmp.cpp
+++ b/test/aampcli/aampcli_kmp.cpp
@@ -33,7 +33,8 @@ static int main_func( gpointer user_data )
 
 extern "C" void kmp_init( void )
 {
-#if defined(__APPLE__)
+#if defined(__APPLE__) && defined(__aarch64__)
+// this workaround needed/working only on new 64 bit mac
 		gst_macos_main_simple(main_func, NULL );
 #else
 		main_func(NULL);


### PR DESCRIPTION
Reason for Change: use gst_macos_main_simple workaround only on newer macs
Test Procedure: compile on x86 mac
Risks: Low