### PR TITLE
VPLAY-9935 warning: initialized lambda captures are a C++14 extension…

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8776,7 +8776,9 @@ void StreamAbstractionAAMP_MPD::PushEncryptedHeaders(std::map<int, std::string>&
 		{
 			// Download the video, audio & subtitle fragments in a separate parallel thread.
 			AAMPLOG_DEBUG("Submitting job for init encrypted header track %d", it->first);
-			mTrackWorkers[it->first]->SubmitJob([this, track = it->first, header = it->second]() { CacheEncryptedHeader(track, header); });
+			auto track = it->first;
+			auto header = it->second;
+			mTrackWorkers[it->first]->SubmitJob([this, track, header]() { CacheEncryptedHeader(track, header); });
 		}
 		else
 		{


### PR DESCRIPTION
VPLAY-9935 warning: initialized lambda captures are a C++14 extension…

Reason for Change: address longstanding compilation warning

Test Procedure: compilation warning no longer seen
Risks: Low