### PR TITLE
VPLAY-9946: Playback failed in for certain live channels

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -369,6 +369,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "forceLLDFlow", eAAMPConfig_ForceLLDFlow, false},
 	{false, "monitorAV", eAAMPConfig_MonitorAV, true},
 	{false, "enablePTSRestampForHlsTs", eAAMPConfig_HlsTsEnablePTSReStamp, true},
+	{true, "overrideMediaHeaderDuration", eAAMPConfig_OverrideMediaHeaderDuration, true}
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -209,6 +209,7 @@ typedef enum
 	eAAMPConfig_ForceLLDFlow,						/**< Config to forcefully process LLD workflow even if they are live SLD */
 	eAAMPConfig_MonitorAV,						/**< enable background monitoring of audio/video positions to infer video freeze, audio drop, or av sync issues */
 	eAAMPConfig_HlsTsEnablePTSReStamp,
+	eAAMPConfig_OverrideMediaHeaderDuration, /**< enable overriding media header duration for live streams to 0 */
 	eAAMPConfig_BoolMaxValue						/**< Max value of bool config always last element */
 
 } AAMPConfigSettingBool;

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -931,6 +931,13 @@ bool MediaTrack::ProcessFragmentChunk()
 				ClearMediaHeaderDuration(cachedFragment);
 			}
 		}
+		else if (pContext && ISCONFIGSET(eAAMPConfig_OverrideMediaHeaderDuration))
+		{
+			if (!pContext->trickplayMode)
+			{
+				ClearMediaHeaderDuration(cachedFragment);
+			}
+		}
 		if (mSubtitleParser && type == eTRACK_SUBTITLE)
 		{
 			mSubtitleParser->processData(cachedFragment->fragment.GetPtr(), cachedFragment->fragment.GetLen(), cachedFragment->position, cachedFragment->duration);
@@ -1342,6 +1349,13 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 					ClearMediaHeaderDuration(cachedFragment);
 				}
 			}
+		}
+		else if (ISCONFIGSET(eAAMPConfig_OverrideMediaHeaderDuration) &&
+			(eMEDIAFORMAT_DASH == aamp->mMediaFormat) &&
+			(aamp->IsLive()))
+		{
+			// Only for Live and DASH streams
+			ClearMediaHeaderDuration(cachedFragment);
 		}
 		if ((mSubtitleParser || (aamp->IsGstreamerSubsEnabled())) && type == eTRACK_SUBTITLE)
 		{


### PR DESCRIPTION
Reason for change: Clear duration value in mdhd mp4 box in init fragment for live streams. This ensures qtdemux will sent a segment event prior to playback start
Test Procedure: Linear channel playback should work as expected Risks: Low