### PR TITLE
VPLAY-9692 [AAMP] Missing player ID with FetcherLoop

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -260,6 +260,7 @@ void AAMPGstPlayer::RegisterFirstFrameCallbacks()
 {
 	playerInstance->callbackMap[InterfaceCB::firstVideoFrameDisplayed] = [this]()
 	{
+		UsingPlayerId playerId(aamp->mPlayerId);
 		aamp->NotifyFirstVideoFrameDisplayed();
 	};
 	playerInstance->callbackMap[InterfaceCB::idleCb] = [this]()
@@ -279,13 +280,16 @@ void AAMPGstPlayer::RegisterFirstFrameCallbacks()
 	};
 	playerInstance->callbackMap[InterfaceCB::firstVideoFrameReceived] = [this]()
 	{
+		UsingPlayerId playerId(aamp->mPlayerId);
 		aamp->NotifyFirstFrameReceived(this->playerInstance->GetCCDecoderHandle());
 	};
 	playerInstance->callbackMap[InterfaceCB::notifyEOS] = [this]()
 	{
+		UsingPlayerId playerId(aamp->mPlayerId);
 		aamp->NotifyEOSReached();
 	};
 	playerInstance->FirstFrameCallback([this](int mediatype, bool notifyFirstBuffer, bool initCC, bool& requireFirstVideoFrameDisplay, bool &audioOnly) {
+		UsingPlayerId playerId(aamp->mPlayerId);
 		this->NotifyFirstFrame((AampMediaType)mediatype, notifyFirstBuffer, initCC, requireFirstVideoFrameDisplay, audioOnly);
 	});
 	playerInstance->setupStreamCallbackMap[InterfaceCB::startNewSubtitleStream] = [this](int streamId)
@@ -306,6 +310,7 @@ void AAMPGstPlayer::RegisterFirstFrameCallbacks()
 	});
 	playerInstance->TearDownCallback([this](bool status, int mediaType)
 									 {
+		UsingPlayerId playerId(aamp->mPlayerId);
 		if(status)
 		{
 			privateContext->mBufferControl[(AampMediaType)mediaType].teardownStart();
@@ -536,6 +541,7 @@ static void HandleRedButtonCallback(const char *data, AAMPGstPlayer * _this)
  */
 static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 {
+	UsingPlayerId playerId( _this->aamp->mPlayerId );
 	switch(busEvent.msgType)
 	{
 		case MESSAGE_ERROR:

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -270,6 +270,7 @@ void AAMPGstPlayer::RegisterFirstFrameCallbacks()
 	};
 	playerInstance->callbackMap[InterfaceCB::progressCb] = [this]()
 	{
+		UsingPlayerId playerId(aamp->mPlayerId);
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)
 		{
 			privateContext->mBufferControl[i].update(this, static_cast<AampMediaType>(i));

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -1030,6 +1030,7 @@ MPD* PrivateCDAIObjectMPD::GetAdMPD(std::string &manifestUrl, bool &finalManifes
  */
 bool PrivateCDAIObjectMPD::FulFillAdObject()
 {
+	UsingPlayerId playerId(mAamp->mPlayerId);
 	bool ret = true;
 	AampMPDParseHelper adMPDParseHelper;
 	bool adStatus = false;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9639,6 +9639,7 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
  */
 void StreamAbstractionAAMP_MPD::FetcherLoop()
 {
+	UsingPlayerId playerId(aamp->mPlayerId);
 	aamp_setThreadName("aampFragmentDownloader");
 	bool exitFetchLoop = false;
 	bool trickPlay = (AAMP_NORMAL_PLAY_RATE != aamp->rate);
@@ -12845,6 +12846,7 @@ void StreamAbstractionAAMP_MPD::StartLatencyMonitorThread()
  */
 void StreamAbstractionAAMP_MPD::MonitorLatency()
 {
+	UsingPlayerId playerId(aamp->mPlayerId);
 	int latencyMonitorDelay = GETCONFIGVALUE(eAAMPConfig_LatencyMonitorDelay);
 	int latencyMonitorInterval = GETCONFIGVALUE(eAAMPConfig_LatencyMonitorInterval);
 	double minbuffer = GETCONFIGVALUE(eAAMPConfig_LowLatencyMinBuffer);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1627,8 +1627,8 @@ void MediaTrack::NotifyCachedSubtitleFragmentAvailable()
  */
 void MediaTrack::RunInjectLoop()
 {
-	AAMPLOG_WARN("fragment injector started. track %s", name);
 	UsingPlayerId playerId( aamp->mPlayerId );
+	AAMPLOG_WARN("fragment injector started. track %s", name);
 
 	bool notifyFirstFragment = true;
 	bool keepInjecting = true;


### PR DESCRIPTION
Reason for change: Add playerID for all independent threads
Risks: Low
Priority: P1

Signed-off-by: nu641001 <nu641001@gmail.com>