### PR TITLE
VPLAY-9677 [ENT-4082] AAMP TSB - Configuration Enabled/Disabled

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7257,9 +7257,9 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 				mMediaStreamContext[eMEDIATYPE_AUX_AUDIO]->enabled = false;
 			}
 
-			if(ISCONFIGSET(eAAMPConfig_LocalTSBEnabled) && aamp->IsIframeExtractionEnabled())
+			if( aamp->IsLocalAAMPTsbFromConfig() && aamp->IsIframeExtractionEnabled())
 			{
-				/** Fake the iframe track if local TSB enabled and stream is LLD */
+				/** Fake the iframe track if AAMP TSB and i-frame extraction are enabled */
 				isIframeAdaptationAvailable = true;
 			}
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1230,6 +1230,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, mTrickModePositionEOS(0.0)
 	, mTSBSessionManager(NULL)
 	, mLocalAAMPTsb(false), mLocalAAMPInjectionEnabled(false)
+	, mLocalAAMPTsbFromConfig(false)
 	, mbPauseOnStartPlayback(false)
 	, mTSBStore(nullptr)
 	, mIsFlushFdsInCurlStore(false)
@@ -5758,7 +5759,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	tmpVar = GETCONFIGVALUE_PRIV(eAAMPConfig_PlaylistTimeout);
 	mPlaylistTimeoutMs = CONVERT_SEC_TO_MS(tmpVar);
 	mTsbType = GETCONFIGVALUE_PRIV(eAAMPConfig_TsbType);
-
+	mLocalAAMPTsbFromConfig = ISCONFIGSET_PRIV(eAAMPConfig_LocalTSBEnabled) || mTsbType == "local";
 	if(mPlaylistTimeoutMs <= 0) mPlaylistTimeoutMs = mManifestTimeoutMs;
 	if(AAMP_DEFAULT_SETTING == GETCONFIGOWNER_PRIV(eAAMPConfig_PlaylistTimeout))
 	{
@@ -6857,7 +6858,7 @@ std::string PrivateInstanceAAMP::GetThumbnails(double tStart, double tEnd)
 		}
 		cJSON_AddNumberToObject(root,"width",width);
 		cJSON_AddNumberToObject(root,"height",height);
-		
+
 		cJSON *tile = cJSON_AddArrayToObject(root,"tile");
 		for( const ThumbnailData &iter : datavec )
 		{
@@ -13160,7 +13161,7 @@ void PrivateInstanceAAMP::CreateTsbSessionManager()
 			AAMPLOG_INFO("Destroying TSB Session Manager %p", mTSBSessionManager);
 			SAFE_DELETE(mTSBSessionManager);
 		}
-		if(ISCONFIGSET_PRIV(eAAMPConfig_LocalTSBEnabled))
+		if(IsLocalAAMPTsbFromConfig())
 		{
 			if (ISCONFIGSET_PRIV(eAAMPConfig_EnablePTSReStamp))
 			{

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -2229,7 +2229,7 @@ public:
 	 *   @return void
 	 */
 	void SetState( AAMPPlayerState state, bool generateEvent=true );
-	
+
 	/**
 	 *   @fn GetState
 	 *
@@ -3832,6 +3832,14 @@ public:
 	}
 
 	/**
+	 * @brief Is AAMP local TSB enabled/disabled from config
+	 */
+	bool IsLocalAAMPTsbFromConfig()
+	{
+		return mLocalAAMPTsbFromConfig;
+	};
+
+	/**
 	 * @brief Set AAMP local TSB injection flag
 	 */
 	void SetLocalAAMPTsbInjection(bool value);
@@ -3866,7 +3874,7 @@ public:
 	 */
 	const char* getStringForPlaybackError(PlaybackErrorType errorType);
 	bool mPausePositionMonitoringThreadStarted; // Flag to indicate PausePositionMonitoring thread started
-	
+
 	/**
 	 *	@fn CalculateTrickModePositionEOS
 	 *		- this function only works for (rate > 1) - see priv_aamp.cpp
@@ -4105,11 +4113,12 @@ protected:
 	AampTSBSessionManager *mTSBSessionManager;
 	bool mLocalAAMPInjectionEnabled;					/**< Injecting segments from AAMP Local TSB */
 	bool mLocalAAMPTsb;									/**< AAMP Local TSB enabled for the current channel
-															(localTSBEnabled and enablePTSReStamp enabled, and playing DASH content) */
+															(localTSBEnabled and enablePTSReStamp enabled, and playing linear DASH content) */
 	bool mbPauseOnStartPlayback;						/**< Start playback in paused state */
 
 	std::mutex mPreProcessLock;
 	bool mIsChunkMode;		/** LLD ChunkMode */
+	bool mLocalAAMPTsbFromConfig;						/**< AAMP TSB enabled in the configuration, regardless of the current channel */
 
 private:
 	void SetCMCDTrackData(AampMediaType mediaType);

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -349,7 +349,10 @@ public:
 		// This call creates the TSB Store if it doesn't exist.
 		(void)GetTSBStore(config, AampLogManager::aampLogger, TSB::LogLevel::TRACE);
 	}
-
+	void SetLocalAAMPTsbFromConfig(bool value)
+	{
+		mLocalAAMPTsbFromConfig = value;
+	}
 	};
 	TestablePrivAamp *testp_aamp{nullptr};
 };
@@ -395,6 +398,7 @@ TEST_F(PrivAampPrivTests, SetPreferredLanguagesPlayingLiveAampTsbTest)
 	tracks.push_back(AudioTrackInfo("idx0", "lang0", "rend0", "trackName0", "codec0", 0, "type0", false, "label0", "type0", true));
 	tracks.push_back(AudioTrackInfo("idx1", "lang1", "rend1", "trackName1", "codec1", 0, "type1", false, "label1", "type1", true));
 	testp_aamp->SetLocalAAMPTsb(true);
+	testp_aamp->SetLocalAAMPTsbFromConfig(true);
 	testp_aamp->SetTsbSessionManager();
 	testp_aamp->SetTsbStore();
 	testp_aamp->preferredLanguagesString = "lang0";
@@ -413,7 +417,6 @@ TEST_F(PrivAampPrivTests, SetPreferredLanguagesPlayingLiveAampTsbTest)
 	EXPECT_CALL(*g_mockAampJsonObject, get("name", An<std::string&>())).WillOnce(Return(false));
 	EXPECT_CALL(*g_mockAampJsonObject, get("label", An<std::string&>())).WillOnce(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_LocalTSBEnabled)).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(true));
 
 	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
@@ -452,6 +455,7 @@ TEST_F(PrivAampPrivTests, SetPreferredLanguagesPlayingFromAampTsbTest)
 	testp_aamp->SetLocalAAMPTsb(true);
 	/* Simulate playing from AAMP TSB by setting the injection flag to true */
 	testp_aamp->SetLocalAAMPTsbInjection(true);
+	testp_aamp->SetLocalAAMPTsbFromConfig(true);
 	testp_aamp->SetTsbSessionManager();
 	testp_aamp->SetTsbStore();
 	testp_aamp->preferredLanguagesString = "lang0";
@@ -470,7 +474,6 @@ TEST_F(PrivAampPrivTests, SetPreferredLanguagesPlayingFromAampTsbTest)
 	EXPECT_CALL(*g_mockAampJsonObject, get("name", An<std::string&>())).WillOnce(Return(false));
 	EXPECT_CALL(*g_mockAampJsonObject, get("label", An<std::string&>())).WillOnce(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_LocalTSBEnabled)).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(true));
 
 	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));


### PR DESCRIPTION
Reason For Change: AAMP TSB can be enabled 2 ways in the config

Test Procedure: L1 and L2 5004 and 5002

Change-Id: Ic950b5cf4c52dc1676d331fac7c3c6079c392936