### PR TITLE
VPLAY-9391 -AAMP TSB - OOB subtitles

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12216,6 +12216,12 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param )
 						}
 					}
 					seek_pos_seconds = GetPositionSeconds();
+
+					if (IsLocalAAMPTsb())
+					{
+						mAampTsbLanguageChangeInProgress = true;
+					}
+
 					TeardownStream(false);
 					if(IsFogTSBSupported() &&
 				 	((languagePresent && !languageAvailabilityInManifest) ||
@@ -12227,7 +12233,28 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param )
 						ReloadTSB();
 					}
 
-					TuneHelper(eTUNETYPE_SEEK);
+					if(IsLocalAAMPTsb())
+					{
+						AAMPLOG_WARN("Flush the TSB before seeking to live");
+
+						/* If AAMP TSB is enabled, flush the TSB before seeking to live */
+						if(mTSBSessionManager)
+						{
+							AAMPLOG_INFO("Recreate the TSB Session Manager and Tune to Live");
+							CreateTsbSessionManager();
+							SetLocalAAMPTsbInjection(false);
+							TuneHelper(eTUNETYPE_SEEKTOLIVE);
+						}
+						else
+						{
+							AAMPLOG_ERR("TSB Session Manager is NULL");
+						}
+					}
+					else
+					{
+						TuneHelper(eTUNETYPE_SEEK);
+					}
+
 					discardEnteringLiveEvt = false;
 				}
 				ReleaseStreamLock();

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -528,16 +528,6 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest4)
 	EXPECT_STREQ(mPrivateInstanceAAMP->preferredTextRenditionString.c_str(), "rend1");
 }
 
-TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest1)
-{
-	mPrivateInstanceAAMP->preferredTextNameString = "English";
-	//when Local TSB playback is in progress!!. SetPreferredTextLanguages() will be ignored
-	mPrivateInstanceAAMP->SetLocalAAMPTsb(true);
-	mPrivateInstanceAAMP->SetPreferredTextLanguages("{\"name\":\"Spanish\"}");
-	EXPECT_STREQ(mPrivateInstanceAAMP->preferredTextNameString.c_str(), "English");
-
-}
-
 TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest2)
 {
 	std::vector<TextTrackInfo> tracks;


### PR DESCRIPTION
Reason for Change: OOB subtitles support when using TSB.
Test Procedure: L1 & L2.  Full stack validation.
Risks: Low