### PR TITLE
VPLAY-10074 FakePlayerSecManager.cpp:170:9: warning: reference to stack memory associated with local variable 'callback' returned [-Wreturn-stack-address]

### DIFF
--- a/test/utests/fakes/FakePlayerSecManager.cpp
+++ b/test/utests/fakes/FakePlayerSecManager.cpp
@@ -166,7 +166,7 @@ void PlayerSecManager::setWatermarkSessionEvent_CB(const std::function<void(uint
  */
 std::function<void(uint32_t, uint32_t, const std::string&)>& PlayerSecManager::getWatermarkSessionEvent_CB( )
 {
-	std::function<void(uint32_t, uint32_t, const std::string&)> callback = nullptr;
+	static std::function<void(uint32_t, uint32_t, const std::string&)> callback = nullptr;
 	return callback;
 }
 


### PR DESCRIPTION
VPLAY-10074 FakePlayerSecManager.cpp:170:9: warning: reference to stack memory associated with local variable 'callback' returned [-Wreturn-stack-address]

eliminate a compilation warning seen building utests