### PR TITLE
VPLAY-9799 : Negative Buffer value seen on performing Go to live/FFWD…

### DIFF
--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -928,6 +928,7 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 * @return string playlist URI
 		 ***************************************************************************/
 		std::string GetPlaylistURI(TrackType trackType, StreamOutputFormat* format = NULL);
+		int lastSelectedProfileIndex;	/**< Variable  to restore in case of playlist download failure */
 		/***************************************************************************
 		 * @fn StopInjection
 		 *


### PR DESCRIPTION
… after rewind operation on linear channels / SLE contents

Revert "VPLAY-9393 HLS bitrate remains low post stream freeze"

Reason for Change: Revert "VPLAY-9393 HLS bitrate remains low post stream freeze" which is causing the issue Test Procedure: Please see the ticket
Risks: Low
priority:P1
This reverts commit 633f0b67c48230438cfe3764bf8d490d379d138e.