### PR TITLE
VPLAY-9903 Add a clean build option to aamp-cli

### DIFF
--- a/install-aamp.sh
+++ b/install-aamp.sh
@@ -59,6 +59,11 @@ source scripts/install_aampcliKotlin.sh
 
 # VARIABLES
 
+if [ ${OPTION_CLEAN_BUILD} = true ] ; then
+    sudo rm -rf .libs
+    sudo rm -rf build
+fi
+
 # Elapsed time
 SECONDS=0
 

--- a/install-aamp.sh
+++ b/install-aamp.sh
@@ -57,13 +57,6 @@ source scripts/install_aampcli.sh
 # aampcli on Kotlin install and build
 source scripts/install_aampcliKotlin.sh
 
-# VARIABLES
-
-if [ ${OPTION_CLEAN_BUILD} = true ] ; then
-    sudo rm -rf .libs
-    sudo rm -rf build
-fi
-
 # Elapsed time
 SECONDS=0
 
@@ -81,6 +74,13 @@ declare LOCAL_DEPS_BUILD_DIR
 
 # Get and process install options
 install_options_fn "$@" 
+
+if [ ${OPTION_CLEAN_BUILD} = true ] ; then
+    echo "Clean build selected - removing build and libs directories"
+    sudo rm -rf .libs
+    sudo rm -rf build
+fi
+
 INSTALL_STATUS_ARR+=("install_options_fn check passed.")
 
 tools_banner_fn

--- a/scripts/install_options.sh
+++ b/scripts/install_options.sh
@@ -32,6 +32,7 @@ OPTION_SUBTEC_SKIP=false
 OPTION_AAMPCLIKOTLIN_SKIP=false
 OPTION_SUBTEC_BUILD=true
 OPTION_SUBTEC_CLEAN=false
+OPTION_CLEAN_BUILD=false
 OPTION_GOOGLETEST_REFERENCE="tags/release-1.11.0"
 
 
@@ -39,7 +40,7 @@ OPTION_GOOGLETEST_REFERENCE="tags/release-1.11.0"
 function install_options_fn()
 {
   # Parse optional command line parameters
-  while getopts ":d:b:cf:np:r:g:qsk" OPT; do
+  while getopts ":d:b:cf:np:r:g:qskt" OPT; do
     case ${OPT} in
       d ) # process option d install base directory name
         OPTION_BUILD_DIR=${OPTARG}
@@ -85,7 +86,12 @@ function install_options_fn()
       p )     
         OPTION_PROTOBUF_REFERENCE=${OPTARG}
         echo "protobuf branch : ${PROTOBUF_REFERENCE}"
-        ;;  
+        ;; 
+      t )     
+        OPTION_CLEAN_BUILD=true
+        echo "Will remove .libs and build directories before build"
+        ;;
+
       * )
         echo "'Usage: No flags/options specified - build AAMP with default options
         [-b] Specify aamp branch name (default: current sprint branch)
@@ -97,7 +103,8 @@ function install_options_fn()
 
         [-s] Skip subtec build and installation]"
         echo "        Note:  Subtec is built by default but can be rebuilt separately with the subtec
-        [-k] Skip aamp-cli Kotlin build and installation]"
+        [-k] Skip aamp-cli Kotlin build and installation]
+        [-t] Remove .libs and build directories before build (full rebuild)"
         
         echo "
         [-r] Specify rialto to be built

--- a/scripts/install_options.sh
+++ b/scripts/install_options.sh
@@ -91,7 +91,6 @@ function install_options_fn()
         OPTION_CLEAN_BUILD=true
         echo "Will remove .libs and build directories before build"
         ;;
-
       * )
         echo "'Usage: No flags/options specified - build AAMP with default options
         [-b] Specify aamp branch name (default: current sprint branch)


### PR DESCRIPTION
Reason for change: To add clean build option to aamp-cli (delete .libs/ and build/)
Risks: Low
Priority: P1