### PR TITLE
VPLAY-9707:Fix multi-character character constant warnings

### DIFF
--- a/test/gstTestHarness/mp4demux.cpp
+++ b/test/gstTestHarness/mp4demux.cpp
@@ -56,7 +56,7 @@ uint64_t mp4_AdjustMediaDecodeTime( uint8_t *ptr, size_t len, int64_t pts_restam
 	{
 		uint8_t *next = ptr + READ_U32(ptr);
 		uint32_t type = READ_U32(ptr);
-		if( type == 'tfdt' ) // Track Fragment Base Media Decode Time Box
+		if( type == MultiChar_Constant("tfdt") ) // Track Fragment Base Media Decode Time Box
 		{
 			uint8_t version = READ_VERSION(ptr);
 			int sz = (version==1)?8:4;
@@ -72,15 +72,15 @@ uint64_t mp4_AdjustMediaDecodeTime( uint8_t *ptr, size_t len, int64_t pts_restam
 		{ // walk children
 			switch( type )
 			{
-				case 'traf': // Track Fragment Box
-				case 'moov': // Movie Box
-				case 'trak': // Track Box
-				case 'minf': // Media Information Box
-				case 'dinf': // Data Information Box
-				case 'stbl': // Sample Table Box
-				case 'mvex': // Movie Extends Box
-				case 'moof': // Movie Fragment Boxes
-				case 'mdia': // Media Box
+				case MultiChar_Constant("traf"): // Track Fragment Box
+				case MultiChar_Constant("moov"): // Movie Box
+				case MultiChar_Constant("trak"): // Track Box
+				case MultiChar_Constant("minf"): // Media Information Box
+				case MultiChar_Constant("dinf"): // Data Information Box
+				case MultiChar_Constant("stbl"): // Sample Table Box
+				case MultiChar_Constant("mvex"):// Movie Extends Box
+				case MultiChar_Constant("moof"): // Movie Fragment Boxes
+				case MultiChar_Constant("mdia"): // Media Box
 					baseMediaDecodeTime = mp4_AdjustMediaDecodeTime( ptr, next-ptr, pts_restamp_delta );
 					break;
 					

--- a/test/gstTestHarness/mp4demux.hpp
+++ b/test/gstTestHarness/mp4demux.hpp
@@ -31,6 +31,13 @@
 #define PRINTF(...)
 //#define PRINTF printf
 
+#define MultiChar_Constant(Text) \
+	( (static_cast<uint32_t>(Text[0]) << 24) | \
+		(static_cast<uint32_t>(Text[1]) << 16) | \
+		(static_cast<uint32_t>(Text[2]) << 8)  | \
+		(static_cast<uint32_t>(Text[3])) )
+//#Conversion of text in to decimal value
+
 struct Mp4Sample
 {
 	const uint8_t *ptr;
@@ -347,9 +354,9 @@ private:
 		info.stream_format = type;
 		switch( info.stream_format )
 		{
-			case 0x68657631: // 'hev1'
-			case 0x61766331: // 'avc1'
-			case 0x68766331: // 'hvc1'
+			case MultiChar_Constant("hev1"):
+			case MultiChar_Constant("avc1"): 
+			case MultiChar_Constant("hvc1"):
 				SkipBytes(4); // always zero?
 				info.data_reference_index = ReadU32();
 				SkipBytes(16); // always zero?
@@ -365,8 +372,8 @@ private:
 				assert( pad == 0xffff );
 				break;
 				
-			case 0x6D703461: // 'mp4a'
-			case 0x65632D33: // 'ec-3'
+			case MultiChar_Constant("mp4a"): 
+			case MultiChar_Constant("ec-3"): 
 				SkipBytes(4); // zero
 				info.data_reference_index = ReadU32();
 				SkipBytes(8); // zero
@@ -453,7 +460,7 @@ private:
 	void parseCodecConfiguration( uint32_t type, const uint8_t *next )
 	{
 		info.codec_type = type;
-		if( type == 'esds' )
+		if( type == MultiChar_Constant("esds") )
 		{
 			SkipBytes(4);
 			parseCodecConfigHelper( next );
@@ -485,22 +492,22 @@ private:
 				   (type>>24)&0xff, (type>>16)&0xff, (type>>8)&0xff, type&0xff );
 			switch( type )
 			{
-				case 0x68657631: // 'hev1'
-				case 0x68766331: // 'hvc1'
-				case 0x61766331: // 'avc1'
-				case 0x6D703461: // 'mp4a'
-				case 0x65632D33: // 'ec-3'
+				case MultiChar_Constant("hev1"):
+				case MultiChar_Constant("hvc1"): 
+				case MultiChar_Constant("avc1"):
+				case MultiChar_Constant("mp4a"): 
+				case MultiChar_Constant("ec-3"): 
 					parseStreamFormat( type, next, indent );
 					break;
 					
-				case 0x68766343: // 'hvcC'
-				case 0x64656333: // 'dec3'
-				case 0x61766343: // 'avcC'
-				case 0x65736473: // 'esds' Elementary Stream Descriptot Box
+				case MultiChar_Constant("hvcC"): 
+				case MultiChar_Constant("dec3"): 
+				case MultiChar_Constant("avcC"): 
+				case MultiChar_Constant("esds"): // Elementary Stream Descriptot Box
 					parseCodecConfiguration( type, next );
 					break;
 					
-				case 0x66747970: // 'ftyp' FileType Box
+				case MultiChar_Constant("ftyp"): //  FileType Box
 					/*
 					 major_brand // 4 chars
 					 minor_version // 4 bytes
@@ -508,97 +515,97 @@ private:
 					 */
 					break;
 					
-				case 0x6D666864: // 'mfhd':
+				case MultiChar_Constant("mfhd"): 
 					parseMovieFragmentHeaderBox();
 					break;
 					
-				case 0x74666864: // 'tfhd'
+				case MultiChar_Constant("tfhd"): 
 					parseTrackFragmentHeaderBox();
 					break;
 					
-				case 0x7472756E: // 'trun'
+				case MultiChar_Constant("trun"): 
 					parseTrackFragmentRunBox();
 					break;
 					
-				case 0x74666474: // 'tfdt'
+				case MultiChar_Constant("tfdt"): 
 					parseTrackFragmentBaseMediaDecodeTimeBox();
 					break;
 					
-				case 0x6D766864: // 'mvhd'
+				case MultiChar_Constant("mvhd"):
 					parseMovieHeaderBox();
 					break;
 					
-				case 0x6D656864: // 'mehd'
+				case MultiChar_Constant("mehd"): 
 					parseMovieExtendsHeader();
 					break;
 					
-				case 0x74726578: // 'trex'
+				case MultiChar_Constant("trex"): 
 					parseTrackExtendsBox();
 					break;
 					
-				case 0x746B6864: // 'tkhd'
+				case MultiChar_Constant("tkhd"): 
 					parseTrackHeader();
 					break;
 					
-				case 0x6D646864: // 'mdhd'
+				case MultiChar_Constant("mdhd"): 
 					parseMediaHeaderBox();
 					break;
 					
-				case 0x68646C72: // 'hdlr' Handler Reference Box
+				case MultiChar_Constant("hdlr"): // Handler Reference Box
 					/*
 					 handler	vide
 					 name	Bento4 Video Handler
 					 */
 					break;
 					
-				case 0x766D6864: // 'vmhd' Video Media Header
+				case MultiChar_Constant("vmhd"): // Video Media Header
 					/*
 					 graphicsmode	0
 					 opcolor	0,0,0
 					 */
 					break;
 					
-				case 0x736D6864: // 'smhd' Sound Media Header
+				case MultiChar_Constant("smhd"): // Sound Media Header
 					/*
 					 balance	0
 					 */
 					break;
 					
-				case 0x64726566: // 'dref' Data Reference Box
+				case MultiChar_Constant("dref"): // Data Reference Box
 					/*
 					 url
 					 */
 					break;
 					
-				case 0x73747364: // 'stsd' Sample Description Box
+				case MultiChar_Constant("stsd"): // Sample Description Box
 					parseSampleDescriptionBox(next,indent);
 					break;
 					
-				case 0x73747473: // 'stts' DecodingTimeToSample
+				case MultiChar_Constant("stts"): // DecodingTimeToSample
 					break;
-				case 0x73747363: // 'stsc' SampleToChunkBox
+				case MultiChar_Constant("stsc"): //  SampleToChunkBox
 					break;
-				case 0x7374737A: // 'stsz' SampleSizeBoxes
+				case MultiChar_Constant("stsz"): //  SampleSizeBoxes
 					break;
-				case 0x7374636F: // 'stco' ChunkOffsets
+				case MultiChar_Constant("stco"): //  ChunkOffsets
 					break;
-				case 0x73747373: // 'stss' Sync Sample
+				case MultiChar_Constant("stss"): //  Sync Sample
 					break;
-				case 0x70726674: // 'prft' ProducerReferenceTime
+				case MultiChar_Constant("prft"): //  ProducerReferenceTime
 					break;
-				case 0x65647473: // 'edts' Edit Box
+				case MultiChar_Constant("edts"): //  Edit Box
 					break;
-				case 0x6669656C: // 'fiel'
+				case MultiChar_Constant("fiel"): 
 					break;
-				case 0x636F6C72: // 'colr' Color Pattern Atom
+				case MultiChar_Constant("colr"): // Color Pattern Atom
 					break;
-				case 0x70617370: // 'pasp': // Pixel Aspect Ratio
+				case MultiChar_Constant("pasp"): // Pixel Aspect Ratio
 					/*
 					00 00 04 f0 // hSpacing
 					00 00 04 ef // vSpacing
 					*/
 					break;
-				case 0x62747274: // 'btrt' Buffer Time to Render Time
+				case MultiChar_Constant("btrt"): // Buffer Time to Render Time
 					/*
 					00 02 49 f0 // bufferSizeDB
 					00 16 db 90 // maxBitrate
@@ -606,25 +613,25 @@ private:
 					*/
 					break;
 					
-				case 0x73747970: // 'styp' Segment Type Box
-				case 0x73696478: // 'sidx' Segment Index Box
-				case 0x75647461: // 'udta': // User Data Box
-				case 0x6D646174: // 'mdat': // Movie Data Box
+				case MultiChar_Constant("styp"): // Segment Type Box
+				case MultiChar_Constant("sidx"): // Segment Index Box
+				case MultiChar_Constant("udta"): // User Data Box
+				case MultiChar_Constant("mdat"): // Movie Data Box
 					break;
 
-				case 0x6D6F6F66: // 'moof': // Movie Fragment Box
+				case MultiChar_Constant("moof"):  // Movie Fragment Box
 					moof_ptr = ptr-8;
 					DemuxHelper(next, indent+1 ); // walk children
 					break;
 					
-				case 0x74726166: // 'traf' Track Fragment Boxes
-				case 0x6D6F6F76: // 'moov' Movie Boxes
-				case 0x7472616B: // 'trak' Track Box
-				case 0x6D696E66: // 'minf' Media Information Container
-				case 0x64696E66: // 'dinf' Data Information Box
-				case 0x6D766578: // 'mvex' Movie Extends Box
-				case 0x6D646961: // 'mdia' Media Box
-				case 0x7374626C: // 'stbl' Sample Table Box
+				case MultiChar_Constant("traf"): //  Track Fragment Boxes
+				case MultiChar_Constant("moov"): //  Movie Boxes
+				case MultiChar_Constant("trak"): //  Track Box
+				case MultiChar_Constant("minf"): //  Media Information Container
+				case MultiChar_Constant("dinf"): //  Data Information Box
+				case MultiChar_Constant("mvex"): //  Movie Extends Box
+				case MultiChar_Constant("mdia"): //  Media Box
+				case MultiChar_Constant("stbl"): //  Sample Table Box
 					DemuxHelper(next, indent+1 ); // walk children
 					break;
 										

--- a/test/utests/tests/DrmOcdm/DrmHelperTests.cpp
+++ b/test/utests/tests/DrmOcdm/DrmHelperTests.cpp
@@ -28,7 +28,7 @@
 #include <iterator>
 #include "base64.h"
 #include "AampConfig.h"
-
+#include "../../../gstTestHarness/mp4demux.hpp"
 #include "DrmHelper.h"
 
 #include "DrmTestUtils.h"
@@ -411,16 +411,16 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		},
 		{ "AAAAJnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAZI89yVmwY=", // psshData
 			{},
-			'cens'
+			MultiChar_Constant("cens")
 		},
 		{ "AAAAJnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAZIscaJmwY=", // psshData
 			{},
-			'cbc1'
+			MultiChar_Constant("cbc1")
 		},
 		{ "AAAAPnBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB4iFnNoYWthX2NlYzJmNjRhYTc4OTBhMTFI49yVmwY=", // psshData
 			{
 				"0x73,0x68,0x61,0x6B,0x61,0x5F,0x63,0x65,0x63,0x32,0x66,0x36,0x34,0x61,0x61,0x37,0x38,0x39,0x30,0x61,0x31,0x31"
-			}, 'cenc'
+			}, MultiChar_Constant("cenc")
 			// Version 0, AES-CTR full sample encryption
 			// no key ids!
 			// Content ID = shaka_cec2f64aa7890a11
@@ -434,13 +434,13 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		{ "AAAAOHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABgSEC22xI0wH0jqu3cbp6iskEJI49yVmwY=", // psshData
 			{
 				"0x2D,0xB6,0xC4,0x8D,0x30,0x1F,0x48,0xEA,0xBB,0x77,0x1B,0xA7,0xA8,0xAC,0x90,0x42"
-			},'cenc'
+			},MultiChar_Constant("cenc")
 			// Version 0, 'cenc'
 		},
 		{ "AAAAOHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABgSEC22xI0wH0jqu3cbp6iskEJI88aJmwY=", // psshData
 			{
 				"0x2D,0xB6,0xC4,0x8D,0x30,0x1F,0x48,0xEA,0xBB,0x77,0x1B,0xA7,0xA8,0xAC,0x90,0x42"
-			},'cbcs'
+			},MultiChar_Constant("cbcs")
 			// Version 0, 'cbcs'
 		},
 		{ "AAAARHBzc2gBAAAA7e+LqXnWSs6jyCfc1R0h7QAAAAIAAAAAAAAAAAAAAAAAAAAAEREREREREREREREREREREQAAAAA=", // psshData
@@ -453,7 +453,7 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		{"AAAAP3Bzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAAB8SEFYWbwTmlTrikzbYc0PLv+IaBWV6ZHJtSPPGiZsG", // psshData
 			{
 				"0x56,0x16,0x6f,0x04,0xe6,0x95,0x3a,0xe2,0x93,0x36,0xd8,0x73,0x43,0xcb,0xbf,0xe2"
-			},'cbcs'
+			},MultiChar_Constant("cbcs")
 			// Protection Scheme: 63 62 63 73 (cbcs)
 			// Provider: ezdrm
 		},
@@ -497,7 +497,7 @@ TEST_F(DrmHelperTests, TestWidevineHelperParsePsshDrmMetaData)
 		{"AAAAOHBzc2gAAAAA7e+LqXnWSs6jyCfc1R0h7QAAABgSEABFDiYaE6QUtKoKcLv0s6hI49yVmwY=", // psshData
 			{
 				"0x00,0x45,0x0e,0x26,0x1a,0x13,0xa4,0x14,0xb4,0xaa,0x0a,0x70,0xbb,0xf4,0xb3,0xa8"
-			},'cenc'
+			},MultiChar_Constant("cenc")
 			// Protection Scheme: 63 65 6E 63 (cenc)
 			// AES-CTR full sample encryption
 		}


### PR DESCRIPTION
Reason for change: : Rectified Multi char Warnings issues in L1.

Test Procedure:  Refer VPLAY-9707 for clearing warnings due to type conversion errors.
Priority: P2


Signed-off-by: srikanthreddybijjam-comcast<srikanthreddybijjam.2000@gmail.com>