### PR TITLE
RDK-58442: Interim switch off of Secmanager Config

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -860,8 +860,7 @@ void AampConfig::ApplyDeviceCapabilities()
 	SetConfigValue(AAMP_DEFAULT_SETTING, eAAMPConfig_WifiCurlHeader, IsWifiCurlHeader);
 
 	bool isSecMgr = isSecManagerEnabled();
-	SetConfigValue(AAMP_DEFAULT_SETTING, eAAMPConfig_UseSecManager, isSecMgr);
-
+	SetConfigValue(AAMP_DEFAULT_SETTING, eAAMPConfig_UseSecManager, false); //Note: Workaround for DTM-4118 changes to be merged independently and no impact on secmanager license acquistion while playback testing. Will be reverted once RDK-56194 changes merged
 }
 
 std::string AampConfig::GetUserAgentString()


### PR DESCRIPTION
Reason for change: Interim change to avoid playback failure and allow DTM-4118 changes to be merged independently
		   as it replaces shared memory message passing of license metadata to string format.
		   Will be removed once RDK-56194 landed on sprint

Test Procedure: Encrypted Playback should pass
Risks: Low
Priority: P1