### PR TITLE
DELIA-68248 : WPEWebProcess crash with PrivateInstanceAAMP::ProcessPendingDiscontinuity

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4682,7 +4682,7 @@ void PrivateInstanceAAMP::GetOnVideoEndSessionStatData(std::string &data)
 /**
  * @brief Terminate the stream
  */
-void PrivateInstanceAAMP::TeardownStream(bool newTune)
+void PrivateInstanceAAMP::TeardownStream(bool newTune, bool disableDownloads)
 {
 	std::unique_lock<std::recursive_mutex> lock(mLock);
 	//Have to perform this for trick and stop operations but avoid ad insertion related ones
@@ -4739,8 +4739,9 @@ void PrivateInstanceAAMP::TeardownStream(bool newTune)
 	lock.unlock();
 	if (mpStreamAbstractionAAMP)
 	{
-		mpStreamAbstractionAAMP->Stop(false);
-
+		mpStreamAbstractionAAMP->Stop(disableDownloads);
+                // Using StreamLock to make sure this is not interfering with GetFile() from PreCachePlaylistDownloadTask
+		AcquireStreamLock();
 		if(mContentType == ContentType_HDMIIN)
 		{
 			StreamAbstractionAAMP_HDMIIN::ResetInstance();
@@ -4758,6 +4759,7 @@ void PrivateInstanceAAMP::TeardownStream(bool newTune)
 				SAFE_DELETE(mpStreamAbstractionAAMP);
 			}
 		}
+		ReleaseStreamLock();
 	}
 	m_lastSubClockSyncTime = std::chrono::system_clock::time_point();
 
@@ -7471,9 +7473,6 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	// so downloads are disabled among other things
 	SetLocalAAMPTsb(false);
 	SetLocalAAMPTsbInjection(false);
-	// Using StreamLock to make sure this is not interfering with GetFile() from PreCachePlaylistDownloadTask
-	// and protect against the StreamAbstraction object being accessed by a different thread
-	AcquireStreamLock();
 	// Stopping the playback, release all DRM context
 	if (mpStreamAbstractionAAMP)
 	{
@@ -7482,36 +7481,18 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 			ReleaseDynamicDRMToUpdateWait();
 			mDRMLicenseManager->setLicenseRequestAbort(true);
 		}
-		mpStreamAbstractionAAMP->Stop(true);
 		if (HasSidecarData())
 		{ // has sidecar data
 			mpStreamAbstractionAAMP->ResetSubtitle();
 		}
-		//Deleting mpStreamAbstractionAAMP here will prevent the extra stop call in TeardownStream()
-		//and will avoid enableDownload() call being made unnecessarily
-		if(mContentType == ContentType_HDMIIN)
-		{
-			StreamAbstractionAAMP_HDMIIN::ResetInstance();
-			mpStreamAbstractionAAMP = NULL;
-		}
-		else if(mContentType == ContentType_COMPOSITEIN)
-		{
-			StreamAbstractionAAMP_COMPOSITEIN::ResetInstance();
-			mpStreamAbstractionAAMP = NULL;
-		}
-		else
-		{
-			SAFE_DELETE(mpStreamAbstractionAAMP);
-		}
 	}
-	ReleaseStreamLock();
+	TeardownStream(true,true); //disable download as well
+
 	// stop the mpd update immediately after Stream abstraction delete
 	if(mMPDDownloaderInstance != nullptr)
 	{
 		mMPDDownloaderInstance->Release();
 	}
-	TeardownStream(true);
-
 	if(mTSBSessionManager)
 	{
 		// Clear all the local TSB data

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -621,9 +621,10 @@ public:
 	 * @fn TeardownStream
 	 *
 	 * @param[in] newTune - true if operation is a new tune
+	 * @param[in] newTune - true if downwnload need to be disabled
 	 * @return void
 	 */
-	void TeardownStream(bool newTune);
+	void TeardownStream( bool newTune, bool disableDownloads = false );
 
 	/**
 	 * @fn SendMessageOverPipe

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -319,7 +319,7 @@ bool PrivateInstanceAAMP::IsFragmentCachingRequired()
 	return false;
 }
 
-void PrivateInstanceAAMP::TeardownStream(bool newTune)
+void PrivateInstanceAAMP::TeardownStream(bool newTune, bool disableDownloads)
 {
 }
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -339,7 +339,7 @@ bool PrivateInstanceAAMP::IsFragmentCachingRequired()
 	return false;
 }
 
-void PrivateInstanceAAMP::TeardownStream(bool newTune)
+void PrivateInstanceAAMP::TeardownStream(bool newTune, bool disableDownloads)
 {
 }
 

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1818,6 +1818,9 @@ TEST_F(PrivAampTests,TeardownStreamTest_1)
 {
 	p_aamp->TeardownStream(false);
 	EXPECT_EQ(0,p_aamp->mDiscontinuityTuneOperationId);
+	
+	p_aamp->TeardownStream(true,true);
+	EXPECT_EQ(0,p_aamp->mDiscontinuityTuneOperationId);
 }
 
 TEST_F(PrivAampTests,TeardownStreamTest_2)


### PR DESCRIPTION
…scontinuity

Reason for Change: Do not delete stream abstraction instance if pending discontinuity process is in progress
Test Procedure: Please see the ticket
Risks: Low
priority:P0

Change-Id: I11a23f2d483ed3fcaa3b3b517ed7264f93e78f46