### PR TITLE
VPLAY-10116 FakePrivateInstance includes implementation that can crash

### DIFF
--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -316,8 +316,8 @@ void PrivateInstanceAAMP::ResumeDownloads()
 
 void PrivateInstanceAAMP::EnableDownloads()
 {
-	mDownloadsEnabled = true;
-	mDownloadsDisabled.notify_all(); // Signal the condition variable
+//	mDownloadsEnabled = true;
+//	mDownloadsDisabled.notify_all(); // Signal the condition variable
 }
 
 void PrivateInstanceAAMP::AcquireStreamLock()
@@ -643,7 +643,7 @@ void PrivateInstanceAAMP::StoreLanguageList(const std::set<std::string> &langlis
 
 bool PrivateInstanceAAMP::DownloadsAreEnabled(void)
 {
-	bool retVal = mDownloadsEnabled;
+	bool retVal = false;//mDownloadsEnabled;
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
 		retVal = g_mockPrivateInstanceAAMP->DownloadsAreEnabled();
@@ -794,12 +794,12 @@ void PrivateInstanceAAMP::CurlTerm(AampCurlInstance startIdx, unsigned int insta
 void PrivateInstanceAAMP::DisableDownloads(void)
 {
 	std::lock_guard<std::recursive_mutex> guard(mLock);
-	mDownloadsEnabled = true;
+//	mDownloadsEnabled = true;
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
 		g_mockPrivateInstanceAAMP->DisableDownloads();
 	}
-	mDownloadsDisabled.notify_all(); // Signal the condition variable
+//	mDownloadsDisabled.notify_all(); // Signal the condition variable
 }
 
 int PrivateInstanceAAMP::GetInitialBufferDuration()
@@ -1631,7 +1631,6 @@ bool PrivateInstanceAAMP::isDecryptClearSamplesRequired()
 void PrivateInstanceAAMP::ResetTrickStartUTCTime()
 {
 }
-
 
 void PrivateInstanceAAMP::SetLLDashChunkMode(bool enable)
 {

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -316,8 +316,6 @@ void PrivateInstanceAAMP::ResumeDownloads()
 
 void PrivateInstanceAAMP::EnableDownloads()
 {
-//	mDownloadsEnabled = true;
-//	mDownloadsDisabled.notify_all(); // Signal the condition variable
 }
 
 void PrivateInstanceAAMP::AcquireStreamLock()
@@ -483,12 +481,11 @@ std::string PrivateInstanceAAMP::GetAvailableAudioTracks(bool allTrack)
 	}else {
 		return "";
 	}
-
 }
 
 std::string PrivateInstanceAAMP::GetVideoRectangle()
 {
-	std::string video = "videorectangel";
+	std::string video = "VideoRectangle";
 	return video;
 }
 
@@ -498,7 +495,7 @@ void PrivateInstanceAAMP::SetAppName(std::string name)
 
 std::string PrivateInstanceAAMP::GetAppName()
 {
-	std::string name = "appName";
+	std::string name = "AppName";
 	return name;
 }
 
@@ -522,7 +519,7 @@ void PrivateInstanceAAMP::SetTextStyle(const std::string &options)
 
 std::string PrivateInstanceAAMP::GetTextStyle()
 {
-	std::string result = "sampleStyle";
+	std::string result = "TextStyle";
 	return result;
 }
 
@@ -643,7 +640,7 @@ void PrivateInstanceAAMP::StoreLanguageList(const std::set<std::string> &langlis
 
 bool PrivateInstanceAAMP::DownloadsAreEnabled(void)
 {
-	bool retVal = false;//mDownloadsEnabled;
+	bool retVal = false;
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
 		retVal = g_mockPrivateInstanceAAMP->DownloadsAreEnabled();
@@ -793,13 +790,10 @@ void PrivateInstanceAAMP::CurlTerm(AampCurlInstance startIdx, unsigned int insta
 
 void PrivateInstanceAAMP::DisableDownloads(void)
 {
-	std::lock_guard<std::recursive_mutex> guard(mLock);
-//	mDownloadsEnabled = true;
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
 		g_mockPrivateInstanceAAMP->DisableDownloads();
 	}
-//	mDownloadsDisabled.notify_all(); // Signal the condition variable
 }
 
 int PrivateInstanceAAMP::GetInitialBufferDuration()

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -1752,8 +1752,7 @@ TEST_F(PlayerInstanceAAMPTests, SetTextStyleTest)
     mPlayerInstance->SetTextStyle(options);
 }
 TEST_F(PlayerInstanceAAMPTests, GetTextStyleTest){
-    
-    const std::string expectedTextStyle = "sampleStyle";
+    const std::string expectedTextStyle = "TextStyle";
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_PLAYING));
     std::string result = mPlayerInstance->GetTextStyle();
     EXPECT_STREQ(expectedTextStyle.c_str(),result.c_str());
@@ -1993,11 +1992,10 @@ TEST_F(PlayerInstanceAAMPTests, SetRuntimeDRMConfigSupportTest2)
     mPlayerInstance->SetRuntimeDRMConfigSupport(DynamicDRMSupported);
 }
 TEST_F(PlayerInstanceAAMPTests, GetVideoRectangleTest) {
-     std::string expectedRectangle = "videorectangel";
-
-    EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_PLAYING));
-    std::string videoRectangle = mPlayerInstance->GetVideoRectangle();
-   EXPECT_STREQ(expectedRectangle.c_str(),videoRectangle.c_str());
+	std::string expectedRectangle = "VideoRectangle";
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_PLAYING));
+	std::string videoRectangle = mPlayerInstance->GetVideoRectangle();
+	EXPECT_STREQ(expectedRectangle.c_str(),videoRectangle.c_str());
 }
 TEST_F(PlayerInstanceAAMPTests, GetThumbnailsTest)
 {


### PR DESCRIPTION
VPLAY-10116 FakePrivateInstance includes implementation that can crash at runtime

100% reproducible crash in xcode running (for example) AdManagerMPDTests.
Issue seen in FakePrivateInstanceAAMP, PrivateInstanceAAMP::DownloadsAreEnabled

As a fake module, this is meant to include only stub implementation to avoid linker problems - not expected to be functional. But there are few methods that reference member state.