### PR TITLE
VPLAY-10020 : Set PlayerState to IDLE during stop

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -492,11 +492,11 @@ Example:
 | paused | 6 | eSTATE_PAUSED | Indicates player is paused |
 | seeking | 7 | eSTATE_SEEKING | Indicates player is seeking |
 | playing | 8 | eSTATE_PLAYING | Indicates player is in playing state  |
-| stopping | 9 | eSTATE_STOPPING | Deprecated  |
-| stopped | 10 | eSTATE_STOPPED | Not supported for all stream types. To be deprecated |
+| stopping | 9 | eSTATE_STOPPING | Stop in progress |
+| stopped | 10 | eSTATE_STOPPED | Deprecated |
 | complete | 11 | eSTATE_COMPLETE | Indicates the end of media |
 | error | 12 | eSTATE_ERROR | Indicates error in playback |
-| released | 13 | eSTATE_RELEASED | To be deprecated |
+| released | 13 | eSTATE_RELEASED | Indicates all Player resources released (equivalent to eSTATE_IDLE) |
 
 ---
 

--- a/compositein_shim.cpp
+++ b/compositein_shim.cpp
@@ -110,7 +110,7 @@ void StreamAbstractionAAMP_COMPOSITEIN::ResetInstance()
 	{
 		if(mCompositeinInstance->aamp != NULL)
 		{
-			mCompositeinInstance->aamp->SetState(eSTATE_STOPPED);
+			mCompositeinInstance->aamp->SetState(eSTATE_STOPPING);
 		}
 		//clear aamp
 		mCompositeinInstance->aamp = NULL;

--- a/hdmiin_shim.cpp
+++ b/hdmiin_shim.cpp
@@ -122,7 +122,7 @@ void StreamAbstractionAAMP_HDMIIN::ResetInstance()
 	{
 		if(mHdmiinInstance->aamp != NULL)
 		{
-			mHdmiinInstance->aamp->SetState(eSTATE_STOPPED);
+			mHdmiinInstance->aamp->SetState(eSTATE_STOPPING);
 		}
 		//clear aamp
 		mHdmiinInstance->aamp = NULL;

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2144,7 +2144,7 @@ std::string PlayerInstanceAAMP::GetManifest(void)
 			case eSTATE_ERROR:
 			case eSTATE_IDLE:
 			case eSTATE_RELEASED:
-			case eSTATE_STOPPED:
+			case eSTATE_STOPPING:
 				AAMPLOG_WARN( "PlayerState=%d",state );
 				break;
 			default:

--- a/rmf_shim.cpp
+++ b/rmf_shim.cpp
@@ -128,7 +128,7 @@ void StreamAbstractionAAMP_RMF::Stop(bool clearChannelData)
 		return;
 
 	thunderAccessObj.StopRmf();
-	aamp->SetState(eSTATE_STOPPED);
+	aamp->SetState(eSTATE_STOPPING);
 }
 
 /**

--- a/videoin_shim.cpp
+++ b/videoin_shim.cpp
@@ -178,7 +178,7 @@ void StreamAbstractionAAMP_VIDEOIN::OnInputStatusChanged(std::string strStatus)
 		}
 		else if(0 == strStatus.compare("stopped"))
 		{
-			aamp->SetState(eSTATE_STOPPED);
+			aamp->SetState(eSTATE_STOPPING);
 		}
 	}
 }


### PR DESCRIPTION
Reason for change: AAMP Player State Simplification (deprecate RELEASED, STOPPED)
Test Procedure: Test procedure updated in the ticket
Risks: Medium