### PR TITLE
VPLAY-9137:[AAMP] [STB] [DVR-HOT] Play/Pause Position have wrong value

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -790,10 +790,15 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				aamp->NotifySpeedChanged(rate, false);
 				return;
 			}
+			// Adjusting the play/pause position value
+			double offset = aamp->GetFormatPositionOffsetInMSecs();
+			double formattedCurrPos = aamp->GetPositionMilliseconds() - offset;
+			double formattedSeekPos = (aamp->seek_pos_seconds * 1000.0) - offset;
 
-			AAMPLOG_WARN("aamp_SetRate (%f)overshoot(%d) ProgressReportDelta:(%d) ", rate,overshootcorrection,timeDeltaFromProgReport);
-			AAMPLOG_WARN("aamp_SetRate rate(%f)->(%f) cur pipeline: %s. Adj position: %f Play/Pause Position:%lld", aamp->rate,rate,aamp->pipeline_paused ? "paused" : "playing",aamp->seek_pos_seconds,aamp->GetPositionMilliseconds()); // current position relative to tune time
-
+			AAMPLOG_WARN("aamp_SetRate (%f)overshoot(%d) ProgressReportDelta:(%d) ", rate, overshootcorrection, timeDeltaFromProgReport);
+			AAMPLOG_WARN("aamp_SetRate rate(%f)->(%f) cur pipeline: %s. Adj position: %f Play/Pause Position:%lld",
+					aamp->rate, rate,aamp->pipeline_paused ? "paused" : "playing", formattedSeekPos, (static_cast<long long int>(formattedCurrPos)));
+			
 			if (!aamp->mSeekFromPausedState && (rate == aamp->rate) && !aamp->mbDetached)
 			{ // no change in desired play rate
 				// no deferring for playback resume

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2009,8 +2009,6 @@ bool PrivateInstanceAAMP::IsAtLivePoint()
 	}
 	return false;
 }
-
-
 /**
  * @brief API to correct the latency by adjusting rate of playback
  */
@@ -2100,22 +2098,14 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 		**  -A good candidate for future refactoring*/
 		mNewSeekInfo.Update(position, seek_pos_seconds);
 		int CurrentPositionDeltaToManifestEnd = end - position;
-		double reportFormatPosition = position;
-		if ((!ISCONFIGSET_PRIV(eAAMPConfig_UseAbsoluteTimeline) || !IsLiveStream()) && mProgressReportOffset > 0)
+
+		double offset = GetFormatPositionOffsetInMSecs();
+		/* Need to get the formatted position, start and end value */
+		double reportFormattedCurrPos = position - offset;
+		if (start != -1 && end != -1)
 		{
-			// Adjust progress positions for VOD, Linear without absolute timeline
-			start -= (mProgressReportOffset * 1000);
-			reportFormatPosition -= (mProgressReportOffset * 1000);
-			end -= (mProgressReportOffset * 1000);
-		}
-		else if(ISCONFIGSET_PRIV(eAAMPConfig_UseAbsoluteTimeline) &&
-			mProgressReportOffset > 0 && IsLiveStream() &&
-			eABSOLUTE_PROGRESS_WITHOUT_AVAILABILITY_START == GETCONFIGVALUE_PRIV(eAAMPConfig_PreferredAbsoluteProgressReporting))
-		{
-			// Adjust progress positions for linear stream with absolute timeline config from AST
-			start -= (mProgressReportAvailabilityOffset * 1000);
-			reportFormatPosition -= (mProgressReportAvailabilityOffset * 1000);
-			end -= (mProgressReportAvailabilityOffset * 1000);
+			start -= offset;
+			end -= offset;
 		}
 
 		// If tsb is not available for linear send -1  for start and end
@@ -2148,7 +2138,6 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			{
 				mMPDDownloaderInstance->SetBufferAvailability((int)bufferedDuration);
 				mMPDDownloaderInstance->SetCurrentPositionDeltaToManifestEnd(CurrentPositionDeltaToManifestEnd);
-
 			}
 		}
 
@@ -2179,7 +2168,6 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 		{
 	   		currentRate  = rate;
 		}
-
 		// This is a short-term solution. We are not acquiring StreamLock here, so we could still access mpStreamAbstractionAAMP
 		// as its getting deleted. StreamLock is acquired for a lot stuff, so getting it here would lead to unexpected delays
 		// Another approach would be to save the bitrate in a local variable as bitrateChangedEvents are fired
@@ -2190,14 +2178,14 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			bps = mpStreamAbstractionAAMP->GetVideoBitrate();
 		}
 
-		ProgressEventPtr evt = std::make_shared<ProgressEvent>(duration, reportFormatPosition, start, end, speed, videoPTS, bufferedDuration, seiTimecode.c_str(), latency, bps, mNetworkBandwidth, currentRate, GetSessionId());
+		ProgressEventPtr evt = std::make_shared<ProgressEvent>(duration, reportFormattedCurrPos, start, end, speed, videoPTS, bufferedDuration, seiTimecode.c_str(), latency, bps, mNetworkBandwidth, currentRate, GetSessionId());
 
 		if (trickStartUTCMS >= 0 && (bProcessEvent || mFirstProgress))
 		{
 			if (mFirstProgress)
 			{
 				mFirstProgress = false;
-				AAMPLOG_WARN("Send first progress event with position %ld", (long)(reportFormatPosition / 1000));
+				AAMPLOG_WARN("Send first progress event with position %ld", (long)(reportFormattedCurrPos / 1000));
 			}
 
 
@@ -2227,7 +2215,7 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 				{
 					AAMPLOG_MIL("aamp pos: [%ld..%ld..%ld..%lld..%.2f..%.2f..%s..%ld..%ld..%.2f]",
 						(long)(start / 1000),
-						(long)(reportFormatPosition / 1000),
+						(long)(reportFormattedCurrPos / 1000),
 						(long)(end / 1000),
 						(long long) videoPTS,
 						(double)(bufferedDuration / 1000.0),
@@ -13734,4 +13722,26 @@ void PrivateInstanceAAMP::SendMonitorAVEvent(const std::string &status, int64_t 
 		MonitorAVStatusEventPtr evt = std::make_shared<MonitorAVStatusEvent>(status, videoPositionMS, audioPositionMS, timeInStateMS, GetSessionId());
 		mEventManager->SendEvent(evt, AAMP_EVENT_SYNC_MODE);
 	}
+}
+/**
+ * @fn GetFormatPositionOffsetInMSecs
+ * @brief API to get the offset value in msecs for the position values to be reported.
+ * @return Offset value in msecs
+ */
+double PrivateInstanceAAMP::GetFormatPositionOffsetInMSecs()
+{
+	double offset = 0;
+	if ((!ISCONFIGSET_PRIV(eAAMPConfig_UseAbsoluteTimeline) || !IsLiveStream()) && mProgressReportOffset > 0)
+	{
+		// Adjust progress positions for VOD, Linear without absolute timeline
+		offset = mProgressReportOffset * 1000;
+	}
+	else if(ISCONFIGSET_PRIV(eAAMPConfig_UseAbsoluteTimeline) &&
+		mProgressReportOffset > 0 && IsLiveStream() &&
+		eABSOLUTE_PROGRESS_WITHOUT_AVAILABILITY_START == GETCONFIGVALUE_PRIV(eAAMPConfig_PreferredAbsoluteProgressReporting))
+	{
+		// Adjust progress positions for linear stream with absolute timeline config from AST
+		offset = mProgressReportAvailabilityOffset * 1000;
+	}
+	return offset;
 }

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3888,6 +3888,7 @@ public:
 	 * @return A constant character pointer to the error string corresponding to the provided error type.
 	 */
 	const char* getStringForPlaybackError(PlaybackErrorType errorType);
+
 	bool mPausePositionMonitoringThreadStarted; // Flag to indicate PausePositionMonitoring thread started
 
 	/**
@@ -3906,6 +3907,13 @@ public:
 	 * @retval current live play position of the stream in seconds.
 	 */
 	 double GetLivePlayPosition(void);
+	
+	/**
+	 * @fn GetFormatPositionOffsetInMSecs
+	 * @brief API to get the offset value in msecs for the position values to be reported.
+	 * @return Offset value in msecs
+	 */
+	double GetFormatPositionOffsetInMSecs();
 
 protected:
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1666,3 +1666,7 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 void PrivateInstanceAAMP::SendMonitorAVEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
 {
 }
+double PrivateInstanceAAMP::GetFormatPositionOffsetInMSecs()
+{
+	return 0;
+}

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -4359,3 +4359,30 @@ TEST_F(PrivAampTests, VerifyTrickModePositionEOS)
 	/*The calculation involves NOW_STEADY_TS_SECS_FP, in SetRate and calculatedTrickModeEosPos, which will differ a bit, hence using EXPECT_NEAR */
 	EXPECT_NEAR(p_aamp->mTrickModePositionEOS, calculatedTrickModeEosPos, kAbsErrorLivePlayPosition);
 }
+TEST_F(PrivAampTests,GetFormatPositionOffsetTest)
+{
+	double offset = 0.0;
+	p_aamp->mProgressReportOffset = 1.2; // Set a valid progress report offset
+	p_aamp->mProgressReportAvailabilityOffset = 2.5; // Set availability offset
+
+	// Case 1: eAAMPConfig_UseAbsoluteTimeline is false
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseAbsoluteTimeline)).WillRepeatedly(Return(false));
+	offset = p_aamp->GetFormatPositionOffsetInMSecs();
+	EXPECT_EQ(offset, 1.2 * 1000); // Expect offset to be calculated based on mProgressReportOffset
+
+	// Case 2: eAAMPConfig_UseAbsoluteTimeline is true and IsLiveStream() is true
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseAbsoluteTimeline)).WillRepeatedly(Return(true));
+	p_aamp->SetIsLiveStream(true);
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_PreferredAbsoluteProgressReporting))
+		.WillRepeatedly(Return(eABSOLUTE_PROGRESS_WITHOUT_AVAILABILITY_START));	
+	offset = p_aamp->GetFormatPositionOffsetInMSecs();
+	EXPECT_EQ(offset, 2.5 * 1000); // Expect offset to be calculated based on mProgressReportAvailabilityOffset
+
+	// Case 3: If IsLiveStream() is false
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseAbsoluteTimeline)).WillRepeatedly(Return(true));
+	p_aamp->SetIsLiveStream(false); // Set live stream to false
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_PreferredAbsoluteProgressReporting))
+		.WillRepeatedly(Return(eABSOLUTE_PROGRESS_WITHOUT_AVAILABILITY_START));
+	offset = p_aamp->GetFormatPositionOffsetInMSecs();
+	EXPECT_EQ(offset, 1.2 * 1000); // Expect offset to be 0 since IsLiveStream() is false
+}


### PR DESCRIPTION
Reason for change:When an CDVR Hot recording is played and we try to pause the playback we are getting wrong Play/Pause Position Risks: Low
Test Procedure: Refer jira ticket
Priority: P2

Signed-off-by: varshnie <varshniblue14@gmail.com>
