### PR TITLE
VPLAY-9137:[AAMP] [STB] [DVR-HOT] Play/Pause Position have wrong value

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -789,10 +789,15 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				aamp->NotifySpeedChanged(rate, false);
 				return;
 			}
+			// Adjusting the play/pause position value
+			double offset = aamp->GetFormatPositionOffsetInMSecs();
+			double formattedCurrPos = aamp->GetPositionMilliseconds() - offset;
+			double formattedSeekPos = (aamp->seek_pos_seconds * 1000.0) - offset;
 
-			AAMPLOG_WARN("aamp_SetRate (%f)overshoot(%d) ProgressReportDelta:(%d) ", rate,overshootcorrection,timeDeltaFromProgReport);
-			AAMPLOG_WARN("aamp_SetRate rate(%f)->(%f) cur pipeline: %s. Adj position: %f Play/Pause Position:%lld", aamp->rate,rate,aamp->pipeline_paused ? "paused" : "playing",aamp->seek_pos_seconds,aamp->GetPositionMilliseconds()); // current position relative to tune time
-
+			AAMPLOG_WARN("aamp_SetRate (%f)overshoot(%d) ProgressReportDelta:(%d) ", rate, overshootcorrection, timeDeltaFromProgReport);
+			AAMPLOG_WARN("aamp_SetRate rate(%f)->(%f) cur pipeline: %s. Adj position: %f Play/Pause Position:%lld",
+					aamp->rate, rate,aamp->pipeline_paused ? "paused" : "playing", formattedSeekPos, (static_cast<long long int>(formattedCurrPos)));
+			
 			if (!aamp->mSeekFromPausedState && (rate == aamp->rate) && !aamp->mbDetached)
 			{ // no change in desired play rate
 				// no deferring for playback resume

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3886,6 +3886,7 @@ public:
 	 * @return A constant character pointer to the error string corresponding to the provided error type.
 	 */
 	const char* getStringForPlaybackError(PlaybackErrorType errorType);
+
 	bool mPausePositionMonitoringThreadStarted; // Flag to indicate PausePositionMonitoring thread started
 
 	/**
@@ -3904,6 +3905,13 @@ public:
 	 * @retval current live play position of the stream in seconds.
 	 */
 	 double GetLivePlayPosition(void);
+	
+	/**
+	 * @fn GetFormatPositionOffsetInMSecs
+	 * @brief API to get the offset value in msecs for the position values to be reported.
+	 * @return Offset value in msecs
+	 */
+	double GetFormatPositionOffsetInMSecs();
 
 protected:
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1685,3 +1685,7 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
 {
 }
+double PrivateInstanceAAMP::GetFormatPositionOffsetInMSecs()
+{
+	return 0;
+}


### PR DESCRIPTION
Reason for change:When an CDVR Hot recording is played and we try to pause the playback we are getting wrong Play/Pause Position Risks: Low
Test Procedure: Refer jira ticket
Priority: P2

Signed-off-by: varshnie <varshniblue14@gmail.com>
