### PR TITLE
VPLAY-9627: Crash(29398566) observed during channel change on linear …

### DIFF
--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -473,25 +473,19 @@ DrmSession* DrmSessionManager::createDrmSession(int &err, std::shared_ptr<DrmHel
 	if (code != KEY_INIT)
 	{
 		MW_LOG_WARN(" Unable to initialize DrmSession : Key State %d ", code);
-		std::lock_guard<std::mutex> guard(cachedKeyMutex);
- 		cachedKeyIDs[selectedSlot].isFailedKeyId = true;
-		return nullptr;
+		goto failure;
 	}
 
 	if(m_drmConfigParam->mIsFakeTune)
 	{
 		MW_LOG_MIL( "Exiting fake tune after DRM initialization.");
-		std::lock_guard<std::mutex> guard(cachedKeyMutex);
-		cachedKeyIDs[selectedSlot].isFailedKeyId = true;
-		return nullptr;
+		goto failure;
 	}
 	code =this->AcquireLicenseCb(drmHelper, selectedSlot, cdmError,  (GstMediaType)streamType, metaDataPtr, false);
 	if (code != KEY_READY)
 	{
 		MW_LOG_WARN(" Unable to get Ready Status DrmSession : Key State %d ", code);
-		std::lock_guard<std::mutex> guard(cachedKeyMutex);
-		cachedKeyIDs[selectedSlot].isFailedKeyId = true;
-		return nullptr;
+		goto failure; 
 	}
 
 #ifdef USE_SECMANAGER
@@ -505,6 +499,20 @@ DrmSession* DrmSessionManager::createDrmSession(int &err, std::shared_ptr<DrmHel
 #endif
 
 	return drmSessionContexts[selectedSlot].drmSession;
+
+	failure:
+	{
+		std::lock_guard<std::mutex> guard(cachedKeyMutex);
+		if (cachedKeyIDs)
+		{
+			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		}
+		else
+		{
+			MW_LOG_WARN("Not updating failure as cachedKeyIDs freed");
+		}
+	}
+	return nullptr;
 }
 
 /**


### PR DESCRIPTION
…channels

Reason for change: Changed DrmSessionManager::createDrmSession() to check for cachedKeyIDs before updating it's failed status during failure. This will avoid crash due to race condition caused by stop()
Test Procedure: Refer Jira
Risks: Low