### PR TITLE
VPLAY-9834: fix godspell warnings from MonitorAV changes

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -467,7 +467,7 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{DEFAULT_MONITOR_AVSYNC_NEGATIVE_DELTA_MS,"monitorAVSyncThresholdNegative",eAAMPConfig_MonitorAVSyncThresholdNegative,true,eCONFIG_RANGE_MONITOR_AVSYNC_THRESHOLD_NEGATIVE },
 	{DEFAULT_MONITOR_AV_JUMP_THRESHOLD_MS,"monitorAVJumpThreshold",eAAMPConfig_MonitorAVJumpThreshold,true,eCONFIG_RANGE_MONITOR_AVSYNC_JUMP_THRESHOLD },
 	{DEFAULT_PROGRESS_LOGGING_DIVISOR,"progressLoggingDivisor",eAAMPConfig_ProgressLoggingDivisor,false},
-	{DEFAULT_MONITORAVREPORTING_INTERVAL, "monitorAVReportingInterval", eAAMPConfig_MonitorAVReportingInterval, false},
+	{DEFAULT_MONITOR_AV_REPORTING_INTERVAL, "monitorAVReportingInterval", eAAMPConfig_MonitorAVReportingInterval, false},
 	// aliases, kept for backwards compatibility
 	{DEFAULT_INIT_BITRATE,"defaultBitrate",eAAMPConfig_DefaultBitrate,true },
 	{DEFAULT_INIT_BITRATE_4K,"defaultBitrate4K",eAAMPConfig_DefaultBitrate4K,true },

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -141,7 +141,7 @@
 #define MIN_MONITOR_AV_JUMP_THRESHOLD_MS 1 	/**< minimum  jump threshold to trigger MonitorAV reporting */
 #define MAX_MONITOR_AV_JUMP_THRESHOLD_MS 10000 	/**< maximum jump threshold to trigger MonitorAV reporting */
 #define DEFAULT_MONITOR_AV_JUMP_THRESHOLD_MS 100 	/**< default jump threshold to MonitorAV reporting */
-#define DEFAULT_MONITORAVREPORTING_INTERVAL 1000 /**< time interval in ms for MonitorAV reporting */
+#define DEFAULT_MONITOR_AV_REPORTING_INTERVAL 1000 /**< time interval in ms for MonitorAV reporting */
 
 // We can enable the following once we have a thread monitoring video PTS progress and triggering subtec clock fast update when we detect video freeze. Disabled it for now for brute force fast refresh..
 //#define SUBTEC_VARIABLE_CLOCK_UPDATE_RATE   /* enable this to make the clock update rate dynamic*/

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -385,7 +385,7 @@ void AAMPGstPlayer::NotifyFirstFrame(int mediatype, bool notifyFirstBuffer, bool
 AAMPGstPlayer::AAMPGstPlayer(PrivateInstanceAAMP *aamp, id3_callback_t id3HandlerCallback, std::function<void(const unsigned char *, int, int, int) > exportFrames):
 	aamp(NULL), mEncryptedAamp(NULL), privateContext(NULL),
 	mBufferingLock(), trickTeardown(false), m_ID3MetadataHandler{id3HandlerCallback},
-	cbExportYUVFrame(NULL), monitorAVTimerId(0), mMonitorAVInterval(0)
+	cbExportYUVFrame(NULL), monitorAvTimerId(0), mMonitorAVInterval(0)
 
 {
 	privateContext = new AAMPGstPlayerPriv();
@@ -798,7 +798,7 @@ void AAMPGstPlayer::Configure(StreamOutputFormat format, StreamOutputFormat audi
 									  bESChangeStatus,forwardAudioToAux,setReadyAfterPipelineCreation,
 									  isSubEnable, trackId, rate, PIPELINE_NAME, PipelinePriority, FirstFrameFlag, aamp->GetManifestUrl().c_str());
 	AAMPLOG_TRACE("exiting AAMPGstPlayer");
-	StartMonitorAVTimer();
+	StartMonitorAvTimer();
 }
 
 /**
@@ -834,7 +834,7 @@ void AAMPGstPlayer::EndOfStreamReached(AampMediaType type)
 void AAMPGstPlayer::Stop(bool keepLastFrame)
 {
 	AAMPLOG_MIL("entering AAMPGstPlayer_Stop keepLastFrame %d", keepLastFrame);
-	StopMonitorAVTimer();
+	StopMonitorAvTimer();
 	playerInstance->Stop(keepLastFrame);
 
 	aamp->seiTimecode.assign("");
@@ -1249,7 +1249,7 @@ bool AAMPGstPlayer::CheckForPTSChangeWithTimeout(long timeout)
  * @param user_data Pointer to the AAMPGstPlayer instance
  * @return TRUE to continue the timer, FALSE to stop it
  */
-static gboolean MonitorAVTimerCallback(gpointer user_data)
+static gboolean MonitorAvTimerCallback(gpointer user_data)
 {
 	AAMPGstPlayer *player  = static_cast<AAMPGstPlayer*>(user_data);
 	if (player && player->playerInstance != nullptr)
@@ -1260,7 +1260,7 @@ static gboolean MonitorAVTimerCallback(gpointer user_data)
 		{
 			if(monitorAVState.tLastSampled == 0 || monitorAVState.description == nullptr)
 			{
-				MW_LOG_INFO("MonitorAVTimerCallback: tLastSampled(%lld) or description(%p) not available, skipping report",
+				MW_LOG_INFO("MonitorAvTimerCallback: tLastSampled(%lld) or description(%p) not available, skipping report",
 						monitorAVState.tLastSampled, monitorAVState.description);
 			}
 			else
@@ -1274,7 +1274,7 @@ static gboolean MonitorAVTimerCallback(gpointer user_data)
 				{
 					timeInState = player->GetMonitorAVInterval(); // Cap to reporting interval
 				}
-				player->aamp->SendMonitorAVEvent(monitorAVState.description,
+				player->aamp->SendMonitorAvEvent(monitorAVState.description,
 						monitorAVState.av_position[eMEDIATYPE_VIDEO],
 						monitorAVState.av_position[eMEDIATYPE_AUDIO],
 						timeInState);
@@ -1287,19 +1287,19 @@ static gboolean MonitorAVTimerCallback(gpointer user_data)
 /**
  * @brief Start the MonitorAV timer to report AV status
  */
-void AAMPGstPlayer::StartMonitorAVTimer()
+void AAMPGstPlayer::StartMonitorAvTimer()
 {
-	if (aamp->mConfig->IsConfigSet(eAAMPConfig_MonitorAV) && monitorAVTimerId == 0)
+	if (aamp->mConfig->IsConfigSet(eAAMPConfig_MonitorAV) && monitorAvTimerId == 0)
 	{
 		// mMonitorAVInterval is in milliseconds
-		monitorAVTimerId = g_timeout_add(mMonitorAVInterval, MonitorAVTimerCallback, this);
-		if (monitorAVTimerId == 0)
+		monitorAvTimerId = g_timeout_add(mMonitorAVInterval, MonitorAvTimerCallback, this);
+		if (monitorAvTimerId == 0)
 		{
-			AAMPLOG_WARN("Failed to start MonitorAVTimer");
+			AAMPLOG_WARN("Failed to start MonitorAvTimer");
 		}
 		else
 		{
-			AAMPLOG_MIL("MonitorAVTimer started with interval %d ms", mMonitorAVInterval);
+			AAMPLOG_MIL("MonitorAvTimer started with interval %d ms", mMonitorAVInterval);
 		}
 	}
 }
@@ -1307,12 +1307,12 @@ void AAMPGstPlayer::StartMonitorAVTimer()
 /**
  * @brief Stop the MonitorAV timer
  */
-void AAMPGstPlayer::StopMonitorAVTimer()
+void AAMPGstPlayer::StopMonitorAvTimer()
 {
-	if (monitorAVTimerId != 0)
+	if (monitorAvTimerId != 0)
 	{
-		g_source_remove(monitorAVTimerId);
-		monitorAVTimerId = 0;
-		AAMPLOG_MIL("MonitorAVTimer stopped");
+		g_source_remove(monitorAvTimerId);
+		monitorAvTimerId = 0;
+		AAMPLOG_MIL("MonitorAvTimer stopped");
 	}
 }

--- a/aampgstplayer.h
+++ b/aampgstplayer.h
@@ -419,12 +419,12 @@ public:
 	/**
 	 * @brief Start the MonitorAV timer to report AV status
 	 */
-	void StartMonitorAVTimer();
+	void StartMonitorAvTimer();
 
 	/**
 	 * @brief Start the MonitorAV timer to report AV status
 	 */
-	void StopMonitorAVTimer();
+	void StopMonitorAvTimer();
 
 	/**
 	 * @brief Get the monitor AV interval in milliseconds
@@ -434,7 +434,7 @@ public:
 private:
 	std::mutex mBufferingLock;
 	id3_callback_t m_ID3MetadataHandler; /**< Function to call to generate the JS event for in ID3 packet */
-	guint monitorAVTimerId; /**< Timer ID for monitoring AV events */
+	guint monitorAvTimerId; /**< Timer ID for monitoring AV events */
 	int mMonitorAVInterval; /**< Interval in milliseconds for monitoring AV events */
 
 public:

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13718,7 +13718,7 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 }
 
 /**
- * @brief Send MonitorAVEvent
+ * @brief Send MonitorAvEvent
  * @param[in] status - Current MonitorAV status
  * @param[in] videoPositionMS - video position in milliseconds
  * @param[in] audioPositionMS - audio position in milliseconds
@@ -13727,7 +13727,7 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
  * It is used to monitor the audio and video status during playback.
  * It is called when the playback is enabled (mbPlayEnabled is true).
  */
-void PrivateInstanceAAMP::SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
+void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
 {
 	if(mbPlayEnabled)
 	{

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3866,13 +3866,13 @@ public:
 	void SetPauseOnStartPlayback(bool enable);
 
 	/**
-	 * @brief Send MonitorAVEvent
+	 * @brief Send MonitorAvEvent
 	 * @param[in] status - Current MonitorAV status
 	 * @param[in] videoPositionMS - video position in milliseconds
 	 * @param[in] audioPositionMS - audio position in milliseconds
 	 * @param[in] timeInStateMS - time in state in milliseconds
 	 */
-	void SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS);
+	void SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS);
 
 	/**
 	 * @brief Determines if decrypt should be called on clear samples

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1663,6 +1663,6 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 	return 0.0;
 }
 
-void PrivateInstanceAAMP::SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
+void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
 {
 }


### PR DESCRIPTION
Reason for change: fix flagged typos raised by spell check
Test Procedure: run godspell tool
Risks: Low