### PR TITLE
VPLAY-10090 VPLAY-10399 - Audio loss in Trick to play transition in L2 tests

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -1564,6 +1564,8 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	{
 		MW_LOG_ERR("Seek failed");
 		SetPendingSeek(true);
+		//Save the updated seek position
+		SetSeekPosition(position);
 	}
 
 	if ((gstPrivateContext->usingRialtoSink) &&

--- a/test/utests/fakes/FakeAampGstPlayer.cpp
+++ b/test/utests/fakes/FakeAampGstPlayer.cpp
@@ -36,6 +36,10 @@ AAMPGstPlayer::~AAMPGstPlayer()
 
 void AAMPGstPlayer::Configure(StreamOutputFormat format, StreamOutputFormat audioFormat, StreamOutputFormat auxFormat, StreamOutputFormat subFormat, bool bESChangeStatus, bool forwardAudioToAux, bool setReadyAfterPipelineCreation)
 {
+	if (g_mockAampGstPlayer != nullptr)
+	{
+		g_mockAampGstPlayer->Configure(format, audioFormat, auxFormat, subFormat, bESChangeStatus, forwardAudioToAux, setReadyAfterPipelineCreation);
+	}
 }
 
 bool AAMPGstPlayer::SendCopy( AampMediaType mediaType, const void *ptr, size_t len, double fpts, double fdts, double duration)

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -280,5 +280,13 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 {
     
 }
-bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate) { return false; }
+bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate)
+{
+	bool shouldFlush = false;
+	if (g_mockStreamAbstractionAAMP_MPD)
+	{
+		shouldFlush = g_mockStreamAbstractionAAMP_MPD->DoEarlyStreamSinkFlush(newTune, rate);
+	}
+	return shouldFlush;
+}
 bool StreamAbstractionAAMP_MPD::DoStreamSinkFlushOnDiscontinuity() { return false; }

--- a/test/utests/mocks/MockAampGstPlayer.h
+++ b/test/utests/mocks/MockAampGstPlayer.h
@@ -54,6 +54,8 @@ public:
     MOCK_METHOD(bool, SetPlayBackRate, (double), (override));
 
     MOCK_METHOD(void, SeekStreamSink, (double , double ), (override));
+
+    MOCK_METHOD(void, Configure, (StreamOutputFormat format, StreamOutputFormat audioFormat, StreamOutputFormat auxFormat, StreamOutputFormat subFormat, bool bESChangeStatus, bool forwardAudioToAux, bool setReadyAfterPipelineCreation), (override));
 };
 
 extern MockAAMPGstPlayer *g_mockAampGstPlayer;

--- a/test/utests/mocks/MockStreamAbstractionAAMP.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP.h
@@ -114,6 +114,8 @@ public:
 	MOCK_METHOD(bool, SelectPreferredTextTrack, (TextTrackInfo& selectedTextTrack), (override));
 
 	MOCK_METHOD(bool, IsEOSReached, (), (override));
+
+	MOCK_METHOD(bool, DoEarlyStreamSinkFlush, (bool newTune, float rate), (override));
 };
 
 extern MockStreamAbstractionAAMP *g_mockStreamAbstractionAAMP;

--- a/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
@@ -37,6 +37,7 @@ public:
 	MOCK_METHOD(IPeriod *, GetPeriod, ());
 	MOCK_METHOD(double, GetStreamPosition, (), (override));
 	MOCK_METHOD(void, GetStreamFormat, (StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &auxAudioOutputFormat, StreamOutputFormat &subtitleOutputFormat), (override));
+	MOCK_METHOD(bool, DoEarlyStreamSinkFlush, (bool newTune, float rate), (override));
   };
 
 extern MockStreamAbstractionAAMP_MPD *g_mockStreamAbstractionAAMP_MPD;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -4443,11 +4443,13 @@ TEST_F(PrivAampPrivTests, TuneHelperWithAampTsbConfigureFlushSequence)
 
 	//Verify the sequence for SeekToLive
 	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, DoEarlyStreamSinkFlush(false, AAMP_NORMAL_PLAY_RATE)).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampGstPlayer, Configure(_,_,_,_,_,_,_)).InSequence(s);
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_)).InSequence(s);
 	testp_aamp->TuneHelper(eTUNETYPE_SEEKTOLIVE);
 
 	//Verify the sequence for newTune
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, DoEarlyStreamSinkFlush(true, AAMP_NORMAL_PLAY_RATE)).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampGstPlayer, Configure(_,_,_,_,_,_,_)).InSequence(s);
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_)).InSequence(s);
 	testp_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL);

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -4416,6 +4416,51 @@ TEST_F(PrivAampPrivTests, TuneHelperWithAampTsbSeekToLiveWhenTsbIsNotEmpty)
 }
 
 /**
+ * @test PrivAampTests::TuneHelperWithAampTsbConfigureFlushSequence
+ * @brief Test the method TuneHelper for the order of Configure and Flush calls.
+ *
+ * This test verifies that Flush is called after Configure in TuneHelper
+ * function.
+ */
+TEST_F(PrivAampPrivTests, TuneHelperWithAampTsbConfigureFlushSequence)
+{
+	constexpr double SEEK_POS = 123;
+	constexpr double ABS_END_POS = 150.0;
+	testp_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP_MPD;
+	testp_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
+	testp_aamp->rate = AAMP_NORMAL_PLAY_RATE;
+	testp_aamp->seek_pos_seconds = SEEK_POS;
+	testp_aamp->SetLLDashChunkMode(true);
+	testp_aamp->SetLocalAAMPTsb(true);
+	testp_aamp->SetLocalAAMPTsbInjection(true);
+	testp_aamp->mAbsoluteEndPosition = ABS_END_POS;
+	testp_aamp->culledSeconds = SEEK_POS;
+	testp_aamp->SetState(eSTATE_PLAYING);
+	::testing::Sequence s;
+	AampLLDashServiceData stAampLLDashServiceData;
+	stAampLLDashServiceData.lowLatencyMode = true;
+	testp_aamp->SetLLDashServiceData(stAampLLDashServiceData);
+
+	//Verify the sequence for SeekToLive
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	EXPECT_CALL(*g_mockAampGstPlayer, Configure(_,_,_,_,_,_,_)).InSequence(s);
+	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_)).InSequence(s);
+	testp_aamp->TuneHelper(eTUNETYPE_SEEKTOLIVE);
+
+	//Verify the sequence for newTune
+	EXPECT_CALL(*g_mockAampGstPlayer, Configure(_,_,_,_,_,_,_)).InSequence(s);
+	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_)).InSequence(s);
+	testp_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL);
+
+	//Verify the sequence for eTUNETYPE_SEEK
+	testp_aamp->SetLocalAAMPTsb(true);
+	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_)).InSequence(s);
+	EXPECT_CALL(*g_mockAampGstPlayer, Configure(_,_,_,_,_,_,_)).InSequence(s);
+	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_)).InSequence(s);
+	testp_aamp->TuneHelper(eTUNETYPE_SEEK);
+}
+
+/**
  * @test PrivAampTests::NotifyEOSReached
  * @brief Test the method NotifyEOSReached with AAMP TSB enabled, Rate a negative value and SetIsLive true.
  *


### PR DESCRIPTION
Reason for change: Audio is lost while performing live pause  and fast forward to live using LLD test asset in L2 test environment.
Changes: Perform Flush after Configure in TuneHelper. Also, call flush with shouldTearDown false, because in case of a new tune, pipeline might not be in a playing/paused state which causes Flush() to destroy the pipeline. This has to be avoided.
Test Procedure: Refer Jira Ticket