### PR TITLE
Default to use main_func for x86 Mac since  gst_macos_main is not available.

### DIFF
--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -412,7 +412,7 @@ static int main_func(int argc, char **argv)
 
 int main( int argc, char **argv )
 {
-#if defined(__APPLE__) && !defined(USE_OPENGL)
+#if defined(__APPLE__) && !defined(USE_OPENGL) && defined(__aarch64__)
 	return gst_macos_main((GstMainFunc)main_func, argc, argv, NULL);
 #else
 	return main_func(argc,argv);


### PR DESCRIPTION
Default to use main_func for x86 Mac since  gst_macos_main is not available.

Risks: Low
Priority: P1