### PR TITLE
VPLAY-9391 [ENT-4082] Allow text track change with AAMP TSB enabled

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -11852,13 +11852,6 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param )
 	bool accessibilityPresent = false;
 	std::vector<std::string> inputTextLanguagesList;
 
-	// IsLocalAAMPTsb will be set once the playback of HiFi LLD stream starts and local TSB config is enabled
-	if (IsLocalAAMPTsb())
-	{
-		AAMPLOG_WARN("Local TSB playback is in progress!!. SetPreferredTextLanguages() will be ignored!!");
-		return;
-	}
-
 	try
 	{
 		jsObject = new AampJsonObject(param);


### PR DESCRIPTION
Reason for change: Allow text track change with AAMP TSB enabled

Test Procedure: Enable AAMP TSB and switch text track

Risks: Low