### PR TITLE
VPLAY-9640: Adding networkTimeouLLD config for Low latency downloads

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -476,6 +476,7 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 static const ConfigLookupEntryFloat mConfigLookupTableFloat[AAMPCONFIG_FLOAT_COUNT] =
 {
 	{CURL_FRAGMENT_DL_TIMEOUT,"networkTimeout",eAAMPConfig_NetworkTimeout,true},
+	{TIMEOUT_FOR_LLD, "networkTimeoutLLD", eAAMPConfig_NetworkTimeoutLLD, true}, // used for low latency dash
 	{CURL_FRAGMENT_DL_TIMEOUT,"manifestTimeout",eAAMPConfig_ManifestTimeout,true},
 	{0.0,"playlistTimeout",eAAMPConfig_PlaylistTimeout,true},
 	{DEFAULT_REPORT_PROGRESS_INTERVAL,"progressReportingInterval",eAAMPConfig_ReportProgressInterval,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -314,6 +314,7 @@ typedef enum
 typedef enum
 {
 	eAAMPConfig_NetworkTimeout,						/**< Fragment download timeout in sec*/
+	eAAMPConfig_NetworkTimeoutLLD,						/**< Fragment download timeout in sec for Low Latency Dash*/
 	eAAMPConfig_ManifestTimeout,						/**< Manifest download timeout in sec*/
 	eAAMPConfig_PlaylistTimeout,						/**< playlist download time out in sec*/
 	eAAMPConfig_ReportProgressInterval,					/**< Interval of progress reporting*/

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13597,7 +13597,7 @@ void PrivateInstanceAAMP::SetLLDashChunkMode(bool enable)
 		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_MinABRNWBufferRampDown,AAMP_LOW_BUFFER_BEFORE_RAMPDOWN_FOR_LLD);
 		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_MaxABRNWBufferRampUp,AAMP_HIGH_BUFFER_BEFORE_RAMPUP_FOR_LLD);
 
-		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_NetworkTimeout,TIMEOUT_FOR_LLD); /* Use 3sec for fragment download timout for LLD */
+		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_NetworkTimeout, GETCONFIGVALUE_PRIV(eAAMPConfig_NetworkTimeoutLLD)); /* Use 3sec for fragment download timout for LLD */
 		mNetworkTimeoutMs  = (uint32_t) CONVERT_SEC_TO_MS(GETCONFIGVALUE_PRIV(eAAMPConfig_NetworkTimeout));
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)
 		{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13597,7 +13597,7 @@ void PrivateInstanceAAMP::SetLLDashChunkMode(bool enable)
 		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_MinABRNWBufferRampDown,AAMP_LOW_BUFFER_BEFORE_RAMPDOWN_FOR_LLD);
 		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_MaxABRNWBufferRampUp,AAMP_HIGH_BUFFER_BEFORE_RAMPUP_FOR_LLD);
 
-		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_NetworkTimeout, GETCONFIGVALUE_PRIV(eAAMPConfig_NetworkTimeoutLLD)); /* Use 3sec for fragment download timout for LLD */
+		SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING,eAAMPConfig_NetworkTimeout, GETCONFIGVALUE_PRIV(eAAMPConfig_NetworkTimeoutLLD)); /* Use 3sec for fragment download timeout for LLD */
 		mNetworkTimeoutMs  = (uint32_t) CONVERT_SEC_TO_MS(GETCONFIGVALUE_PRIV(eAAMPConfig_NetworkTimeout));
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)
 		{


### PR DESCRIPTION
Reason for change: New downloaded timeout in LLD rather than hard coded one
Risks: Low
Test Procedure: Test with
Priority: P1