### PR TITLE
VPLAY-9881: Crash (54812090) observed during channel change on DVR as…

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1092,6 +1092,13 @@ void PlayerInstanceAAMP::SeekInternal(double secondsRelativeToTuneTime, bool kee
 	bool sentSpeedChangedEv = false;
 	bool isSeekToLiveOrEnd = false;
 	TuneType tuneType = eTUNETYPE_SEEK;
+
+	if( std::isnan(secondsRelativeToTuneTime) )
+	{
+		AAMPLOG_ERR("Seek value not in allowed range, exiting");
+		return;
+	}
+
 	if( aamp )
 	{
 		AAMPPlayerState state = GetState();


### PR DESCRIPTION
…sets

Reason for change: Crash happened when requsted seek value is NaN. Added NaN check to log an error & exit during that scenario. Test Procedure: Refer Jira
Risks: Low
Priority: P1