### PR TITLE
VPLAY-9842 Observed i-frames are moving Fastly at the end of the live edge position during trick play

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5763,7 +5763,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	tmpVar = GETCONFIGVALUE_PRIV(eAAMPConfig_PlaylistTimeout);
 	mPlaylistTimeoutMs = CONVERT_SEC_TO_MS(tmpVar);
 	mTsbType = GETCONFIGVALUE_PRIV(eAAMPConfig_TsbType);
-	mLocalAAMPTsbFromConfig = ISCONFIGSET_PRIV(eAAMPConfig_LocalTSBEnabled) || mTsbType == "local";
+	mLocalAAMPTsbFromConfig = ISCONFIGSET_PRIV(eAAMPConfig_LocalTSBEnabled) || (mTsbType == "local" && !IsFogUrl(mainManifestUrl));
 	if(mPlaylistTimeoutMs <= 0) mPlaylistTimeoutMs = mManifestTimeoutMs;
 	if(AAMP_DEFAULT_SETTING == GETCONFIGOWNER_PRIV(eAAMPConfig_PlaylistTimeout))
 	{
@@ -5821,7 +5821,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 
 	CreateTsbSessionManager();
 
-	mFogTSBEnabled = strcasestr(mainManifestUrl, AAMP_FOG_TSB_URL_KEYWORD) && ISCONFIGSET_PRIV(eAAMPConfig_Fog);
+	mFogTSBEnabled = IsFogUrl(mainManifestUrl);
 
 	std::string sTraceId = (pTraceID?pTraceID:"unknown");
 	//CMCD to be enabled for player direct downloads, not for Fog . All downloads in Fog , CMCD response to be done in Fog.
@@ -9068,6 +9068,12 @@ std::vector<float> PrivateInstanceAAMP::getSupportedPlaybackSpeeds(void)
 	}
 	return supportedPlaybackSpeeds;
 }
+
+bool PrivateInstanceAAMP::IsFogUrl(const char *mainManifestUrl)
+{
+	return strcasestr(mainManifestUrl, AAMP_FOG_TSB_URL_KEYWORD) && ISCONFIGSET_PRIV(eAAMPConfig_Fog);
+}
+
 /**
  * @brief  Generate media metadata event based on parsed attribute values.
  *

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5763,7 +5763,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	tmpVar = GETCONFIGVALUE_PRIV(eAAMPConfig_PlaylistTimeout);
 	mPlaylistTimeoutMs = CONVERT_SEC_TO_MS(tmpVar);
 	mTsbType = GETCONFIGVALUE_PRIV(eAAMPConfig_TsbType);
-	mLocalAAMPTsbFromConfig = ISCONFIGSET_PRIV(eAAMPConfig_LocalTSBEnabled) || mTsbType == "local";
+	mLocalAAMPTsbFromConfig = ISCONFIGSET_PRIV(eAAMPConfig_LocalTSBEnabled) || (mTsbType == "local" && !IsFogUrl());
 	if(mPlaylistTimeoutMs <= 0) mPlaylistTimeoutMs = mManifestTimeoutMs;
 	if(AAMP_DEFAULT_SETTING == GETCONFIGOWNER_PRIV(eAAMPConfig_PlaylistTimeout))
 	{
@@ -5821,7 +5821,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 
 	CreateTsbSessionManager();
 
-	mFogTSBEnabled = strcasestr(mainManifestUrl, AAMP_FOG_TSB_URL_KEYWORD) && ISCONFIGSET_PRIV(eAAMPConfig_Fog);
+	mFogTSBEnabled = IsFogUrl();
 
 	std::string sTraceId = (pTraceID?pTraceID:"unknown");
 	//CMCD to be enabled for player direct downloads, not for Fog . All downloads in Fog , CMCD response to be done in Fog.
@@ -9068,6 +9068,12 @@ std::vector<float> PrivateInstanceAAMP::getSupportedPlaybackSpeeds(void)
 	}
 	return supportedPlaybackSpeeds;
 }
+
+bool PrivateInstanceAAMP::IsFogUrl(void)
+{
+	return strcasestr(mainManifestUrl, AAMP_FOG_TSB_URL_KEYWORD) && ISCONFIGSET_PRIV(eAAMPConfig_Fog);
+}
+
 /**
  * @brief  Generate media metadata event based on parsed attribute values.
  *

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -4139,5 +4139,6 @@ protected:
 private:
 	void SetCMCDTrackData(AampMediaType mediaType);
 	std::vector<float> getSupportedPlaybackSpeeds(void);
+	bool IsFogUrl(const char *mainManifestUrl);
 };
 #endif // PRIVAAMP_H

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -4139,5 +4139,6 @@ protected:
 private:
 	void SetCMCDTrackData(AampMediaType mediaType);
 	std::vector<float> getSupportedPlaybackSpeeds(void);
+	bool IsFogUrl(void);
 };
 #endif // PRIVAAMP_H


### PR DESCRIPTION
Reason for Change: Disable AAMP TSB if FOG is used
Test Procedure: Please see the ticket
Risks: Low