### PR TITLE
VPLAY-8590: Implement AAMPEvent for reporting AV status

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -207,6 +207,8 @@ Configuration options are passed to AAMP using the UVE initConfig method. This a
 | showDiagnosticsOverlay | Number | 0 (None) | Configures the diagnostics overlay: 0 (None), 1 (Minimal), 2 (Extended). Controls the visibility and level of detail for diagnostics displayed during playback. Refer [Diagnostics Overlay Configuration](#diagnostics-overlay-configuration)
 | localTSBEnabled | Boolean | False | Enable use of time shift buffer (TSB) for live playback, leveraging local storage.  Use of a TSB allows pause, seek, fast forward/rewind operations beyond the size of the default manifest live window supported by the CDN |
 | tsbLength | Number | 3600 (1 hour) or 1500 (25 min) | Max duration (seconds) of Local TSB to build up before culling  (not recommended for apps to change) |
+| monitorAV | Boolean | False | Enable background monitoring of audio/video positions to infer video freeze, audio drop, or av sync issues |
+| monitorAVReportingInterval | Number | 1000 | Timeout in milliseconds for reporting MonitorAV events |
 
 Example:
 ```js
@@ -2265,6 +2267,22 @@ Example:
 ```
 ---
 
+### monitorAVStatus
+
+**Event Payload:**
+- sessionId: string Refer to [load](#load-uri_autoplay_tuneparams) API for details
+- currentState: string
+- videoPosMs : number
+- audioPosMs : number
+- timeInStateMs : number
+
+**Description:**
+- Player periodically reports the video and audio position to the application which could be used to infer video freeze, audio drop, or av sync issues.
+- Reporting interval can be configured using monitorAVReportingInterval which ranges from 1s to 60s.
+- Player also sends a currentState which is identified by the player based on the continuous a/v positions.
+
+---
+
 <div style="page-break-after: always;"></div>
 
 ## Client DAI Feature Support
@@ -3577,7 +3595,9 @@ Aug 2024
     - wifiCurlHeader ( default value changed to false )
     - enableMediaProcessor ( default value changed to true )
     - enablePTSRestampForHlsTs
+    - monitorAV
     - monitorAVSyncThreshold
     - monitorAVJumpThreshold
     - progressLoggingDivisor
     - showDiagnosticsOverlay ( added example in Appendix )
+    - monitorAVReportingInterval

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -466,6 +466,7 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{DEFAULT_MONITOR_AVSYNC_NEGATIVE_DELTA_MS,"monitorAVSyncThresholdNegative",eAAMPConfig_MonitorAVSyncThresholdNegative,true,eCONFIG_RANGE_MONITOR_AVSYNC_THRESHOLD_NEGATIVE },
 	{DEFAULT_MONITOR_AV_JUMP_THRESHOLD_MS,"monitorAVJumpThreshold",eAAMPConfig_MonitorAVJumpThreshold,true,eCONFIG_RANGE_MONITOR_AVSYNC_JUMP_THRESHOLD },
 	{DEFAULT_PROGRESS_LOGGING_DIVISOR,"progressLoggingDivisor",eAAMPConfig_ProgressLoggingDivisor,false},
+	{DEFAULT_MONITORAVREPORTING_INTERVAL, "monitorAVReportingInterval", eAAMPConfig_MonitorAVReportingInterval, false},
 	// aliases, kept for backwards compatibility
 	{DEFAULT_INIT_BITRATE,"defaultBitrate",eAAMPConfig_DefaultBitrate,true },
 	{DEFAULT_INIT_BITRATE_4K,"defaultBitrate4K",eAAMPConfig_DefaultBitrate4K,true },

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -304,6 +304,7 @@ typedef enum
 	eAAMPConfig_MonitorAVSyncThresholdNegative,				/**< (negative) milliseconds threshold for video behind audio to be considered as unacceptable avsync*/
 	eAAMPConfig_MonitorAVJumpThreshold,				/**< configures threshold aligned audio,video positions advancing together by unexpectedly large delta to be reported as jump in milliseconds*/
 	eAAMPConfig_ProgressLoggingDivisor,				/**<  Divisor to avoid printing the progress report too frequently in the log */
+	eAAMPConfig_MonitorAVReportingInterval,			/**< Timeout in milliseconds for reporting MonitorAV events */
 	eAAMPConfig_IntMaxValue							/**< Max value of int config always last element*/
 } AAMPConfigSettingInt;
 #define AAMPCONFIG_INT_COUNT (eAAMPConfig_IntMaxValue)

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -141,6 +141,7 @@
 #define MIN_MONITOR_AV_JUMP_THRESHOLD_MS 1 	/**< minimum  jump threshold to trigger MonitorAV reporting */
 #define MAX_MONITOR_AV_JUMP_THRESHOLD_MS 10000 	/**< maximum jump threshold to trigger MonitorAV reporting */
 #define DEFAULT_MONITOR_AV_JUMP_THRESHOLD_MS 100 	/**< default jump threshold to MonitorAV reporting */
+#define DEFAULT_MONITORAVREPORTING_INTERVAL 1000 /**< time interval in ms for MonitorAV reporting */
 
 // We can enable the following once we have a thread monitoring video PTS progress and triggering subtec clock fast update when we detect video freeze. Disabled it for now for brute force fast refresh..
 //#define SUBTEC_VARIABLE_CLOCK_UPDATE_RATE   /* enable this to make the clock update rate dynamic*/

--- a/AampEvent.cpp
+++ b/AampEvent.cpp
@@ -1628,9 +1628,9 @@ const std::string &ContentProtectionDataEvent::getStreamType() const
 /*
  * @brief ManifestRefreshEvent Constructor
  */
-ManifestRefreshEvent::ManifestRefreshEvent(uint32_t manifestDuration,int noOfPeriods, uint32_t manifestPublishedTime, std::string sid,const char * manifestType):
+ManifestRefreshEvent::ManifestRefreshEvent(uint32_t manifestDuration,int noOfPeriods, uint32_t manifestPublishedTime, const std::string &manifestType, std::string sid):
 	AAMPEventObject(AAMP_EVENT_MANIFEST_REFRESH_NOTIFY, std::move(sid))
-	, mManifestDuration(manifestDuration),mNoOfPeriods(noOfPeriods),mManifestPublishedTime(manifestPublishedTime),mManifestType(manifestType)
+	, mManifestDuration(manifestDuration), mNoOfPeriods(noOfPeriods), mManifestPublishedTime(manifestPublishedTime), mManifestType(manifestType)
 {
 
 }
@@ -1646,13 +1646,12 @@ uint32_t ManifestRefreshEvent::getManifestDuration() const
 }
 
 /**
- * @brief Get ManifestFile Duration for Linear DASH
+ * @brief Get ManifestFile type for Linear DASH
  *
- * @return ManifestFile Duration
+ * @return ManifestFile type
  */
-const char * ManifestRefreshEvent::getManifestType() const
+const std::string& ManifestRefreshEvent::getManifestType() const
 {
-
    return mManifestType;
 }
 
@@ -1693,4 +1692,54 @@ TuneTimeMetricsEvent::TuneTimeMetricsEvent(const std::string &timeMetricData, st
 const std::string &TuneTimeMetricsEvent::getTuneMetricsData() const
 {
 	return mTuneMetricsData;
+}
+
+/**
+ * @fn MonitorAVStatusEvent Constructor
+ */
+MonitorAVStatusEvent::MonitorAVStatusEvent(const std::string &state, int64_t videoPosMs, int64_t audioPosMs, uint64_t timeInStateMs, std::string sid):
+		AAMPEventObject(AAMP_EVENT_MONITORAV_STATUS, std::move(sid)), mMonitorAVStatus(state), mVideoPositionMS(videoPosMs),
+		mAudioPositionMS(audioPosMs), mTimeInStateMS(timeInStateMs)
+{
+
+}
+
+/**
+ * @brief getMonitorAVStatus
+ *
+ * @return MonitorAVStatus
+ */
+const std::string &MonitorAVStatusEvent::getMonitorAVStatus() const
+{
+	return mMonitorAVStatus;
+}
+
+/**
+ * @brief getVideoPositionMS
+ *
+ * @return Video Position in MS
+ */
+int64_t MonitorAVStatusEvent::getVideoPositionMS() const
+{
+	return mVideoPositionMS;
+}
+
+/**
+ * @brief getAudioPositionMS
+ *
+ * @return Audio Position in MS
+ */
+int64_t MonitorAVStatusEvent::getAudioPositionMS() const
+{
+	return mAudioPositionMS;
+}
+
+/**
+ * @brief getTimeInStateMS
+ *
+ * @return Time in the current state in MS
+ */
+uint64_t MonitorAVStatusEvent::getTimeInStateMS() const
+{
+	return mTimeInStateMS;
 }

--- a/AampEvent.h
+++ b/AampEvent.h
@@ -94,6 +94,7 @@ typedef enum
 	AAMP_EVENT_MANIFEST_REFRESH_NOTIFY,	/**< 43, DASH Manifest refresh notification*/
 	AAMP_EVENT_TUNE_TIME_METRICS,	/**< 44, Event when Tune time metric data sends*/
 	AAMP_EVENT_NEED_MANIFEST_DATA, /**< 45, DASH need preprocessed manifest notification */
+	AAMP_EVENT_MONITORAV_STATUS,	/**< 46, MonitorAV status notification */
 	AAMP_MAX_NUM_EVENTS
 } AAMPEventType;
 
@@ -498,6 +499,17 @@ struct AAMPEvent
 		{
 			const char *mTuneMetricData;	/**< Tune timemetric data */
 		} tuneMetricData;
+
+		/**
+		 * @brief Structure of the monitorAV status event
+		 */
+		struct
+		{
+			const char *mMonitorAVStatus;	/**< MonitorAV status */
+			int64_t mVideoPositionMS;	/**< Video position in milliseconds */
+			int64_t mAudioPositionMS;	/**< Audio position in milliseconds */
+			uint64_t mTimeInStateMS;	/**< Time in the current state in milliseconds */
+		} monitorAVStatus;
 	} data;
 
 	/**
@@ -543,19 +555,19 @@ public:
 
 	AAMPEventObject() = delete;
 	/**
-         * @brief Copy constructor disabled
-         *
-         */
+	 * @brief Copy constructor disabled
+	 */
 	AAMPEventObject(const AAMPEventObject&) = delete;
 	/**
-         * @brief assignment operator disabled
-         *
-         */
+	 * @brief assignment operator disabled
+	 */
 	AAMPEventObject& operator=(const AAMPEventObject&) = delete;
 
 	/**
 	 * @fn AAMPEventObject
-	 */ 	 
+	 * @param[in] type - Event type
+	 * @param[in] sid - Session ID
+	 */
 	AAMPEventObject(AAMPEventType type, std::string sid);
 
 	/**
@@ -568,7 +580,9 @@ public:
 	 */
 	AAMPEventType getType() const;
 
-
+	/**
+	 * @fn getSessionId
+	 */
 	const std::string & GetSessionId() const { return mSessionID; }
 	
 };
@@ -2209,39 +2223,39 @@ class WatermarkSessionUpdateEvent: public AAMPEventObject
 {
 	uint32_t mSessionHandle; /**< Playback session handle used to track and manage sessions  */
 	uint32_t mStatus; 	 /**< Provides the status of the watermark session.  */
-        std::string mSystem; 	 /**< Describes content watermarking protection provider  */
+	std::string mSystem; 	 /**< Describes content watermarking protection provider  */
 public:
-        WatermarkSessionUpdateEvent() = delete;
-        WatermarkSessionUpdateEvent(const WatermarkSessionUpdateEvent&) = delete;
-        WatermarkSessionUpdateEvent& operator=(const WatermarkSessionUpdateEvent&) = delete;
+	WatermarkSessionUpdateEvent() = delete;
+	WatermarkSessionUpdateEvent(const WatermarkSessionUpdateEvent&) = delete;
+	WatermarkSessionUpdateEvent& operator=(const WatermarkSessionUpdateEvent&) = delete;
 
-        /**
-         * @brief WatermarkSessionUpdateEvent Constructor
-         * @param[in]  sessionHandle - Handle used to track and manage session
-         * @param[in]  status - Status of the watermark session
-         * @param[in]  system - Watermarking protection provider
-         */
-        WatermarkSessionUpdateEvent(uint32_t sessionHandle, uint32_t status, const std::string &system, std::string sid) : AAMPEventObject(AAMP_EVENT_WATERMARK_SESSION_UPDATE, std::move(sid = {})) , mSessionHandle(sessionHandle), mStatus(status), mSystem(system)
-        {}
+	/**
+	 * @brief WatermarkSessionUpdateEvent Constructor
+	 * @param[in]  sessionHandle - Handle used to track and manage session
+	 * @param[in]  status - Status of the watermark session
+	 * @param[in]  system - Watermarking protection provider
+	 */
+	WatermarkSessionUpdateEvent(uint32_t sessionHandle, uint32_t status, const std::string &system, std::string sid) : AAMPEventObject(AAMP_EVENT_WATERMARK_SESSION_UPDATE, std::move(sid = {})) , mSessionHandle(sessionHandle), mStatus(status), mSystem(system)
+	{}
 
-        /**
-         * @brief WatermarkSessionUpdateEvent Destructor
-         */
-        virtual ~WatermarkSessionUpdateEvent() { }
+	/**
+	 * @brief WatermarkSessionUpdateEvent Destructor
+	 */
+	virtual ~WatermarkSessionUpdateEvent() { }
 
-        /**
-         * @brief Get session handle
-         *
-         * @return session handle
-         */
-        uint32_t getSessionHandle() const { return mSessionHandle; }
+	/**
+	 * @brief Get session handle
+	 *
+	 * @return session handle
+	 */
+	uint32_t getSessionHandle() const { return mSessionHandle; }
 
-	    /**
-         * @brief Get session status 
-         *
-         * @return status
-         */
-        uint32_t getStatus() const { return mStatus; }
+	/**
+	 * @brief Get session status 
+	 *
+	 * @return status
+	 */
+	uint32_t getStatus() const { return mStatus; }
 
 	/**
 	 * @brief Get System
@@ -2299,7 +2313,7 @@ class ManifestRefreshEvent: public AAMPEventObject
 	uint32_t mManifestDuration;	/**< Manifest duration  */
 	uint32_t mManifestPublishedTime;	/** mpd published time data from the download manifest */
 	int mNoOfPeriods;	/**< No of periods count */
-	const char * mManifestType; /**<Manifest type */
+	std::string mManifestType; /**<Manifest type */
 public:
 	ManifestRefreshEvent() = delete;
 	ManifestRefreshEvent(const ManifestRefreshEvent&) = delete;
@@ -2308,7 +2322,7 @@ public:
 	/**
 	 * @fn ManifestRefreshEvent
 	 */
-	ManifestRefreshEvent(uint32_t manifestDuration, int noOfPeriods, uint32_t manifestPublishedTime, std::string sid,const char *manifestType);
+	ManifestRefreshEvent(uint32_t manifestDuration, int noOfPeriods, uint32_t manifestPublishedTime, const std::string &manifestType, std::string sid);
 
 	/**
 	 * @brief ManifestRefreshEvent Destructor
@@ -2333,7 +2347,7 @@ public:
 	/**
 	 * @fn getManifestType
 	 */
-	const char *getManifestType() const;
+	const std::string &getManifestType() const;
 
 };
 
@@ -2368,6 +2382,59 @@ public:
 	const std::string &getTuneMetricsData() const;
 };
 
+/**
+ * @class MonitorAVStatusEvent
+ * @brief Class for the MonitorAV Status Event
+ */
+class MonitorAVStatusEvent: public AAMPEventObject
+{
+	std::string mMonitorAVStatus;	/**< MonitorAV status */
+	int64_t mVideoPositionMS;	/**< Video position in milliseconds */
+	int64_t mAudioPositionMS;	/**< Audio position in milliseconds */
+	uint64_t mTimeInStateMS;	/**< Time in the current state in milliseconds */
+
+public:
+	MonitorAVStatusEvent() = delete;
+	MonitorAVStatusEvent(const MonitorAVStatusEvent&) = delete;
+	MonitorAVStatusEvent& operator=(const MonitorAVStatusEvent&) = delete;
+
+	/**
+	 * @fn MonitorAVStatusEvent
+	 *
+	 * @param[in] status - MonitorAV status
+	 * @param[in] videoPositionMS - Video position in milliseconds
+	 * @param[in] audioPositionMS - Audio position in milliseconds
+	 * @param[in] timeInStateMS - Time in the current state in milliseconds
+	 * @param[in] sid - Session Identifier
+	 */
+	MonitorAVStatusEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, std::string sid);
+
+	/**
+	 * @brief MonitorAVStatusEvent Destructor
+	 */
+	virtual ~MonitorAVStatusEvent() { }
+
+	/**
+	 * @fn getMonitorAVStatus
+	 */
+	const std::string &getMonitorAVStatus() const;
+
+	/**
+	 * @fn getVideoPositionMS
+	 */
+	int64_t getVideoPositionMS() const;
+
+	/**
+	 * @fn getAudioPositionMS
+	 */
+	int64_t getAudioPositionMS() const;
+
+	/**
+	 * @fn getTimeInStateMS
+	 */
+	uint64_t getTimeInStateMS() const;
+};
+
 
 using AAMPEventPtr = std::shared_ptr<AAMPEventObject>;
 using MediaErrorEventPtr = std::shared_ptr<MediaErrorEvent>;
@@ -2399,6 +2466,7 @@ using WatermarkSessionUpdateEventPtr = std::shared_ptr<WatermarkSessionUpdateEve
 using ContentProtectionDataEventPtr = std::shared_ptr<ContentProtectionDataEvent>;
 using ManifestRefreshEventPtr = std::shared_ptr<ManifestRefreshEvent>;
 using TuneTimeMetricsEventPtr = std::shared_ptr<TuneTimeMetricsEvent>;
+using MonitorAVStatusEventPtr = std::shared_ptr<MonitorAVStatusEvent>;
 
 #endif /* __AAMP_EVENTS_H__ */
 

--- a/AampEventListener.cpp
+++ b/AampEventListener.cpp
@@ -294,7 +294,7 @@ static void GenerateLegacyAAMPEvent(const AAMPEventPtr &e, AAMPEvent &event)
 			event.data.manifestRefreshData.manifestDuration = ev->getManifestDuration();
 			event.data.manifestRefreshData.noOfPeriods = ev->getNoOfPeriods();
 			event.data.manifestRefreshData.manifestPublishedTime = ev->getManifestPublishedTime();
-			event.data.manifestRefreshData.manifestType = ev->getManifestType();
+			event.data.manifestRefreshData.manifestType = ev->getManifestType().c_str();
 			break;
 		}
 		case AAMP_EVENT_TUNE_TIME_METRICS:
@@ -302,6 +302,14 @@ static void GenerateLegacyAAMPEvent(const AAMPEventPtr &e, AAMPEvent &event)
 			TuneTimeMetricsEventPtr ev = std::dynamic_pointer_cast<TuneTimeMetricsEvent>(e);
 			event.data.tuneMetricData.mTuneMetricData = ev->getTuneMetricsData().c_str();
 			break;
+		}
+		case AAMP_EVENT_MONITORAV_STATUS:
+		{
+			MonitorAVStatusEventPtr ev = std::dynamic_pointer_cast<MonitorAVStatusEvent>(e);
+			event.data.monitorAVStatus.mMonitorAVStatus = ev->getMonitorAVStatus().c_str();
+			event.data.monitorAVStatus.mVideoPositionMS = ev->getVideoPositionMS();
+			event.data.monitorAVStatus.mAudioPositionMS = ev->getAudioPositionMS();
+			event.data.monitorAVStatus.mTimeInStateMS = ev->getTimeInStateMS();
 		}
 		default:
 			// Some events without payload also falls here, for now

--- a/aampgstplayer.h
+++ b/aampgstplayer.h
@@ -105,7 +105,6 @@ private:
 	bool SendHelper(AampMediaType mediaType, const void *ptr, size_t len, double fpts, double fdts, double duration, bool copy, double fragmentPTSoffset, bool initFragment = false, bool discontinuity = false);
 
 public:
-
 	class PrivateInstanceAAMP *aamp;
 	class PrivateInstanceAAMP *mEncryptedAamp;
 	InterfacePlayerRDK* playerInterface;
@@ -415,15 +414,32 @@ public:
 	void RegisterFirstFrameCallbacks();
 	void NotifyFirstFrame(int mediatype, bool notifyFirstBuffer, bool initCC, bool &requireFirstVideoFrameDisplay, bool &audioOnly);
 	void UnregisterBusCb();
-		void UnregisterFirstFrameCallbacks();
+	void UnregisterFirstFrameCallbacks();
+
+	/**
+	 * @brief Start the MonitorAV timer to report AV status
+	 */
+	void StartMonitorAVTimer();
+
+	/**
+	 * @brief Start the MonitorAV timer to report AV status
+	 */
+	void StopMonitorAVTimer();
+
+	/**
+	 * @brief Get the monitor AV interval in milliseconds
+	 */
+	int GetMonitorAVInterval() const { return mMonitorAVInterval; }
 
 private:
 	std::mutex mBufferingLock;
 	id3_callback_t m_ID3MetadataHandler; /**< Function to call to generate the JS event for in ID3 packet */
+	guint monitorAVTimerId; /**< Timer ID for monitoring AV events */
+	int mMonitorAVInterval; /**< Interval in milliseconds for monitoring AV events */
 
 public:
 	AampLogManager *mLogObj;
-		InterfacePlayerRDK *playerInstance ;
+	InterfacePlayerRDK *playerInstance ;
 };
 
 #endif // AAMPGSTPLAYER_H

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4649,9 +4649,9 @@ void StreamAbstractionAAMP_MPD::MPDUpdateCallbackExec()
 				manifestDuration = mMPDParser->GetMediaPresentationDuration();
 			}
 
-			const char *manifestType = mMPDParser->IsLiveManifest() ? "dynamic" : "static";
-			AAMPLOG_INFO( "Send RefreshNotify Dur[%" PRIu64 "] NoOfPeriods[%d] PubTime[%u] ManifestType[%s]", manifestDuration,mMPDParser->GetNumberOfPeriods(),tmpManifestDnldRespPtr->mMPDInstance->GetFetchTime(),manifestType);
-			aamp->SendEvent(std::make_shared<ManifestRefreshEvent>(manifestDuration,mMPDParser->GetNumberOfPeriods(),tmpManifestDnldRespPtr->mMPDInstance->GetFetchTime(), aamp->GetSessionId(),manifestType),AAMP_EVENT_ASYNC_MODE);
+			std::string manifestType = mMPDParser->IsLiveManifest() ? "dynamic" : "static";
+			AAMPLOG_INFO( "Send RefreshNotify Dur[%" PRIu64 "] NoOfPeriods[%d] PubTime[%u] ManifestType[%s]", manifestDuration, mMPDParser->GetNumberOfPeriods(), tmpManifestDnldRespPtr->mMPDInstance->GetFetchTime(), manifestType.c_str());
+			aamp->SendEvent(std::make_shared<ManifestRefreshEvent>(manifestDuration, mMPDParser->GetNumberOfPeriods(), tmpManifestDnldRespPtr->mMPDInstance->GetFetchTime(), manifestType, aamp->GetSessionId()), AAMP_EVENT_ASYNC_MODE);
 		}
 	}
 	else

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -1933,7 +1933,6 @@ public:
 	{
 		ManifestRefreshEventPtr evt = std::dynamic_pointer_cast<ManifestRefreshEvent>(e);
 		JSStringRef prop;
-		const char* manifestType = evt->getManifestType();
 		prop = JSStringCreateWithUTF8CString("manifestDuration");
 		JSObjectSetProperty(context, eventObj, prop, JSValueMakeNumber(context, evt->getManifestDuration()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
@@ -1947,7 +1946,7 @@ public:
 		JSStringRelease(prop);
 
 		prop = JSStringCreateWithUTF8CString("manifestType");
-		JSObjectSetProperty(context, eventObj, prop, aamp_CStringToJSValue(context, manifestType), kJSPropertyAttributeReadOnly, NULL);
+		JSObjectSetProperty(context, eventObj, prop, aamp_CStringToJSValue(context, evt->getManifestType().c_str()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
 	}
 };
@@ -1989,6 +1988,52 @@ public:
 	}
 };
 
+/**
+ * @class AAMP_JSListener_MonitorAVStatus
+ * @brief Event listener impl for provide monitorAVStatus AAMP event
+ */
+class AAMP_JSListener_MonitorAVStatus : public AAMP_JSListener
+{
+public:
+	/**
+	* @brief AAMP_JSListener_MonitorAVStatus Constructor
+	* @param[in] aamp instance of AAMP_JS
+	* @param[in] type event type
+	* @param[in] jsCallback callback to be registered as listener
+	*/
+	AAMP_JSListener_MonitorAVStatus(AAMP_JS* aamp, AAMPEventType type, JSObjectRef jsCallback) : AAMP_JSListener(aamp, type, jsCallback)
+	{
+	}
+
+	/**
+	* @brief Set JS event properties
+	* @param[in] e AAMP event object
+	* @param[in] context JS execution context
+	* @param[out] eventObj JS event object
+	*/
+	void setEventProperties(const AAMPEventPtr& e, JSContextRef context, JSObjectRef eventObj)
+	{
+		MonitorAVStatusEventPtr evt = std::dynamic_pointer_cast<MonitorAVStatusEvent>(e);
+		JSStringRef prop;
+		const char* monitorAVStatus = evt->getMonitorAVStatus().c_str();
+		prop = JSStringCreateWithUTF8CString("currentState");
+		LOG_TRACE("AAMP_Listener_MonitorAVStatus MonitorAVStatus data %s", monitorAVStatus);
+		JSObjectSetProperty(context, eventObj, prop, aamp_CStringToJSValue(context, monitorAVStatus), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("videoPosMs");
+		JSObjectSetProperty(context, eventObj, prop, JSValueMakeNumber(context, evt->getVideoPositionMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("audioPosMs");
+		JSObjectSetProperty(context, eventObj, prop, JSValueMakeNumber(context, evt->getAudioPositionMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("timeInStateMs");
+		JSObjectSetProperty(context, eventObj, prop, JSValueMakeNumber(context, evt->getTimeInStateMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+	}
+};
 /**
  * @brief Callback invoked from JS to add an event listener for a particular event
  * @param[in] context JS execution context
@@ -2160,6 +2205,10 @@ void AAMP_JSListener::AddEventListener(AAMP_JS* aamp, AAMPEventType type, JSObje
 	else if(type == AAMP_EVENT_TUNE_TIME_METRICS)
 	{
 		pListener = new AAMP_JSListener_TuneMetricData(aamp, type, jsCallback);
+	}
+	else if (type == AAMP_EVENT_MONITORAV_STATUS)
+	{
+		pListener = new AAMP_JSListener_MonitorAVStatus(aamp, type, jsCallback);
 	}
 	else
 	{

--- a/jsbindings/jseventlistener.cpp
+++ b/jsbindings/jseventlistener.cpp
@@ -1599,7 +1599,7 @@ public:
         JSStringRelease(prop);
 
 		prop = JSStringCreateWithUTF8CString("manifestType");
-		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, aamp_CStringToJSValue(p_obj->_ctx, evt->getManifestType()), kJSPropertyAttributeReadOnly, NULL);
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, aamp_CStringToJSValue(p_obj->_ctx, evt->getManifestType().c_str()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
 	}
 
@@ -1638,8 +1638,41 @@ public:
 		LOG_TRACE("AAMP_Listener_TuneMetricData Tunemetric data %s", tuneMetricData);
 		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, aamp_CStringToJSValue(p_obj->_ctx, tuneMetricData), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
-    }
+	}
 
+};
+
+class AAMP_Listener_MonitorAVStatus : public AAMP_JSEventListener
+{
+public:
+	AAMP_Listener_MonitorAVStatus(PrivAAMPStruct_JS *obj, AAMPEventType type, JSObjectRef jsCallback)
+		: AAMP_JSEventListener(obj, type, jsCallback)
+	{
+	}
+
+	void SetEventProperties(const AAMPEventPtr& ev, JSObjectRef jsEventObj)
+	{
+		MonitorAVStatusEventPtr evt = std::dynamic_pointer_cast<MonitorAVStatusEvent>(ev);
+		JSStringRef prop;
+		const char* monitorAVStatus = evt->getMonitorAVStatus().c_str();
+
+		prop = JSStringCreateWithUTF8CString("currentState");
+		LOG_TRACE("AAMP_Listener_MonitorAVStatus MonitorAVStatus data %s", monitorAVStatus);
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, aamp_CStringToJSValue(p_obj->_ctx, monitorAVStatus), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("videoPosMs");
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getVideoPositionMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("audioPosMs");
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getAudioPositionMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("timeInStateMs");
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getTimeInStateMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+	}
 };
 
 /// -----------------------------------------------------------------------------------------
@@ -1856,6 +1889,9 @@ void AAMP_JSEventListener::AddEventListener(PrivAAMPStruct_JS* obj, AAMPEventTyp
 			break;
 		case AAMP_EVENT_TUNE_TIME_METRICS:
 			pListener = new AAMP_Listener_TuneMetricData(obj, type, jsCallback);
+			break;
+		case AAMP_EVENT_MONITORAV_STATUS:
+			pListener = new AAMP_Listener_MonitorAVStatus(obj, type, jsCallback);
 			break;
 		// Following events are not having payload and hence falls under default case
 		// AAMP_EVENT_EOS, AAMP_EVENT_TUNED, AAMP_EVENT_ENTERING_LIVE,

--- a/jsbindings/jsutils.cpp
+++ b/jsbindings/jsutils.cpp
@@ -131,6 +131,7 @@ static EventTypeMap aamp_eventTypes[] =
 	{ AAMP_EVENT_MANIFEST_REFRESH_NOTIFY, "manifestRefresh"},
 	{ AAMP_EVENT_TUNE_TIME_METRICS, "tuneMetricsData" },
 	{ AAMP_EVENT_NEED_MANIFEST_DATA, "needManifest" },
+	{ AAMP_EVENT_MONITORAV_STATUS, "monitorAVStatus"},
 	{ (AAMPEventType)0, "" }
 };
 
@@ -187,6 +188,7 @@ static EventTypeMap aampPlayer_eventTypes[] =
 	{ AAMP_EVENT_MANIFEST_REFRESH_NOTIFY, "manifestRefresh"},
 	{ AAMP_EVENT_TUNE_TIME_METRICS, "tuneMetricsData" },
 	{ AAMP_EVENT_NEED_MANIFEST_DATA, "needManifest" },
+	{ AAMP_EVENT_MONITORAV_STATUS, "monitorAVStatus" },
 	{ (AAMPEventType)0, "" }
 };
 

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -562,18 +562,22 @@ gboolean InterfacePlayerRDK::IdleCallbackOnEOS(gpointer user_data)
 	return G_SOURCE_REMOVE;
 }
 
+/**
+ * @brief Updates the monitor AV status.
+ *
+ * @param[in] pInterfacePlayerRDK pointer to InterfacePlayerRDK instance
+ */
 void MonitorAV( InterfacePlayerRDK *pInterfacePlayerRDK )
 {
 	const int AVSYNC_POSITIVE_THRESHOLD_MS = pInterfacePlayerRDK->m_gstConfigParam->monitorAvsyncThresholdPositiveMs;
 	const int AVSYNC_NEGATIVE_THRESHOLD_MS = pInterfacePlayerRDK->m_gstConfigParam->monitorAvsyncThresholdNegativeMs;
 	const int JUMP_THRESHOLD_MS = pInterfacePlayerRDK->m_gstConfigParam->monitorAvJumpThresholdMs;
 
-
 	GstState state = GST_STATE_VOID_PENDING;
 	GstState pending = GST_STATE_VOID_PENDING;
 	GstClockTime timeout = 0;
 	gint64 av_position[2] = {0,0};
-	gint rc = gst_element_get_state(pInterfacePlayerRDK->gstPrivateContext->pipeline, &state, &pending, timeout );
+	gint rc = gst_element_get_state(pInterfacePlayerRDK->gstPrivateContext->pipeline, &state, &pending, timeout);
 	if( rc == GST_STATE_CHANGE_SUCCESS )
 	{
 		if( state == GST_STATE_PLAYING )

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -244,6 +244,12 @@ struct MonitorAVState
 	const char *description;
 	gint64 av_position[2];
 	bool happy;
+
+	MonitorAVState() : tLastReported(0), tLastSampled(0), description(nullptr), happy(false)
+	{
+		av_position[0] = 0; // Video position
+		av_position[1] = 0; // Audio position
+	}
 };
 /**
  * @struct GstPlayerPriv
@@ -1088,6 +1094,12 @@ public:
 	 * @param[in] debugLevel The level of debug logging to enable.
 	 */
 	void EnableGstDebugLogging(std::string debugLevel);
+
+	/**
+	 * @brief Gets the monitor AV state.
+	 * @return A pointer to the MonitorAVState structure containing the AV status or nullptr.
+	 */
+	const MonitorAVState& GetMonitorAVState() const { return gstPrivateContext->monitorAVstate; }
 };
 struct data
 {

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -148,6 +148,7 @@ std::shared_ptr<PlayerIarmRfcInterface> pPlayerIarmRfcInterface = NULL;
 static unsigned int ui32CurlTrace = 0;
 
 bool PrivateInstanceAAMP::mTrackGrowableBufMem;
+
 /**
  * @struct CurlCbContextSyncTime
  * @brief context during curl callbacks
@@ -6102,7 +6103,6 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	// do not change location of this set, it should be done after sending previous VideoEnd data which
 	// is done in TuneHelper->SendVideoEndEvent function.
 	this->mTraceUUID = sTraceId;
-
 }
 
 /**
@@ -13714,4 +13714,23 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 		pos -= (mProgressReportOffset * 1000);
 	}
 	return pos;
+}
+
+/**
+ * @brief Send MonitorAVEvent
+ * @param[in] status - Current MonitorAV status
+ * @param[in] videoPositionMS - video position in milliseconds
+ * @param[in] audioPositionMS - audio position in milliseconds
+ * @param[in] timeInStateMS - time in state in milliseconds
+ * @details This function sends a MonitorAVStatusEvent to the event manager.
+ * It is used to monitor the audio and video status during playback.
+ * It is called when the playback is enabled (mbPlayEnabled is true).
+ */
+void PrivateInstanceAAMP::SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
+{
+	if(mbPlayEnabled)
+	{
+		MonitorAVStatusEventPtr evt = std::make_shared<MonitorAVStatusEvent>(status, videoPositionMS, audioPositionMS, timeInStateMS, GetSessionId());
+		mEventManager->SendEvent(evt, AAMP_EVENT_SYNC_MODE);
+	}
 }

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3866,6 +3866,15 @@ public:
 	void SetPauseOnStartPlayback(bool enable);
 
 	/**
+	 * @brief Send MonitorAVEvent
+	 * @param[in] status - Current MonitorAV status
+	 * @param[in] videoPositionMS - video position in milliseconds
+	 * @param[in] audioPositionMS - audio position in milliseconds
+	 * @param[in] timeInStateMS - time in state in milliseconds
+	 */
+	void SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS);
+
+	/**
 	 * @brief Determines if decrypt should be called on clear samples
 	 * @return Flag to indicate if should decrypt
 	 */

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -664,7 +664,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		{
 			std::string manifest;
 			ManifestRefreshEventPtr ev = std::dynamic_pointer_cast<ManifestRefreshEvent>(e);
-			printf("\n[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType());
+			printf("\n[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
 			manifest = mAampcli.mSingleton->GetManifest();
 			printf("\n [AAMPCLI] Dash  Manifest length [%zu]\n",manifest.length());
 			break;
@@ -731,6 +731,11 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 			printf("[AAMPCLI] updateManifest\n");
 			mAampcli.mSingleton->updateManifest(manifestData.c_str());
 			break;
+		}
+		case AAMP_EVENT_MONITORAV_STATUS:
+		{
+			MonitorAVStatusEventPtr ev = std::dynamic_pointer_cast<MonitorAVStatusEvent>(e);
+			printf("[AAMPCLI] AAMP_EVENT_MONITORAV_STATUS\tstatus=%s\tvposition =%" PRId64 "\taposition=%" PRId64 "\ttimeInStateMS= %" PRIu64 "\n", ev->getMonitorAVStatus().c_str(), ev->getVideoPositionMS(), ev->getAudioPositionMS(), ev->getTimeInStateMS());
 		}
 		case AAMP_EVENT_REPORT_ANOMALY:
 		{

--- a/test/utests/fakes/FakeAampEvent.cpp
+++ b/test/utests/fakes/FakeAampEvent.cpp
@@ -449,7 +449,7 @@ const std::vector<uint8_t> &ContentProtectionDataEvent::getKeyID() const { retur
 /*
  * @brief ManifestRefreshEvent Constructor
  */
-ManifestRefreshEvent::ManifestRefreshEvent(uint32_t manifestDuration,int noOfPeriods, uint32_t manifestPublishedTime, std::string sid, const char *manifestType):
+ManifestRefreshEvent::ManifestRefreshEvent(uint32_t manifestDuration,int noOfPeriods, uint32_t manifestPublishedTime, const std::string &manifestType, std::string sid):
 	AAMPEventObject(AAMP_EVENT_MANIFEST_REFRESH_NOTIFY, std::move(sid))
 	, mManifestDuration(manifestDuration),mNoOfPeriods(noOfPeriods),mManifestPublishedTime(manifestPublishedTime)
 {
@@ -471,9 +471,8 @@ uint32_t ManifestRefreshEvent::getManifestDuration() const
  *
  * @return ManifestType
  */
-const char * ManifestRefreshEvent::getManifestType() const
+const std::string& ManifestRefreshEvent::getManifestType() const
 {
-
    return mManifestType;
 }
 
@@ -529,3 +528,51 @@ MetricsDataEvent::MetricsDataEvent(MetricsDataType dataType, const std::string &
 MetricsDataType MetricsDataEvent::getMetricsDataType() const { return mMetricsDataType; }
 const std::string &MetricsDataEvent::getMetricUUID() const { return mMetricUUID; }
 const std::string &MetricsDataEvent::getMetricsData() const { return mMetricsData; }
+
+/**
+ * @fn MonitorAVStatusEvent Constructor                                                                                               */
+MonitorAVStatusEvent::MonitorAVStatusEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, std::string sid):
+		AAMPEventObject(AAMP_EVENT_MONITORAV_STATUS, std::move(sid)), mMonitorAVStatus(status), mVideoPositionMS(videoPositionMS),
+		mAudioPositionMS(audioPositionMS), mTimeInStateMS(timeInStateMS)
+{
+}
+
+/**
+ * @brief getMonitorAVStatus
+ *
+ * @return MonitorAVStatus
+ */
+const std::string &MonitorAVStatusEvent::getMonitorAVStatus() const
+{
+	return mMonitorAVStatus;
+}
+
+/**
+ * @brief getVideoPositionMS
+ *
+ * @return Video Position in MS
+ */
+int64_t MonitorAVStatusEvent::getVideoPositionMS() const
+{
+	return mVideoPositionMS;
+}
+
+/**
+ * @brief getAudioPositionMS
+ *
+ * @return Audio Position in MS
+ */
+int64_t MonitorAVStatusEvent::getAudioPositionMS() const
+{
+	return mAudioPositionMS;
+}
+
+/**
+ * @brief getTimeInStateMS
+ *
+ * @return Time in the current state in MS
+ */
+uint64_t MonitorAVStatusEvent::getTimeInStateMS() const
+{
+	return mTimeInStateMS;
+}

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1662,3 +1662,7 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 {
 	return 0.0;
 }
+
+void PrivateInstanceAAMP::SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
+{
+}

--- a/test/utests/tests/AampEventTests/AampEventTests.cpp
+++ b/test/utests/tests/AampEventTests/AampEventTests.cpp
@@ -1033,8 +1033,8 @@ protected:
         manifestDuration = 100;
         noOfPeriods = 3;
         manifestPublishedTime = 12345;
-        manifestType ="dynamic";
-        event = new ManifestRefreshEvent(manifestDuration, noOfPeriods, manifestPublishedTime, session_id,manifestType);
+        manifestType = "dynamic";
+        event = new ManifestRefreshEvent(manifestDuration, noOfPeriods, manifestPublishedTime, manifestType, session_id);
     }
 
     void TearDown() override {
@@ -1045,7 +1045,7 @@ protected:
     uint32_t manifestDuration;
     int noOfPeriods;
     uint32_t manifestPublishedTime;
-    const char *manifestType;
+    std::string manifestType;
     ManifestRefreshEvent* event;
 };
 
@@ -1080,4 +1080,32 @@ TEST_F(TuneTimeMetricsEventTest, Constructor) {
 TEST_F(TuneTimeMetricsEventTest, GetTuneMetricsData) {
     
     EXPECT_EQ(event->getTuneMetricsData(), timeMetricData);
+}
+
+class MonitorAVStatusEventTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		status = "ok";
+		videoPositionMS = 3717;
+		audioPositionMS = 3717;
+		timeInStateMS = 1748499898430;
+		monitorEvent = new MonitorAVStatusEvent(status,videoPositionMS,audioPositionMS,timeInStateMS,session_id);
+	}
+
+	void TearDown() override {
+		delete monitorEvent;
+	}
+
+	MonitorAVStatusEvent* monitorEvent;
+	std::string status;
+	int64_t videoPositionMS;
+	int64_t audioPositionMS;
+	uint64_t timeInStateMS;
+};
+
+TEST_F(MonitorAVStatusEventTest, ConstructorTest){
+	EXPECT_EQ(monitorEvent->getMonitorAVStatus().c_str(),status);
+	EXPECT_EQ(monitorEvent->getVideoPositionMS(), videoPositionMS);
+	EXPECT_EQ(monitorEvent->getAudioPositionMS(), audioPositionMS);
+	EXPECT_EQ(monitorEvent->getTimeInStateMS(), timeInStateMS);
 }


### PR DESCRIPTION
Reason for change: Define MonitorAVStatus event. Add timer for periodically fetching AV status and implement the JS listeners for same.
Test Procedure: As mentioned in the ticket
Risks: Low