### PR TITLE
VPLAY-10194 -AAMP Tune() leaking mCdaiObject Object

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6118,12 +6118,8 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 		mfirstTuneFmt = (int)mMediaFormat;
 	}
 
-	if(mCdaiObject != NULL)
-	{
-		SAFE_DELETE(mCdaiObject);
-		mCdaiObject = NULL;
-	}
-
+	SAFE_DELETE(mCdaiObject);
+	
 	AcquireStreamLock();
 	TuneHelper(tuneType);
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6117,7 +6117,13 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	{ // TODO: make mFirstTuneFormat of type MediaFormat
 		mfirstTuneFmt = (int)mMediaFormat;
 	}
-	mCdaiObject = NULL;
+
+	if(mCdaiObject != NULL)
+	{
+		SAFE_DELETE(mCdaiObject);
+		mCdaiObject = NULL;
+	}
+
 	AcquireStreamLock();
 	TuneHelper(tuneType);
 


### PR DESCRIPTION
Reason for Change: When tuning mCdaiObject is leaked.
Test Procedure: L1/L2 Full Stack testing
Risks: Low