### PR TITLE
VPLAY-9946: Playback failed in for certain live channels

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -365,7 +365,8 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "monitorAV", eAAMPConfig_MonitorAV, true},
 	{false, "enablePTSRestampForHlsTs", eAAMPConfig_HlsTsEnablePTSReStamp, true},
 	{false, "useMp4Demux", eAAMPConfig_UseMp4Demux,false },
-	{false, "curlThroughput", eAAMPConfig_CurlThroughput, false }
+	{false, "curlThroughput", eAAMPConfig_CurlThroughput, false },
+	{true, "overrideMediaHeaderDuration", eAAMPConfig_OverrideMediaHeaderDuration, true}
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -211,6 +211,7 @@ typedef enum
 	eAAMPConfig_HlsTsEnablePTSReStamp,
 	eAAMPConfig_UseMp4Demux,
 	eAAMPConfig_CurlThroughput,
+	eAAMPConfig_OverrideMediaHeaderDuration, /**< enable overriding media header duration for live streams to 0 */
 	eAAMPConfig_BoolMaxValue						/**< Max value of bool config always last element */
 
 } AAMPConfigSettingBool;

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -931,6 +931,13 @@ bool MediaTrack::ProcessFragmentChunk()
 				ClearMediaHeaderDuration(cachedFragment);
 			}
 		}
+		else if (pContext && ISCONFIGSET(eAAMPConfig_OverrideMediaHeaderDuration))
+		{
+			if (!pContext->trickplayMode)
+			{
+				ClearMediaHeaderDuration(cachedFragment);
+			}
+		}
 		if (mSubtitleParser && type == eTRACK_SUBTITLE)
 		{
 			mSubtitleParser->processData(cachedFragment->fragment.GetPtr(), cachedFragment->fragment.GetLen(), cachedFragment->position, cachedFragment->duration);
@@ -1347,6 +1354,13 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 					ClearMediaHeaderDuration(cachedFragment);
 				}
 			}
+		}
+		else if (ISCONFIGSET(eAAMPConfig_OverrideMediaHeaderDuration) &&
+			(eMEDIAFORMAT_DASH == aamp->mMediaFormat) &&
+			(aamp->IsLive()))
+		{
+			// Only for Live and DASH streams
+			ClearMediaHeaderDuration(cachedFragment);
 		}
 		if ((mSubtitleParser || (aamp->IsGstreamerSubsEnabled())) && type == eTRACK_SUBTITLE)
 		{


### PR DESCRIPTION
Reason for change: Clear duration value in mdhd mp4 box in init fragment for live streams. This ensures qtdemux will sent a segment event prior to playback start
Test Procedure: Linear channel playback should work as expected Risks: Low