### PR TITLE
VPLAY-9678: Crash(60223193) observed during channel change on linear …

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2656,7 +2656,15 @@ std::string PlayerInstanceAAMP::GetAvailableAudioTracks(bool allTrack)
 	std::string ret;
 	if( aamp )
 	{
-		ret = aamp->GetAvailableAudioTracks(allTrack);
+		AAMPPlayerState state = aamp->GetState();
+		if (state != eSTATE_IDLE && state != eSTATE_ERROR)
+		{
+			ret = aamp->GetAvailableAudioTracks(allTrack);
+		}
+		else
+		{
+			AAMPLOG_WARN("operation is not allowed when player in %d state !", state);
+		}
 	}
 	return ret;
 }

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2055,6 +2055,24 @@ TEST_F(PlayerInstanceAAMPTests, GetAvailableVideoTracksTest)
 
 }
 
+TEST_F(PlayerInstanceAAMPTests, GetAvailableAudioTracksTest1)
+{
+    std::string result;
+    mPrivateInstanceAAMP->SetState(eSTATE_ERROR);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_ERROR));
+    std::string availableTracks = mPlayerInstance->GetAvailableAudioTracks();
+    EXPECT_STREQ(result.c_str(),availableTracks.c_str());
+}
+
+TEST_F(PlayerInstanceAAMPTests, GetAvailableAudioTracksTest2)
+{
+    std::string result;
+    mPrivateInstanceAAMP->SetState(eSTATE_IDLE);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_IDLE));
+    std::string availableTracks = mPlayerInstance->GetAvailableAudioTracks();
+    EXPECT_STREQ(result.c_str(),availableTracks.c_str());
+}
+
 TEST_F(PlayerInstanceAAMPTests, GetAudioTrackInfoTest)
 {
     std::string result = "AudioTrack";


### PR DESCRIPTION

Reason for change: Added ERROR or IDLE state check guard before calling GetAvailableAudioTracks() to avoid this crash. Added L1 to catch this. Test Procedure: Refer Jira
Risks: Low