### PR TITLE
VPLAY-9794 [ENT-4082] Use chunk mode flag for TotalInjectedDuration calc

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4451,7 +4451,7 @@ double MediaTrack::GetTotalInjectedDuration()
 {
 	std::lock_guard<std::mutex> lock(mTrackParamsMutex);
 	double ret = totalInjectedDuration;
-	if (IsInjectionFromCachedFragmentChunks())
+	if (aamp->GetLLDashChunkMode())
 	{
 		ret = totalInjectedChunksDuration;
 	}


### PR DESCRIPTION
Reason for change: Calculate the right total injected duration

Test Procedure: Verify log line from GetBufferStatus

Risks: Low