### PR TITLE
VPLAY-9999: Progress value for latency displayed as wrong for LLD

### DIFF
--- a/AampMPDParseHelper.cpp
+++ b/AampMPDParseHelper.cpp
@@ -195,11 +195,10 @@ void AampMPDParseHelper::parseMPD()
 	if(mpdAttributes.find("publishTime") != mpdAttributes.end())
 	{
 		publishTimeStr = mpdAttributes["publishTime"];
-	}
-
-	if(!publishTimeStr.empty())
-	{
-		mPublishTime = ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str());
+		if(!publishTimeStr.empty())
+		{
+			mPublishTime = ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str());
+		}
 	}
 
 	mNumberOfPeriods = (int)mMPDInstance->GetPeriods().size();

--- a/AampMPDParseHelper.cpp
+++ b/AampMPDParseHelper.cpp
@@ -32,7 +32,7 @@
 */
 AampMPDParseHelper::AampMPDParseHelper() 	: mMPDInstance(NULL),mIsLiveManifest(false),mMinUpdateDurationMs(0),
 				mIsFogMPD(false),
-				mAvailabilityStartTime(0.0),mSegmentDurationSeconds(0),mTSBDepth(0.0),
+				mAvailabilityStartTime(0.0),mPublishTime(0.0),mSegmentDurationSeconds(0),mTSBDepth(0.0),
 				mPresentationOffsetDelay(0.0),mMediaPresentationDuration(0),
 				mMyObjectMutex(),mPeriodEncryptionMap(),mNumberOfPeriods(0),mPeriodEmptyMap(),mLiveTimeFragmentSync(false),mHasServerUtcTime(false),mUpperBoundaryPeriod(0),mLowerBoundaryPeriod(0),mMPDPeriodDetails(),mDeltaTime(0.0)
 {
@@ -88,6 +88,7 @@ void AampMPDParseHelper::Clear()
 	mIsFogMPD       =   false;
 	mMinUpdateDurationMs    =   0;
 	mAvailabilityStartTime  =   0.0;
+	mPublishTime = 0.0;
 	mSegmentDurationSeconds =   0;
 	mTSBDepth       =   0.0;
 	mPresentationOffsetDelay    =   0.0;
@@ -189,6 +190,16 @@ void AampMPDParseHelper::parseMPD()
 	if(mpdAttributes.find("fogtsb") != mpdAttributes.end())
 	{
 		mIsFogMPD = true;
+	}
+	std::string publishTimeStr;
+	if(mpdAttributes.find("publishTime") != mpdAttributes.end())
+	{
+		publishTimeStr = mpdAttributes["publishTime"];
+	}
+
+	if(!publishTimeStr.empty())
+	{
+		mPublishTime = ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str());
 	}
 
 	mNumberOfPeriods = (int)mMPDInstance->GetPeriods().size();

--- a/AampMPDParseHelper.h
+++ b/AampMPDParseHelper.h
@@ -249,6 +249,13 @@ public :
 	*/	
 	double GetAvailabilityStartTime() { return mAvailabilityStartTime;}
 	/**
+	*
+	*   @fn GetPublishTime
+	*   @brief  Returns PublishTime from the manifest
+	* 	@retval double . PublishTime
+	*/
+	double GetPublishTime() { return mPublishTime; }
+	/**
 	*   @fn GetSegmentDurationSeconds
 	*   @brief  Returns SegmentDuration from the manifest  
  	* 	@retval uint64_t . SegmentDuration
@@ -488,6 +495,8 @@ private:
 	uint64_t mMinUpdateDurationMs;
 	/* storage for Availability Start Time */
 	double mAvailabilityStartTime;
+	/* storage for Publish Time in seconds*/
+	double mPublishTime;
 	/* storage for Segment Duration in seconds */
 	uint64_t mSegmentDurationSeconds;
 	/* storage of TSB Depth */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8478,7 +8478,7 @@ void StreamAbstractionAAMP_MPD::UpdateCulledAndDurationFromPeriodInfo(std::vecto
 			double latencyAdjustedEndPosition = aamp->mAbsoluteEndPosition + GETCONFIGVALUE(eAAMPConfig_LLTargetLatency);
 			if(latencyAdjustedEndPosition < mMPDParseHelper->GetPublishTime())
 			{
-				AAMPLOG_ERR("latencyAdjustedEndPosition %lf is less than PublishTime %lf, May be a bug in the stream!!", aamp->mAbsoluteEndPosition, mMPDParseHelper->GetPublishTime());
+				AAMPLOG_ERR("latencyAdjustedEnd %lf < publishTime %lf, Bug in the stream!!", aamp->mAbsoluteEndPosition, mMPDParseHelper->GetPublishTime());
 			}
 		}
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8472,6 +8472,15 @@ void StreamAbstractionAAMP_MPD::UpdateCulledAndDurationFromPeriodInfo(std::vecto
 			}
 			aamp->mAbsoluteEndPosition += aamp->culledSeconds;
 		}
+		if(mLowLatencyMode)
+		{
+			// Logging the stream issue if the latency adjusted end position is less than publish time.
+			double latencyAdjustedEndPosition = aamp->mAbsoluteEndPosition + GETCONFIGVALUE(eAAMPConfig_LLTargetLatency);
+			if(latencyAdjustedEndPosition < mMPDParseHelper->GetPublishTime())
+			{
+				AAMPLOG_ERR("latencyAdjustedEndPosition %lf is less than PublishTime %lf, May be a bug in the stream!!", aamp->mAbsoluteEndPosition, mMPDParseHelper->GetPublishTime());
+			}
+		}
 
 		mPrevFirstPeriodStart = firstPeriodStart;
 		AAMPLOG_INFO("Culled seconds: %f, Updated culledSeconds: %lf AbsoluteEndPosition: %lf PrevFirstPeriodStart: %lf", culled, mCulledSeconds, aamp->mAbsoluteEndPosition, mPrevFirstPeriodStart);


### PR DESCRIPTION
Reason for change:Introducing an error log to capture manifest issues Risks: Low
Test Procedure: Test with channel 922
Priority: P1