### PR TITLE
VPLAY-9741 [ENT-4082] JSPP crashed while doing channel zapping

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -934,7 +934,6 @@ protected:
 	std::mutex mutex;                   /**< protection of track variables accessed from multiple threads */
 	bool ptsError;                      /**< flag to indicate if last injected fragment has ptsError */
 	bool abortInject;                   /**< Abort inject operations if flag is set*/
-	bool abortInjectChunk;              /**< Abort inject operations if flag is set*/
 	std::mutex audioMutex;              /**< protection of audio track reconfiguration */
 	bool loadNewAudio;                  /**< Flag to indicate new audio loading started on seamless audio switch */
 	std::mutex subtitleMutex;


### PR DESCRIPTION
Reason for change: Fix a crash when doing channel change

Summary of changes:
* Clear the AAMP TSB flags before stopping and destroying the StreamAbstraction object.
* Acquire the Stream lock before stopping the StreamAbstraction object
* Use MediaTrack::abortInject flag for both cache (regular and chunk)
* Add aditional log lines when thread MonitorBufferHealth is created and destroyed

Test Procedure: Repeated channel changes and confirm there is no crash

Risks: Medium