### PR TITLE
VPLAY-9707:fix multi-character character constant warnings

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1702,7 +1702,11 @@ public:
 	 *   @param[in] cdaiObj - Pointer to Client Side DAI object.
 	 */
 	virtual void SetCDAIObject(CDAIObject *cdaiObj) {};
-
+	/**
+	 * @brief Get the segment time scale of the video stream
+	 * @return timescale of the video stream
+	 */
+	virtual uint32_t GetVideoTimeScale() { return 1; };
 	/**
 	 *   @fn IsEOSReached
 	 *
@@ -2063,9 +2067,10 @@ protected:
 
 	/**
 	 * @brief This function is used to initialize the media processor for ISOBMFF streams.
-	 * @param[in] passThroughMode - true if processor should skip parsing PTS and flush
+	 * @param[in] initBasePTSFromManifest - true if segment timeline is used, false otherwise
+	 * @return void
 	 */
-	void InitializeMediaProcessor(bool passThroughMode = false);
+	void InitializeMediaProcessor(bool initBasePTSFromManifest = false);
 
 //private:
 protected:

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7431,8 +7431,6 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo& selected
  */
 bool StreamAbstractionAAMP_HLS::DoEarlyStreamSinkFlush(bool newTune, float rate)
 {
-	bool doFlush = !newTune;
-	AAMPLOG_INFO("doFlush=%d, newTune=%d, rate=%f", doFlush, newTune, rate);
 	// Live adjust or syncTrack occurred, send an updated flush event
-	return doFlush;
+	return (!newTune);
 }

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4188,7 +4188,6 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			}
 			if(!mLowLatencyMode && ISCONFIGSET(eAAMPConfig_EnableMediaProcessor))
 			{
-				// For segment timeline based streams, media processor is initialized in passthrough mode
 				InitializeMediaProcessor(mIsSegmentTimelineEnabled);
 			}
 		}
@@ -9499,7 +9498,6 @@ bool StreamAbstractionAAMP_MPD::IndexSelectedPeriod(bool periodChanged, bool adS
 		}
 		if (!mLowLatencyMode && ISCONFIGSET(eAAMPConfig_EnableMediaProcessor))
 		{
-			// For segment timeline based streams, media processor is initialized in passthrough mode
 			InitializeMediaProcessor(mIsSegmentTimelineEnabled);
 		}
 		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp) && (rate == AAMP_NORMAL_PLAY_RATE) && mMediaStreamContext[eMEDIATYPE_SUBTITLE]->enabled)
@@ -14052,6 +14050,26 @@ void StreamAbstractionAAMP_MPD::GetNextAdInBreak(int direction)
 	{
 		AAMPLOG_ERR("Invalid value[%d] for direction, not expected!", direction);
 	}
+}
+
+/**
+ * @fn GetVideoTimeScale
+ * @brief Get the timescale of the video stream
+ * @return The time scale of the video stream, or 1 if not available
+ */
+uint32_t StreamAbstractionAAMP_MPD::GetVideoTimeScale(void)
+{
+	uint32_t ret = 1; // Default value
+	MediaStreamContext *track = mMediaStreamContext[eMEDIATYPE_VIDEO];
+	if (track && track->enabled && track->fragmentDescriptor.TimeScale > 0)
+	{
+		ret = track->fragmentDescriptor.TimeScale;
+	}
+	else
+	{
+		AAMPLOG_WARN("Video track not available! Returning default value: %u", ret);
+	}
+	return ret;
 }
 
 /**

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -274,6 +274,12 @@ public:
 	 */
 	void SeekPosUpdate(double secondsRelativeToTuneTime) override;
 	virtual void SetCDAIObject(CDAIObject *cdaiObj) override;
+	/**
+	 * @fn GetVideoTimeScale
+	 * @brief returns the time scale of the video stream
+	 * @return time scale of the video stream
+	 */
+	uint32_t GetVideoTimeScale(void) override;
 
 	/**
 	 * @fn GetAvailableAudioTracks

--- a/isobmff/isobmffprocessor.cpp
+++ b/isobmff/isobmffprocessor.cpp
@@ -37,17 +37,15 @@ static const char *IsoBmffProcessorTypeName[] =
 /**
  *  @brief IsoBmffProcessor constructor
  */
-IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType,
-	bool passThrough, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor) :
-	p_aamp(aamp), type(trackType), peerProcessor(peerBmffProcessor), peerSubtitleProcessor(peerSubProcessor), basePTS(0),
+IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
+	: p_aamp(aamp), type(trackType), peerProcessor(peerBmffProcessor), peerSubtitleProcessor(peerSubProcessor), basePTS(0),
 	processPTSComplete(false), timeScale(0), initSegment(), resetPTSInitSegment(),
 	playRate(1.0f), aborted(false), m_mutex(), m_cond(),initSegmentProcessComplete(false),
 	isRestampConfigEnabled(false),
 	sumPTS(0),prevPTS(UINT64_MAX),currTimeScale(0), startPos(DEFAULT_DURATION),
 	prevPosition(-1), prevDuration(0.0), scalingOfPTSComplete(false),timeScaleChangeState(eBMFFPROCESSOR_INIT_TIMESCALE),
 	mediaFormat(eMEDIAFORMAT_UNKNOWN), enabled(true), trackOffsetInSecs(DEFAULT_DURATION), peerListeners(),
-	initSegmentTransferMutex(), skipMutex(), skipPointMap(),ptsDiscontinuity(false), nextPos(-1),
-	passThroughMode(passThrough)
+	initSegmentTransferMutex(), skipMutex(), skipPointMap(),ptsDiscontinuity(false), nextPos(-1)
 {
 	AAMPLOG_WARN("IsoBmffProcessor:: Created IsoBmffProcessor(%p) for type:%d and peerProcessor(%p)", this, type, peerBmffProcessor);
 	if (peerProcessor)
@@ -68,14 +66,6 @@ IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback
 	{
 		isRestampConfigEnabled = true;
 		AAMPLOG_WARN("IsoBmffProcessor:: %s mediaFormat=%d old PTS RE-STAMP ENABLED", IsoBmffProcessorTypeName[type],mediaFormat);
-	}
-	if (passThroughMode && isRestampConfigEnabled)
-	{
-		// If restamp is enabled, we cannot set pass through mode as basePTS and timeScale values are required
-		// This is a warning as this is not an expected scenario
-		AAMPLOG_WARN("IsoBmffProcessor %s Failed to set passThrough mode(%d) as restamp enabled(%d)",
-				IsoBmffProcessorTypeName[type], passThroughMode, isRestampConfigEnabled);
-		passThroughMode = false;
 	}
 }
 
@@ -98,19 +88,9 @@ bool IsoBmffProcessor::sendSegment(AampGrowableBuffer* pBuffer,double position,d
 	AAMPLOG_INFO("IsoBmffProcessor %s sending segment at pos:%f dur:%f fragmentPTSoffset: %.3f", IsoBmffProcessorTypeName[type], position, duration, fragmentPTSoffset);
 	bool ret = true;
 	ptsError = false;
-
 	if (!initSegmentProcessComplete)
 	{
-		if (passThroughMode)
-		{
-			// Populate the PTS and timeScale values for the first time without caching or syncing
-			// Its required for resetPTSOnSubtitleSwitch and resetPTSOnAudioSwitch
-			ret = updatePTSAndTimeScaleFromBuffer(pBuffer);
-		}
-		else
-		{
-			ret = setTuneTimePTS(pBuffer,position,duration,discontinuous,isInit);
-		}
+		ret = setTuneTimePTS(pBuffer,position,duration,discontinuous,isInit);
 	}
 	if (ret)
 	{
@@ -246,6 +226,7 @@ bool IsoBmffProcessor::setTuneTimePTS(AampGrowableBuffer *fragBuffer, double pos
 				uint32_t tScale = 0;
 				if (buffer.getTimeScale(tScale))
 				{
+
 					currTimeScale = tScale;
 					AAMPLOG_INFO("IsoBmffProcessor %s TimeScale %u (%u)", IsoBmffProcessorTypeName[type], currTimeScale,currTimeScale);
 				}
@@ -1328,49 +1309,14 @@ void IsoBmffProcessor::initProcessorForRestamp()
 	// Hence setting timeScale changed state to complete
 	timeScaleChangeState = eBMFFPROCESSOR_TIMESCALE_COMPLETE;
 }
-
 /**
- * @fn updatePTSAndTimeScaleFromBuffer
- *
- * @param[in] pBuffer - Pointer to the AampGrowableBuffer
- * @return true if PTS and time scale read successfully, false otherwise
+ * @brief Initialize the base PTS from manifest, This will be used to set the basePTS and timeScale in the segment timeline streams
+ * @param[in] pts - PTS value from manifest
+ * @param[in] tScale - Time scale value from manifest
  */
-bool IsoBmffProcessor::updatePTSAndTimeScaleFromBuffer(AampGrowableBuffer *pBuffer)
+void IsoBmffProcessor::InitializeBasePTSFromManifest(uint64_t pts, uint32_t tScale)
 {
-	bool ret = false;
-	std::unique_lock<std::mutex> lock(m_mutex);
-	if (pBuffer && pBuffer->GetPtr() && pBuffer->GetLen() > 0)
-	{
-		IsoBmffBuffer buffer;
-		buffer.setBuffer((uint8_t *)pBuffer->GetPtr(), pBuffer->GetLen());
-		buffer.parseBuffer();
-		if(buffer.isInitSegment())
-		{
-			uint32_t tScale = 0;
-			if (buffer.getTimeScale(tScale))
-			{
-				currTimeScale = tScale;
-				timeScale = tScale;
-				AAMPLOG_INFO("IsoBmffProcessor %s TimeScale %" PRIu32 "", IsoBmffProcessorTypeName[type], currTimeScale);
-			}
-		}
-		else
-		{
-			// Init segment was parsed and stored previously. Find the base PTS now
-			uint64_t fPts = 0;
-			if (buffer.getFirstPTS(fPts))
-			{
-				basePTS = fPts;
-				processPTSComplete = true;
-				AAMPLOG_WARN("IsoBmffProcessor %s Base PTS (%" PRIu64 ") set", IsoBmffProcessorTypeName[type], basePTS);
-				initSegmentProcessComplete = true;
-			}
-		}
-		ret = true;
-	}
-	else
-	{
-		AAMPLOG_WARN("IsoBmffProcessor %s readPTSAndTimeScaleFromBuffer: Buffer(%p) is empty or null", IsoBmffProcessorTypeName[type], pBuffer);
-	}
-	return ret;
+	currTimeScale = tScale;
+	setBasePTS(pts, tScale);
+	initSegmentProcessComplete = true;
 }

--- a/isobmff/isobmffprocessor.h
+++ b/isobmff/isobmffprocessor.h
@@ -109,17 +109,15 @@ class IsoBmffProcessor : public MediaProcessor
 
 public:
 	/**
-	 * @fn IsoBmffProcessor Constructor
+	 * @fn IsoBmffProcessor
 	 *
 	 * @param[in] aamp - PrivateInstanceAAMP pointer
-	 * @param[in] id3_hdl - ID3 callback handler
 	 * @param[in] trackType - track type (A/V)
-	 * @param[in] passThrough - true if pass through mode, false otherwise
 	 * @param[in] peerBmffProcessor - peer instance of IsoBmffProcessor
-	 * @param[in] peerSubProcessor - peer instance of IsoBmffProcessor for subtitles
 	 */
-	IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType,
-		bool passThrough, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor);
+	// IsoBmffProcessor(class PrivateInstanceAAMP *aamp, IsoBmffProcessorType trackType = eBMFFPROCESSOR_TYPE_VIDEO, IsoBmffProcessor* peerBmffProcessor = NULL, MediaProcessor* peerSubProcessor = NULL);
+	IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType = eBMFFPROCESSOR_TYPE_VIDEO,
+		IsoBmffProcessor* peerBmffProcessor = NULL, IsoBmffProcessor* peerSubProcessor = NULL);
 
 	/**
 	 * @fn ~IsoBmffProcessor
@@ -294,12 +292,12 @@ public:
 	* @brief Initialize the processor to advance to restamp phase directly
 	*/
 	void initProcessorForRestamp();
-
 	/**
-	 * @brief getPassThroughMode
-	 * @return true if pass through mode, false otherwise
-	 */
-	bool getPassThroughMode() { return passThroughMode; }
+	* @brief Set base PTS from the manifest, this prevents calling setTunetimePTS()
+	* @param[in] pts - PTS value
+	* @param[in] tScale - TimeScale value
+	*/
+	void InitializeBasePTSFromManifest(uint64_t pts, uint32_t tScale);
 
 private:
 
@@ -487,14 +485,6 @@ private:
 	 */
 	void resetInternal();
 
-	/**
-	 * @fn updatePTSAndTimeScaleFromBuffer
-	 *
-	 * @param[in] pBuffer - Pointer to the AampGrowableBuffer
-	 * @return true if PTS and time scale read successfully, false otherwise
-	 */
-	bool updatePTSAndTimeScaleFromBuffer(AampGrowableBuffer *pBuffer);
-
 	PrivateInstanceAAMP *p_aamp;
 	timeScaleChangeStateType timeScaleChangeState;
 	MediaFormat mediaFormat;
@@ -525,7 +515,6 @@ private:
 	bool aborted; // flag to indicate if the module is active
 	bool enabled;
 	bool ptsDiscontinuity;
-	bool passThroughMode; // flag to indicate if the processor is in pass through mode
 
 	std::vector<AampGrowableBuffer *> initSegment;
 	std::vector<stInitRestampSegment *> resetPTSInitSegment;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6570,6 +6570,8 @@ bool PrivateInstanceAAMP::IsPlayEnabled()
  */
 void PrivateInstanceAAMP::detach()
 {
+	// Protect against StreamAbstraction being modified from a different thread
+	AcquireStreamLock();
 	if(mpStreamAbstractionAAMP && mbPlayEnabled) //Player is running
 	{
 		pipeline_paused = true;
@@ -6608,6 +6610,7 @@ void PrivateInstanceAAMP::detach()
 	{
 		AampStreamSinkManager::GetInstance().DeactivatePlayer(this, false);
 	}
+	ReleaseStreamLock();
 }
 
 /**

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4466,7 +4466,7 @@ double MediaTrack::GetTotalInjectedDuration()
 {
 	std::lock_guard<std::mutex> lock(mTrackParamsMutex);
 	double ret = totalInjectedDuration;
-	if (IsInjectionFromCachedFragmentChunks())
+	if (aamp->GetLLDashChunkMode())
 	{
 		ret = totalInjectedChunksDuration;
 	}

--- a/test/gstTestHarness/mp4demux.cpp
+++ b/test/gstTestHarness/mp4demux.cpp
@@ -21,6 +21,12 @@
 #include <stdio.h>
 #include <inttypes.h>
 
+#define STR_TO_DECIMAL(str) \
+    ( (static_cast<uint32_t>((str)[0]) << 24) | \
+      (static_cast<uint32_t>((str)[1]) << 16) | \
+      (static_cast<uint32_t>((str)[2]) << 8)  | \
+      (static_cast<uint32_t>((str)[3])) )
+
 static void WriteBytes( uint8_t *ptr, int n, uint64_t value )
 {
 	while( n>0 )
@@ -56,7 +62,7 @@ uint64_t mp4_AdjustMediaDecodeTime( uint8_t *ptr, size_t len, int64_t pts_restam
 	{
 		uint8_t *next = ptr + READ_U32(ptr);
 		uint32_t type = READ_U32(ptr);
-		if( type == 'tfdt' ) // Track Fragment Base Media Decode Time Box
+		if( type == STR_TO_DECIMAL("tfdt")/*'tfdt' */) // Track Fragment Base Media Decode Time Box
 		{
 			uint8_t version = READ_VERSION(ptr);
 			int sz = (version==1)?8:4;
@@ -72,15 +78,15 @@ uint64_t mp4_AdjustMediaDecodeTime( uint8_t *ptr, size_t len, int64_t pts_restam
 		{ // walk children
 			switch( type )
 			{
-				case 'traf': // Track Fragment Box
-				case 'moov': // Movie Box
-				case 'trak': // Track Box
-				case 'minf': // Media Information Box
-				case 'dinf': // Data Information Box
-				case 'stbl': // Sample Table Box
-				case 'mvex': // Movie Extends Box
-				case 'moof': // Movie Fragment Boxes
-				case 'mdia': // Media Box
+				case STR_TO_DECIMAL("traf")://'traf': // Track Fragment Box
+				case STR_TO_DECIMAL("moov")://'moov': // Movie Box
+				case STR_TO_DECIMAL("trak")://'trak': // Track Box
+				case STR_TO_DECIMAL("minf")://'minf': // Media Information Box
+				case STR_TO_DECIMAL("dinf")://'dinf': // Data Information Box
+				case STR_TO_DECIMAL("stbl")://'stbl': // Sample Table Box
+				case STR_TO_DECIMAL("mves")://'mvex': // Movie Extends Box
+				case STR_TO_DECIMAL("moof")://'moof': // Movie Fragment Boxes
+				case STR_TO_DECIMAL("mdia")://'mdia': // Media Box
 					baseMediaDecodeTime = mp4_AdjustMediaDecodeTime( ptr, next-ptr, pts_restamp_delta );
 					break;
 					

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -279,3 +279,7 @@ bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate)
 {
     return false;
 }
+uint32_t StreamAbstractionAAMP_MPD::GetVideoTimeScale(void)
+{
+    return 1;
+}

--- a/test/utests/fakes/FakeIsoBmffProcessor.cpp
+++ b/test/utests/fakes/FakeIsoBmffProcessor.cpp
@@ -22,7 +22,7 @@
 
 MockIsoBmffProcessor* g_mockIsoBmffProcessor = nullptr;
 
-IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, bool passThrough, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
+IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
 {
 }
 
@@ -86,7 +86,6 @@ void IsoBmffProcessor::abortWaitForVideoPTS()
 void IsoBmffProcessor::resetPTSOnSubtitleSwitch(AampGrowableBuffer *pBuffer, double position)
 {
 }
-bool IsoBmffProcessor::updatePTSAndTimeScaleFromBuffer(AampGrowableBuffer *pBuffer)
+void IsoBmffProcessor::InitializeBasePTSFromManifest(uint64_t pts, uint32_t tScale)
 {
-    return true;
 }

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -393,7 +393,7 @@ void StreamAbstractionAAMP::SetVideoPlaybackRate(float rate)
 	}
 }
 
-void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
+void StreamAbstractionAAMP::InitializeMediaProcessor(bool initBasePTSFromManifest)
 {
 }
 

--- a/test/utests/tests/DrmOcdm/DrmHelperTests.cpp
+++ b/test/utests/tests/DrmOcdm/DrmHelperTests.cpp
@@ -391,6 +391,14 @@ TEST_F(DrmHelperTests, TestCreatePlayReadyHelperNegative)
 	}
 }
 
+static uint32_t Decimalvalue(const char* s)
+{
+	return (static_cast<uint32_t>(s[0]) << 24) |
+		(static_cast<uint32_t>(s[1]) << 16) |
+		(static_cast<uint32_t>(s[2]) << 8)  |
+		(static_cast<uint32_t>(s[3]));
+}
+
 TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 {
 	struct
@@ -411,16 +419,16 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		},
 		{ "AAAAJnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAZI89yVmwY=", // psshData
 			{},
-			'cens'
+			Decimalvalue("cens")//'cens'
 		},
 		{ "AAAAJnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAZIscaJmwY=", // psshData
 			{},
-			'cbc1'
+			Decimalvalue("cbc1")//'cbc1'
 		},
 		{ "AAAAPnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB4iFnNoYWthX2NlYzJmNjRhYTc4OTBhMTFI49yVmwY=", // psshData
 			{
 				"0x73,0x68,0x61,0x6B,0x61,0x5F,0x63,0x65,0x63,0x32,0x66,0x36,0x34,0x61,0x61,0x37,0x38,0x39,0x30,0x61,0x31,0x31"
-			}, 'cenc'
+			}, Decimalvalue("cenc")//'cenc'
 			// Version 0, AES-CTR full sample encryption
 			// no key ids!
 			// Content ID = shaka_cec2f64aa7890a11
@@ -434,13 +442,13 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		{ "AAAAOHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABgSEC22xI0wH0jqu3cbp6iskEJI49yVmwY=", // psshData
 			{
 				"0x2D,0xB6,0xC4,0x8D,0x30,0x1F,0x48,0xEA,0xBB,0x77,0x1B,0xA7,0xA8,0xAC,0x90,0x42"
-			},'cenc'
+			},Decimalvalue("cenc")//'cenc'
 			// Version 0, 'cenc'
 		},
 		{ "AAAAOHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABgSEC22xI0wH0jqu3cbp6iskEJI88aJmwY=", // psshData
 			{
 				"0x2D,0xB6,0xC4,0x8D,0x30,0x1F,0x48,0xEA,0xBB,0x77,0x1B,0xA7,0xA8,0xAC,0x90,0x42"
-			},'cbcs'
+			},Decimalvalue("cbcs")//'cbcs'
 			// Version 0, 'cbcs'
 		},
 		{ "AAAARHBzc2gBAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAIAAAAAAAAAAAAAAAAAAAAAEREREREREREREREREREREQAAAAA=", // psshData
@@ -453,7 +461,7 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		{"AAAAP3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB8SEFYWbwTmlTrikzbYc0PLv+IaBWV6ZHJtSPPGiZsG", // psshData
 			{
 				"0x56,0x16,0x6f,0x04,0xe6,0x95,0x3a,0xe2,0x93,0x36,0xd8,0x73,0x43,0xcb,0xbf,0xe2"
-			},'cbcs'
+			},Decimalvalue("cbcs")//'cbcs'
 			// Protection Scheme: 63 62 63 73 (cbcs)
 			// Provider: ezdrm
 		},
@@ -497,7 +505,7 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		{"AAAAOHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABgSEABFDiYaE6QUtKoKcLv0s6hI49yVmwY=", // psshData
 			{
 				"0x00,0x45,0x0e,0x26,0x1a,0x13,0xa4,0x14,0xb4,0xaa,0x0a,0x70,0xbb,0xf4,0xb3,0xa8"
-			},'cenc'
+			},Decimalvalue("cenc")//'cenc'
 			// Protection Scheme: 63 65 6E 63 (cenc)
 			// AES-CTR full sample encryption
 		}

--- a/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
+++ b/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
@@ -528,7 +528,8 @@ public:
 
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
-
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));
@@ -627,7 +628,6 @@ TEST_F(AdSelectionTests, WaitForAdFallbackTest)
 	std::string currentPeriodId = "p0";
 	mStreamAbstractionAAMP_MPD->IncrementIteratorPeriodIdx();
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 
 	/*
@@ -693,7 +693,6 @@ TEST_F(AdSelectionTests, onAdEventTest_1)
 		std::make_pair (0, AdOnPeriod(0, 0)), // for adId1 idx=0, offset=0s
 	});
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_START, "p1", _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_START, "adId1", _, _, _, _, _, _)).Times(1);
@@ -735,8 +734,6 @@ TEST_F(AdSelectionTests, onAdEventTest_2)
 	});
 
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_START, "p1", _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
@@ -820,8 +817,6 @@ TEST_F(AdSelectionTests, onAdEventTest_4)
 	});
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_START, adPeriodId, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
@@ -884,8 +879,6 @@ TEST_F(AdSelectionTests, onAdEventTest_5)
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_END, "adId1", _, _, _, _, _, _)).Times(1);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::AD_FINISHED));
@@ -948,8 +941,6 @@ TEST_F(AdSelectionTests, onAdEventTest_6)
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
 
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_ERROR, "adId1", _, _, _, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_END, "adId1", _, _, _, _, _, _)).Times(1);
@@ -1078,8 +1069,6 @@ TEST_F(AdSelectionTests, onAdEventTest_8)
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_END, adPeriodId, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
 	EXPECT_FALSE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
@@ -1153,8 +1142,6 @@ TEST_F(AdSelectionTests, onAdEventTest_9)
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_START, "adId2", _, _, _, _, _, _)).Times(1);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
@@ -1219,8 +1206,6 @@ TEST_F(AdSelectionTests, onAdEventTest_10)
 	});
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_START, "adId1", _, _, _, _, _, _)).Times(1);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::BASE_OFFSET_CHANGE));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
@@ -1374,8 +1359,6 @@ TEST_F(AdSelectionTests, onAdEventTest_13)
 
 	mStreamAbstractionAAMP_MPD->SetBasePeriodoffset(30);
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
@@ -1446,8 +1429,6 @@ TEST_F(AdSelectionTests, onAdEventTest_14)
 	});
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 	mStreamAbstractionAAMP_MPD->SetBasePeriodoffset(30);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
 
@@ -1513,8 +1494,6 @@ TEST_F(AdSelectionTests, onAdEventTest_15)
 	});
 
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::INIT));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
 
@@ -1602,8 +1581,6 @@ TEST_F(AdSelectionTests, AdTransitionTest)
 	std::string currentPeriodId = "p0";
 	mStreamAbstractionAAMP_MPD->IncrementIteratorPeriodIdx();
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _)).Times(AnyNumber());
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(AnyNumber());
 
@@ -1711,8 +1688,6 @@ TEST_F(AdSelectionTests, AdTransitionTest_PausedWithAampTSB)
 	std::string currentPeriodId = "p0";
 	mStreamAbstractionAAMP_MPD->IncrementIteratorPeriodIdx();
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _)).Times(AnyNumber());
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(AnyNumber());
 
@@ -1896,8 +1871,6 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 		.Times(1)
 		.WillOnce(Return(true));
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _)).Times(AnyNumber());
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(AnyNumber());
 

--- a/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
+++ b/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
@@ -45,8 +45,7 @@ using ::testing::AnyNumber;
 
 AampConfig *gpGlobalConfig{nullptr};
 
-// Base test fixture for IsoBmffProcessor tests
-class IsoBmffProcessorBaseTests : public ::testing::Test
+class IsoBmffProcessorTests : public ::testing::Test
 {
 	protected:
 		IsoBmffProcessor *mIsoBmffProcessor{};
@@ -56,17 +55,13 @@ class IsoBmffProcessorBaseTests : public ::testing::Test
 		MediaProcessor::process_fcn_t mProcessorFn{};
 		std::thread asyncTask;
 
-		// To be set by derived classes
-		virtual bool IsPTSReStampEnabled() const = 0;
-		virtual bool IsPTMEnabled() const = 0;
-
 		void SetUp() override
 		{
 			mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
 			g_mockPrivateInstanceAAMP = new MockPrivateInstanceAAMP();
 			g_mockAampConfig = new MockAampConfig();
 			g_mockIsoBmffBuffer = new MockIsoBmffBuffer();
-			EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(IsPTSReStampEnabled()));
+			EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(true));
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetMediaFormatTypeEnum()).WillRepeatedly(Return(eMEDIAFORMAT_HLS_MP4));
 			EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_FragmentDownloadFailThreshold)).WillRepeatedly(Return(10));
 			EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_,_)).WillRepeatedly(Return(true));
@@ -74,9 +69,9 @@ class IsoBmffProcessorBaseTests : public ::testing::Test
 
 			id3_callback_t id3Handler = nullptr;
 
-			mAudIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_AUDIO, IsPTMEnabled(), nullptr, nullptr);
-			mSubIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_SUBTITLE, IsPTMEnabled(), nullptr, nullptr);
-			mIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_VIDEO, IsPTMEnabled(), mAudIsoBmffProcessor, mSubIsoBmffProcessor);
+			mAudIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_AUDIO);
+			mSubIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_SUBTITLE);
+			mIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_VIDEO, mAudIsoBmffProcessor, mSubIsoBmffProcessor);
 		}
 
 		void TearDown() override
@@ -100,19 +95,6 @@ class IsoBmffProcessorBaseTests : public ::testing::Test
 		}
 };
 
-class IsoBmffProcessorTests : public IsoBmffProcessorBaseTests
-{
-	protected:
-		bool IsPTSReStampEnabled() const override { return true; }
-		bool IsPTMEnabled() const override { return false; }
-};
-
-class IsoBmffProcessorPTMTests : public IsoBmffProcessorBaseTests
-{
-	protected:
-		bool IsPTSReStampEnabled() const override { return false; }
-		bool IsPTMEnabled() const override { return true; }
-};
 
 //Race condition between setTuneTimePTS and reset calls
 TEST_F(IsoBmffProcessorTests, abortTests1)
@@ -731,50 +713,4 @@ TEST_F(IsoBmffProcessorTests, ptsTests_4)
 	buffer.Free();
 	restampedPTS = mIsoBmffProcessor->getSumPTS() - vDuration;
 	EXPECT_EQ(restampedPTS, rslt); // Restamped PTS will not update on dup fragment
-}
-
-// Validates the scenario where PTM and Restamp are both on
-TEST_F(IsoBmffProcessorTests, PTMOnRestampOnTest)
-{
-	// With restamp config enabled, PTM should be disabled
-	IsoBmffProcessor *processor = new IsoBmffProcessor(mPrivateInstanceAAMP, nullptr, eBMFFPROCESSOR_TYPE_AUDIO, true /* passThrough */, nullptr, nullptr);
-	EXPECT_EQ(processor->getPassThroughMode(), false);
-	delete processor;
-}
-
-// Validates the sendSegment calls with PTM enabled and restamp disabled
-TEST_F(IsoBmffProcessorPTMTests, passThroughTests1)
-{
-	AampGrowableBuffer buffer("IsoBmffProcessorPTMTests-passThroughTests1");
-	buffer.AppendBytes("SampleData", 10); // Dummy data to simulate a buffer
-
-	double position = 0, duration = 0;
-	bool discontinuous = false, ptsError = false;
-	uint64_t basePts = 240000;
-	uint32_t vCurrTS = 24000;
-
-	// 3 sendSegment calls and configured with HLS_MP4 content type
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _, _)).Times(3);
-
-	// Expecting the timescale to be read first
-	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(true));
-	EXPECT_CALL(*g_mockIsoBmffBuffer, getTimeScale(_)).WillOnce(DoAll(SetArgReferee<0>(vCurrTS), Return(true)));
-
-	bool ret = mIsoBmffProcessor->sendSegment(&buffer, position, duration, 0.0, discontinuous, true, mProcessorFn, ptsError);
-	EXPECT_TRUE(ret);
-
-	// Expecting the base PTS to be read
-	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(false));
-	EXPECT_CALL(*g_mockIsoBmffBuffer, getFirstPTS(_)).WillOnce(DoAll(SetArgReferee<0>(basePts), Return(true)));
-
-	ret = mIsoBmffProcessor->sendSegment(&buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
-	EXPECT_TRUE(ret);
-
-	// Not expecting any more calls to parse buffer
-	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).Times(0);
-
-	ret = mIsoBmffProcessor->sendSegment(&buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
-	EXPECT_TRUE(ret);
-
-	buffer.Free();
 }

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioOnlyTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioOnlyTests.cpp
@@ -274,7 +274,7 @@ public:
 
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
-
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
@@ -236,7 +236,7 @@ public:
 
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
-
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -237,7 +237,7 @@ public:
 
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
-
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -466,7 +466,7 @@ public:
 
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
-
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -312,6 +312,7 @@ public:
 
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
@@ -2762,7 +2763,6 @@ TEST_F(FunctionalTests, FindServerUTCTimeTest)
 	AAMPStatusType status = InitializeMPD(manifest);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
 }
-
 TEST_F(StreamAbstractionAAMP_MPDTest, CheckAdResolvedStatus_FirstTryAdBreakNotResolved)
 {
 	std::string periodId = "periodId1";

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/LinearFOGTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/LinearFOGTests.cpp
@@ -304,7 +304,7 @@ public:
 
                 /* Initialize MPD. */
                 EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
-
+                EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
                 EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
                         .Times(AnyNumber())
                         .WillRepeatedly(Return(eSTATE_PREPARING));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/StreamSelectionTest.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/StreamSelectionTest.cpp
@@ -530,7 +530,7 @@ public:
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING))
 			.Times(AnyNumber());
-
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/subtitleTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/subtitleTests.cpp
@@ -251,6 +251,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 		/* Initialize MPD. */
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));


### PR DESCRIPTION
Reason for change:warning due to multiple char conversion to uint32_t 
Test Procedure: Refer VPLAY-9707 for clearing warnings due to type conversion errors. 
Priority: P2

Signed-off-by: Srikanth2000<srikanthreddybijjam.2000@gmail.com>