### PR TITLE
VPLAY-9626 [ENT-4082] Move helper fn to class PrivateInstanceAAMP

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -452,7 +452,7 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 			}
 
 			// If injection is from chunk buffer, remove the fragment for injection
-			if(IsInjectionFromCachedFragmentChunks())
+			if(aamp->IsInjectionFromCachedFragmentChunks())
 			{
 				UpdateTSAfterInject();
 			}

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -765,15 +765,6 @@ public:
 	 */
 	void ResetTrickModePtsRestamping(void);
 
-	/**
-	 * @fn IsInjectionFromCachedFragmentChunks
-	 *
-	 * @brief Are fragments to inject coming from mCachedFragmentChunks
-	 *
-	 * @return True if fragments to inject are coming from mCachedFragmentChunks
-	 */
-	bool IsInjectionFromCachedFragmentChunks();
-
 protected:
 	/**
 	 * @fn UpdateTSAfterInject

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -923,7 +923,7 @@ bool StreamAbstractionAAMP_MPD::FetchFragment(MediaStreamContext *pMediaStreamCo
 			{
 				// Insert a dummy fragment with discontinuity, since we didn't get an init fragments so it wouldn't get flagged
 				CachedFragment* cachedFragment = nullptr;
-				if(pMediaStreamContext->IsInjectionFromCachedFragmentChunks())
+				if(aamp->IsInjectionFromCachedFragmentChunks())
 				{
 					if(pMediaStreamContext->WaitForCachedFragmentChunkInjected())
 					{
@@ -948,7 +948,7 @@ bool StreamAbstractionAAMP_MPD::FetchFragment(MediaStreamContext *pMediaStreamCo
 					cachedFragment->profileIndex=0;
 					cachedFragment->isDummy=true;
 					cachedFragment->type=pMediaStreamContext->mediaType;
-					if(pMediaStreamContext->IsInjectionFromCachedFragmentChunks())
+					if(aamp->IsInjectionFromCachedFragmentChunks())
 					{
 						pMediaStreamContext->UpdateTSAfterChunkFetch();
 					}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3264,6 +3264,7 @@ void PrivateInstanceAAMP::NotifyEOSReached()
 			return;
 		}
 
+		TuneType tuneType = eTUNETYPE_SEEKTOLIVE;
 		/* If rate is normal play, no need to seek to live etc. This can be due to the EPG changing rate from RWD to play near begging of the TSB. */
 		if (rate < AAMP_RATE_PAUSE)
 		{
@@ -3278,20 +3279,14 @@ void PrivateInstanceAAMP::NotifyEOSReached()
 			}
 			// A new report progress event to be emitted with position 0 when rewind reaches BOS
 			ReportProgress(true, true);
-			rate = AAMP_NORMAL_PLAY_RATE;
-			AcquireStreamLock();
-			TuneHelper(eTUNETYPE_SEEK);
-			ReleaseStreamLock();
-			NotifySpeedChanged(rate);
+			tuneType = eTUNETYPE_SEEK;
 		}
-		else if (rate > AAMP_NORMAL_PLAY_RATE)
-		{
-			rate = AAMP_NORMAL_PLAY_RATE;
-			AcquireStreamLock();
-			TuneHelper(eTUNETYPE_SEEKTOLIVE);
-			ReleaseStreamLock();
-			NotifySpeedChanged(rate);
-		}
+
+		rate = AAMP_NORMAL_PLAY_RATE;
+		AcquireStreamLock();
+		TuneHelper(tuneType);
+		ReleaseStreamLock();
+		NotifySpeedChanged(rate);
 	}
 	else
 	{
@@ -13714,4 +13709,16 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 		pos -= (mProgressReportOffset * 1000);
 	}
 	return pos;
+}
+
+bool PrivateInstanceAAMP::IsInjectionFromCachedFragmentChunks()
+{
+	// CachedFragmentChunks is used for LL-DASH and for any content if AAMP TSB is enabled
+	bool isLLDashChunkMode = GetLLDashChunkMode();
+	bool aampTsbEnabled = IsLocalAAMPTsb();
+	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled;
+
+	AAMPLOG_TRACE("isLLDashChunkMode %d aampTsbEnabled %d ret %d",
+				  isLLDashChunkMode, aampTsbEnabled, isInjectionFromCachedFragmentChunks);
+	return isInjectionFromCachedFragmentChunks;
 }

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3898,6 +3898,15 @@ public:
 	 */
 	 double GetLivePlayPosition(void);
 
+	/**
+	 * @fn IsInjectionFromCachedFragmentChunks
+	 *
+	 * @brief Are fragments to inject coming from mCachedFragmentChunks
+	 *
+	 * @return True if fragments to inject are coming from mCachedFragmentChunks
+	 */
+	bool IsInjectionFromCachedFragmentChunks();
+
 protected:
 
 	/**

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1388,7 +1388,7 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 		}
 
 		// Release the memory and Update the inject
-		if(IsInjectionFromCachedFragmentChunks())
+		if(aamp->IsInjectionFromCachedFragmentChunks())
 		{
 			UpdateTSAfterChunkInject();
 		}
@@ -1406,7 +1406,7 @@ bool MediaTrack::InjectFragment()
 {
 	bool ret = true;
 	bool isChunkMode = aamp->GetLLDashChunkMode() && (aamp->IsLocalAAMPTsbInjection() == false);
-	bool isChunkBuffer = IsInjectionFromCachedFragmentChunks();
+	bool isChunkBuffer = aamp->IsInjectionFromCachedFragmentChunks();
 	bool lowLatency = aamp->GetLLDashServiceData()->lowLatencyMode;
 	StreamAbstractionAAMP* pContext = GetContext();
 
@@ -1824,7 +1824,7 @@ void MediaTrack::FlushFetchedFragments()
 void MediaTrack::FlushFragments()
 {
 	AAMPLOG_WARN("[%s]", name);
-	if(IsInjectionFromCachedFragmentChunks())
+	if(aamp->IsInjectionFromCachedFragmentChunks())
 	{
 		for (int i = 0; i < maxCachedFragmentChunksPerTrack; i++)
 		{
@@ -4418,7 +4418,7 @@ double MediaTrack::GetTotalInjectedDuration()
 {
 	std::lock_guard<std::mutex> lock(mTrackParamsMutex);
 	double ret = totalInjectedDuration;
-	if (IsInjectionFromCachedFragmentChunks())
+	if (aamp->IsInjectionFromCachedFragmentChunks())
 	{
 		ret = totalInjectedChunksDuration;
 	}
@@ -4485,16 +4485,4 @@ void MediaTrack::HandleFragmentPositionJump(CachedFragment* cachedFragment)
 			}
 		}
 	}
-}
-
-bool MediaTrack::IsInjectionFromCachedFragmentChunks()
-{
-	// CachedFragmentChunks is used for LL-DASH and for any content if AAMP TSB is enabled
-	bool isLLDashChunkMode = aamp->GetLLDashChunkMode();
-	bool aampTsbEnabled = aamp->IsLocalAAMPTsb();
-	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled;
-
-	AAMPLOG_TRACE("[%s] isLLDashChunkMode %d aampTsbEnabled %d ret %d",
-				  name, isLLDashChunkMode, aampTsbEnabled, isInjectionFromCachedFragmentChunks);
-	return isInjectionFromCachedFragmentChunks;
 }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1662,3 +1662,13 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 {
 	return 0.0;
 }
+
+bool PrivateInstanceAAMP::IsInjectionFromCachedFragmentChunks()
+{
+	bool isInjectionFromCachedFragmentChunks = false;
+	if (g_mockPrivateInstanceAAMP)
+	{
+		isInjectionFromCachedFragmentChunks = g_mockPrivateInstanceAAMP->IsInjectionFromCachedFragmentChunks();
+	}
+	return isInjectionFromCachedFragmentChunks;
+}

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -421,12 +421,6 @@ void MediaTrack::FlushFragmentChunks()
 {
 }
 
-bool MediaTrack::IsInjectionFromCachedFragmentChunks()
-{
-	bool ret = false;
-	return ret;
-}
-
 void MediaTrack::ClearMediaHeaderDuration(CachedFragment* cachedFragment)
 {
 }

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -83,6 +83,7 @@ public:
 	MOCK_METHOD(void, BlockUntilGstreamerWantsData, (void(*cb)(void), int , int ));
 	MOCK_METHOD(void, WaitForDiscontinuityProcessToComplete, ());
 	MOCK_METHOD(double, GetLivePlayPosition, ());
+	MOCK_METHOD(bool, IsInjectionFromCachedFragmentChunks, ());
 };
 
 extern MockPrivateInstanceAAMP *g_mockPrivateInstanceAAMP;

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -305,6 +305,8 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 			}
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillOnce(Return(tsbSessionManager));
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(_, _, _, _, _, _, _, _, _, _, _, _, _, _)).WillOnce(Return(true));
+			// Chunk cache is used for chunked fragments or when AAMP TSB is enabled
+			EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(chunk||tsb));
 		}
 };
 

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -217,6 +217,7 @@ TEST_P(MediaTrackDashPtsRestampNotConfiguredTests, PtsRestampNotConfiguredTest)
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentChunkCached))
 		.WillRepeatedly(Return(1));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _)).WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(testParam.lowLatencyMode));
 
 	TestableMediaTrack mediaTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "media",
 								  mStreamAbstractionAAMP_MPD};
@@ -270,6 +271,7 @@ TEST_P(MediaTrackDashQtDemuxOverrideConfiguredTests, QtDemuxOverrideConfiguredTe
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentChunkCached))
 		.WillRepeatedly(Return(1));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _)).WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(testParam.lowLatencyMode));
 
 	TestableMediaTrack mediaTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "media",
 								  mStreamAbstractionAAMP_MPD};
@@ -328,6 +330,7 @@ TEST_P(MediaTrackDashTrickModePtsRestampValidPlayRateTests, ValidPlayRateTest)
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentChunkCached))
 		.WillRepeatedly(Return(1));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _)).WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(testParam.lowLatencyMode));
 
 	TestableMediaTrack iframeTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "iframe",
 								   mStreamAbstractionAAMP_MPD};
@@ -486,6 +489,7 @@ TEST_P(MediaTrackDashPlaybackPtsRestampTests, PlaybackTest)
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentChunkCached))
 		.WillRepeatedly(Return(1));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _)).WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(lowLatencyMode));
 
 	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video",
 								  mStreamAbstractionAAMP_MPD};

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -542,19 +542,20 @@ R"(<?xml version="1.0" encoding="utf-8"?>
     </Period>
 </MPD>
 )";
-    status = InitializeMPD(manifest);
-    EXPECT_EQ(status, eAAMPSTATUS_OK);
-    MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_AUDIO);
-    EXPECT_NE(track, nullptr);
-    MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
-    EXPECT_EQ(pMediaStreamContext->adaptationSetIdx,0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
+	status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_AUDIO);
+	EXPECT_NE(track, nullptr);
+	MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
+	EXPECT_EQ(pMediaStreamContext->adaptationSetIdx,0);
 	//mPrivateInstanceAAMP->SetPreferredLanguages("ger",NULL,NULL,NULL,NULL,NULL,NULL);//switching to german audio
-    pMediaStreamContext->enabled = true;
+	pMediaStreamContext->enabled = true;
 	mPrivateInstanceAAMP->preferredLanguagesList.push_back("ger");
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetPositionMilliseconds()).WillRepeatedly(Return(0.0));
 
 	mStreamAbstractionAAMP_MPD->SwitchAudioTrack();
-    EXPECT_EQ(pMediaStreamContext->adaptationSetIdx,2);
-    EXPECT_EQ(pMediaStreamContext->adaptationSetId,3);
+	EXPECT_EQ(pMediaStreamContext->adaptationSetIdx,2);
+	EXPECT_EQ(pMediaStreamContext->adaptationSetId,3);
 }

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -809,6 +809,7 @@ TEST_F(FetcherLoopTests, BasicFetcherLoop)
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, false, _, _, _, _, _))
 		.WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 	status = InitializeMPD(mVodManifest);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
 
@@ -1023,6 +1024,7 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 )";
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _, _, _))
 				.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 
 	AAMPStatusType status = InitializeMPD(manifest, eTUNETYPE_NEW_NORMAL, 10.0);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
@@ -1039,8 +1041,6 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetPositionMilliseconds()).WillRepeatedly(Return(0.0));
 
 	mTestableStreamAbstractionAAMP_MPD->SwitchAudioTrack();
-
-
 }
 
 /**

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -993,6 +993,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.WillOnce(Return(true));
 
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifyOnEnteringLive()).Times(1);
 	status = InitializeMPD(manifest, eTUNETYPE_SEEKTOLIVE, initialSeekPosition); (void)status;
 
@@ -2509,6 +2510,7 @@ TEST_F(FunctionalTests, ChunkMode_LLD)
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashAdjustSpeed())
 		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, _, _, _, _, _, _))
 		.WillRepeatedly(Return(true));
@@ -2579,6 +2581,7 @@ TEST_F(FunctionalTests, ChunkMode_LLD_ForMaxLatency_Case)
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashAdjustSpeed())
 		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, _, _, _, _, _, _))
 		.WillRepeatedly(Return(true));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/subtitleTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/subtitleTests.cpp
@@ -414,6 +414,7 @@ TEST_F(SubtitleTrackTests, SwitchSubtitleTrack)
     </Period>
 </MPD>
 )";
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 	status = InitializeMPD(manifest);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
 	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_SUBTITLE);
@@ -454,6 +455,7 @@ TEST_F(SubtitleTrackTests, RefreshTrack)
     </Period>
 </MPD>
 )";
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 	status = InitializeMPD(manifest);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
 	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_SUBTITLE);
@@ -522,6 +524,7 @@ TEST_F(SubtitleTrackTests, SkipSubtitleFetchTests)
         .Times(2);//init segment is  available for audio and video so set to true
 	EXPECT_CALL(*g_mockMediaStreamContext,CacheFragment(_, _, _, _, _, false, _, _, _, _, _))
         .Times(1);//init segment is not available for subtitle so set to false
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 
 	status = InitializeMPD(manifest);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -290,6 +290,7 @@ TEST_F(TrackInjectTests, RunInjectLoopTestNonLLD)
 		.WillOnce(Return(true))
 		.WillOnce(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_VIDEO, _, _, _, _, _, false, false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData( _, _, _));
 	EXPECT_EQ(mPrivateInstanceAAMP->GetLLDashChunkMode(),false); //Check setup
@@ -315,6 +316,7 @@ TEST_F(TrackInjectTests, RunInjectLoopTestNonLLDInit)
 		.WillOnce(Return(true))
 		.WillOnce(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _, _, _, _, _, true, false));
 	EXPECT_EQ(mPrivateInstanceAAMP->GetLLDashChunkMode(),false); //Check setup
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData( _, _, _));
@@ -343,6 +345,7 @@ TEST_F(TrackInjectTests, RunInjectLoopTestLLD)
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
 		.WillOnce(Return(true));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(true));
 
 	char unParsedBuffer[] = "AAAAAAAAAAAAAAAAAA";
 	int parsedBufferSize = 12, unParsedBufferSize = sizeof(unParsedBuffer);
@@ -383,6 +386,7 @@ TEST_F(TrackInjectTests, RunInjectLoopTestLLDInit)
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _, _, _, _, _, true, false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(true));
 
 	mMediaTrack->RunInjectLoop();
 }


### PR DESCRIPTION
Reason for change: Refactor the code
Summary of changes:
* Move IsInjectionFromCachedFragmentChunks() to PrivateInstanceAAMP
* Simplify NotifyEOSReached()
* Update L1 tests, fakes and mocks

Test Procedure: Verify that there are no regressions

Risks: Low