### PR TITLE
VPLAY-9810:Add droppedFrames to MonitorAV event

### DIFF
--- a/AampEvent.cpp
+++ b/AampEvent.cpp
@@ -152,12 +152,13 @@ float SpeedChangedEvent::getRate() const
  * @brief ProgressEvent Constructor
  *
  */
-ProgressEvent::ProgressEvent(double duration, double position, double start, double end, float speed, long long pts, double bufferedDuration, std::string seiTimecode, double liveLatency, long profileBandwidth, long networkBandwidth, double currentPlayRate, 
+ProgressEvent::ProgressEvent(double duration, double position, double start, double end, float speed, long long pts, double videoBufferedDuration, double audioBufferedDuration, std::string seiTimecode, double liveLatency, long profileBandwidth, long networkBandwidth, double currentPlayRate, 
 	std::string sid):
 		AAMPEventObject(AAMP_EVENT_PROGRESS, std::move(sid)), mDuration(duration),
 		mPosition(position), mStart(start),
 		mEnd(end), mSpeed(speed), mPTS(pts),
-		mBufferedDuration(bufferedDuration),
+		mVideoBufferedDurationMs(videoBufferedDuration),
+		mAudioBufferedDurationMs(audioBufferedDuration),
 		mSEITimecode(seiTimecode),
 		mLiveLatency(liveLatency),
 		mProfileBandwidth(profileBandwidth),
@@ -228,13 +229,23 @@ long long ProgressEvent::getPTS() const
 }
 
 /**
- * @brief Get Buffered Duration
+ * @brief Get Video Buffered Duration in milliseconds
  *
- * @return Buffered duration
+ * @return Video Buffered Duration
  */
-double ProgressEvent::getBufferedDuration() const
+double ProgressEvent::getVideoBufferedDuration() const
 {
-	return mBufferedDuration;
+	return mVideoBufferedDurationMs;
+}
+
+/**
+ * @brief Get Audio Buffered Duration in milliseconds
+ *
+ * @return Audio Buffered Duration
+ */
+double ProgressEvent::getAudioBufferedDuration() const
+{
+	return mAudioBufferedDurationMs;
 }
 
 /**
@@ -1632,9 +1643,9 @@ const std::string &TuneTimeMetricsEvent::getTuneMetricsData() const
 /**
  * @fn MonitorAVStatusEvent Constructor
  */
-MonitorAVStatusEvent::MonitorAVStatusEvent(const std::string &state, int64_t videoPosMs, int64_t audioPosMs, uint64_t timeInStateMs, std::string sid):
+MonitorAVStatusEvent::MonitorAVStatusEvent(const std::string &state, int64_t videoPosMs, int64_t audioPosMs, uint64_t timeInStateMs, std::string sid, uint64_t droppedFrames):
 		AAMPEventObject(AAMP_EVENT_MONITORAV_STATUS, std::move(sid)), mMonitorAVStatus(state), mVideoPositionMS(videoPosMs),
-		mAudioPositionMS(audioPosMs), mTimeInStateMS(timeInStateMs)
+		mAudioPositionMS(audioPosMs), mTimeInStateMS(timeInStateMs), mDroppedFrames(droppedFrames)
 {
 
 }
@@ -1677,4 +1688,14 @@ int64_t MonitorAVStatusEvent::getAudioPositionMS() const
 uint64_t MonitorAVStatusEvent::getTimeInStateMS() const
 {
 	return mTimeInStateMS;
+}
+
+/**
+ * @brief getDroppedFrames
+ *
+ * @return Dropped Frames Count
+ */
+uint64_t MonitorAVStatusEvent::getDroppedFrames() const
+{
+	return mDroppedFrames;
 }

--- a/AampEvent.h
+++ b/AampEvent.h
@@ -246,6 +246,7 @@ struct AAMPEvent
 			double endMilliseconds;      		/**< time shift buffer end position (relative to tune time - starts at zero) */
 			long long videoPTS; 			/**< Video Presentation 90 Khz time-stamp  */
 			double videoBufferedMilliseconds;	/**< current duration of buffered video ready to playback */
+			double audioBufferedMilliseconds;	/**< current duration of buffered audio ready to playback */
 			const char* timecode;			/**< SEI Timecode information */
 			double liveLatency;			/**< Live latency */
 			long profileBandwidth;      /**< Profile Bandwidth */
@@ -509,6 +510,7 @@ struct AAMPEvent
 			int64_t mVideoPositionMS;	/**< Video position in milliseconds */
 			int64_t mAudioPositionMS;	/**< Audio position in milliseconds */
 			uint64_t mTimeInStateMS;	/**< Time in the current state in milliseconds */
+			uint64_t mDroppedFrames;   /**< Dropped Frames Count */
 		} monitorAVStatus;
 	} data;
 
@@ -707,7 +709,8 @@ class ProgressEvent: public AAMPEventObject
 	double mEnd;			/**< time shift buffer end position (relative to tune time - starts at zero) in MS */
 	float mSpeed;			/**< current trick speed (1.0 for normal play rate) */
 	long long mPTS;			/**< Video Presentation 90 Khz time-stamp  */
-	double mBufferedDuration;	/**< current duration of buffered video ready to playback */
+	double mVideoBufferedDurationMs; /**< current duration of buffered video ready to playback */
+	double mAudioBufferedDurationMs; /**< current duration of buffered audio ready to playback */
 	std::string mSEITimecode;   	/**< SEI Timecode information */
 	double mLiveLatency;		/**< Live latency */
 	long mProfileBandwidth;     /**<Profile Bandwidth */
@@ -728,7 +731,8 @@ public:
 	 * @param[in]  end      - End Position
 	 * @param[in]  speed    - Current Speed
 	 * @param[in]  pts      - Video PTS
-	 * @param[in]  bufferedDuration - buffered duration
+	 * @param[in]  videobufferedDuration - video buffered duration in milliseconds
+	 * @param[in]  audiobufferedDuration - audio buffered duration in milliseconds
 	 * @param[in]  seiTimecode      - Time code
 	 * @param[in]  liveLatency      - Live latency
 	 * @param[in]  profileBandwidth - profile Bandwidth
@@ -736,7 +740,7 @@ public:
 	 * @param[in]  currentPlayRate - currentPlayRate
 
 	 */
-	ProgressEvent(double duration, double position, double start, double end, float speed, long long pts, double bufferedDuration, std::string seiTimecode, double liveLatency, long profileBandwidth, long networkBandwidth, double currentPlayRate, std::string sid);
+	ProgressEvent(double duration, double position, double start, double end, float speed, long long pts, double videoBufferedDuration, double AudioBufferedDuration, std::string seiTimecode, double liveLatency, long profileBandwidth, long networkBandwidth, double currentPlayRate, std::string sid);
 
 	/**
 	 * @brief ProgressEvent Destructor
@@ -777,12 +781,17 @@ public:
 	long long getPTS() const;
 
 	/**
-	 * @fn getBufferedDuration
+	 * @fn getVideoBufferedDuration in milliseconds
 	 */
-	double getBufferedDuration() const;
+	double getVideoBufferedDuration() const;
 
 	/**
-	 * @fn getSEITimeCode
+	 * @fn getAudioBufferedDuration in milliseconds
+	 */
+	double getAudioBufferedDuration() const;
+
+	/**
+	 * @fn getSEITimeCode in Milli Seconds
 	 */
 	const char* getSEITimeCode() const;
 
@@ -2399,6 +2408,7 @@ class MonitorAVStatusEvent: public AAMPEventObject
 	int64_t mVideoPositionMS;	/**< Video position in milliseconds */
 	int64_t mAudioPositionMS;	/**< Audio position in milliseconds */
 	uint64_t mTimeInStateMS;	/**< Time in the current state in milliseconds */
+	uint64_t mDroppedFrames;   /**< Dropped Frames Count */
 
 public:
 	MonitorAVStatusEvent() = delete;
@@ -2414,7 +2424,7 @@ public:
 	 * @param[in] timeInStateMS - Time in the current state in milliseconds
 	 * @param[in] sid - Session Identifier
 	 */
-	MonitorAVStatusEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, std::string sid);
+	MonitorAVStatusEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, std::string sid, uint64_t droppedFrames);
 
 	/**
 	 * @brief MonitorAVStatusEvent Destructor
@@ -2440,6 +2450,11 @@ public:
 	 * @fn getTimeInStateMS
 	 */
 	uint64_t getTimeInStateMS() const;
+
+	/**
+	 * @fn getDroppedFrames
+	 */
+	uint64_t getDroppedFrames() const;
 };
 
 

--- a/AampEventListener.cpp
+++ b/AampEventListener.cpp
@@ -67,7 +67,8 @@ static void GenerateLegacyAAMPEvent(const AAMPEventPtr &e, AAMPEvent &event)
 			event.data.progress.startMilliseconds = ev->getStart();
 			event.data.progress.endMilliseconds = ev->getEnd();
 			event.data.progress.videoPTS = ev->getPTS();
-			event.data.progress.videoBufferedMilliseconds = ev->getBufferedDuration();
+			event.data.progress.videoBufferedMilliseconds = ev->getVideoBufferedDuration();
+			event.data.progress.audioBufferedMilliseconds = ev->getAudioBufferedDuration();
 			event.data.progress.timecode = ev->getSEITimeCode();
 			event.data.progress.liveLatency = ev->getLiveLatency();
 			event.data.progress.profileBandwidth = ev->getProfileBandwidth();
@@ -310,6 +311,7 @@ static void GenerateLegacyAAMPEvent(const AAMPEventPtr &e, AAMPEvent &event)
 			event.data.monitorAVStatus.mVideoPositionMS = ev->getVideoPositionMS();
 			event.data.monitorAVStatus.mAudioPositionMS = ev->getAudioPositionMS();
 			event.data.monitorAVStatus.mTimeInStateMS = ev->getTimeInStateMS();
+			event.data.monitorAVStatus.mDroppedFrames = ev->getDroppedFrames();
 		}
 		default:
 			// Some events without payload also falls here, for now

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1764,6 +1764,13 @@ public:
 	double GetBufferedVideoDurationSec();
 
 	/**
+	 *   @fn GetBufferedAudioDurationSec
+	 *
+	 *   @return duration of currently buffered audio in seconds
+	 */
+	double GetBufferedAudioDurationSec();
+
+	/**
 	 *   @fn UpdateStreamInfoBitrateData
 	 *
 	 *   @param[in]  profileIndex - profile index of current fetched fragment
@@ -2067,7 +2074,7 @@ protected:
 	 *
 	 *   @return buffer value based on Local TSB
 	 */
-	double GetBufferValue(MediaTrack *video);
+	double GetBufferValue(MediaTrack *track);
 
 	/**
 	 *   @fn GetDesiredProfileBasedOnCache

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1281,10 +1281,12 @@ static gboolean MonitorAvTimerCallback(gpointer user_data)
 				{
 					timeInState = player->GetMonitorAVInterval(); // Cap to reporting interval
 				}
+				GstPlaybackQualityStruct* playbackQuality = player->playerInstance->GetVideoPlaybackQuality();
 				player->aamp->SendMonitorAvEvent(monitorAVState.description,
 						monitorAVState.av_position[eMEDIATYPE_VIDEO],
 						monitorAVState.av_position[eMEDIATYPE_AUDIO],
-						timeInState);
+						timeInState,
+						playbackQuality? playbackQuality->dropped : 0);
 			}
 		}
 	}

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -764,7 +764,11 @@ public:
 		JSStringRelease(name);
 
 		name = JSStringCreateWithUTF8CString("videoBufferedMiliseconds"); // FIXME
-		JSObjectSetProperty(context, eventObj, name, JSValueMakeNumber(context, evt->getBufferedDuration()), kJSPropertyAttributeReadOnly, NULL);
+		JSObjectSetProperty(context, eventObj, name, JSValueMakeNumber(context, evt->getVideoBufferedDuration()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(name);
+
+		name = JSStringCreateWithUTF8CString("audioBufferedMiliseconds"); // FIXME
+		JSObjectSetProperty(context, eventObj, name, JSValueMakeNumber(context, evt->getAudioBufferedDuration()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(name);
 
 		name = JSStringCreateWithUTF8CString("timecode");
@@ -2037,6 +2041,11 @@ public:
 		prop = JSStringCreateWithUTF8CString("timeInStateMs");
 		JSObjectSetProperty(context, eventObj, prop, JSValueMakeNumber(context, evt->getTimeInStateMS()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("droppedFrames");
+		JSObjectSetProperty(context, eventObj, prop, JSValueMakeNumber(context, evt->getDroppedFrames()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
 	}
 };
 /**

--- a/jsbindings/jseventlistener.cpp
+++ b/jsbindings/jseventlistener.cpp
@@ -120,7 +120,11 @@ public:
 		JSStringRelease(prop);
 
 		prop = JSStringCreateWithUTF8CString("videoBufferedMiliseconds");
-		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getBufferedDuration()), kJSPropertyAttributeReadOnly, NULL);
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getVideoBufferedDuration()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("audioBufferedMiliseconds");
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getAudioBufferedDuration()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
 
 		prop = JSStringCreateWithUTF8CString("timecode");
@@ -1675,6 +1679,10 @@ public:
 
 		prop = JSStringCreateWithUTF8CString("timeInStateMs");
 		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getTimeInStateMS()), kJSPropertyAttributeReadOnly, NULL);
+		JSStringRelease(prop);
+
+		prop = JSStringCreateWithUTF8CString("droppedFrames");
+		JSObjectSetProperty(p_obj->_ctx, jsEventObj, prop, JSValueMakeNumber(p_obj->_ctx, evt->getDroppedFrames()), kJSPropertyAttributeReadOnly, NULL);
 		JSStringRelease(prop);
 	}
 };

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2040,7 +2040,8 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 		double start = -1;
 		double end = -1;
 		long long videoPTS = -1;
-		double bufferedDuration = 0.0;
+		double videoBufferedDuration = 0.0;
+		double audioBufferedDuration = 0.0;
 		bool bProcessEvent = true;
 		double latency = 0;
 
@@ -2088,8 +2089,10 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			std::lock_guard<std::recursive_mutex> guard(mStreamLock);
 			if (mpStreamAbstractionAAMP)
 			{
-				bufferedDuration = mpStreamAbstractionAAMP->GetBufferedVideoDurationSec() * 1000.0;
+				videoBufferedDuration = mpStreamAbstractionAAMP->GetBufferedVideoDurationSec() * 1000.0;
+				audioBufferedDuration = mpStreamAbstractionAAMP->GetBufferedAudioDurationSec() * 1000.0;
 			}
+
 		}
 		if ((mReportProgressPosn == position) && !pipeline_paused && beginningOfStream != true)
 		{
@@ -2142,7 +2145,7 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			// update available buffer to Manifest refresh cycle .
 			if(mMPDDownloaderInstance != nullptr)
 			{
-				mMPDDownloaderInstance->SetBufferAvailability((int)bufferedDuration);
+				mMPDDownloaderInstance->SetBufferAvailability((int)videoBufferedDuration);
 				mMPDDownloaderInstance->SetCurrentPositionDeltaToManifestEnd(CurrentPositionDeltaToManifestEnd);
 			}
 		}
@@ -2184,7 +2187,7 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			bps = mpStreamAbstractionAAMP->GetVideoBitrate();
 		}
 
-		ProgressEventPtr evt = std::make_shared<ProgressEvent>(duration, reportFormattedCurrPos, start, end, speed, videoPTS, bufferedDuration, seiTimecode.c_str(), latency, bps, mNetworkBandwidth, currentRate, GetSessionId());
+		ProgressEventPtr evt = std::make_shared<ProgressEvent>(duration, reportFormattedCurrPos, start, end, speed, videoPTS, videoBufferedDuration, audioBufferedDuration, seiTimecode.c_str(), latency, bps, mNetworkBandwidth, currentRate, GetSessionId());
 
 		if (trickStartUTCMS >= 0 && (bProcessEvent || mFirstProgress))
 		{
@@ -2198,7 +2201,7 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			if(mAampLLDashServiceData.lowLatencyMode && mConfig->GetConfigOwner(eAAMPConfig_InfoLogging) == AAMP_DEFAULT_SETTING)
 			{
 				int abrMinBuffer = AAMP_BUFFER_MONITOR_GREEN_THRESHOLD_LLD;
-				bool bufferBelowMin = bufferedDuration < (abrMinBuffer * 1000);
+				bool bufferBelowMin = videoBufferedDuration < (abrMinBuffer * 1000);
 
 				if (bufferBelowMin && !mIsLoggingNeeded)
 				{
@@ -2219,12 +2222,13 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 				int divisor = GETCONFIGVALUE_PRIV(eAAMPConfig_ProgressLoggingDivisor);
 				if( divisor==0 || (tick++ % divisor) == 0 )
 				{
-					AAMPLOG_MIL("aamp pos: [%ld..%ld..%ld..%lld..%.2f..%.2f..%s..%ld..%ld..%.2f]",
+					AAMPLOG_MIL("aamp pos: [%ld..%ld..%ld..%lld..%.2f..%.2f..%.2f..%s..%ld..%ld..%.2f]",
 						(long)(start / 1000),
 						(long)(reportFormattedCurrPos / 1000),
 						(long)(end / 1000),
 						(long long) videoPTS,
-						(double)(bufferedDuration / 1000.0),
+						(double)(videoBufferedDuration / 1000.0),
+						(double)(audioBufferedDuration /1000.0),
 						(latency / 1000),
 						seiTimecode.c_str(),
 						bps,
@@ -2238,7 +2242,7 @@ void PrivateInstanceAAMP::ReportProgress(bool sync, bool beginningOfStream)
 			if(mTelemetryInterval > 0 && (diff > mTelemetryInterval))
 			{
 				mLastTelemetryTimeMS = currTimeMS;
-				profiler.SetLatencyParam(latency, (double)(bufferedDuration/1000.0), currentRate, mNetworkBandwidth);
+				profiler.SetLatencyParam(latency, (double)(videoBufferedDuration/1000.0), currentRate, mNetworkBandwidth);
 				profiler.GetTelemetryParam();
 			}
 
@@ -13779,15 +13783,16 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
  * @param[in] videoPositionMS - video position in milliseconds
  * @param[in] audioPositionMS - audio position in milliseconds
  * @param[in] timeInStateMS - time in state in milliseconds
+ * @param[in] droppedFrames - dropped frames count
  * @details This function sends a MonitorAVStatusEvent to the event manager.
  * It is used to monitor the audio and video status during playback.
  * It is called when the playback is enabled (mbPlayEnabled is true).
  */
-void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
+void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, uint64_t droppedFrames)
 {
 	if(mbPlayEnabled)
 	{
-		MonitorAVStatusEventPtr evt = std::make_shared<MonitorAVStatusEvent>(status, videoPositionMS, audioPositionMS, timeInStateMS, GetSessionId());
+		MonitorAVStatusEventPtr evt = std::make_shared<MonitorAVStatusEvent>(status, videoPositionMS, audioPositionMS, timeInStateMS, GetSessionId(), droppedFrames);
 		mEventManager->SendEvent(evt, AAMP_EVENT_SYNC_MODE);
 	}
 }

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3868,8 +3868,9 @@ public:
 	 * @param[in] videoPositionMS - video position in milliseconds
 	 * @param[in] audioPositionMS - audio position in milliseconds
 	 * @param[in] timeInStateMS - time in state in milliseconds
+	 * @param[in] droppedFrames - dropped frames count
 	 */
-	void SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS);
+	void SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, uint64_t droppedFrames);
 
 	/**
 	 * @brief Determines if decrypt should be called on clear samples

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2440,22 +2440,22 @@ void StreamAbstractionAAMP::ConfigureTimeoutOnBuffer()
 /**
  *  @brief Update rampdown profile on network failure
  */
-double StreamAbstractionAAMP::GetBufferValue(MediaTrack *video)
+double StreamAbstractionAAMP::GetBufferValue(MediaTrack *track)
 {
 	double bufferValue = 0.0;
-	if (video)
+	if (track)
 	{
-		bufferValue = video->GetBufferedDuration();
-		if (aamp->IsLocalAAMPTsb() && video->IsLocalTSBInjection()) /**< Update buffer value based on manifest endDelta if it is LOCAL TSB LLD playback*/
+		bufferValue = track->GetBufferedDuration();
+		if (aamp->IsLocalAAMPTsb() && track->IsLocalTSBInjection()) /**< Update buffer value based on manifest endDelta if it is LOCAL TSB LLD playback*/
 		{
 			AampTSBSessionManager *tsbSessionManager = aamp->GetTSBSessionManager();
 			if(tsbSessionManager)
 			{
 				double manifestEndDelta = tsbSessionManager->GetManifestEndDelta();
 				bufferValue = (manifestEndDelta + aamp->mLiveOffset); /**< Buffer should be calculated from live offset*/
-				bufferValue += video->fragmentDurationSeconds; /**< Adjust with last fragment; One fragment may be downloading and not yet completed*/
+				bufferValue += track->fragmentDurationSeconds; /**< Adjust with last fragment; One fragment may be downloading and not yet completed*/
 				AAMPLOG_INFO("Inverse Buffer (%.02lf)sec based on TSB end point delta (%.02lf)sec and live offset (%.02lf)sec and fragmentDuration for adjust (%.02lf)sec !!",
-							 bufferValue, manifestEndDelta, aamp->mLiveOffset, video->fragmentDurationSeconds);
+							 bufferValue, manifestEndDelta, aamp->mLiveOffset, track->fragmentDurationSeconds);
 				if(bufferValue < 0) /** Correct the inverse buffer; it may become -ve*/
 				{
 					bufferValue = 0;
@@ -3651,6 +3651,25 @@ double StreamAbstractionAAMP::GetBufferedVideoDurationSec()
 	if(video)
 	{
 		bufferValue = GetBufferValue(video);
+	}
+	return bufferValue;
+}
+
+/**
+ *  @brief Get buffered audio duration in seconds
+ */
+double StreamAbstractionAAMP::GetBufferedAudioDurationSec()
+{
+	double bufferValue = -1.0;
+	// do not support trickplay track
+	if(AAMP_NORMAL_PLAY_RATE != aamp->rate)
+	{
+		return bufferValue;
+	}
+	MediaTrack *audio = GetMediaTrack(eTRACK_AUDIO);
+	if(audio)
+	{
+		bufferValue = GetBufferValue(audio);
 	}
 	return bufferValue;
 }

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -543,7 +543,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 						snprintf( seekableRange, sizeof(seekableRange), "[start=%.3fs end=%.3fs]", start/1000.0, end/1000.0 );
 					}
 
-					printf("[AAMPCLI] AAMP_EVENT_PROGRESS duration=%.3fs position=%.3fs seekableRange%s currRate=%.3f bufferedDuration=%.3fs PTS=%lld timecode='%s' latency=%.3fs profileBandwidth=%ld networkBandwidth=%ld currentPlayRate=%.3f sessionId='%s'\n", ev->getDuration()/1000.0, ev->getPosition()/1000.0, seekableRange, ev->getSpeed(), ev->getBufferedDuration()/1000.0, ev->getPTS(), ev->getSEITimeCode(), ev->getLiveLatency()/1000.0, ev->getProfileBandwidth(), ev->getNetworkBandwidth(), ev->getCurrentPlayRate(), ev->GetSessionId().c_str());
+					printf("[AAMPCLI] AAMP_EVENT_PROGRESS duration=%.3fs position=%.3fs seekableRange%s currRate=%.3f bufferedVideoDuration=%.3fs bufferedAudioDuration=%.3fs  PTS=%lld timecode='%s' latency=%.3fs profileBandwidth=%ld networkBandwidth=%ld currentPlayRate=%.3f sessionId='%s'\n", ev->getDuration()/1000.0, ev->getPosition()/1000.0, seekableRange, ev->getSpeed(), ev->getVideoBufferedDuration()/1000.0, ev->getAudioBufferedDuration()/1000.0, ev->getPTS(), ev->getSEITimeCode(), ev->getLiveLatency()/1000.0, ev->getProfileBandwidth(), ev->getNetworkBandwidth(), ev->getCurrentPlayRate(), ev->GetSessionId().c_str());
 				}
 			}
 			break;
@@ -734,7 +734,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		case AAMP_EVENT_MONITORAV_STATUS:
 		{
 			MonitorAVStatusEventPtr ev = std::dynamic_pointer_cast<MonitorAVStatusEvent>(e);
-			printf("[AAMPCLI] AAMP_EVENT_MONITORAV_STATUS\tstatus=%s\tvposition =%" PRId64 "\taposition=%" PRId64 "\ttimeInStateMS= %" PRIu64 "\n", ev->getMonitorAVStatus().c_str(), ev->getVideoPositionMS(), ev->getAudioPositionMS(), ev->getTimeInStateMS());
+			printf("[AAMPCLI] AAMP_EVENT_MONITORAV_STATUS\tstatus=%s\tvposition =%" PRId64 "\taposition=%" PRId64 "\ttimeInStateMS= %" PRIu64 "\tdroppedFrames= %" PRIu64 "\n", ev->getMonitorAVStatus().c_str(), ev->getVideoPositionMS(), ev->getAudioPositionMS(), ev->getTimeInStateMS(), ev->getDroppedFrames());
 		}
 		case AAMP_EVENT_REPORT_ANOMALY:
 		{

--- a/test/utests/fakes/FakeAampEvent.cpp
+++ b/test/utests/fakes/FakeAampEvent.cpp
@@ -257,7 +257,7 @@ bool BufferingChangedEvent::buffering() const
 	return false;
 }
 
-ProgressEvent::ProgressEvent(double duration, double position, double start, double end, float speed, long long pts, double bufferedDuration, std::string seiTimecode,double liveLatency, long profileBandwidth, long networkBandwidth, double currentPlayRate, std::string sid):
+ProgressEvent::ProgressEvent(double duration, double position, double start, double end, float speed, long long pts, double videoBufferedDuration, double audioBufferedDuration, std::string seiTimecode,double liveLatency, long profileBandwidth, long networkBandwidth, double currentPlayRate, std::string sid):
 		AAMPEventObject(AAMP_EVENT_PROGRESS, std::move(sid))
 {
 }
@@ -267,7 +267,8 @@ double ProgressEvent::getPosition(void) const{ return 0.0; }
 double ProgressEvent::getLiveLatency(void) const{ return 0.0; }
 const char* ProgressEvent::getSEITimeCode(void) const{ return NULL; }
 double ProgressEvent::getCurrentPlayRate(void) const{ return 0.0; }
-double ProgressEvent::getBufferedDuration(void) const{ return 0.0; }
+double ProgressEvent::getVideoBufferedDuration(void) const{ return 0.0; }
+double ProgressEvent::getAudioBufferedDuration(void) const{ return 0.0; }
 long ProgressEvent::getNetworkBandwidth(void) const{ return 0; }
 long ProgressEvent::getProfileBandwidth(void) const{ return 0; }
 double ProgressEvent::getEnd(void) const{ return 0.0; }
@@ -544,9 +545,9 @@ const std::string &MetricsDataEvent::getMetricsData() const { return mMetricsDat
 
 /**
  * @fn MonitorAVStatusEvent Constructor                                                                                               */
-MonitorAVStatusEvent::MonitorAVStatusEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, std::string sid):
+MonitorAVStatusEvent::MonitorAVStatusEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, std::string sid, uint64_t droppedFrames):
 		AAMPEventObject(AAMP_EVENT_MONITORAV_STATUS, std::move(sid)), mMonitorAVStatus(status), mVideoPositionMS(videoPositionMS),
-		mAudioPositionMS(audioPositionMS), mTimeInStateMS(timeInStateMS)
+		mAudioPositionMS(audioPositionMS), mTimeInStateMS(timeInStateMS), mDroppedFrames(droppedFrames)
 {
 }
 
@@ -588,4 +589,14 @@ int64_t MonitorAVStatusEvent::getAudioPositionMS() const
 uint64_t MonitorAVStatusEvent::getTimeInStateMS() const
 {
 	return mTimeInStateMS;
+}
+
+/**
+ * @brief getDroppedFrames
+ *
+ * @return Dropped Frames Count
+ */
+uint64_t MonitorAVStatusEvent::getDroppedFrames() const
+{
+	return mDroppedFrames;
 }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1684,7 +1684,7 @@ double PrivateInstanceAAMP::GetStreamPositionMs()
 	return 0.0;
 }
 
-void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS)
+void PrivateInstanceAAMP::SendMonitorAvEvent(const std::string &status, int64_t videoPositionMS, int64_t audioPositionMS, uint64_t timeInStateMS, uint64_t droppedFrames)
 {
 }
 double PrivateInstanceAAMP::GetFormatPositionOffsetInMSecs()

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -49,6 +49,11 @@ double StreamAbstractionAAMP::GetBufferedVideoDurationSec()
 	return 0.0;
 }
 
+double StreamAbstractionAAMP::GetBufferedAudioDurationSec()
+{
+	return 0.0;
+}
+
 void StreamAbstractionAAMP::MuteSubtitles(bool mute)
 {
 	if (g_mockStreamAbstractionAAMP != nullptr)
@@ -371,7 +376,7 @@ void MediaTrack::AbortWaitForCachedFragmentChunk()
 {
 }
 
-double StreamAbstractionAAMP::GetBufferValue(MediaTrack *video)
+double StreamAbstractionAAMP::GetBufferValue(MediaTrack *track)
 {
 	return 0;
 }

--- a/test/utests/tests/AampEventTests/AampEventTests.cpp
+++ b/test/utests/tests/AampEventTests/AampEventTests.cpp
@@ -158,7 +158,8 @@ protected:
             2000.0,   // end
             1.0,      // speed
             1234567,  // pts
-            800.0,    // buffered duration
+            800.0,    // video buffered duration
+            800.0,    // audio buffered duration
             "00:00:00:00",  // sei timecode
             5.0,      // live latency
             500,   // profile bandwidth
@@ -183,7 +184,8 @@ TEST_F(ProgressEventTest, GetFunctionsTest) {
     EXPECT_DOUBLE_EQ(progressEvent->getEnd(), 2000.0);
     EXPECT_FLOAT_EQ(progressEvent->getSpeed(), 1.0);
     EXPECT_EQ(progressEvent->getPTS(), 1234567);
-    EXPECT_DOUBLE_EQ(progressEvent->getBufferedDuration(), 800.0);
+    EXPECT_DOUBLE_EQ(progressEvent->getVideoBufferedDuration(), 800.0);
+    EXPECT_DOUBLE_EQ(progressEvent->getAudioBufferedDuration(), 800.0);
     EXPECT_STREQ(progressEvent->getSEITimeCode(), "00:00:00:00");
     EXPECT_DOUBLE_EQ(progressEvent->getLiveLatency(), 5.0);
     EXPECT_EQ(progressEvent->getProfileBandwidth(), 500);
@@ -1092,7 +1094,8 @@ protected:
 		videoPositionMS = 3717;
 		audioPositionMS = 3717;
 		timeInStateMS = 1748499898430;
-		monitorEvent = new MonitorAVStatusEvent(status,videoPositionMS,audioPositionMS,timeInStateMS,session_id);
+		droppedFrames = 0;
+		monitorEvent = new MonitorAVStatusEvent(status,videoPositionMS,audioPositionMS,timeInStateMS,session_id,droppedFrames);
 	}
 
 	void TearDown() override {
@@ -1104,6 +1107,7 @@ protected:
 	int64_t videoPositionMS;
 	int64_t audioPositionMS;
 	uint64_t timeInStateMS;
+	uint64_t droppedFrames;
 };
 
 TEST_F(MonitorAVStatusEventTest, ConstructorTest){
@@ -1111,4 +1115,5 @@ TEST_F(MonitorAVStatusEventTest, ConstructorTest){
 	EXPECT_EQ(monitorEvent->getVideoPositionMS(), videoPositionMS);
 	EXPECT_EQ(monitorEvent->getAudioPositionMS(), audioPositionMS);
 	EXPECT_EQ(monitorEvent->getTimeInStateMS(), timeInStateMS);
+	EXPECT_EQ(monitorEvent->getDroppedFrames(), droppedFrames);
 }


### PR DESCRIPTION
Reason for change:Added audio buffered duration as a part of mediaprogress event and dropped frames as part of monitorav event Risks: Low
Test Procedure: Refer jira ticket
Priority: P2

Signed-off-by: varshnie varshniblue14@gmail.com