### PR TITLE
RDKEMW-5467 : Set PlayerState to IDLE during stop

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7685,7 +7685,7 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	EnableDownloads();
 
 	AampStreamSinkManager::GetInstance().DeactivatePlayer(this, true);
-	SetState( eSTATE_RELEASED, sendStateChangeEvent );
+	SetState( eSTATE_IDLE, sendStateChangeEvent );
 
 	// Revert all custom specific setting, tune specific setting and stream specific setting , back to App/default setting
 	mConfig->RestoreConfiguration(AAMP_CUSTOM_DEV_CFG_SETTING);


### PR DESCRIPTION
Reason for change: EPG currently behaves badly when state is set to eSTATE_RELEASED instead of eSTATE_IDLE after stopping
Test Procedure: Tune to any linear channels, Try changing the channels and see tune was successful with out any blue screen
Risks: Medium