### PR TITLE
VPLAY-9946: L1 errors fixed

### DIFF
--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -575,6 +575,8 @@ TEST_P(MediaTrackDashTrickModePtsRestampInvalidPlayRateTests, InvalidPlayRateTes
 	// There should be no PTS restamping for normal play rate media fragments in this test
 	EXPECT_CALL(*g_mockIsoBmffHelper, RestampPts(_, _, _, _, _)).Times(0);
 
+		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_OverrideMediaHeaderDuration))
+		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -183,7 +183,8 @@ public:
 			{eAAMPConfig_MPDDiscontinuityHandlingCdvr, true},
 			{eAAMPConfig_ForceMultiPeriodDiscontinuity, false},
 			{eAAMPConfig_SuppressDecode, false},
-			{eAAMPConfig_InterruptHandling, false}};
+			{eAAMPConfig_InterruptHandling, false},
+			{eAAMPConfig_OverrideMediaHeaderDuration, false}};
 
 	BoolConfigSettings mBoolConfigSettings;
 


### PR DESCRIPTION
Reason for change: Added expect call to failing tests Test Procedure: L1 tests should pass
Priority: P2
Risks:Low