### PR TITLE
VPLAY-9627: Crash(29398566) observed during channel change on linear …

### DIFF
--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -481,7 +481,10 @@ DrmSession* DrmSessionManager::createDrmSession(int &err, std::shared_ptr<DrmHel
 	{
 		MW_LOG_WARN(" Unable to initialize DrmSession : Key State %d ", code);
 		std::lock_guard<std::mutex> guard(cachedKeyMutex);
- 		cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		if (cachedKeyIDs)
+		{
+			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		}
 		return nullptr;
 	}
 
@@ -489,7 +492,10 @@ DrmSession* DrmSessionManager::createDrmSession(int &err, std::shared_ptr<DrmHel
 	{
 		MW_LOG_MIL( "Exiting fake tune after DRM initialization.");
 		std::lock_guard<std::mutex> guard(cachedKeyMutex);
-		cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		if (cachedKeyIDs)
+		{
+			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		}
 		return nullptr;
 	}
 	code =this->AcquireLicenseCb(drmHelper, selectedSlot, cdmError,  (GstMediaType)streamType, metaDataPtr, false);
@@ -497,7 +503,10 @@ DrmSession* DrmSessionManager::createDrmSession(int &err, std::shared_ptr<DrmHel
 	{
 		MW_LOG_WARN(" Unable to get Ready Status DrmSession : Key State %d ", code);
 		std::lock_guard<std::mutex> guard(cachedKeyMutex);
-		cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		if (cachedKeyIDs)
+		{
+			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+		}
 		return nullptr;
 	}
 


### PR DESCRIPTION
…channels

Reason for change: Changed DrmSessionManager::createDrmSession() to check for cachedKeyIDs before updating it's failed status during failure. This will avoid crash due to race condition caused by stop()
Test Procedure: Refer Jira
Risks: Low
Priority: P1