### PR TITLE
VPLAY-9299:Address 200ms tune delay when using enableMediaProcessor as true

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1153,6 +1153,21 @@ public:
 	{
 		return 0.0;
 	}
+	/*
+	*   @brief Should flush the stream sink on new tune or not.
+	*
+	*   @param[in] newTune - true if this is a new tune, false if it is a seek
+	*   @param[in] rate - playback rate
+	*   @return true if stream should be flushed, false otherwise
+	*/
+	virtual bool DoEarlyStreamSinkFlush(bool newTune, float rate) { return false; }
+
+	/**
+	 * @brief Should flush the stream sink on discontinuity or not.
+	 *
+	 * @return true if stream should be flushed, false otherwise
+	 */
+	virtual bool DoStreamSinkFlushOnDiscontinuity() { return false; }
 
 	/**
 	 * @brief Sets the minimum buffer for ABR (Adaptive Bit Rate).
@@ -2064,8 +2079,12 @@ protected:
 	 * @brief Initialize ISOBMFF Media Processor
 	 *
 	 * @return void
+	 * 
+	 * @brief This function is used to initialize the media processor for ISOBMFF streams.
+	 * 
+	 * @param[in] passThroughMode - true if processor should skip parsing PTS and flush
 	 */
-	void InitializeMediaProcessor();
+	void InitializeMediaProcessor(bool passThroughMode = false);
 
 //private:
 protected:

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7436,4 +7436,42 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo& selected
 	}
 	return bestTrackFound;
 }
-
+/*
+ * @fn DoEarlyStreamSinkFlush
+ * @brief Checks if the stream need to be flushed or not
+ *
+ * @param newTune true if this is a new tune, false otherwise
+ * @param rate playback rate
+ * @return true if stream should be flushed, false otherwise
+ */
+bool StreamAbstractionAAMP_HLS::DoEarlyStreamSinkFlush(bool newTune, float rate)
+{
+	// Live adjust or syncTrack occurred, send an updated flush event
+	bool doFlush = !newTune;
+	TrackState *video = trackState[eMEDIATYPE_VIDEO];
+	if (video && video->streamOutputFormat == FORMAT_ISO_BMFF)
+	{
+		// doFlush for non mp4 formats. HLS MP4 uses media processor to handle flushes
+		doFlush = false;
+	}
+	AAMPLOG_INFO("doFlush=%d, newTune=%d, rate=%f", doFlush, newTune, rate);
+	return doFlush;
+}
+/*
+ * @brief Should flush the stream sink on discontinuity or not.
+ *
+ * @return true if stream should be flushed, false otherwise
+ */
+bool StreamAbstractionAAMP_HLS::DoStreamSinkFlushOnDiscontinuity()
+{
+	// doFlush for non mp4 formats.
+	bool doFlush = true;
+	TrackState *video = trackState[eMEDIATYPE_VIDEO];
+	if (video && video->streamOutputFormat == FORMAT_ISO_BMFF)
+	{
+		// HLS MP4 uses media processor to handle flushes
+		doFlush = false;
+	}
+	AAMPLOG_INFO("doFlush=%d", doFlush);
+	return doFlush;
+}

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -1031,7 +1031,21 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 * @return bool
 		 ***************************************************************************/
 		bool SelectPreferredTextTrack(TextTrackInfo& selectedTextTrack) override;
+		/***************************************************************************
+		 * @fn DoEarlyStreamSinkFlush
+		 *
+		 * @param[in] newTune true if new tune
+		 * @param[in] rate playback rate
+		 * @return bool true if stream should be flushed
+		 ***************************************************************************/
+		bool DoEarlyStreamSinkFlush(bool newTune, float rate) override;
 
+		/***************************************************************************
+		 * @brief Should flush the stream sink on discontinuity or not.
+		 *
+		 * @return true if stream should be flushed, false otherwise
+		 ***************************************************************************/
+		virtual bool DoStreamSinkFlushOnDiscontinuity() override;
 	protected:
 		/***************************************************************************
 		 * @fn GetStreamInfo

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -159,6 +159,8 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 	,mAudioSurplus(0)
 	,mVideoSurplus(0)
 	,mLivePeriodCulledSeconds(0)
+	,mIsSegmentTimelineEnabled(false)
+	,mSeekedInPeriod(false)
 {
 	this->aamp = aamp;
 	if (aamp->mDRMLicenseManager)
@@ -3996,6 +3998,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 		if(mCurrentPeriod != NULL)
 		{
 			mBasePeriodId = mCurrentPeriod->GetId();
+			mIsSegmentTimelineEnabled = mMPDParseHelper->aamp_HasSegmentTimeline(mCurrentPeriod);
 		}
 		else
 		{
@@ -4187,7 +4190,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			}
 			if(!mLowLatencyMode && ISCONFIGSET(eAAMPConfig_EnableMediaProcessor))
 			{
-				InitializeMediaProcessor();
+				// For segment timeline based streams, media processor is initialized in passthrough mode
+				InitializeMediaProcessor(mIsSegmentTimelineEnabled);
 			}
 		}
 		else
@@ -5995,7 +5999,7 @@ bool StreamAbstractionAAMP_MPD::GetBestTextTrackByLanguage( TextTrackInfo &selec
 
 void StreamAbstractionAAMP_MPD::StartSubtitleParser()
 {
-	struct MediaStreamContext *subtitle = mMediaStreamContext[eMEDIATYPE_SUBTITLE];
+	class MediaStreamContext *subtitle = mMediaStreamContext[eMEDIATYPE_SUBTITLE];
 	if (subtitle && subtitle->enabled && subtitle->mSubtitleParser)
 	{
 		auto seekPoint = aamp->seek_pos_seconds;
@@ -6033,7 +6037,7 @@ void StreamAbstractionAAMP_MPD::StartSubtitleParser()
 
 void StreamAbstractionAAMP_MPD::PauseSubtitleParser(bool pause)
 {
-	struct MediaStreamContext *subtitle = mMediaStreamContext[eMEDIATYPE_SUBTITLE];
+	class MediaStreamContext *subtitle = mMediaStreamContext[eMEDIATYPE_SUBTITLE];
 	if (subtitle && subtitle->enabled && subtitle->mSubtitleParser)
 	{
 		AAMPLOG_INFO("setting subtitles pause state = %d", pause);
@@ -9529,7 +9533,8 @@ bool StreamAbstractionAAMP_MPD::IndexSelectedPeriod(bool periodChanged, bool adS
 		}
 		if (!mLowLatencyMode && ISCONFIGSET(eAAMPConfig_EnableMediaProcessor))
 		{
-			InitializeMediaProcessor();
+			// For segment timeline based streams, media processor is initialized in passthrough mode
+			InitializeMediaProcessor(mIsSegmentTimelineEnabled);
 		}
 		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp) && (rate == AAMP_NORMAL_PLAY_RATE) && mMediaStreamContext[eMEDIATYPE_SUBTITLE]->enabled)
 		{
@@ -9555,6 +9560,7 @@ bool StreamAbstractionAAMP_MPD::IndexSelectedPeriod(bool periodChanged, bool adS
 				SeekInPeriod(seekPositionSeconds);
 				// Ad shorter than base period, set flag to adjust calculation on next call to UpdatePtsOffset()
 				mShortAdOffsetCalc = true;
+				mSeekedInPeriod = true;
 			}
 		}
 	}
@@ -9622,10 +9628,16 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
 				{
 					AAMPLOG_WARN("StreamAbstractionAAMP_MPD: discontinuity detected nextSegmentTime %" PRIu64 " FirstSegmentStartTime %" PRIu64 " ", nextSegmentTime, segmentStartTime);
 					discontinuity = true;
-					if (segmentTemplates.GetTimescale() != 0)
+					// mFirstPTS should not be updated if we are coming out of partial ad playback mSeekedInPeriod = true
+					if (segmentTemplates.GetTimescale() != 0 && !mSeekedInPeriod)
 					{
 						mFirstPTS = (double)segmentStartTime / (double)segmentTemplates.GetTimescale();
-					} // CID:186900 - divide by zero
+					}
+					else
+					{
+						AAMPLOG_WARN("StreamAbstractionAAMP_MPD: Not updating mFirstPTS TimeScale(0) or mSeekedInPeriod(%d)", mSeekedInPeriod);
+					}
+					mSeekedInPeriod = false;
 					double startTime = (mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) - mAvailabilityStartTime);
 					if ((startTime != 0) && !aamp->IsUninterruptedTSB())
 					{
@@ -14114,4 +14126,48 @@ void StreamAbstractionAAMP_MPD::GetNextAdInBreak(int direction)
 	{
 		AAMPLOG_ERR("Invalid value[%d] for direction, not expected!", direction);
 	}
+}
+/*
+ * @fn DoEarlyStreamSinkFlush
+ * @brief Checks if the stream need to be flushed or not
+ *
+ * @param newTune true if this is a new tune, false otherwise
+ * @param rate playback rate
+ * @return true if stream should be flushed, false otherwise
+ */
+bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate)
+{
+	/* Determine if early stream sink flush is needed based on configuration and playback state
+	 * Do flush to PTS position from manifest when:
+	 * 1. EnableMediaProcessor is disabled or EnableMediaProcessor enabled but segment timeline enabled (media processor will not flush in this case), OR
+	 * 2. EnablePTSReStamp is disabled, or play rate is normal (AAMP_NORMAL_PLAY_RATE). Here, we are using the flush(0) that occurs else where
+	 */
+	bool enableMediaProcessor = ISCONFIGSET(eAAMPConfig_EnableMediaProcessor);
+	bool enablePTSReStamp = ISCONFIGSET(eAAMPConfig_EnablePTSReStamp);
+	bool doFlush = ((!enableMediaProcessor || mIsSegmentTimelineEnabled) &&
+					(!enablePTSReStamp || rate == AAMP_NORMAL_PLAY_RATE));
+	AAMPLOG_INFO("doFlush=%d, newTune=%d, rate=%f", doFlush, newTune, rate);
+	return doFlush;
+}
+
+/**
+ * @brief Should flush the stream sink on discontinuity or not.
+ * When segment timeline is enabled, media processor will be in pass-through mode
+ * and will not do delayed flush.
+ * @return true if stream should be flushed, false otherwise
+ */
+bool StreamAbstractionAAMP_MPD::DoStreamSinkFlushOnDiscontinuity()
+{
+	/*
+	 * Truth table for DoStreamSinkFlushOnDiscontinuity:
+	 * | enableMediaProcessor | mIsSegmentTimelineEnabled | Result |
+	 * |----------------------|---------------------------|--------|
+	 * | false                | false                     | true   | (there will be no delayed flush)
+	 * | false                | true                      | true   |
+	 * | true                 | false                     | false  | (media processor will do delayed flush)
+	 * | true                 | true                      | true   | (media processor will not flush)
+	 */
+	bool doFlush = (!ISCONFIGSET(eAAMPConfig_EnableMediaProcessor) || mIsSegmentTimelineEnabled);
+	AAMPLOG_INFO("doFlush=%d", doFlush);
+	return doFlush;
 }

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -549,6 +549,23 @@ public:
 	 * @return true if AAMP is using an iframe track, false otherwise
 	 */
 	bool UseIframeTrack(void) override;
+	/*
+	 * @fn DoEarlyStreamSinkFlush
+	 * @brief Checks if the stream need to be flushed or not
+	 *
+	 * @param newTune true if this is a new tune, false otherwise
+	 * @param rate playback rate
+	 * @return true if stream should be flushed, false otherwise
+	 */
+	bool DoEarlyStreamSinkFlush(bool newTune, float rate) override;
+
+	/**
+	 * @brief Should flush the stream sink on discontinuity or not.
+	 * When segment timeline is enabled, media processor will be in pass-through mode
+	 * and will not do delayed flush.
+	 * @return true if stream should be flushed, false otherwise
+	 */
+	virtual bool DoStreamSinkFlushOnDiscontinuity() override;
 
 protected:
 	/**
@@ -1136,6 +1153,7 @@ protected:
 	bool playlistDownloaderThreadStarted; // Playlist downloader thread start status
 	bool isVidDiscInitFragFail;
 	double mLivePeriodCulledSeconds;
+	bool mIsSegmentTimelineEnabled;   /**< Flag to indicate if segment timeline is enabled, to determine if PTS is available from manifest */
 
 	// In case of streams with multiple video Adaptation Sets, A profile
 	// is a combination of an Adaptation Set and Representation within
@@ -1171,6 +1189,7 @@ protected:
 	std::vector<IFCS *>mFcsSegments;
 	AampTime mAudioSurplus;
 	AampTime mVideoSurplus;
+	bool mSeekedInPeriod; /*< Flag to indicate if seeked in period */
 	/**
 	 * @fn isAdbreakStart
 	 * @param[in] period instance.

--- a/fragmentcollector_progressive.cpp
+++ b/fragmentcollector_progressive.cpp
@@ -296,3 +296,16 @@ BitsPerSecond StreamAbstractionAAMP_PROGRESSIVE::GetMaxBitrate()
 { // STUB
 	return 0;
 }
+/*
+ * @fn DoEarlyStreamSinkFlush
+ * @brief Checks if the stream need to be flushed or not
+ *
+ * @param newTune true if this is a new tune, false otherwise
+ * @param rate playback rate
+ * @return true if stream should be flushed, false otherwise
+ */
+bool StreamAbstractionAAMP_PROGRESSIVE::DoEarlyStreamSinkFlush(bool newTune, float rate)
+{
+    // Always flush for progressive content
+    return true;
+}

--- a/fragmentcollector_progressive.h
+++ b/fragmentcollector_progressive.h
@@ -117,6 +117,15 @@ public:
      * @fn FragmentCollector
      */
     void FragmentCollector();
+	/*
+     * @fn DoEarlyStreamSinkFlush
+     * @brief Checks if the stream need to be flushed or not
+     *
+     * @param newTune true if this is a new tune, false otherwise
+     * @param rate playback rate
+     * @return true if stream should be flushed, false otherwise
+     */
+    bool DoEarlyStreamSinkFlush(bool newTune, float rate) override;
 
 private:
     void StreamFile( const char *uri, int *http_error );

--- a/isobmff/isobmffprocessor.cpp
+++ b/isobmff/isobmffprocessor.cpp
@@ -37,7 +37,8 @@ static const char *IsoBmffProcessorTypeName[] =
 /**
  *  @brief IsoBmffProcessor constructor
  */
-IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
+IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, bool passThrough, 
+	IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
 	: p_aamp(aamp), type(trackType), peerProcessor(peerBmffProcessor), peerSubtitleProcessor(peerSubProcessor), basePTS(0),
 	processPTSComplete(false), timeScale(0), initSegment(), resetPTSInitSegment(),
 	playRate(1.0f), aborted(false), m_mutex(), m_cond(),initSegmentProcessComplete(false),
@@ -45,7 +46,7 @@ IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback
 	sumPTS(0),prevPTS(UINT64_MAX),currTimeScale(0), startPos(DEFAULT_DURATION),
 	prevPosition(-1), prevDuration(0.0), scalingOfPTSComplete(false),timeScaleChangeState(eBMFFPROCESSOR_INIT_TIMESCALE),
 	mediaFormat(eMEDIAFORMAT_UNKNOWN), enabled(true), trackOffsetInSecs(DEFAULT_DURATION), peerListeners(),
-	initSegmentTransferMutex(), skipMutex(), skipPointMap(),ptsDiscontinuity(false), nextPos(-1)
+	initSegmentTransferMutex(), skipMutex(), skipPointMap(),ptsDiscontinuity(false), nextPos(-1), passThroughMode(passThrough)
 {
 	AAMPLOG_WARN("IsoBmffProcessor:: Created IsoBmffProcessor(%p) for type:%d and peerProcessor(%p)", this, type, peerBmffProcessor);
 	if (peerProcessor)
@@ -66,6 +67,14 @@ IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback
 	{
 		isRestampConfigEnabled = true;
 		AAMPLOG_WARN("IsoBmffProcessor:: %s mediaFormat=%d old PTS RE-STAMP ENABLED", IsoBmffProcessorTypeName[type],mediaFormat);
+	}
+	if (passThroughMode && isRestampConfigEnabled)
+	{
+		// If restamp is enabled, we cannot set pass through mode as basePTS and timeScale values are required
+		// This is a warning as this is not an expected scenario
+		AAMPLOG_WARN("IsoBmffProcessor %s Failed to set passThrough mode(%d) as restamp enabled(%d)",
+				IsoBmffProcessorTypeName[type], passThroughMode, isRestampConfigEnabled);
+		passThroughMode = false;
 	}
 }
 
@@ -90,7 +99,16 @@ bool IsoBmffProcessor::sendSegment(AampGrowableBuffer* pBuffer,double position,d
 	ptsError = false;
 	if (!initSegmentProcessComplete)
 	{
-		ret = setTuneTimePTS(pBuffer,position,duration,discontinuous,isInit);
+		if (passThroughMode)
+		{
+			// Populate the PTS and timeScale values for the first time without caching or syncing
+			// Its required for resetPTSOnSubtitleSwitch and resetPTSOnAudioSwitch
+			ret = updatePTSAndTimeScaleFromBuffer(pBuffer);
+		}
+		else
+		{
+			ret = setTuneTimePTS(pBuffer,position,duration,discontinuous,isInit);
+		}
 	}
 	if (ret)
 	{
@@ -1308,4 +1326,49 @@ void IsoBmffProcessor::initProcessorForRestamp()
 	// We need to get the sumPTS from video to start restamping subtitles
 	// Hence setting timeScale changed state to complete
 	timeScaleChangeState = eBMFFPROCESSOR_TIMESCALE_COMPLETE;
+}
+/*
+ * @fn updatePTSAndTimeScaleFromBuffer
+ *
+ * @param[in] pBuffer - Pointer to the AampGrowableBuffer
+ * @return true if PTS and time scale read successfully, false otherwise
+ */
+bool IsoBmffProcessor::updatePTSAndTimeScaleFromBuffer(AampGrowableBuffer *pBuffer)
+{
+	bool ret = false;
+	std::unique_lock<std::mutex> lock(m_mutex);
+	if (pBuffer && pBuffer->GetPtr() && pBuffer->GetLen() > 0)
+	{
+		IsoBmffBuffer buffer;
+		buffer.setBuffer((uint8_t *)pBuffer->GetPtr(), pBuffer->GetLen());
+		buffer.parseBuffer();
+		if(buffer.isInitSegment())
+		{
+			uint32_t tScale = 0;
+			if (buffer.getTimeScale(tScale))
+			{
+				currTimeScale = tScale;
+				timeScale = tScale;
+				AAMPLOG_INFO("IsoBmffProcessor %s TimeScale %" PRIu32 "", IsoBmffProcessorTypeName[type], currTimeScale);
+			}
+		}
+		else
+		{
+			// Init segment was parsed and stored previously. Find the base PTS now
+			uint64_t fPts = 0;
+			if (buffer.getFirstPTS(fPts))
+			{
+				basePTS = fPts;
+				processPTSComplete = true;
+				AAMPLOG_WARN("IsoBmffProcessor %s Base PTS (%" PRIu64 ") set", IsoBmffProcessorTypeName[type], basePTS);
+				initSegmentProcessComplete = true;
+			}
+		}
+		ret = true;
+	}
+	else
+	{
+		AAMPLOG_WARN("IsoBmffProcessor %s readPTSAndTimeScaleFromBuffer: Buffer(%p) is empty or null", IsoBmffProcessorTypeName[type], pBuffer);
+	}
+	return ret;
 }

--- a/isobmff/isobmffprocessor.h
+++ b/isobmff/isobmffprocessor.h
@@ -116,7 +116,7 @@ public:
 	 * @param[in] peerBmffProcessor - peer instance of IsoBmffProcessor
 	 */
 	// IsoBmffProcessor(class PrivateInstanceAAMP *aamp, IsoBmffProcessorType trackType = eBMFFPROCESSOR_TYPE_VIDEO, IsoBmffProcessor* peerBmffProcessor = NULL, MediaProcessor* peerSubProcessor = NULL);
-	IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType = eBMFFPROCESSOR_TYPE_VIDEO,
+	IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType = eBMFFPROCESSOR_TYPE_VIDEO, bool passThrough = false, 
 		IsoBmffProcessor* peerBmffProcessor = NULL, IsoBmffProcessor* peerSubProcessor = NULL);
 
 	/**
@@ -292,6 +292,11 @@ public:
 	* @brief Initialize the processor to advance to restamp phase directly
 	*/
 	void initProcessorForRestamp();
+	/*
+	 * @brief getPassThroughMode
+	 * @return true if pass through mode, false otherwise
+	 */
+	bool getPassThroughMode() { return passThroughMode; }
 
 private:
 
@@ -478,6 +483,13 @@ private:
 	 * @return void
 	 */
 	void resetInternal();
+	/*
+	 * @fn updatePTSAndTimeScaleFromBuffer
+	 *
+	 * @param[in] pBuffer - Pointer to the AampGrowableBuffer
+	 * @return true if PTS and time scale read successfully, false otherwise
+	 */
+	bool updatePTSAndTimeScaleFromBuffer(AampGrowableBuffer *pBuffer);
 
 	PrivateInstanceAAMP *p_aamp;
 	timeScaleChangeStateType timeScaleChangeState;
@@ -509,6 +521,7 @@ private:
 	bool aborted; // flag to indicate if the module is active
 	bool enabled;
 	bool ptsDiscontinuity;
+	bool passThroughMode; // flag to indicate if the processor is in pass through mode
 
 	std::vector<AampGrowableBuffer *> initSegment;
 	std::vector<stInitRestampSegment *> resetPTSInitSegment;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3083,32 +3083,38 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 			// The same thread will be executing operations involving TeardownStream.
 			mpStreamAbstractionAAMP->StopInjection();
 
-			// TODO: There is a possible issue hiding in the bushes. The audio codec switching use-case, Flush is done first and the Configure()
-			// So the new audio playbin will miss the Flush() and might not sync with video (which received the Flush) properly
-			if (((mMediaFormat != eMEDIAFORMAT_HLS_MP4) && (!ISCONFIGSET_PRIV(eAAMPConfig_EnablePTSReStamp))) ||  mVideoFormat != FORMAT_ISO_BMFF )
+			mpStreamAbstractionAAMP->GetStreamFormat(mVideoFormat, mAudioFormat, mAuxFormat, mSubtitleFormat);
+			
+			StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
+			if (sink)
 			{
- 				StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-				if (sink)
+			/*
+			 *  Truth table for Flush call as per previous impl for reference
+			 *  ContentType   | PTS ReStamp | Video Format | DoStreamSinkFlushOnDiscontinuity | Flush
+			 *  --------------|-------------|--------------|----------------------------------|--------
+			 *  HLS MP4       | NO          | ISO BMFF     | NO                               | NO
+			 *  HLS MP4       | YES         | ISO BMFF     | NO                               | NO
+			 *  HLS TS        | NO          | MPEGTS       | NO                               | YES
+			 *  HLS TS        | YES         | MPEGTS       | NO                               | YES
+			 *  DASH MP4      | NO          | ISO BMFF     | NO                               | YES
+			 *  DASH MP4      | YES         | ISO BMFF     | NO                               | NO
+			 *  DASH MP4      | YES         | ISO BMFF     | YES                              | YES
+			 *  In HLS MP4, DASH, mediaProcessor will be doing a delayed flush
+			 *  Only in DASH, PTS values will be known from manifest. If that is the case, flush from here.
+			 *  Content types other than HLS and DASH are not expected to have discontinuity.
+			 */
+				if (mpStreamAbstractionAAMP->DoStreamSinkFlushOnDiscontinuity())
 				{
 					if(mDiscontinuityFound)
 					{
 						profiler.ProfileBegin(PROFILE_BUCKET_DISCO_FLUSH);
 					}
-					if (!ISCONFIGSET_PRIV(eAAMPConfig_EnablePTSReStamp))
-					{
- 						sink->Flush(mpStreamAbstractionAAMP->GetFirstPTS(), rate);
-					}
+					sink->Flush(mpStreamAbstractionAAMP->GetFirstPTS(), rate);
 					if(mDiscontinuityFound)
 					{
 						profiler.ProfileEnd(PROFILE_BUCKET_DISCO_FLUSH);
 					}
- 				}
-			}
-
-			mpStreamAbstractionAAMP->GetStreamFormat(mVideoFormat, mAudioFormat, mAuxFormat, mSubtitleFormat);
-			StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-			if (sink)
-			{
+				}
 				sink->Configure(
 					mVideoFormat,
 					mAudioFormat,
@@ -3117,7 +3123,7 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 					mpStreamAbstractionAAMP->GetESChangeStatus(),
 					mpStreamAbstractionAAMP->GetAudioFwdToAuxStatus(),
 					mIsTrackIdMismatch /*setReadyAfterPipelineCreation*/);
-			}
+			}		
 			mpStreamAbstractionAAMP->ResetESChangeStatus();
 
 			bool isRateCorrectionEnabled = ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection);
@@ -5470,73 +5476,25 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			mFirstVideoFrameDisplayedEnabled = true;
 			mPauseOnFirstVideoFrameDisp = true;
 		}
-
-		if (mMediaFormat == eMEDIAFORMAT_HLS)
-		{
-			//Live adjust or syncTrack occurred, sent an updated flush event
-			if (!newTune)
-			{
-				StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-				if (sink)
-				{
-					sink->Flush(mpStreamAbstractionAAMP->GetFirstPTS(), rate);
-				}
-			}
-		}
-		else if (mMediaFormat == eMEDIAFORMAT_DASH)
-		{
-			/*
-			   commenting the Flush call with updatedSeekPosition as a work around for
-			   Trick play freeze issues observed for partner cDVR content
-			   @TODO Need to investigate and identify proper way to send Flush and segment
-			   events to avoid the freeze
-			if (!(newTune || (eTUNETYPE_RETUNE == tuneType)) && !IsFogTSBSupported())
-			{
-				StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-				if (sink)
-				{
-					sink->Flush(updatedSeekPosition, rate);
-				}
-			}
-			else
-			{
-				StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-				if (sink)
-				{
-					sink->Flush(0, rate);
-				}
-			}
-				*/
-			StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-			if (sink && (mAampLLDashServiceData.lowLatencyMode || !ISCONFIGSET_PRIV(eAAMPConfig_EnableMediaProcessor)))
-			{
-				/* Do flush to PTS position when:
-				*	Not PTS restamp
-				*	OR normal play
-				* This means we skip this flush when
-				*	trickplay and PTS restamp
-				*	and we are using the flush(0) that occurs else where
-				*/
-				if (!ISCONFIGSET_PRIV(eAAMPConfig_EnablePTSReStamp) || rate == AAMP_NORMAL_PLAY_RATE )
-				{
-					sink->Flush(mpStreamAbstractionAAMP->GetFirstPTS(), rate);
-				}
-			}
-		}
-		else if (mMediaFormat == eMEDIAFORMAT_PROGRESSIVE)
+		/* executing the flush earlier in order to avoid the tune delay while waiting for the first video and audio fragment to download
+		 * and retrieving the pts value, as in the segmenttimeline streams we get the pts value from manifest itself
+		 */
+		if (mpStreamAbstractionAAMP->DoEarlyStreamSinkFlush(newTune, rate))
 		{
 			StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 			if (sink)
 			{
-				sink->Flush(updatedSeekPosition, rate);
+				double flushPosition = (mMediaFormat == eMEDIAFORMAT_PROGRESSIVE) ? updatedSeekPosition : mpStreamAbstractionAAMP->GetFirstPTS();
+				sink->Flush(flushPosition, rate);
 			}
-			// ff trick mode, mp4 content is single file and muted audio to avoid glitch
+		}
+		if (mMediaFormat == eMEDIAFORMAT_PROGRESSIVE)
+		{
 			if (rate > AAMP_NORMAL_PLAY_RATE)
 			{
-				volume = 0;
+				volume = 0; // Mute audio to avoid glitches
 			}
-			// reset seek_pos after updating playback start, since mp4 content provide absolute position value
-			seek_pos_seconds = 0;
+			seek_pos_seconds = 0; // Reset seek position
 		}
 
 		// Increase Buffer value dynamically according to Max Profile Bandwidth to accommodate HiFi Content Buffers

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -823,6 +823,7 @@ bool MediaTrack::CheckForDiscontinuity(CachedFragment* cachedFragment, bool& fra
 				}
 				else
 				{
+					AAMPLOG_WARN("discontinuity ignored for other AV track, no need to process %s track", name);
 					// reset the flag when both the paired discontinuities ignored; since no buffer pushed before.
 					aamp->ResetTrackDiscontinuityIgnoredStatus();
 					aamp->UnblockWaitForDiscontinuityProcessToComplete();
@@ -4002,8 +4003,10 @@ void StreamAbstractionAAMP::SetVideoPlaybackRate(float rate)
  * @brief Initialize ISOBMFF Media Processor
  *
  * @return void
+ * 
+ * @param[in] passThroughMode - true if processor should skip parsing PTS and flush
  */
-void StreamAbstractionAAMP::InitializeMediaProcessor()
+void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 {
 	std::shared_ptr<IsoBmffProcessor> peerAudioProcessor = nullptr;
 	std::shared_ptr<IsoBmffProcessor> peerSubtitleProcessor = nullptr;
@@ -4021,7 +4024,7 @@ void StreamAbstractionAAMP::InitializeMediaProcessor()
 			if(eMEDIATYPE_SUBTITLE != i)
 			{
 				std::shared_ptr<IsoBmffProcessor> processor = std::make_shared<IsoBmffProcessor>(aamp, mID3Handler, (IsoBmffProcessorType) i,
-																peerAudioProcessor.get(), peerSubtitleProcessor.get());
+																passThroughMode, peerAudioProcessor.get(), peerSubtitleProcessor.get());
 				track->SourceFormat(FORMAT_ISO_BMFF);
 				track->playContext = std::static_pointer_cast<MediaProcessor>(processor);
 				track->playContext->setRate(aamp->rate, PlayMode_normal);
@@ -4038,7 +4041,7 @@ void StreamAbstractionAAMP::InitializeMediaProcessor()
 			{
 				if(FORMAT_SUBTITLE_MP4 == subtitleFormat)
 				{
-					peerSubtitleProcessor = std::make_shared<IsoBmffProcessor>(aamp, nullptr, (IsoBmffProcessorType) i);
+					peerSubtitleProcessor = std::make_shared<IsoBmffProcessor>(aamp, nullptr, (IsoBmffProcessorType) i, passThroughMode, nullptr,nullptr);
 					track->playContext = std::static_pointer_cast<MediaProcessor>(peerSubtitleProcessor);
 					track->playContext->setRate(aamp->rate, PlayMode_normal);
 				}

--- a/test/utests/fakes/FakeAampMPDParseHelper.cpp
+++ b/test/utests/fakes/FakeAampMPDParseHelper.cpp
@@ -239,3 +239,7 @@ double AampMPDParseHelper::GetPeriodNewContentDurationMs(IPeriod * period, uint6
 {
 	return 0;
 }
+bool AampMPDParseHelper::aamp_HasSegmentTimeline(IPeriod * period)
+{
+	return false;
+}

--- a/test/utests/fakes/FakeDrmInterface.cpp
+++ b/test/utests/fakes/FakeDrmInterface.cpp
@@ -33,10 +33,6 @@ DrmInterface::DrmInterface(PrivateInstanceAAMP* aamp):mAesKeyBuf("aesKeyBuf")
 DrmInterface::~DrmInterface()
 {
 }
-
-void DrmInterface::UpdateAamp(PrivateInstanceAAMP*)
-{
-}
 void DrmInterface::TerminateCurlInstance(int mCurlInstance)
 {
 }
@@ -78,4 +74,8 @@ void DrmInterface::GetCurlInit(int &curlInstance)
 void DrmInterface::getHlsDrmSession(std::shared_ptr <HlsDrmBase>&bridge, std::shared_ptr<DrmHelper> &drmHelper ,  DrmSession* &session , int streamType)
 {
 
+}
+void DrmInterface::UpdateAamp(PrivateInstanceAAMP* aamp)
+{
+    
 }

--- a/test/utests/fakes/FakeFragmentCollector_HLS.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_HLS.cpp
@@ -80,3 +80,7 @@ StreamAbstractionAAMP::ABRMode StreamAbstractionAAMP_HLS::GetABRMode() { return 
 void StreamAbstractionAAMP_HLS::RefreshTrack(AampMediaType type) { }
 
 bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo& selectedTextTrack) { return true; }
+
+bool StreamAbstractionAAMP_HLS::DoEarlyStreamSinkFlush(bool newTune, float rate){ return false; }
+
+bool StreamAbstractionAAMP_HLS::DoStreamSinkFlushOnDiscontinuity() { return false; }

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -280,3 +280,8 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 {
     
 }
+bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate)
+{
+    return false;
+}
+bool StreamAbstractionAAMP_MPD::DoStreamSinkFlushOnDiscontinuity() { return false; }

--- a/test/utests/fakes/FakeFragmentCollector_Progressive.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_Progressive.cpp
@@ -50,3 +50,7 @@ void StreamAbstractionAAMP_PROGRESSIVE::FetcherLoop()
 {
 
 }
+bool StreamAbstractionAAMP_PROGRESSIVE::DoEarlyStreamSinkFlush(bool newTune, float rate)
+{
+    return false;
+}

--- a/test/utests/fakes/FakeIsoBmffProcessor.cpp
+++ b/test/utests/fakes/FakeIsoBmffProcessor.cpp
@@ -22,7 +22,7 @@
 
 MockIsoBmffProcessor* g_mockIsoBmffProcessor = nullptr;
 
-IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
+IsoBmffProcessor::IsoBmffProcessor(class PrivateInstanceAAMP *aamp, id3_callback_t id3_hdl, IsoBmffProcessorType trackType, bool passThrough,IsoBmffProcessor* peerBmffProcessor, IsoBmffProcessor* peerSubProcessor)
 {
 }
 
@@ -85,4 +85,8 @@ void IsoBmffProcessor::abortWaitForVideoPTS()
 }
 void IsoBmffProcessor::resetPTSOnSubtitleSwitch(AampGrowableBuffer *pBuffer, double position)
 {
+}
+bool IsoBmffProcessor::updatePTSAndTimeScaleFromBuffer(AampGrowableBuffer *pBuffer)
+{
+    return true;
 }

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -392,9 +392,9 @@ void StreamAbstractionAAMP::SetVideoPlaybackRate(float rate)
 		g_mockStreamAbstractionAAMP->SetVideoPlaybackRate(rate);
 	}
 }
-
-void StreamAbstractionAAMP::InitializeMediaProcessor()
+void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 {
+	
 }
 
 void StreamAbstractionAAMP::UpdateIframeTracks()

--- a/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
+++ b/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
@@ -45,7 +45,7 @@ using ::testing::AnyNumber;
 
 AampConfig *gpGlobalConfig{nullptr};
 
-class IsoBmffProcessorTests : public ::testing::Test
+class IsoBmffProcessorBaseTests : public ::testing::Test
 {
 	protected:
 		IsoBmffProcessor *mIsoBmffProcessor{};
@@ -54,6 +54,9 @@ class IsoBmffProcessorTests : public ::testing::Test
 		PrivateInstanceAAMP *mPrivateInstanceAAMP{};
 		MediaProcessor::process_fcn_t mProcessorFn{};
 		std::thread asyncTask;
+		// To be set by derived classes
+		virtual bool IsPTSReStampEnabled() const = 0;
+		virtual bool IsPTMEnabled() const = 0;
 
 		void SetUp() override
 		{
@@ -61,17 +64,17 @@ class IsoBmffProcessorTests : public ::testing::Test
 			g_mockPrivateInstanceAAMP = new MockPrivateInstanceAAMP();
 			g_mockAampConfig = new MockAampConfig();
 			g_mockIsoBmffBuffer = new MockIsoBmffBuffer();
-			EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(true));
+			EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(IsPTSReStampEnabled()));
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetMediaFormatTypeEnum()).WillRepeatedly(Return(eMEDIAFORMAT_HLS_MP4));
 			EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_FragmentDownloadFailThreshold)).WillRepeatedly(Return(10));
 			EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_,_)).WillRepeatedly(Return(true));
 			EXPECT_CALL(*g_mockIsoBmffBuffer, setBuffer(_,_)).Times(AnyNumber());
 
 			id3_callback_t id3Handler = nullptr;
-
-			mAudIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_AUDIO);
-			mSubIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_SUBTITLE);
-			mIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_VIDEO, mAudIsoBmffProcessor, mSubIsoBmffProcessor);
+			
+			mAudIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_AUDIO, IsPTMEnabled(),nullptr, nullptr);
+			mSubIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_SUBTITLE, IsPTMEnabled(),nullptr, nullptr);
+			mIsoBmffProcessor = new IsoBmffProcessor(mPrivateInstanceAAMP, id3Handler, eBMFFPROCESSOR_TYPE_VIDEO, IsPTMEnabled(),mAudIsoBmffProcessor, mSubIsoBmffProcessor);
 		}
 
 		void TearDown() override
@@ -94,7 +97,19 @@ class IsoBmffProcessorTests : public ::testing::Test
 			g_mockAampConfig = nullptr;
 		}
 };
+class IsoBmffProcessorTests : public IsoBmffProcessorBaseTests
+{
+	protected:
+		bool IsPTSReStampEnabled() const override { return true; }
+		bool IsPTMEnabled() const override { return false; }
+};
 
+class IsoBmffProcessorPTMTests : public IsoBmffProcessorBaseTests
+{
+	protected:
+		bool IsPTSReStampEnabled() const override { return false; }
+		bool IsPTMEnabled() const override { return true; }
+};
 
 //Race condition between setTuneTimePTS and reset calls
 TEST_F(IsoBmffProcessorTests, abortTests1)
@@ -713,4 +728,48 @@ TEST_F(IsoBmffProcessorTests, ptsTests_4)
 	buffer.Free();
 	restampedPTS = mIsoBmffProcessor->getSumPTS() - vDuration;
 	EXPECT_EQ(restampedPTS, rslt); // Restamped PTS will not update on dup fragment
+}
+// Validates the scenario where PTM and Restamp are both on
+TEST_F(IsoBmffProcessorTests, PTMOnRestampOnTest)
+{
+	// With restamp config enabled, PTM should be disabled
+	IsoBmffProcessor *processor = new IsoBmffProcessor(mPrivateInstanceAAMP, nullptr, eBMFFPROCESSOR_TYPE_AUDIO, true /* passThrough */,nullptr,nullptr);
+	EXPECT_EQ(processor->getPassThroughMode(), false);
+	delete processor;
+}
+// Validates the sendSegment calls with PTM enabled and restamp disabled
+TEST_F(IsoBmffProcessorPTMTests, passThroughTests1)
+{
+	AampGrowableBuffer buffer("IsoBmffProcessorPTMTests-passThroughTests1");
+	buffer.AppendBytes("SampleData", 10); // Dummy data to simulate a buffer
+
+	double position = 0, duration = 0;
+	bool discontinuous = false, ptsError = false;
+	uint64_t basePts = 240000;
+	uint32_t vCurrTS = 24000;
+
+	// 3 sendSegment calls and configured with HLS_MP4 content type
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _, _)).Times(3);
+
+	// Expecting the timescale to be read first
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getTimeScale(_)).WillOnce(DoAll(SetArgReferee<0>(vCurrTS), Return(true)));
+
+	bool ret = mIsoBmffProcessor->sendSegment(&buffer, position, duration, 0.0, discontinuous, true, mProcessorFn, ptsError);
+	EXPECT_TRUE(ret);
+
+	// Expecting the base PTS to be read
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(false));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getFirstPTS(_)).WillOnce(DoAll(SetArgReferee<0>(basePts), Return(true)));
+
+	ret = mIsoBmffProcessor->sendSegment(&buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
+	EXPECT_TRUE(ret);
+
+	// Not expecting any more calls to parse buffer
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).Times(0);
+
+	ret = mIsoBmffProcessor->sendSegment(&buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
+	EXPECT_TRUE(ret);
+
+	buffer.Free();
 }

--- a/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
@@ -151,7 +151,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest2)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
-		.Times(2);
+		.Times(1);
 	
 	mPrivateInstanceAAMP->SetPreferredLanguages("lang1", NULL, NULL, NULL, NULL);
 
@@ -185,7 +185,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest3)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
-		.Times(2);
+		.Times(1);
 	
 	mPrivateInstanceAAMP->SetPreferredLanguages("lang0,lang2", NULL, NULL, NULL, NULL);
 
@@ -252,7 +252,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest5)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
-		.Times(2);
+		.Times(1);
 	
 	mPrivateInstanceAAMP->SetPreferredLanguages("{\"languages\":\"lang1\"}", NULL, NULL, NULL, NULL);
 
@@ -317,7 +317,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest7)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
-		.Times(2);
+		.Times(1);
 	
 	mPrivateInstanceAAMP->SetPreferredLanguages("lang1", NULL, NULL, NULL, NULL);
 
@@ -357,7 +357,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest8)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
-		.Times(2);
+		.Times(1);
 	
 	mPrivateInstanceAAMP->SetPreferredLanguages("lang1", NULL, NULL, NULL, NULL);
 

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -418,7 +418,7 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest1)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.Times(1);
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
-		.Times(2);
+		.Times(1);
 	mPrivateInstanceAAMP->SetPreferredTextLanguages("{\"rendition\":\"rend0\"}");
 
 	/* Verify the preferred rendition list. */


### PR DESCRIPTION
Reason for change: The delayed flush in media processor adds to tune delay. Since SegmentTimeline based streams provide the PTS values in the manifest, there is no need to parse the firstPTS from the segment. Risks: Low
Test Procedure: Refer jira ticket
Priority: P1

Signed-off-by: lashmintha <lashminthaj17@gmail.com>
