### PR TITLE
VPLAY-9566 [ENT-4082] Audio track change after FF to live plays from …

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -398,6 +398,8 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 					CacheTsbFragment(fragmentToTsbSessionMgr);
 				}
 				SetLocalTSBInjection(false);
+				// If all of the active media contexts are no longer injecting from TSB, update the AAMP flag
+				aamp->UpdateLocalAAMPTsbInjection();
 			}
 			else if (fragmentToTsbSessionMgr->initFragment && !IsLocalTSBInjection() && !aamp->pipeline_paused)
 			{

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -648,7 +648,7 @@ public:
 	 *
 	 * @return true if injection is from local AAMP TSB, false otherwise
 	 */
-	bool IsLocalTSBInjection() {return mIsLocalTSBInjection.load();}
+	bool IsLocalTSBInjection();
 
 	/**
 	 * @brief Returns if the end of track reached.

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -11823,18 +11823,8 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 							{
 								AAMPLOG_INFO("Recreate the TSB Session Manager");
 								CreateTsbSessionManager();
-								/* Check if we are on the live edge or in the TSB */
-								if(IsLocalAAMPTsbInjection())
-								{
-									AAMPLOG_INFO("Playing from TSB Buffer!");
-									SetLocalAAMPTsbInjection(false);
-									TuneHelper(eTUNETYPE_NEW_END);
-								}
-								else
-								{
-									AAMPLOG_INFO("Playing from the live edge!");
-									TuneHelper(eTUNETYPE_SEEKTOLIVE);
-								}
+								SetLocalAAMPTsbInjection(false);
+								TuneHelper(eTUNETYPE_SEEKTOLIVE);
 							}
 							else
 							{
@@ -13483,6 +13473,32 @@ void PrivateInstanceAAMP::SetLocalAAMPTsbInjection(bool value)
 bool PrivateInstanceAAMP::IsLocalAAMPTsbInjection()
 {
 	return mLocalAAMPInjectionEnabled;
+}
+
+void PrivateInstanceAAMP::UpdateLocalAAMPTsbInjection()
+{
+	bool TSBInjectionActive = false;
+
+	if (mpStreamAbstractionAAMP)
+	{
+		for (int i = 0; i < AAMP_TRACK_COUNT; i++)
+		{
+			auto track = mpStreamAbstractionAAMP->GetMediaTrack(static_cast<TrackType>(i));
+			if ((nullptr != track) && (track->Enabled()))
+			{
+				if (track->IsLocalTSBInjection())
+				{
+					TSBInjectionActive = true;
+					break;
+				}
+			}
+		}
+
+		if (!TSBInjectionActive)
+		{
+			SetLocalAAMPTsbInjection(false);
+		}
+	}
 }
 
 void PrivateInstanceAAMP::IncreaseGSTBufferSize()

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3840,6 +3840,12 @@ public:
 	 * @brief Is AAMP local TSB injection enabled/disabled
 	 */
 	bool IsLocalAAMPTsbInjection();
+
+	/**
+	 * @brief Clear Local AAMP TSB injection flag if there are no media tracks playing from TSB
+	 */
+	void UpdateLocalAAMPTsbInjection();
+
 	/**
 	 * @brief Increase Buffer value dynamically according to Max Profile Bandwidth to accommodate Larger Buffers
 	 */

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3174,6 +3174,16 @@ void MediaTrack::SetLocalTSBInjection(bool value)
 }
 
 /**
+ * @brief Is injection from local AAMP TSB
+ *
+ * @return true if injection is from local AAMP TSB, false otherwise
+ */
+bool MediaTrack::IsLocalTSBInjection()
+{
+	return mIsLocalTSBInjection.load();
+}
+
+/**
  * @brief Function to Resume track downloader
  */
 void StreamAbstractionAAMP::ResumeTrackDownloadsHandler( )

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1491,6 +1491,14 @@ bool PrivateInstanceAAMP::IsLocalAAMPTsbInjection()
 	return false;
 }
 
+void PrivateInstanceAAMP::UpdateLocalAAMPTsbInjection()
+{
+	if (g_mockPrivateInstanceAAMP)
+	{
+		g_mockPrivateInstanceAAMP->UpdateLocalAAMPTsbInjection();
+	}
+}
+
 bool PrivateInstanceAAMP::GetLLDashAdjustSpeed(void)
 {
 	if (g_mockPrivateInstanceAAMP)

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -164,7 +164,14 @@ void MediaTrack::AbortWaitForPlaylistDownload()
 
 bool MediaTrack::Enabled()
 {
-	return true;
+	bool enabled = true;
+
+	// When using mock, delegate to mock implementation
+	if (auto* mock = dynamic_cast<MockMediaTrack*>(this)) {
+		enabled = mock->Enabled();
+	}
+
+	return enabled;
 }
 
 void MediaTrack::FlushFragments()
@@ -257,6 +264,18 @@ bool MediaTrack::SignalIfEOSReached()
 
 void MediaTrack::SetLocalTSBInjection(bool value)
 {
+}
+
+bool MediaTrack::IsLocalTSBInjection()
+{
+	bool localTsbInjection = false;
+
+	// When using mock, delegate to mock implementation
+	if (auto* mock = dynamic_cast<MockMediaTrack*>(this)) {
+		localTsbInjection = mock->IsLocalTSBInjection();
+	}
+
+	return localTsbInjection;
 }
 
 bool StreamAbstractionAAMP::CheckForRampDownLimitReached()

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -30,58 +30,59 @@ public:
 
 	MOCK_METHOD(void, StartPausePositionMonitoring, (long long pausePositionMilliseconds));
 
-    MOCK_METHOD(void, StopPausePositionMonitoring, (std::string reason));
+	MOCK_METHOD(void, StopPausePositionMonitoring, (std::string reason));
 
-    MOCK_METHOD(AAMPPlayerState, GetState, ());
+	MOCK_METHOD(AAMPPlayerState, GetState, ());
 
-    MOCK_METHOD(void, SetState, (AAMPPlayerState state));
+	MOCK_METHOD(void, SetState, (AAMPPlayerState state));
 
-    MOCK_METHOD(bool, GetFile, (std::string remoteUrl, AampMediaType mediaType, AampGrowableBuffer *buffer, std::string& effectiveUrl,
-                int * http_error, double *downloadTime, const char *range, unsigned int curlInstance,
-                bool resetBuffer, BitsPerSecond *bitrate, int * fogError,
-                double fragmentDurationSeconds, ProfilerBucketType bucketType, int maxInitDownloadTimeMS));
-    MOCK_METHOD(void, SetStreamFormat, (StreamOutputFormat videoFormat, StreamOutputFormat audioFormat, StreamOutputFormat auxFormat));
+	MOCK_METHOD(bool, GetFile, (std::string remoteUrl, AampMediaType mediaType, AampGrowableBuffer *buffer, std::string& effectiveUrl,
+				int * http_error, double *downloadTime, const char *range, unsigned int curlInstance,
+				bool resetBuffer, BitsPerSecond *bitrate, int * fogError,
+				double fragmentDurationSeconds, ProfilerBucketType bucketType, int maxInitDownloadTimeMS));
+	MOCK_METHOD(void, SetStreamFormat, (StreamOutputFormat videoFormat, StreamOutputFormat audioFormat, StreamOutputFormat auxFormat));
 
-    MOCK_METHOD(std::string, GetAvailableAudioTracks, (bool allTrack));
-    MOCK_METHOD(int,GetAudioTrack,());
-    MOCK_METHOD(void, SendErrorEvent, (AAMPTuneFailure, const char *, bool, int32_t, int32_t, int32_t, const std::string &));
-    MOCK_METHOD(void, SendStreamTransfer, (AampMediaType, AampGrowableBuffer*, double, double, double, double, bool, bool));
-    MOCK_METHOD(bool, SendStreamCopy, (AampMediaType, const void *, size_t, double, double, double));
-    MOCK_METHOD(MediaFormat,GetMediaFormatTypeEnum,());
-    MOCK_METHOD(long long, GetPositionMs, ());
-    MOCK_METHOD(long long, GetPositionMilliseconds, ());
-    MOCK_METHOD(int, ScheduleAsyncTask, (IdleTask task, void *arg, std::string taskName));
-    MOCK_METHOD(bool, RemoveAsyncTask, (int taskId));
+	MOCK_METHOD(std::string, GetAvailableAudioTracks, (bool allTrack));
+	MOCK_METHOD(int,GetAudioTrack,());
+	MOCK_METHOD(void, SendErrorEvent, (AAMPTuneFailure, const char *, bool, int32_t, int32_t, int32_t, const std::string &));
+	MOCK_METHOD(void, SendStreamTransfer, (AampMediaType, AampGrowableBuffer*, double, double, double, double, bool, bool));
+	MOCK_METHOD(bool, SendStreamCopy, (AampMediaType, const void *, size_t, double, double, double));
+	MOCK_METHOD(MediaFormat,GetMediaFormatTypeEnum,());
+	MOCK_METHOD(long long, GetPositionMs, ());
+	MOCK_METHOD(long long, GetPositionMilliseconds, ());
+	MOCK_METHOD(int, ScheduleAsyncTask, (IdleTask task, void *arg, std::string taskName));
+	MOCK_METHOD(bool, RemoveAsyncTask, (int taskId));
 
-    MOCK_METHOD(const std::string &, GetSessionId, ());
+	MOCK_METHOD(const std::string &, GetSessionId, ());
 
-    MOCK_METHOD(std::shared_ptr<TSB::Store>, GetTSBStore, (const TSB::Store::Config& config, TSB::LogFunction logger, TSB::LogLevel level));
+	MOCK_METHOD(std::shared_ptr<TSB::Store>, GetTSBStore, (const TSB::Store::Config& config, TSB::LogFunction logger, TSB::LogLevel level));
 
-    MOCK_METHOD(void, FoundEventBreak, (const std::string &adBreakId, uint64_t startMS, EventBreakInfo brInfo));
-    MOCK_METHOD(void, SaveNewTimedMetadata, (long long timeMS, const char* id, double durationMS));
-    MOCK_METHOD(bool, DownloadsAreEnabled, ());
-    MOCK_METHOD(void, SendAdResolvedEvent, (const std::string &adId, bool status, uint64_t startMS, uint64_t durationMs));
-    MOCK_METHOD(uint32_t, GetAudTimeScale, ());
-    MOCK_METHOD(uint32_t, GetVidTimeScale, ());
-    MOCK_METHOD(void, ProcessID3Metadata, (char *, size_t , AampMediaType , uint64_t ));
-    MOCK_METHOD(void, SetPauseOnStartPlayback, (bool enable));
-    MOCK_METHOD(bool, isDecryptClearSamplesRequired, ());
-    MOCK_METHOD(long long, DurationFromStartOfPlaybackMs, ());
-    MOCK_METHOD(bool, IsLocalAAMPTsbInjection, ());
-    MOCK_METHOD(bool,  GetLLDashAdjustSpeed, ());
-    MOCK_METHOD(double, GetLLDashCurrentPlayBackRate, ());
-    MOCK_METHOD(void, StopDownloads, ());
-    MOCK_METHOD(void, ResumeDownloads, ());
-    MOCK_METHOD(void, TuneHelper, (TuneType tuneType, bool seekWhilePaused));
-    MOCK_METHOD(AampTSBSessionManager*, GetTSBSessionManager, ());
-    MOCK_METHOD(void, NotifyOnEnteringLive, ());
+	MOCK_METHOD(void, FoundEventBreak, (const std::string &adBreakId, uint64_t startMS, EventBreakInfo brInfo));
+	MOCK_METHOD(void, SaveNewTimedMetadata, (long long timeMS, const char* id, double durationMS));
+	MOCK_METHOD(bool, DownloadsAreEnabled, ());
+	MOCK_METHOD(void, SendAdResolvedEvent, (const std::string &adId, bool status, uint64_t startMS, uint64_t durationMs));
+	MOCK_METHOD(uint32_t, GetAudTimeScale, ());
+	MOCK_METHOD(uint32_t, GetVidTimeScale, ());
+	MOCK_METHOD(void, ProcessID3Metadata, (char *, size_t , AampMediaType , uint64_t ));
+	MOCK_METHOD(void, SetPauseOnStartPlayback, (bool enable));
+	MOCK_METHOD(bool, isDecryptClearSamplesRequired, ());
+	MOCK_METHOD(long long, DurationFromStartOfPlaybackMs, ());
+	MOCK_METHOD(bool, IsLocalAAMPTsbInjection, ());
+	MOCK_METHOD(void, UpdateLocalAAMPTsbInjection, ());
+	MOCK_METHOD(bool,  GetLLDashAdjustSpeed, ());
+	MOCK_METHOD(double, GetLLDashCurrentPlayBackRate, ());
+	MOCK_METHOD(void, StopDownloads, ());
+	MOCK_METHOD(void, ResumeDownloads, ());
+	MOCK_METHOD(void, TuneHelper, (TuneType tuneType, bool seekWhilePaused));
+	MOCK_METHOD(AampTSBSessionManager*, GetTSBSessionManager, ());
+	MOCK_METHOD(void, NotifyOnEnteringLive, ());
 
-    MOCK_METHOD(void, SendAdPlacementEvent, (AAMPEventType, const std::string &, uint32_t, uint64_t, uint32_t, uint32_t, bool, long));
-    MOCK_METHOD(void, SendAdReservationEvent, (AAMPEventType, const std::string &, uint64_t, uint64_t, bool));
-    MOCK_METHOD(void, CalculateTrickModePositionEOS, ());
-    MOCK_METHOD(void, BlockUntilGstreamerWantsData, (void(*cb)(void), int , int ));
-    MOCK_METHOD(void, WaitForDiscontinuityProcessToComplete, ());
-    MOCK_METHOD(double, GetLivePlayPosition, ());
+	MOCK_METHOD(void, SendAdPlacementEvent, (AAMPEventType, const std::string &, uint32_t, uint64_t, uint32_t, uint32_t, bool, long));
+	MOCK_METHOD(void, SendAdReservationEvent, (AAMPEventType, const std::string &, uint64_t, uint64_t, bool));
+	MOCK_METHOD(void, CalculateTrickModePositionEOS, ());
+	MOCK_METHOD(void, BlockUntilGstreamerWantsData, (void(*cb)(void), int , int ));
+	MOCK_METHOD(void, WaitForDiscontinuityProcessToComplete, ());
+	MOCK_METHOD(double, GetLivePlayPosition, ());
 };
 
 extern MockPrivateInstanceAAMP *g_mockPrivateInstanceAAMP;

--- a/test/utests/mocks/MockStreamAbstractionAAMP.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP.h
@@ -23,6 +23,30 @@
 #include <gmock/gmock.h>
 #include "StreamAbstractionAAMP.h"
 
+class MockMediaTrack : public MediaTrack
+{
+public:
+	MockMediaTrack(TrackType type, PrivateInstanceAAMP *aamp, const char *name)
+		: MediaTrack(type, aamp, name) {}
+	MOCK_METHOD(bool, IsLocalTSBInjection, ());
+	MOCK_METHOD(bool, Enabled, ());
+	MOCK_METHOD(void, ProcessPlaylist, (AampGrowableBuffer& newPlaylist, int http_error));
+	MOCK_METHOD(std::string&, GetPlaylistUrl, ());
+	MOCK_METHOD(std::string&, GetEffectivePlaylistUrl, ());
+	MOCK_METHOD(void, SetEffectivePlaylistUrl, (std::string url));
+	MOCK_METHOD(long long, GetLastPlaylistDownloadTime, ());
+	MOCK_METHOD(void, SetLastPlaylistDownloadTime, (long long time));
+	MOCK_METHOD(long, GetMinUpdateDuration, ());
+	MOCK_METHOD(int, GetDefaultDurationBetweenPlaylistUpdates, ());
+	MOCK_METHOD(void, ABRProfileChanged, ());
+	MOCK_METHOD(void, updateSkipPoint, (double position, double duration ));
+	MOCK_METHOD(void, setDiscontinuityState, (bool isDiscontinuity));
+	MOCK_METHOD(void, abortWaitForVideoPTS, ());
+	MOCK_METHOD(double, GetBufferedDuration, ());
+	MOCK_METHOD(class StreamAbstractionAAMP*, GetContext, ());
+	MOCK_METHOD(void, InjectFragmentInternal, (CachedFragment* cachedFragment, bool &fragmentDiscarded,bool isDiscontinuity));
+};
+
 class MockStreamAbstractionAAMP : public StreamAbstractionAAMP
 {
 public:

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -298,6 +298,10 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 				mStreamAbstractionAAMP_MPD->mTuneType = eTUNETYPE_SEEKTOLIVE;
 				EXPECT_CALL(*g_mockTSBSessionManager, GetTsbReader(_)).WillRepeatedly(Return(mTsbReader));
 				mTsbReader->mEosReached = true;
+				if (!paused)
+				{
+					EXPECT_CALL(*g_mockPrivateInstanceAAMP, UpdateLocalAAMPTsbInjection());
+				}
 			}
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillOnce(Return(tsbSessionManager));
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(_, _, _, _, _, _, _, _, _, _, _, _, _, _)).WillOnce(Return(true));

--- a/test/utests/tests/PrivAampTests/CMakeLists.txt
+++ b/test/utests/tests/PrivAampTests/CMakeLists.txt
@@ -44,23 +44,24 @@ include_directories(${LIBCJSON_INCLUDE_DIRS})
 include_directories(${AAMP_ROOT}/tsb/api)
 include_directories(${AAMP_ROOT}/middleware)
 
-set(TEST_SOURCES    PrivAampTests.cpp
-                    PrivAampAAMPTests.cpp)
+set(TEST_SOURCES	PrivAampTests.cpp
+					PrivAampAAMPTests.cpp
+					PrivAampTests_TsbInjection.cpp)
 set(AAMP_SOURCES ${AAMP_ROOT}/priv_aamp.cpp)
-add_executable(${EXEC_NAME}
-               ${TEST_SOURCES}
-               ${AAMP_SOURCES})
+add_executable(	${EXEC_NAME}
+				${TEST_SOURCES}
+				${AAMP_SOURCES})
 set_target_properties(${EXEC_NAME} PROPERTIES FOLDER "utests")
 target_compile_definitions(${EXEC_NAME} PRIVATE USE_SECMANAGER)
 
 if (CMAKE_XCODE_BUILD_SYSTEM)
-  # XCode schema target
-  xcode_define_schema(${EXEC_NAME})
+	# XCode schema target
+	xcode_define_schema(${EXEC_NAME})
 endif()
 
 if (COVERAGE_ENABLED)
-    include(CodeCoverage)
-    APPEND_COVERAGE_COMPILER_FLAGS()
+		include(CodeCoverage)
+		APPEND_COVERAGE_COMPILER_FLAGS()
 endif()
 target_link_libraries(${EXEC_NAME} fakes -pthread ${GLIB_LINK_LIBRARIES} ${OS_LD_FLAGS} ${GMOCK_LINK_LIBRARIES} ${GTEST_LINK_LIBRARIES} ${UUID_LINK_LIBRARIES})
 aamp_utest_run_add(${EXEC_NAME})

--- a/test/utests/tests/PrivAampTests/PrivAampTests_TsbInjection.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests_TsbInjection.cpp
@@ -1,0 +1,193 @@
+/*
+* If not stated otherwise in this file or this component's license file the
+* following copyright and licenses apply:
+*
+* Copyright 2025 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "priv_aamp.h"
+#include "MockStreamAbstractionAAMP.h"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::WithParamInterface;
+
+class PrivAampTests : public ::testing::Test
+{
+public:
+	PrivateInstanceAAMP *p_aamp{nullptr};
+	AampConfig *config{nullptr};
+
+protected:
+	void SetUp() override
+	{
+		config=new AampConfig();
+		p_aamp = new PrivateInstanceAAMP(config);
+		g_mockStreamAbstractionAAMP = new NiceMock<MockStreamAbstractionAAMP>(p_aamp);
+	}
+
+	void TearDown() override
+	{
+		delete g_mockStreamAbstractionAAMP;
+		g_mockStreamAbstractionAAMP = nullptr;
+
+		delete p_aamp;
+		p_aamp = nullptr;
+
+		delete config;
+		config = nullptr;
+	}
+};
+
+// Track injection status structure
+struct TrackInjectionParams
+{
+	bool videoInjection;
+	bool audioInjection;
+	bool subtitleInjection;
+	bool auxAudioInjection;
+	bool videoTrackEnabled;
+
+	// For test name generation
+	std::string ToString() const
+	{
+		std::stringstream ss;
+		ss << "V" << videoInjection
+		   << "_A" << audioInjection
+		   << "_S" << subtitleInjection
+		   << "_X" << auxAudioInjection
+		   << "_VE" << videoTrackEnabled;
+		return ss.str();
+	}
+};
+
+class TestPrivateInstanceAAMPTracks : public PrivAampTests,
+									  public WithParamInterface<TrackInjectionParams>
+{
+protected:
+	void SetUp() override
+	{
+		PrivAampTests::SetUp();
+		p_aamp->SetLocalAAMPTsbInjection(true);
+		p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	}
+
+	// Helper to create mock track
+	std::shared_ptr<MockMediaTrack> CreateMockTrack(TrackType type, const char* name)
+	{
+		return std::make_shared<NiceMock<MockMediaTrack>>(type, p_aamp, name);
+	}
+
+	// Helper to setup track expectations
+	void SetupTrackExpectations(TrackType type, std::shared_ptr<MockMediaTrack> track,
+								bool injection, bool enabled, int expectGetTrackCalls, int expectedCalls)
+	{
+		if (expectGetTrackCalls > 0)
+		{
+			EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(type))
+				.Times(expectGetTrackCalls)
+				.WillRepeatedly(Return(track.get()));
+
+			if (track)
+			{
+				EXPECT_CALL(*track, Enabled())
+					.Times(expectGetTrackCalls)
+					.WillRepeatedly(Return((enabled) ? true : false));
+
+				if (enabled)
+				{
+					EXPECT_CALL(*track, IsLocalTSBInjection())
+						.Times(expectedCalls)
+						.WillRepeatedly(Return(injection));
+				}
+			}
+		}
+	}
+};
+
+TEST_P(TestPrivateInstanceAAMPTracks, UpdateLocalAAMPTsbInjection)
+{
+	const auto& params = GetParam();
+	const bool hasActiveVideoInjection = params.videoInjection && params.videoTrackEnabled;
+
+	const bool expectedInjection = hasActiveVideoInjection || params.audioInjection ||
+								   params.subtitleInjection || params.auxAudioInjection;
+
+	// Calculate expected call counts based on short-circuit evaluation
+	const int expectVideoCheck = (hasActiveVideoInjection) ? 1 : 0;
+	const int expectAudioCheck = (hasActiveVideoInjection) ? 0 : 1;
+	const int expectSubtitleCheck = (hasActiveVideoInjection || params.audioInjection) ? 0 : 1;
+	const int expectAuxCheck = (hasActiveVideoInjection || params.audioInjection || params.subtitleInjection) ? 0 : 1;
+
+	// Create tracks
+	auto videoTrack = CreateMockTrack(eTRACK_VIDEO, "VIDEO");
+	auto audioTrack = CreateMockTrack(eTRACK_AUDIO, "AUDIO");
+	auto subtitleTrack = params.subtitleInjection ? CreateMockTrack(eTRACK_SUBTITLE, "SUBTITLE") : nullptr;
+	auto auxTrack = CreateMockTrack(eTRACK_AUX_AUDIO, "AUX_AUDIO");
+
+	// Setup expectations
+	SetupTrackExpectations(eTRACK_VIDEO, videoTrack, params.videoInjection, params.videoTrackEnabled, 1, expectVideoCheck);
+	SetupTrackExpectations(eTRACK_AUDIO, audioTrack, params.audioInjection, true, expectAudioCheck, expectAudioCheck);
+	SetupTrackExpectations(eTRACK_SUBTITLE, subtitleTrack, params.subtitleInjection, true, expectSubtitleCheck, expectSubtitleCheck);
+	SetupTrackExpectations(eTRACK_AUX_AUDIO, auxTrack, params.auxAudioInjection, true, expectAuxCheck, expectAuxCheck);
+
+	// Execute test
+	p_aamp->UpdateLocalAAMPTsbInjection();
+
+	// Verify results
+	EXPECT_EQ(p_aamp->IsLocalAAMPTsbInjection(), expectedInjection);
+}
+
+// Generate test cases for all track combinations
+std::vector<TrackInjectionParams> GenerateTestCases() {
+	std::vector<TrackInjectionParams> cases;
+	for (int i = 0; i < 16; i++) {
+		cases.push_back({
+			static_cast<bool>(i & 0x8),
+			static_cast<bool>(i & 0x4),
+			static_cast<bool>(i & 0x2),
+			static_cast<bool>(i & 0x1),
+			static_cast<bool>(i & 0x8) // Video track enabled if video injection is true
+		});
+	}
+
+	//test track is not enabled, but the injection is enabled
+	cases.push_back({
+		true,
+		false,
+		false,
+		false,
+		false // Video track not enabled
+	});
+
+	return cases;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	TSBInjectionTests,
+	TestPrivateInstanceAAMPTracks,
+	::testing::ValuesIn(GenerateTestCases()),
+	[](const testing::TestParamInfo<TrackInjectionParams>& info) {
+		return info.param.ToString();
+	}
+);
+


### PR DESCRIPTION
…live edge instead of live playing position

Reason for change: When changing the prefered language whilst injecting from the local TSB the wrong seek is being used. Resulting in seeking to the very live edge, and not to the live position.

Test procedure: On a SLD channel with multiple languages (i.e 172) with fog dissabled, and local TSB enabled:
 Pause for a couple of minutes
 FFWD to live edge so the automatic transition to play occurs
 Change the language from Welsh to English
 Observe play continues, there will be a small AV glitch as we are
effectively seeking to the same position as we are currently playing

Risk: Low

Signed-off-by: Dominic Holden<doholden@synamedia.com>

Change-Id: Id42d7c9bd9a98f913180e7ba77131e3df7762be1