### PR TITLE
VPLAY-10265: Playback Rate Correction Issue Observed in LLD Channel

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -3682,7 +3682,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 		}
 		if (eTUNETYPE_NEW_NORMAL == tuneType)
 		{
-			double currentTime = NOW_STEADY_TS_SECS_FP;
+			double currentTime = NOW_SYSTEM_TS_SECS_FP;
 			aamp->mLiveEdgeDeltaFromCurrentTime = currentTime - aamp->mAbsoluteEndPosition;
 			AAMPLOG_INFO("currentTime %lfs mAbsoluteEndPosition %lfs mLiveEdgeDeltaFromCurrentTime %lfs", currentTime, aamp->mAbsoluteEndPosition, aamp->mLiveEdgeDeltaFromCurrentTime );
 		}

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -326,7 +326,7 @@ public:
 		{
 			/*	NOW_STEADY_TS_MS used in calulation will have different between calling Init and used in comparison as under. Hence EXPECT_NEAR is used
 				Assumption here is that it takes less than a second to excute Init and then perform comparison here */
-			EXPECT_NEAR(mPrivateInstanceAAMP->mLiveEdgeDeltaFromCurrentTime, NOW_STEADY_TS_SECS_FP - mPrivateInstanceAAMP->mAbsoluteEndPosition, 1);
+			EXPECT_NEAR(mPrivateInstanceAAMP->mLiveEdgeDeltaFromCurrentTime, NOW_SYSTEM_TS_SECS_FP - mPrivateInstanceAAMP->mAbsoluteEndPosition, 1);
 		}
 		return status;
 	}


### PR DESCRIPTION
Reason for change: Fixing the STEADY clock to SYSTEM clock for matching both values.
Risks: Low
Test Procedure: Test with LLD channels
Priority: P1