### PR TITLE
VPLAY-9872: [ENT-4082] AAMP_EVENT_AD_ events incorrect

### DIFF
--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1620,11 +1620,10 @@ public:
 
 	/**
 	 *   @fn ReportAdProgress
-	 *   @param[in]  sync - Flag to indicate that event should be synchronous
 	 *   @param[in]  positionMs - Position value in milliseconds
 	 *   @return void
 	 */
-	void ReportAdProgress(bool sync = true, double positionMs = -1);
+	void ReportAdProgress(double positionMs = -1);
 
 	/**
 	 *   @fn GetDurationMs


### PR DESCRIPTION
Reason for change: When playing AD back then intermittently the AD progress is reported as 0% twice before is starts progressing as 3%, 6% etc.
Also AAMP_EVENT_AD_PLACEMENT_PROGRESS event can be sent before AAMP_EVENT_AD_PLACEMENT_START