### PR TITLE
VPLAY-10196: Observed Black screen with No AV on playing ColdDVR asset

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1366,10 +1366,9 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 			}
 		}
 		else if (ISCONFIGSET(eAAMPConfig_OverrideMediaHeaderDuration) &&
-			(eMEDIAFORMAT_DASH == aamp->mMediaFormat) &&
-			(aamp->IsLive()))
+			(eMEDIAFORMAT_DASH == aamp->mMediaFormat))
 		{
-			// Only for Live and DASH streams
+			// Only for DASH streams
 			ClearMediaHeaderDuration(cachedFragment);
 		}
 		if ((mSubtitleParser || (aamp->IsGstreamerSubsEnabled())) && type == eTRACK_SUBTITLE)


### PR DESCRIPTION
Reason for change: Clear duration value in mdhd mp4 box in init fragment for DVR streams as well. This ensures qtdemux will sent a segment event prior to playback start
Test Procedure: DVR playback should work
Risks: Low