### PR TITLE
VPLAY-9694 optimize LLD to leverage http 1.1 chunked transfer mode

### DIFF
--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -1472,6 +1472,25 @@ int aamp_SetThreadSchedulingParameters(int policy, int priority)
 	AAMPLOG_INFO("Thread scheduling parameters set successfully.");
 	return result; // Success
 }
+
+int aamp_hascii_char_to_number( char c )
+{
+	int rc = -1;
+	if( isdigit(c) )
+	{
+		rc = (c-'0');
+	}
+	else
+	{
+		c = toupper(c);
+		if( c>='A' && c<='F' )
+		{
+			rc = 10 + (c-'A');
+		}
+	}
+	return rc;
+}
+
 /*
  * EOF
  */

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -418,5 +418,11 @@ void aamp_setThreadName(const char *name);
  */
 int aamp_SetThreadSchedulingParameters(int policy, int priority);
 
+/**
+ * @brief map ascii character to base16 number
+ * @param c '0'..'9', 'a'..'f', or 'A'..'F'
+ * @retval corredponding number (0..15) for character or -1 if invalid
+ */
+int aamp_hascii_char_to_number( char c );
 
 #endif  /* __AAMP_UTILS_H__ */

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -234,6 +234,21 @@ public:
  */
 struct CurlCallbackContext
 {
+	// HTTP/1.1 Chunked Transfer Protocol
+	typedef enum
+	{
+		eTRANSFER_STATE_READING_CHUNK_SIZE, // reading hascii chunk size
+		eTRANSFER_STATE_PENDING_CHUNK_START_LF, // chunk size read, along with following CR delimiter - waiting for LF
+		eTRANSFER_STATE_READING_CHUNK_DATA, // collecting binary payload for chunk
+		eTRANSFER_STATE_PENDING_CHUNK_END_CR, // chunk payload has been read, next byte expected to be chunk-end CR
+		eTRANSFER_STATE_PENDING_CHUNK_END_LF // chunk payload and first CR delimiter read; waiting for LF
+	} TransferState;
+	struct
+	{
+		size_t remaining;
+		TransferState state;
+	} mTransferState;
+	
 	PrivateInstanceAAMP *aamp;
 	AampMediaType mediaType;
 	std::vector<std::string> allResponseHeaders;
@@ -248,11 +263,9 @@ struct CurlCallbackContext
 	long long downloadStartTime;
 	long long processDelay; /**< Indicate the external process delay in curl operation; especially for lld*/
 
-	CurlCallbackContext() : aamp(NULL), buffer(NULL), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false), chunkedDownload(false),  mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""}, contentLength(0),downloadStartTime(-1), processDelay(0)
-	{
-
-	}
-	CurlCallbackContext(PrivateInstanceAAMP *_aamp, AampGrowableBuffer *_buffer) : aamp(_aamp), buffer(_buffer), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false),  chunkedDownload(false), mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""},  contentLength(0),downloadStartTime(-1){}
+	CurlCallbackContext() : aamp(NULL), buffer(NULL), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false), chunkedDownload(false),  mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""}, contentLength(0),downloadStartTime(-1), processDelay(0),mTransferState(){}
+	
+	CurlCallbackContext(PrivateInstanceAAMP *_aamp, AampGrowableBuffer *_buffer) : aamp(_aamp), buffer(_buffer), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false),  chunkedDownload(false), mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""},  contentLength(0),downloadStartTime(-1), mTransferState(){}
 
 	~CurlCallbackContext() {}
 

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -234,6 +234,21 @@ public:
  */
 struct CurlCallbackContext
 {
+	// HTTP/1.1 Chunked Transfer Protocol
+	typedef enum
+	{
+		eTRANSFER_STATE_READING_CHUNK_SIZE, // reading hascii chunk size
+		eTRANSFER_STATE_PENDING_CHUNK_START_LF, // chunk size read, along with following CR delimiter - waiting for LF
+		eTRANSFER_STATE_READING_CHUNK_DATA, // collecting binary payload data for chunk
+		eTRANSFER_STATE_PENDING_CHUNK_END_CR, // chunk payload has been read, next byte expected to be chunk-end CR
+		eTRANSFER_STATE_PENDING_CHUNK_END_LF // chunk payload and first CR delimiter read; waiting for LF
+	} TransferState;
+	struct
+	{
+		size_t remaining;
+		TransferState state;
+	} mTransferState;
+	
 	PrivateInstanceAAMP *aamp;
 	AampMediaType mediaType;
 	std::vector<std::string> allResponseHeaders;
@@ -248,11 +263,9 @@ struct CurlCallbackContext
 	long long downloadStartTime;
 	long long processDelay; /**< Indicate the external process delay in curl operation; especially for lld*/
 
-	CurlCallbackContext() : aamp(NULL), buffer(NULL), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false), chunkedDownload(false),  mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""}, contentLength(0),downloadStartTime(-1), processDelay(0)
-	{
-
-	}
-	CurlCallbackContext(PrivateInstanceAAMP *_aamp, AampGrowableBuffer *_buffer) : aamp(_aamp), buffer(_buffer), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false),  chunkedDownload(false), mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""},  contentLength(0),downloadStartTime(-1){}
+	CurlCallbackContext() : aamp(NULL), buffer(NULL), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false), chunkedDownload(false),  mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""}, contentLength(0),downloadStartTime(-1), processDelay(0),mTransferState(){}
+	
+	CurlCallbackContext(PrivateInstanceAAMP *_aamp, AampGrowableBuffer *_buffer) : aamp(_aamp), buffer(_buffer), responseHeaderData(NULL),bitrate(0),downloadIsEncoded(false),  chunkedDownload(false), mediaType(eMEDIATYPE_DEFAULT), remoteUrl(""), allResponseHeaders{""},  contentLength(0),downloadStartTime(-1), mTransferState(){}
 
 	~CurlCallbackContext() {}
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -79,6 +79,8 @@
 #include "AampTSBSessionManager.h"
 #include "SocUtils.h"
 
+#define LEVERAGE_CHUNK_TRANSFER_MODE
+
 #define LOCAL_HOST_IP       "127.0.0.1"
 #define AAMP_MAX_TIME_BW_UNDERFLOWS_TO_TRIGGER_RETUNE_MS (20*1000LL)
 #define AAMP_MAX_TIME_LL_BW_UNDERFLOWS_TO_TRIGGER_RETUNE_MS (AAMP_MAX_TIME_BW_UNDERFLOWS_TO_TRIGGER_RETUNE_MS/10)
@@ -571,6 +573,76 @@ static int ReadConfigNumericHelper(std::string buf, const char* prefixPtr, T& va
 
 // End of helper functions for loading configuration
 
+bool PrivateInstanceAAMP::chunked_write_callback(const char *ptr, size_t numBytes, void *userdata)
+{ // HTTP/1.1 Chunked Transfer Protocol
+	CurlCallbackContext *context = (CurlCallbackContext *)userdata;
+	const char *fin = &ptr[numBytes];
+	while( ptr<fin )
+	{
+		switch( context->mTransferState.state )
+		{
+			case CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_SIZE:
+			{
+				char c = *ptr++;
+				if( c=='\r' )
+				{
+					context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_START_LF;
+				}
+				else
+				{
+					int octet = aamp_hascii_char_to_number(c);
+					if( octet<0 )
+					{
+						return false;
+					}
+					context->mTransferState.remaining <<= 4;
+					context->mTransferState.remaining += octet;
+				}
+			}
+				break;
+				
+			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_START_LF:
+				assert( *ptr++ == '\n' );
+				AAMPLOG_INFO( "CHUNK_SIZE=%zu %s", context->mTransferState.remaining, GetMediaTypeName(context->mediaType) );
+				context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_DATA;
+				break;
+				
+			case CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_DATA:
+				if( context->mTransferState.remaining > 0 )
+				{
+					size_t n = fin - ptr;
+					if( n > context->mTransferState.remaining )
+					{ // clamp
+						n = context->mTransferState.remaining;
+					}
+					context->buffer->AppendBytes( ptr, n );
+					ptr += n;
+					context->mTransferState.remaining -= n;
+				}
+				else
+				{
+					// here we will be at the end of an 'mdat', suitable for injection
+					// bytes collected so far may include 1..4 packed ('moov','mdat') boxes.
+					assert( context->mTransferState.remaining == 0 );
+					context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_CR;
+				}
+				break;
+				
+			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_CR:
+				assert( *ptr++ == '\r' );
+				context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_LF;
+				break;
+				
+			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_LF:
+				assert( *ptr++ == '\n' );
+				context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_SIZE;
+				assert( context->mTransferState.remaining == 0 );
+				break;
+		}
+	}
+	return true;
+}
+
 /**
  * @brief HandleSSLWriteCallback - Handle write callback from CURL
  */
@@ -595,11 +667,29 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 			context->buffer->ReserveBytes(len);
 		}
 		size_t numBytesForBlock = size*nmemb;
-		if(ptr && numBytesForBlock > 0)
-		{
-			context->buffer->AppendBytes( ptr, numBytesForBlock );
-		}
 		ret = numBytesForBlock;
+		if( ptr && numBytesForBlock > 0)
+		{
+#ifdef LEVERAGE_CHUNK_TRANSFER_MODE
+			if( context->chunkedDownload )
+			{
+				if( chunked_write_callback( ptr, numBytesForBlock, userdata ) )
+				{
+					ptr = context->buffer->GetPtr();
+					numBytesForBlock = context->buffer->GetLen();
+				}
+				else
+				{
+					AAMPLOG_ERR("CHUNK_TRANSFER_MODE unexpected data");
+					return 0;
+				}
+			}
+			else
+#endif
+			{
+				context->buffer->AppendBytes( ptr, numBytesForBlock );
+			}
+		}
 		MediaStreamContext *mCtx = context->aamp->GetMediaStreamContext(context->mediaType);
 
 		if(mCtx)
@@ -618,9 +708,17 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 				lock.unlock();
 				AAMPLOG_TRACE("[%d] Caching chunk with size %zu nmemb:%zu size:%zu", context->mediaType, numBytesForBlock, nmemb, size);
 				long long startTime = aamp_GetCurrentTimeMS();
-				mCtx->CacheFragmentChunk(context->mediaType, ptr, numBytesForBlock,context->remoteUrl,context->downloadStartTime);
+				mCtx->CacheFragmentChunk(context->mediaType, ptr,
+										 numBytesForBlock,context->remoteUrl,context->downloadStartTime);
 				context->processDelay += aamp_GetCurrentTimeMS() - startTime;
 				lock.lock();
+				
+#ifdef LEVERAGE_CHUNK_TRANSFER_MODE
+				if( context->chunkedDownload )
+				{
+					context->buffer->Clear();
+				}
+#endif
 			}
 		}
 	}
@@ -732,6 +830,7 @@ size_t PrivateInstanceAAMP::HandleSSLHeaderCallback ( const char *ptr, size_t si
 		}
 		else if (STARTS_WITH_IGNORE_CASE(ptr, TRANSFER_ENCODING_STRING ))
 		{
+			AAMPLOG_INFO( "chunkedDownload: '%.*s'\n", (int)len, ptr );
 			context->chunkedDownload = true;
 		}
 		else if (0 == context->buffer->GetAvail() )
@@ -3941,6 +4040,12 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 		if (curl)
 		{
 			CURL_EASY_SETOPT_STRING(curl, CURLOPT_URL, remoteUrl.c_str());
+			
+			//  by default libcurl handles chunked transfer encoding transparently
+			#ifdef LEVERAGE_CHUNK_TRANSFER_MODE
+			CURL_EASY_SETOPT_LONG(curl, CURLOPT_HTTP_TRANSFER_DECODING, 0);
+			#endif
+			
 			if(this->mAampLLDashServiceData.lowLatencyMode)
 			{
 				CURL_EASY_SETOPT_LONG(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -573,12 +573,59 @@ static int ReadConfigNumericHelper(std::string buf, const char* prefixPtr, T& va
 
 // End of helper functions for loading configuration
 
+//#define SAVE_CHUNKS
+static std::string chunkyPath[2];
+
+static bool gBad = false;
+
 bool PrivateInstanceAAMP::chunked_write_callback(const char *ptr, size_t numBytes, void *userdata)
 { // HTTP/1.1 Chunked Transfer Protocol
 	CurlCallbackContext *context = (CurlCallbackContext *)userdata;
 	const char *fin = &ptr[numBytes];
+	
+	if( 1 )
+	{
+		FILE *f = fopen( chunkyPath[context->mediaType].c_str(), "ab" );
+		assert(f);
+		fwrite( ptr, numBytes, 1, f );
+		fclose(f);
+	}
+	if( gBad )
+	{
+		return true;
+	}
+	
+#ifdef SAVE_CHUNKS
+	static FILE *f[2];
+#endif
 	while( ptr<fin )
 	{
+		const char *state_name = "?";
+		switch( context->mTransferState.state )
+		{
+			case CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_SIZE:
+				state_name = "reading chunk size";
+				break;
+			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_START_LF:
+				state_name = "awaiting start LF";
+				break;
+			case CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_DATA:
+				state_name = "reading chunk data";
+				break;
+			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_CR:
+				state_name = "awaiting end CR";
+				break;
+			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_LF:
+				state_name = "awaiting end LF";
+				break;
+			default:
+				break;
+		}
+		AAMPLOG_INFO("%s (%s)) remaining=%zu",
+				GetMediaTypeName(context->mediaType),
+				state_name,
+				context->mTransferState.remaining );
+		
 		switch( context->mTransferState.state )
 		{
 			case CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_SIZE:
@@ -591,9 +638,12 @@ bool PrivateInstanceAAMP::chunked_write_callback(const char *ptr, size_t numByte
 				else
 				{
 					int octet = aamp_hascii_char_to_number(c);
+					//assert( octet>=0 );
 					if( octet<0 )
 					{
-						return false;
+						gBad = true;
+						return true;
+						//return false;
 					}
 					context->mTransferState.remaining <<= 4;
 					context->mTransferState.remaining += octet;
@@ -602,8 +652,36 @@ bool PrivateInstanceAAMP::chunked_write_callback(const char *ptr, size_t numByte
 				break;
 				
 			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_START_LF:
-				assert( *ptr++ == '\n' );
-				AAMPLOG_INFO( "CHUNK_SIZE=%zu %s", context->mTransferState.remaining, GetMediaTypeName(context->mediaType) );
+				if( *ptr++ != '\n' )
+				{
+					gBad = true;
+					return true;
+				}
+				//assert( *ptr++ == '\n' );
+				
+#ifdef SAVE_CHUNKS
+			{
+				assert( f[context->mediaType] == NULL );
+				char path[256];
+				static int seqNo[2];
+				snprintf( path, sizeof(path), "/Users/pstrof200/Downloads/chunk-archive/%s-%03d-%zu.mp4",
+						GetMediaTypeName(context->mediaType),
+						seqNo[context->mediaType],
+						context->mTransferState.remaining );
+				f[context->mediaType] = fopen( path, "wb" );
+				assert( f );
+				seqNo[context->mediaType]++;
+			}
+#endif
+				
+				if( context->mTransferState.remaining )
+				{
+					AAMPLOG_INFO( "CHUNK_START %zu %s", context->mTransferState.remaining, GetMediaTypeName(context->mediaType) );
+				}
+				else
+				{
+					AAMPLOG_INFO( "CHUNK_END %s", GetMediaTypeName(context->mediaType) );
+				}
 				context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_DATA;
 				break;
 				
@@ -615,26 +693,50 @@ bool PrivateInstanceAAMP::chunked_write_callback(const char *ptr, size_t numByte
 					{ // clamp
 						n = context->mTransferState.remaining;
 					}
+					
+#ifdef SAVE_CHUNKS
+					assert( f[context->mediaType] );
+					fwrite( ptr, n, 1, f[context->mediaType] );
+#endif
 					context->buffer->AppendBytes( ptr, n );
 					ptr += n;
 					context->mTransferState.remaining -= n;
 				}
 				else
 				{
-					// here we will be at the end of an 'mdat', suitable for injection
+#ifdef SAVE_CHUNKS
+					assert( f[context->mediaType] );
+					fclose( f[context->mediaType] );
+					f[context->mediaType] = NULL;
+#endif
+					// here we will presumably be at the end of an 'mdat', suitable for injection
 					// bytes collected so far may include 1..4 packed ('moov','mdat') boxes.
-					assert( context->mTransferState.remaining == 0 );
+					if( context->mTransferState.remaining != 0 )
+					{
+						gBad = true;
+						return true;
+					}
+					//assert( context->mTransferState.remaining == 0 );
 					context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_CR;
 				}
 				break;
 				
 			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_CR:
-				assert( *ptr++ == '\r' );
+				if( *ptr++!='\r' )
+				{
+					gBad = true;
+					return true;
+				}
 				context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_LF;
 				break;
 				
 			case CurlCallbackContext::eTRANSFER_STATE_PENDING_CHUNK_END_LF:
-				assert( *ptr++ == '\n' );
+				if( *ptr++ != '\n' )
+				{
+					gBad = true;
+					return true;
+				}
+				//assert( *ptr++ == '\n' );
 				context->mTransferState.state = CurlCallbackContext::eTRANSFER_STATE_READING_CHUNK_SIZE;
 				assert( context->mTransferState.remaining == 0 );
 				break;
@@ -3978,6 +4080,20 @@ void PrivateInstanceAAMP::SetCMCDTrackData(AampMediaType mediaType)
  */
 bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaType, AampGrowableBuffer *buffer, std::string& effectiveUrl, int * http_error, double *downloadTimeS, const char *range, unsigned int curlInstance, bool resetBuffer, BitsPerSecond *bitrate, int * fogError, double fragmentDurationS, ProfilerBucketType bucketType, int maxInitDownloadTimeMS)
 {
+	assert( !gBad );
+	size_t pos;
+	switch( mediaType )
+	{
+		case eMEDIATYPE_VIDEO:
+		case eMEDIATYPE_AUDIO:
+			chunkyPath[mediaType] = "/Users/pstrof200/Desktop/outputChunks/out/";
+			pos = remoteUrl.find_last_of('/');
+			chunkyPath[mediaType] += remoteUrl.substr(pos+1);
+			break;
+		default:
+			break;
+	}
+	
 	if( bucketType!=PROFILE_BUCKET_TYPE_COUNT)
 	{
 		profiler.ProfileBegin(bucketType);
@@ -4720,6 +4836,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 		}
 		profiler.ProfileEnd(bucketType);
 	}
+	assert( !gBad );
 	return ret;
 }
 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3686,6 +3686,7 @@ public:
 	 * @retval size consumed or 0 if interrupted
 	 */
 	size_t HandleSSLWriteCallback ( char *ptr, size_t size, size_t nmemb, void* userdata );
+	bool chunked_write_callback( const char *ptr, size_t numBytes, void *userdata );
 
 	/**
 	 * @fn HandleSSLProgressCallback

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -75,7 +75,7 @@ class AampTSBSessionManager;
 #define MANIFEST_TEMP_DATA_LENGTH 100			/**< Manifest temp data length */
 #define  AAMP_LOW_BUFFER_BEFORE_RAMPDOWN_FOR_LLD 3	/**< 3sec buffer before rampdown for lld */
 #define AAMP_HIGH_BUFFER_BEFORE_RAMPUP_FOR_LLD	 4	/**< 4sec buffer before rampup for lld */
-#define TIMEOUT_FOR_LLD	3				/**< 3sec network timeout for lld */
+#define TIMEOUT_FOR_LLD	10 // 3				/**< 3sec network timeout for lld */
 #define MANIFEST_TIMEOUT_FOR_LLD 3      /**< 3 sec timeout for manifest refresh in case of LLD*/
 #define ABR_BUFFER_COUNTER_FOR_LLD 3		/** Counter for steady state rampup/rampdown for lld */
 
@@ -3686,6 +3686,7 @@ public:
 	 * @retval size consumed or 0 if interrupted
 	 */
 	size_t HandleSSLWriteCallback ( char *ptr, size_t size, size_t nmemb, void* userdata );
+	void chunked_write_callback( const char *ptr, size_t numBytes, void *userdata );
 
 	/**
 	 * @fn HandleSSLProgressCallback

--- a/test/utests/fakes/FakeAampUtils.cpp
+++ b/test/utests/fakes/FakeAampUtils.cpp
@@ -608,6 +608,11 @@ const char *mystrstr(const char *haystack_ptr, const char *haystack_fin, const c
 	return NULL;
 }
 
+int aamp_hascii_char_to_number( char c )
+{
+	return -1;
+}
+
 void aamp_setThreadName(const char *name)
 {
 }

--- a/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
+++ b/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
@@ -734,3 +734,32 @@ TEST(_AampUtils, strstr )
 	EXPECT_TRUE( mystrstr(haystack_ptr,&haystack_ptr[9],"is") == &haystack_ptr[4] );
 }
 
+TEST(_AampUtils, hascii_char_to_number )
+{
+	EXPECT_EQ( aamp_hascii_char_to_number('0'),0);
+	EXPECT_EQ( aamp_hascii_char_to_number('1'),1);
+	EXPECT_EQ( aamp_hascii_char_to_number('2'),2);
+	EXPECT_EQ( aamp_hascii_char_to_number('3'),3);
+	EXPECT_EQ( aamp_hascii_char_to_number('4'),4);
+	EXPECT_EQ( aamp_hascii_char_to_number('5'),5);
+	EXPECT_EQ( aamp_hascii_char_to_number('6'),6);
+	EXPECT_EQ( aamp_hascii_char_to_number('7'),7);
+	EXPECT_EQ( aamp_hascii_char_to_number('8'),8);
+	EXPECT_EQ( aamp_hascii_char_to_number('9'),9);
+	EXPECT_EQ( aamp_hascii_char_to_number('a'),10);
+	EXPECT_EQ( aamp_hascii_char_to_number('b'),11);
+	EXPECT_EQ( aamp_hascii_char_to_number('c'),12);
+	EXPECT_EQ( aamp_hascii_char_to_number('d'),13);
+	EXPECT_EQ( aamp_hascii_char_to_number('e'),14);
+	EXPECT_EQ( aamp_hascii_char_to_number('f'),15);
+	EXPECT_EQ( aamp_hascii_char_to_number('A'),10);
+	EXPECT_EQ( aamp_hascii_char_to_number('B'),11);
+	EXPECT_EQ( aamp_hascii_char_to_number('C'),12);
+	EXPECT_EQ( aamp_hascii_char_to_number('D'),13);
+	EXPECT_EQ( aamp_hascii_char_to_number('E'),14);
+	EXPECT_EQ( aamp_hascii_char_to_number('F'),15);
+	EXPECT_EQ( aamp_hascii_char_to_number(' '),-1);
+	EXPECT_EQ( aamp_hascii_char_to_number('x'),-1);
+	EXPECT_EQ( aamp_hascii_char_to_number((char)0x00),-1);
+	EXPECT_EQ( aamp_hascii_char_to_number((char)0xff),-1);
+}


### PR DESCRIPTION
chunked transfer mode is used for media segments being real time transcoded, where (total) content length is not known up front.  This change adds preliminary support to detect chunk boundaries using libcurl.
It also relaxes a curl timeout used for LLDASH, which makes playback more robust.__