### PR TITLE
VPLAY-9522 :SendNewSegmentEvent for mid fragment rampdown

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -925,6 +925,7 @@ public:
 	bool seamlessAudioSwitchInProgress; /**< Flag to indicate seamless audio track switch in progress */
 	bool seamlessSubtitleSwitchInProgress;
 	bool mCheckForRampdown;		        /**< flag to indicate if the track is undergoing rampdown or not */
+	bool shouldSendSegmentEvent;
 
 protected:
 	PrivateInstanceAAMP* aamp;          /**< Pointer to the PrivateInstanceAAMP*/

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1322,3 +1322,10 @@ void AAMPGstPlayer::StopMonitorAvTimer()
 		AAMPLOG_MIL("MonitorAvTimer stopped");
 	}
 }
+
+void AAMPGstPlayer::SendNewSegmentEvent(AampMediaType mediaType, double startPts, double stopPts)
+{
+	GstMediaType type = static_cast<GstMediaType>(mediaType);
+	GstClockTime sendingPts = (GstClockTime)(startPts*GST_SECOND);
+	playerInstance->SendNewSegmentEvent(type, sendingPts, 0 );
+}

--- a/aampgstplayer.h
+++ b/aampgstplayer.h
@@ -431,6 +431,8 @@ public:
 	 */
 	int GetMonitorAVInterval() const { return mMonitorAVInterval; }
 
+	void SendNewSegmentEvent(AampMediaType mediaType, double sendingPts, double stopPts);
+
 private:
 	std::mutex mBufferingLock;
 	id3_callback_t m_ID3MetadataHandler; /**< Function to call to generate the JS event for in ID3 packet */

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -750,6 +750,8 @@ public:
  	*/
 	virtual void NotifyInjectorToPause() {};
 
+	virtual void SendNewSegmentEvent( AampMediaType mediaType, double startPts, double stopPts) {};
+
 };
 
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13796,3 +13796,13 @@ double PrivateInstanceAAMP::GetFormatPositionOffsetInMSecs()
 	}
 	return offset;
 }
+
+void PrivateInstanceAAMP::SendNewSegmentEvent( AampMediaType mediaType, double startPts, double stopPts)
+{
+	AAMPLOG_WARN("RESHMA-->> CALLING GSTREAMER SENDNEWSEGMENTEVENT");
+	StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
+	if(sink)
+	{
+		sink->SendNewSegmentEvent(mediaType, startPts, stopPts);
+	}
+}

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -800,6 +800,7 @@ public:
 	 * This function is invoked continuously when ever there is an update in manifest
 	 */
 	void updateManifest(const char *manifestData);
+	void SendNewSegmentEvent( AampMediaType mediaType, double startPts, double stopPts);
 
 	bool mDiscontinuityFound;
 	int mTelemetryInterval;


### PR DESCRIPTION
Reason for change: SendNewSegmentEvent for mid fragment rampdown
Test Procedure: Updated in ticket
Risks: Medium