### PR TITLE
VPLAY-10204: RDK-E Build issues with Federated 2507

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,12 +211,6 @@ install(TARGETS tsb
 		PUBLIC_HEADER DESTINATION include
 )
 
-option(DISABLE_SECURITY_TOKEN "Disable security token" OFF)
-
-if(DISABLE_SECURITY_TOKEN)
-	add_definitions(-DDISABLE_SECURITY_TOKEN)
-endif()
-
 # Building jsbindings
 if(CMAKE_WPEWEBKIT_JSBINDINGS)
 	message("CMAKE_WPEWEBKIT_JSBINDINGS is set, building jsbindings library")

--- a/middleware/externals/CMakeLists.txt
+++ b/middleware/externals/CMakeLists.txt
@@ -38,6 +38,12 @@ include_directories(${MW_ROOT})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/rdk)
 
+option(DISABLE_SECURITY_TOKEN "Disable security token" OFF)
+
+if(DISABLE_SECURITY_TOKEN)
+	add_definitions(-DDISABLE_SECURITY_TOKEN)
+endif()
+
 # uncomment below to build additional drm support in simulator
 # set(CMAKE_USE_OPENCDM_ADAPTER TRUE)
 # set(CMAKE_USE_OPENCDM_ADAPTER_MOCKS TRUE)

--- a/middleware/externals/playersecmanager/ThunderAccessPlayer.cpp
+++ b/middleware/externals/playersecmanager/ThunderAccessPlayer.cpp
@@ -27,7 +27,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Weffc++"
 #ifdef USE_CPP_THUNDER_PLUGIN_ACCESS
+#ifndef DISABLE_SECURITY_TOKEN
 #include <securityagent/SecurityTokenUtil.h>
+#endif
 #pragma GCC diagnostic pop
 
 using namespace std;
@@ -70,20 +72,25 @@ ThunderAccessPlayer::ThunderAccessPlayer(std::string callsign)
     uint32_t status = Core::ERROR_NONE;
 
     Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), (_T(SERVER_DETAILS)));
-
+    string sToken = "";
+#ifdef DISABLE_SECURITY_TOKEN
+     gSecurityPlayerData.securityToken = "token=" + sToken;
+     gSecurityPlayerData.tokenQueried = true;
+#else
     if(!gSecurityPlayerData.tokenQueried)
     {
         unsigned char buffer[MAX_LENGTH] = {0};
         gSecurityPlayerData.tokenStatus = GetSecurityToken(MAX_LENGTH,buffer);
         if(gSecurityPlayerData.tokenStatus > 0){
             MW_LOG_INFO( "[ThunderAccessPlayer] : GetSecurityToken success");
-            string sToken = (char*)buffer;
+            sToken = (char*)buffer;
             gSecurityPlayerData.securityToken = "token=" + sToken;
         }
         gSecurityPlayerData.tokenQueried = true;
 
         //MW_LOG_WARN( "[ThunderAccessPlayer] securityToken : %s tokenStatus : %d tokenQueried : %s", gSecurityPlayerData.securityToken.c_str(), gSecurityPlayerData.tokenStatus, ((gSecurityPlayerData.tokenQueried)?"true":"false"));
     }
+#endif
 
     if (NULL == controllerObject) {
         /*Passing empty string instead of Controller callsign.This is assumed as controller plugin.*/


### PR DESCRIPTION
Reason for change: Fix RDK-E build issues seen with federated 2507 tag
be extending DISABLE_SECURITY_TOKEN to ThunderAccessPlayer
Test Procedure: Make sure RDK-E/V build passes
Risks: None