### PR TITLE
[VPLAY-10294] Add timestamps to aamp-cli output.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,6 +597,7 @@ set(AAMP_CLI_SOURCES
 	test/aampcli/AampcliVirtualChannelMap.cpp
 	test/aampcli/AampcliShader.cpp
 	test/aampcli/AampcliSubtecSimulator.cpp
+	test/aampcli/AampcliPrintf.cpp
 )
 add_executable(aamp-cli ${AAMP_CLI_SOURCES})
 target_link_libraries(aamp-cli aamp subtec tsb playerfbinterface ${AAMP_CLI_LD_FLAGS} "-lreadline")

--- a/test/aampcli/Aampcli.h
+++ b/test/aampcli/Aampcli.h
@@ -47,6 +47,7 @@
 #include "AampcliSet.h"
 #include "AampcliShader.h"
 #include "middleware/GstUtils.h"
+#include "AampcliPrintf.h"
 
 class MyAAMPEventListener : public AAMPEventObjectListener
 {

--- a/test/aampcli/AampcliGet.cpp
+++ b/test/aampcli/AampcliGet.cpp
@@ -23,6 +23,7 @@
  */
 #include <iomanip>
 #include "AampcliGet.h"
+#include "AampcliPrintf.h"
 
 std::map<std::string,getCommandInfo> Get::getCommands = std::map<std::string,getCommandInfo>();
 std::vector<std::string> Get::commands(0);
@@ -57,11 +58,11 @@ bool Get::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 		{
 			switch(getCmd){
 				case 32:
-					printf("[AAMPCLI] GETTING AVAILABLE THUMBNAIL TRACKS: %s\n", playerInstanceAamp->GetAvailableThumbnailTracks().c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] GETTING AVAILABLE THUMBNAIL TRACKS: %s\n", playerInstanceAamp->GetAvailableThumbnailTracks().c_str() );
 					break;
 
 				case 1:
-					printf("[AAMPCLI] GETTING CURRENT STATE: %d\n", (int) playerInstanceAamp->GetState());
+					AAMPCLI_PRINTF("[AAMPCLI] GETTING CURRENT STATE: %d\n", (int) playerInstanceAamp->GetState());
 					break;
 
 				case 33:
@@ -82,143 +83,143 @@ bool Get::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						//strip formatting so easy to read from l2test
 						json.erase(remove(json.begin(), json.end(), '\n'), json.end());
 						json.erase(remove(json.begin(), json.end(), '\t'), json.end());
-						printf("[AAMPCLI] GETTING THUMBNAIL TIME RANGE DATA %s\n", json.c_str());
+						AAMPCLI_PRINTF("[AAMPCLI] GETTING THUMBNAIL TIME RANGE DATA %s\n", json.c_str());
 					}
 					else
 					{
-						printf("[AAMPCLI] GETTING THUMBNAIL TIME RANGE DATA for duration (%d,%d): %s\n complete.\n",
+						AAMPCLI_PRINTF("[AAMPCLI] GETTING THUMBNAIL TIME RANGE DATA for duration (%d,%d): %s\n complete.\n",
 							   value1, value2, json.c_str());
 					}
 				}
 					break;
 
 				case 24:
-					printf("[AAMPCLI] CURRENT AUDIO TRACK NUMBER: %d\n", playerInstanceAamp->GetAudioTrack() );
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT AUDIO TRACK NUMBER: %d\n", playerInstanceAamp->GetAudioTrack() );
 					break;
 
 				case 25:
-					printf("[AAMPCLI] INITIAL BUFFER DURATION: %d\n", playerInstanceAamp->GetInitialBufferDuration() );
+					AAMPCLI_PRINTF("[AAMPCLI] INITIAL BUFFER DURATION: %d\n", playerInstanceAamp->GetInitialBufferDuration() );
 					break;
 
 				case 26:
-					printf("[AAMPCLI] CURRENT AUDIO TRACK INFO: %s\n", playerInstanceAamp->GetAudioTrackInfo().c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT AUDIO TRACK INFO: %s\n", playerInstanceAamp->GetAudioTrackInfo().c_str() );
 					break;
 
 				case 27:
-					printf("[AAMPCLI] CURRENT TEXT TRACK INFO: %s\n", playerInstanceAamp->GetTextTrackInfo().c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT TEXT TRACK INFO: %s\n", playerInstanceAamp->GetTextTrackInfo().c_str() );
 					break;
 
 				case 28:
-					printf("[AAMPCLI] CURRENT PREPRRED AUDIO PROPERTIES: %s\n", playerInstanceAamp->GetPreferredAudioProperties().c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT PREPRRED AUDIO PROPERTIES: %s\n", playerInstanceAamp->GetPreferredAudioProperties().c_str() );
 					break;
 
 				case 29:
-					printf("[AAMPCLI] CURRENT PREPRRED TEXT PROPERTIES: %s\n", playerInstanceAamp->GetPreferredTextProperties().c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT PREPRRED TEXT PROPERTIES: %s\n", playerInstanceAamp->GetPreferredTextProperties().c_str() );
 					break;
 
 				case 30:
-					printf("[AAMPCLI] CC VISIBILITY STATUS: %s\n",playerInstanceAamp->GetCCStatus()?"ENABLED":"DISABLED");
+					AAMPCLI_PRINTF("[AAMPCLI] CC VISIBILITY STATUS: %s\n",playerInstanceAamp->GetCCStatus()?"ENABLED":"DISABLED");
 					break;
 
 				case 31:
-					printf("[AAMPCLI] CURRENT TEXT TRACK: %d\n", playerInstanceAamp->GetTextTrack() );
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT TEXT TRACK: %d\n", playerInstanceAamp->GetTextTrack() );
 					break;
 
 				case 20:
-					printf("[AAMPCLI] AVAILABLE AUDIO TRACKS: %s\n", playerInstanceAamp->GetAvailableAudioTracks(false).c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] AVAILABLE AUDIO TRACKS: %s\n", playerInstanceAamp->GetAvailableAudioTracks(false).c_str() );
 					break;
 
 				case 34:
-					printf("[AAMPCLI] AVAILABLE VIDEO TRACKS: %s\n", playerInstanceAamp->GetAvailableVideoTracks().c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] AVAILABLE VIDEO TRACKS: %s\n", playerInstanceAamp->GetAvailableVideoTracks().c_str() );
 					break;
 
 				case 35:
-					printf( "[AAMPCLI] LIVE: %s\n", playerInstanceAamp->IsLive()? "TRUE": "FALSE" );
+					AAMPCLI_PRINTF( "[AAMPCLI] LIVE: %s\n", playerInstanceAamp->IsLive()? "TRUE": "FALSE" );
 					break;
 
 				case 36:
-						printf("[AAMPCLI] VIDEO PLAYBACK QUALITY: %s\n", playerInstanceAamp->GetVideoPlaybackQuality().c_str() );
+						AAMPCLI_PRINTF("[AAMPCLI] VIDEO PLAYBACK QUALITY: %s\n", playerInstanceAamp->GetVideoPlaybackQuality().c_str() );
 					break;
 					   
 				case 21:
-					printf("[AAMPCLI] ALL AUDIO TRACKS: %s\n", playerInstanceAamp->GetAvailableAudioTracks(true).c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] ALL AUDIO TRACKS: %s\n", playerInstanceAamp->GetAvailableAudioTracks(true).c_str() );
 					break;
 
 				case 23:
-					printf("[AAMPCLI] ALL TEXT TRACKS: %s\n", playerInstanceAamp->GetAvailableTextTracks(true).c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] ALL TEXT TRACKS: %s\n", playerInstanceAamp->GetAvailableTextTracks(true).c_str() );
 					break;
 
 				case 22:
-					printf("[AAMPCLI] AVAILABLE TEXT TRACKS: %s\n", playerInstanceAamp->GetAvailableTextTracks(false).c_str() );
+					AAMPCLI_PRINTF("[AAMPCLI] AVAILABLE TEXT TRACKS: %s\n", playerInstanceAamp->GetAvailableTextTracks(false).c_str() );
 					break;
 
 				case 2:
-					printf("[AAMPCLI] CURRRENT AUDIO LANGUAGE = %s\n",
+					AAMPCLI_PRINTF("[AAMPCLI] CURRRENT AUDIO LANGUAGE = %s\n",
 							playerInstanceAamp->GetAudioLanguage().c_str());
 					break;
 
 				case 3:
-					printf("[AAMPCLI] CURRRENT DRM  = %s\n",
+					AAMPCLI_PRINTF("[AAMPCLI] CURRRENT DRM  = %s\n",
 							playerInstanceAamp->GetDRM().c_str());
 					break;
 
 				case 4:
-					printf("[AAMPCLI] PLAYBACK POSITION = %lf\n",
+					AAMPCLI_PRINTF("[AAMPCLI] PLAYBACK POSITION = %.3lf\n",
 							playerInstanceAamp->GetPlaybackPosition());
 					break;
 
 				case 5:
-					printf("[AAMPCLI] PLAYBACK DURATION = %lf\n",
+					AAMPCLI_PRINTF("[AAMPCLI] PLAYBACK DURATION = %lf\n",
 							playerInstanceAamp->GetPlaybackDuration());
 					break;
 
 				case 6:
-					printf("[AAMPCLI] CURRENT VIDEO PROFILE BITRATE = %ld\n",
+					AAMPCLI_PRINTF("[AAMPCLI] CURRENT VIDEO PROFILE BITRATE = %ld\n",
 							playerInstanceAamp->GetVideoBitrate());
 					break;
 
 				case 7:
-					printf("[AAMPCLI] INITIAL BITRATE = %ld \n",
+					AAMPCLI_PRINTF("[AAMPCLI] INITIAL BITRATE = %ld \n",
 							playerInstanceAamp->GetInitialBitrate());
 					break;
 
 				case 8:
-					printf("[AAMPCLI] INITIAL BITRATE 4K = %ld \n",
+					AAMPCLI_PRINTF("[AAMPCLI] INITIAL BITRATE 4K = %ld \n",
 							playerInstanceAamp->GetInitialBitrate4k());
 					break;
 
 				case 9:
-					printf("[AAMPCLI] MINIMUM BITRATE = %ld \n",
+					AAMPCLI_PRINTF("[AAMPCLI] MINIMUM BITRATE = %ld \n",
 							playerInstanceAamp->GetMinimumBitrate());
 					break;
 
 				case 10:
-					printf("[AAMPCLI] MAXIMUM BITRATE = %ld \n",
+					AAMPCLI_PRINTF("[AAMPCLI] MAXIMUM BITRATE = %ld \n",
 							playerInstanceAamp->GetMaximumBitrate());
 					break;
 
 				case 11:
-					printf("[AAMPCLI] AUDIO BITRATE = %ld\n",
+					AAMPCLI_PRINTF("[AAMPCLI] AUDIO BITRATE = %ld\n",
 							playerInstanceAamp->GetAudioBitrate());
 					break;
 
 				case 12:
-					printf("[AAMPCLI] Video Zoom mode: %s\n",
+					AAMPCLI_PRINTF("[AAMPCLI] Video Zoom mode: %s\n",
 							(playerInstanceAamp->GetVideoZoom())?"None(Normal)":"Full(Enabled)");
 					break;
 
 				case 13:
-					printf("[AAMPCLI] Video Mute status:%s\n",
+					AAMPCLI_PRINTF("[AAMPCLI] Video Mute status:%s\n",
 							(playerInstanceAamp->GetVideoMute())?"ON":"OFF");
 					break;
 
 				case 14:
-					printf("[AAMPCLI] AUDIO VOLUME = %d\n",
+					AAMPCLI_PRINTF("[AAMPCLI] AUDIO VOLUME = %d\n",
 							playerInstanceAamp->GetAudioVolume());
 					break;
 
 				case 15:
-					printf("[AAMPCLI] PLAYBACK RATE = %d\n",
+					AAMPCLI_PRINTF("[AAMPCLI] PLAYBACK RATE = %d\n",
 							playerInstanceAamp->GetPlaybackRate());
 					break;
 
@@ -232,7 +233,7 @@ bool Get::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							temp += std::to_string(videoBitrates[i]);
 						}
 						temp += " ]";
-						printf( "%s\n", temp.c_str() );
+						AAMPCLI_PRINTF( "%s\n", temp.c_str() );
 						break;
 					}
 
@@ -246,30 +247,30 @@ bool Get::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							temp += std::to_string(audioBitrates[i]);
 						}
 						temp += " ]";
-						printf( "%s\n", temp.c_str() );
+						AAMPCLI_PRINTF( "%s\n", temp.c_str() );
 						break;
 					}
 				case 18:
 					{
 						std::string preferredLanguages = playerInstanceAamp->GetPreferredLanguages();
-						printf("[AAMPCLI] PREFERRED LANGUAGES = \"%s\"\n", preferredLanguages.c_str() );
+						AAMPCLI_PRINTF("[AAMPCLI] PREFERRED LANGUAGES = \"%s\"\n", preferredLanguages.c_str() );
 						break;
 					}
 
 				case 19:
 					{
-						printf("[AAMPCLI] RAMP DOWN LIMIT= %d\n", playerInstanceAamp->GetRampDownLimit());
+						AAMPCLI_PRINTF("[AAMPCLI] RAMP DOWN LIMIT= %d\n", playerInstanceAamp->GetRampDownLimit());
 						break;
 					}
 
 				case 37:
 					{
-						printf("[AAMPCLI] WEBVTT/TTML support: \"%s\"\n", playerInstanceAamp->IsOOBCCRenderingSupported() ? "Enabled" : "Disabled");
+						AAMPCLI_PRINTF("[AAMPCLI] WEBVTT/TTML support: \"%s\"\n", playerInstanceAamp->IsOOBCCRenderingSupported() ? "Enabled" : "Disabled");
 						break;
 					}
 
 				default:
-					printf("[AAMPCLI] Invalid get command %s\n", cmd);
+					AAMPCLI_PRINTF("[AAMPCLI] Invalid get command %s\n", cmd);
 					break;
 			}
 
@@ -277,7 +278,7 @@ bool Get::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 	}
 	else
 	{
-		printf("[AAMPCLI] Invalid get command = %s\n", cmd);
+		AAMPCLI_PRINTF("[AAMPCLI] Invalid get command = %s\n", cmd);
 	}
 
 	return true;
@@ -357,10 +358,10 @@ void Get::addCommand(int value,std::string command,std::string description)
  */
 void Get::ShowHelpGet(){
 
-	printf("******************************************************************************************\n");
-	printf("*   get <command> [<arguments>]\n");
-	printf("*   Usage of Commands, and arguments expected\n");
-	printf("******************************************************************************************\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
+	AAMPCLI_PRINTF("*   get <command> [<arguments>]\n");
+	AAMPCLI_PRINTF("*   Usage of Commands, and arguments expected\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
 
 	if(!commands.empty())
 	{
@@ -374,7 +375,7 @@ void Get::ShowHelpGet(){
 		}
 	}
 
-	printf("****************************************************************************\n");
+	AAMPCLI_PRINTF("****************************************************************************\n");
 }
 
 char * Get::getCommandRecommender(const char *text, int state)

--- a/test/aampcli/AampcliPlaybackCommand.cpp
+++ b/test/aampcli/AampcliPlaybackCommand.cpp
@@ -138,7 +138,7 @@ void PlaybackCommand::HandleCommandBatch()
 
 	if (!batchFile.is_open())
 	{
-		printf("[AAMPCLI] ERROR - unable to open batch file\n");
+		AAMPCLI_PRINTF("[AAMPCLI] ERROR - unable to open batch file\n");
 		return;
 	}
 
@@ -147,13 +147,13 @@ void PlaybackCommand::HandleCommandBatch()
 	{
 		if (line.compare("batch") == 0)
 		{
-			printf("[AAMPCLI] ERROR - nested batch command not allowed\n");
+			AAMPCLI_PRINTF("[AAMPCLI] ERROR - nested batch command not allowed\n");
 			continue;
 		}
 		
 		else if (!line.empty() && line[0] != '#')
 		{
-			printf("[AAMPCLI] Executing command: %s\n", line.c_str());
+			AAMPCLI_PRINTF("[AAMPCLI] Executing command: %s\n", line.c_str());
 			execute(line.c_str(), mAampcli.mSingleton);
 		}
 	}
@@ -165,12 +165,12 @@ void PlaybackCommand::HandleCommandContentType( const char *cmd )
 	if (strlen(cmd) > strlen("contentType "))
 	{
 		mAampcli.mContentType = std::string(&cmd[strlen("contentType ")]);
-		printf("[AAMPCLI] contentType set to %s\n", mAampcli.mContentType.c_str());
+		AAMPCLI_PRINTF("[AAMPCLI] contentType set to %s\n", mAampcli.mContentType.c_str());
 	}
 	else
 	{
 		mAampcli.mContentType.clear();
-		printf("[AAMPCLI] contentType not set\n");
+		AAMPCLI_PRINTF("[AAMPCLI] contentType not set\n");
 	}
 }
 
@@ -196,8 +196,8 @@ void PlaybackCommand::HandleCommandSelect( const char *cmd, PlayerInstanceAAMP *
 		if( found )
 		{
 			//if( found->aamp )
-			{ //Do not edit or remove this following printf - it is used in L2 test
-				printf( "selected player %d (at %p) %s\n",
+			{ //Do not edit or remove this following AAMPCLI_PRINTF - it is used in L2 test
+				AAMPCLI_PRINTF( "selected player %d (at %p) %s\n",
 					   found->GetId(),
 					   found,
 					   found->GetAppName().c_str() );
@@ -206,25 +206,25 @@ void PlaybackCommand::HandleCommandSelect( const char *cmd, PlayerInstanceAAMP *
 			}
 			//else
 			///{
-			//	printf( "error - player exists but is not valid/ready, playerInstanceAamp->aamp is not a valid ptr\n");
+			//	AAMPCLI_PRINTF( "error - player exists but is not valid/ready, playerInstanceAamp->aamp is not a valid ptr\n");
 			//}
 		}
 		else
 		{
-			printf( "No player with ID or name '%s'\n", playerRef);
+			AAMPCLI_PRINTF( "No player with ID or name '%s'\n", playerRef);
 		}
 	}
 	else
 	{
-		printf( "player instances:\n" );
+		AAMPCLI_PRINTF( "player instances:\n" );
 		for( auto player : mAampcli.mPlayerInstances )
 		{ // list available player instances
-			printf( "\t%d %s", player->GetId(), player->GetAppName().c_str() );
+			AAMPCLI_PRINTF( "\t%d %s", player->GetId(), player->GetAppName().c_str() );
 			if( player == playerInstanceAamp )
 			{
-				printf( " (selected)");
+				AAMPCLI_PRINTF( " (selected)");
 			}
-			printf( "\n");
+			AAMPCLI_PRINTF( "\n");
 		}
 	}
 }
@@ -239,7 +239,7 @@ void PlaybackCommand::HandleCommandRelease( const char *cmd, PlayerInstanceAAMP 
 		{
 			if( found == playerInstanceAamp)
 			{
-				printf( "Can not release the active player.\n");
+				AAMPCLI_PRINTF( "Can not release the active player.\n");
 			}
 			else
 			{
@@ -260,10 +260,10 @@ void PlaybackCommand::HandleCommandSleep( const char *cmd )
 	int ms = 0;
 	if( sscanf(cmd, "sleep %d", &ms ) == 1 && ms>0 )
 	{
-		printf( "sleeping for %f seconds\n", ms/1000.0 );
+		AAMPCLI_PRINTF( "sleeping for %f seconds\n", ms/1000.0 );
 		g_usleep (ms * 1000);
-		//Do not edit or remove this following printf - it is used in L2 test
-		printf( "sleep complete\n" );
+		//Do not edit or remove this following AAMPCLI_PRINTF - it is used in L2 test
+		AAMPCLI_PRINTF( "sleep complete\n" );
 	}
 }
 
@@ -288,12 +288,12 @@ void PlaybackCommand::HandleCommandNext( const char *cmd, PlayerInstanceAAMP *pl
 	VirtualChannelInfo *pNextChannel = mVirtualChannelMap.next();
 	if (pNextChannel)
 	{
-		printf("[AAMPCLI] next %d: %s\n", pNextChannel->channelNumber, pNextChannel->name.c_str());
+		AAMPCLI_PRINTF("[AAMPCLI] next %d: %s\n", pNextChannel->channelNumber, pNextChannel->name.c_str());
 		mVirtualChannelMap.tuneToChannel( *pNextChannel, playerInstanceAamp, mAampcli.mbAutoPlay );
 	}
 	else
 	{
-		printf("[AAMPCLI] can not fetch 'next' channel, empty virtual channel map\n");
+		AAMPCLI_PRINTF("[AAMPCLI] can not fetch 'next' channel, empty virtual channel map\n");
 	}
 }
 
@@ -302,12 +302,12 @@ void PlaybackCommand::HandleCommandPrev( const char *cmd, PlayerInstanceAAMP *pl
 	VirtualChannelInfo *pPrevChannel = mVirtualChannelMap.prev();
 	if (pPrevChannel)
 	{
-		printf("[AAMPCLI] next %d: %s\n", pPrevChannel->channelNumber, pPrevChannel->name.c_str());
+		AAMPCLI_PRINTF("[AAMPCLI] next %d: %s\n", pPrevChannel->channelNumber, pPrevChannel->name.c_str());
 		mVirtualChannelMap.tuneToChannel( *pPrevChannel, playerInstanceAamp, mAampcli.mbAutoPlay );
 	}
 	else
 	{
-		printf("[AAMPCLI] can not fetch 'prev' channel, empty virtual channel map\n");
+		AAMPCLI_PRINTF("[AAMPCLI] can not fetch 'prev' channel, empty virtual channel map\n");
 	}
 }
 
@@ -318,12 +318,12 @@ void PlaybackCommand::HandleCommandTuneIndex( const char *cmd, PlayerInstanceAAM
 	VirtualChannelInfo *pChannelInfo = mVirtualChannelMap.find(channelNumber);
 	if (pChannelInfo != NULL)
 	{
-		printf("[AAMPCLI] channel number: %d\n", channelNumber);
+		AAMPCLI_PRINTF("[AAMPCLI] channel number: %d\n", channelNumber);
 		mVirtualChannelMap.tuneToChannel( *pChannelInfo, playerInstanceAamp, mAampcli.mbAutoPlay );
 	}
 	else
 	{
-		printf("[AAMPCLI] channel number: %d was not found\n", channelNumber);
+		AAMPCLI_PRINTF("[AAMPCLI] channel number: %d was not found\n", channelNumber);
 	}
 }
 
@@ -337,7 +337,7 @@ void PlaybackCommand::HandleCommandSetConfig( const char *cmd, PlayerInstanceAAM
 			return;
 		}
 	}
-	printf("Invalid json, note the use of dbl quotes. E.G\nsetconfig {\"info\":true}\n");
+	AAMPCLI_PRINTF("Invalid json, note the use of dbl quotes. E.G\nsetconfig {\"info\":true}\n");
 }
 
 void PlaybackCommand::HandleCommandGetConfig( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp )
@@ -345,11 +345,11 @@ void PlaybackCommand::HandleCommandGetConfig( const char *cmd, PlayerInstanceAAM
 	std::string cfgstring=playerInstanceAamp->GetAAMPConfig();
 	if(!cfgstring.empty())
 	{
-		printf("config:  \n%s\n",cfgstring.c_str());
+		AAMPCLI_PRINTF("config:  \n%s\n",cfgstring.c_str());
 	}
 	else
 	{
-		printf("Error : Config is Empty ");
+		AAMPCLI_PRINTF("Error : Config is Empty ");
 	}
 }
 
@@ -372,7 +372,7 @@ void PlaybackCommand::HandleCommandCustomHeader( const char *cmd, PlayerInstance
 	bool isLicenceHeader=false;
 	cmdptr = strtok (const_cast<char*>(cmd)," ,");
 
-	printf("[AAMPCLI] customheader Command is %s\n" , cmd);
+	AAMPCLI_PRINTF("[AAMPCLI] customheader Command is %s\n" , cmd);
 
 	std::string subString;
 
@@ -381,42 +381,42 @@ void PlaybackCommand::HandleCommandCustomHeader( const char *cmd, PlayerInstance
 	while (cmdptr)
 	{
 		subString.assign(cmdptr);
-		printf("parameter %d, value %.80s\n", parameter, subString.c_str());
+		AAMPCLI_PRINTF("parameter %d, value %.80s\n", parameter, subString.c_str());
 		if ( 3==parameter )
 		{
 			if ((0 == subString.compare(0,4,"true") ))
 			{
-				printf("isLicenceHeader=true\n");
+				AAMPCLI_PRINTF("isLicenceHeader=true\n");
 				isLicenceHeader=true;
 			}
 			else
 			{
-				printf("isLicenceHeader=false\n");
+				AAMPCLI_PRINTF("isLicenceHeader=false\n");
 				isLicenceHeader=false;
 			}
 		}
 		else if ( 1==parameter )
 		{
 			headerName.assign(subString);
-			printf("headerName=%.80s\n", headerName.c_str());
+			AAMPCLI_PRINTF("headerName=%.80s\n", headerName.c_str());
 		}
 		else if ( 2==parameter )
 		{
 			// pass "." to as value to remove the header instead
 			if (0==subString.compare("."))
 			{
-				printf("headerValue empty. Header to be removed.\n");
+				AAMPCLI_PRINTF("headerValue empty. Header to be removed.\n");
 			}
 			else
 			{
 				headerValue.push_back(subString);
-				printf("headerValue=%.80s\n", headerValue.back().c_str());
+				AAMPCLI_PRINTF("headerValue=%.80s\n", headerValue.back().c_str());
 			}
 		}
 		parameter++;
 		cmdptr = strtok (NULL, " ,");
 	}
-	printf("isLicenceHeader=%d\n", isLicenceHeader);
+	AAMPCLI_PRINTF("isLicenceHeader=%d\n", isLicenceHeader);
 	playerInstanceAamp->AddCustomHTTPHeader(headerName, headerValue, isLicenceHeader);
 }
 
@@ -438,12 +438,12 @@ void PlaybackCommand::HandleCommandSubtec( void )
 		snprintf( subtecCommand, MAX_SUBTEC_PATH_LEN, "gnome-terminal -- bash %s/aampcli-run-subtec.sh\n", scriptPath);
 		system(subtecCommand);
 #else
-		printf("[AAMPCLI] WARNING - subtec command not supported on platform\n");
+		AAMPCLI_PRINTF("[AAMPCLI] WARNING - subtec command not supported on platform\n");
 #endif
 	}
 	else
 	{
-		printf("[AAMPCLI] ERROR - unable to get path to subtec run script\n");
+		AAMPCLI_PRINTF("[AAMPCLI] ERROR - unable to get path to subtec run script\n");
 	}
 }
 
@@ -455,7 +455,7 @@ void PlaybackCommand::HandleCommandUnlock( const char *cmd, PlayerInstanceAAMP *
 	long time = -1;
 	if( sscanf(cmd, "unlock %ld", &unlockSeconds) >= 1 )
 	{
-		printf("[AAMPCLI] unlocking for %ld seconds\n" , unlockSeconds);
+		AAMPCLI_PRINTF("[AAMPCLI] unlocking for %ld seconds\n" , unlockSeconds);
 		if(-1 == unlockSeconds)
 		{
 			grace = -1;
@@ -467,7 +467,7 @@ void PlaybackCommand::HandleCommandUnlock( const char *cmd, PlayerInstanceAAMP *
 	}
 	else
 	{
-		printf("[AAMPCLI] unlocking till next program change\n");
+		AAMPCLI_PRINTF("[AAMPCLI] unlocking till next program change\n");
 		eventChange = true;
 	}
 	playerInstanceAamp->DisableContentRestrictions(grace, time, eventChange);
@@ -487,7 +487,7 @@ void PlaybackCommand::HandleCommandFog( const char *cmd, PlayerInstanceAAMP *pla
 {
 	if(!strcmp(cmd, "fog"))
 	{
-		printf("host: %s\n", mFogHostPrefix.c_str());
+		AAMPCLI_PRINTF("host: %s\n", mFogHostPrefix.c_str());
 	}
 	else if(!strncmp(cmd, "fog host=", 9))
 	{
@@ -497,11 +497,11 @@ void PlaybackCommand::HandleCommandFog( const char *cmd, PlayerInstanceAAMP *pla
 		if (std::regex_match(tmpIpv4, ipv4))
 		{
 			mFogHostPrefix = tmpIpv4;
-			printf("host: %s\n", mFogHostPrefix.c_str());
+			AAMPCLI_PRINTF("host: %s\n", mFogHostPrefix.c_str());
 		}
 		else
 		{
-			printf("Invalid ip:port\n");
+			AAMPCLI_PRINTF("Invalid ip:port\n");
 		}
 	}
 	else
@@ -511,12 +511,12 @@ void PlaybackCommand::HandleCommandFog( const char *cmd, PlayerInstanceAAMP *pla
 		{
 			std::string fogUrl;
 			buildFogUrl(mFogHostPrefix, &cmd[4], fogUrl);
-			printf("Tune to: %s\n", fogUrl.c_str());
+			AAMPCLI_PRINTF("Tune to: %s\n", fogUrl.c_str());
 			playerInstanceAamp->Tune(fogUrl.c_str(), mAampcli.mbAutoPlay);
 		}
 		else
 		{
-			printf("Invalid URL\n");
+			AAMPCLI_PRINTF("Invalid URL\n");
 		}
 	}
 }
@@ -534,16 +534,16 @@ void PlaybackCommand::HandleCommandAdvert( const char *cmd, PlayerInstanceAAMP *
 	{
 		if( token == "list" )
 		{
-			printf("[AAMP-CLI] Ad Map:\n");
+			AAMPCLI_PRINTF("[AAMP-CLI] Ad Map:\n");
 			for( const AdvertInfo &advertInfo : mAdvertList )
 			{
-				printf("[AAMP-CLI] advert %s -> %s\n", advertInfo.adBreakId.c_str(), advertInfo.url.c_str() );
+				AAMPCLI_PRINTF("[AAMP-CLI] advert %s -> %s\n", advertInfo.adBreakId.c_str(), advertInfo.url.c_str() );
 			}
 		}
 		else if( token == "clear" )
 		{
 			mAdvertList.clear();
-			printf("[AAMP-CLI] Cleared Ad List\n");
+			AAMPCLI_PRINTF("[AAMP-CLI] Cleared Ad List\n");
 		}
 		else if( token == "map" )
 		{
@@ -551,12 +551,12 @@ void PlaybackCommand::HandleCommandAdvert( const char *cmd, PlayerInstanceAAMP *
 			std::getline( input, advertInfo.adBreakId, ' ' );
 			std::getline( input, advertInfo.url, ' ' );
 			mAdvertList.push_back(advertInfo);
-			printf("[AAMP-CLI] mapped adBreakId %s\n", advertInfo.adBreakId.c_str() );
+			AAMPCLI_PRINTF("[AAMP-CLI] mapped adBreakId %s\n", advertInfo.adBreakId.c_str() );
 		}
 	}
 	else
 	{
-		printf("[AAMP-CLI] ERROR - expected 'advert [list, add, rm]'\n");
+		AAMPCLI_PRINTF("[AAMP-CLI] ERROR - expected 'advert [list, add, rm]'\n");
 	}
 }
 
@@ -572,11 +572,11 @@ void PlaybackCommand::HandleCommandScte35( const char *cmd )
 	if (std::getline(input, token, ' '))
 	{
 		SCTE35SpliceInfo spliceInfo(token);
-		printf("%s\n", spliceInfo.getJsonString(true).c_str());
+		AAMPCLI_PRINTF("%s\n", spliceInfo.getJsonString(true).c_str());
 	}
 	else
 	{
-		printf("[AAMP-CLI] ERROR - expected 'scte35 <base64>'\n");
+		AAMPCLI_PRINTF("[AAMP-CLI] ERROR - expected 'scte35 <base64>'\n");
 	}
 }
 
@@ -584,7 +584,7 @@ void PlaybackCommand::HandleCommandSessionId( const char *cmd )
 {
 	char sid[128] = {'\0'};
 
-	printf("[AAMPCLI] Matched Command SessionID - %s\n", cmd);
+	AAMPCLI_PRINTF("[AAMPCLI] Matched Command SessionID - %s\n", cmd);
 	const auto res = sscanf(cmd, "sessionid %127s", sid);
 
 	if (res == 1)
@@ -598,7 +598,7 @@ void PlaybackCommand::HandleCommandSessionId( const char *cmd )
 			if (inst)
 			{
 				const auto index = inst->GetId();
-				printf("[AAMPCLI] Player: %d - %s | %s\n", index,
+				AAMPCLI_PRINTF("[AAMPCLI] Player: %d - %s | %s\n", index,
 					   mAampcli.GetSessionId(index).c_str(), inst->GetSessionId().c_str());
 			}
 		}
@@ -660,7 +660,7 @@ void PlaybackCommand::HandleCommandBPS( const char *cmd, PlayerInstanceAAMP *pla
 	int rate = 0;
 	if (sscanf(cmd, "bps %d", &rate) == 1)
 	{
-		printf("[AAMPCLI] Set video bitrate %d.\n", rate);
+		AAMPCLI_PRINTF("[AAMPCLI] Set video bitrate %d.\n", rate);
 		playerInstanceAamp->SetVideoBitrate(rate);
 	}
 }
@@ -678,12 +678,12 @@ void PlaybackCommand::HandleCommandTuneData( const char *cmd, PlayerInstanceAAMP
 		mAampcli.mManifestDataUrl = url;
 		if (playerInstanceAamp->isTuneScheme(url.c_str()))
 		{
-			printf("[AAMPCLI] Player: url : %s \n",url.c_str());
+			AAMPCLI_PRINTF("[AAMPCLI] Player: url : %s \n",url.c_str());
 			manifestData = getManifestData(url);
 			playerInstanceAamp->Tune(url.c_str(),mAampcli.mbAutoPlay,nullptr, true, false, nullptr, true, nullptr, 0,"0259343c-cffc-4659-bcd8-97f9dd36f6b1",manifestData.c_str());
 			std::string minimumUpdatePeriod = getMinimumUpdatePeriod(manifestData);
 			double updateVal = ParseISO8601Duration(minimumUpdatePeriod.c_str());
-			printf("[AAMPCLI] Manifest minimumUpdatePeriod = %f \n",updateVal);
+			AAMPCLI_PRINTF("[AAMPCLI] Manifest minimumUpdatePeriod = %f \n",updateVal);
 			int count = 4; //for testing - limit the updates to 4
 			if ( updateVal != 0) //live manifest updates
 			{
@@ -697,17 +697,17 @@ void PlaybackCommand::HandleCommandTuneData( const char *cmd, PlayerInstanceAAMP
 		}
 		else
 		{
-			printf("[AAMP-CLI] ERROR - param '%s'\n",url.c_str());
+			AAMPCLI_PRINTF("[AAMP-CLI] ERROR - param '%s'\n",url.c_str());
 		}
 	}
 	else
 	{
-		printf("[AAMP-CLI] ERROR - expected 'tunedata <url>'\n");
+		AAMPCLI_PRINTF("[AAMP-CLI] ERROR - expected 'tunedata <url>'\n");
 	}
 }void PlaybackCommand::HandleAdTesting()
 {
     mAampcli.mIndexedAds = !mAampcli.mIndexedAds;
-	printf("[AAMPCLI] Ad Testing: %s\n", mAampcli.mIndexedAds ? "Enabled" : "Disabled");
+	AAMPCLI_PRINTF("[AAMPCLI] Ad Testing: %s\n", mAampcli.mIndexedAds ? "Enabled" : "Disabled");
 
 }
 
@@ -719,7 +719,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 {
 	if( cmd[0]=='#' )
 	{ // comment - ignore
-		printf( "%s\n", cmd );
+		AAMPCLI_PRINTF( "%s\n", cmd );
 	}
 	else if( isCommandMatch(cmd,"parse") )
 	{
@@ -736,7 +736,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 	else if( isCommandMatch(cmd,"autoplay") )
 	{
 		mAampcli.mbAutoPlay = !mAampcli.mbAutoPlay;
-		printf( "autoplay = %s\n", mAampcli.mbAutoPlay?"true":"false" );
+		AAMPCLI_PRINTF( "autoplay = %s\n", mAampcli.mbAutoPlay?"true":"false" );
 	}
 	else if( isCommandMatch(cmd,"contentType") )
 	{
@@ -834,14 +834,14 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 	{
 		AampLogManager::lockLogLevel(false);
 		AampLogManager::setLogLevel(eLOGLEVEL_INFO);
-		printf( "[AAMPCLI] core logging noisy\n" );
+		AAMPCLI_PRINTF( "[AAMPCLI] core logging noisy\n" );
 	}
 	else if( isCommandMatch(cmd,"quiet") )
 	{
 		AampLogManager::lockLogLevel(false);
 		AampLogManager::setLogLevel(eLOGLEVEL_ERROR);
 		AampLogManager::lockLogLevel(true);
-		printf( "[AAMPCLI] core logging quiet\n" );
+		AAMPCLI_PRINTF( "[AAMPCLI] core logging quiet\n" );
 	}
 	else if (isCommandMatch(cmd, "exit") )
 	{
@@ -866,7 +866,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 	}
 	else if( isCommandMatch(cmd, "stats") )
 	{
-		printf("[AAMPCLI] statistics:\n%s\n", playerInstanceAamp->GetPlaybackStats().c_str());
+		AAMPCLI_PRINTF("[AAMPCLI] statistics:\n%s\n", playerInstanceAamp->GetPlaybackStats().c_str());
 	}
 	else if( isCommandMatch(cmd,"subtec") )
 	{
@@ -877,7 +877,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 		// history_length is defined in the header file history.h
 		for (int i = 0; i < history_length; i++)
 		{
-			printf ("%s\n", history_get(i) ? history_get(i)->line : "NULL");
+			AAMPCLI_PRINTF ("%s\n", history_get(i) ? history_get(i)->line : "NULL");
 		}
 	}
 	else if( isCommandMatch(cmd,"auto") )
@@ -922,7 +922,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 	}
 	else
 	{
-		printf( "[AAMP-CLI] unmatched command: %s\n", cmd );
+		AAMPCLI_PRINTF( "[AAMP-CLI] unmatched command: %s\n", cmd );
 	}
 	return true;
 }
@@ -984,7 +984,7 @@ void PlaybackCommand::termPlayerLoop()
 		g_main_loop_quit(mAampcli.mAampGstPlayerMainLoop);
 		g_thread_join(mAampcli.mAampMainLoopThread);
 		PlayerCliGstTerm();
-		printf("[AAMPCLI] Exit\n");
+		AAMPCLI_PRINTF("[AAMPCLI] Exit\n");
 	}
 }
 
@@ -1108,12 +1108,12 @@ void PlaybackCommand::parse( const char *path )
 		}
 		else
 		{
-			printf( "unable to open file '%s'\n", path );
+			AAMPCLI_PRINTF( "unable to open file '%s'\n", path );
 		}
 	}
 	else
 	{
-		printf( "usage: parse <path>\n" );
+		AAMPCLI_PRINTF( "usage: parse <path>\n" );
 	}
 }
 
@@ -1125,10 +1125,10 @@ void PlaybackCommand::showHelp(void)
 
 	std::map<std::string,std::string>::iterator playbackCmdItr;
 
-	printf("******************************************************************************************\n");
-	printf("*   <command> [<arguments>]\n");
-	printf("*   Usage of Commands, and arguments expected\n");
-	printf("******************************************************************************************\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
+	AAMPCLI_PRINTF("*   <command> [<arguments>]\n");
+	AAMPCLI_PRINTF("*   Usage of Commands, and arguments expected\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
 
 	for(const auto& itr:commands)
 	{
@@ -1143,7 +1143,7 @@ void PlaybackCommand::showHelp(void)
 		}
 	}
 
-	printf("******************************************************************************************\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
 }
 
 char * PlaybackCommand::commandRecommender(const char *text, int state)
@@ -1215,7 +1215,7 @@ std::string PlaybackCommand::getManifestData(std::string& url)
 						break;
 					default:
 						// http error
-						printf("[AAMPCLI] %s curl error code : %ld",__FUNCTION__,response_code);
+						AAMPCLI_PRINTF("[AAMPCLI] %s curl error code : %ld",__FUNCTION__,response_code);
 						break;
 				}
 			}

--- a/test/aampcli/AampcliPrintf.cpp
+++ b/test/aampcli/AampcliPrintf.cpp
@@ -1,0 +1,90 @@
+/*
+ *   Copyright 2025 RDK Management
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+*/
+
+/***************************************************
+ * @file AampcliPrintf.cpp
+ * @brief printf()-like API for aamp-cli logging.
+ ***************************************************/
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <alloca.h>
+#include <sys/time.h>
+
+#define TIMESTAMP_FMT "%lu.%03lu: "
+
+static int _local_printf(int buf_size, const char *format, va_list ap)
+{
+	char *buf = (char *)alloca(buf_size);
+	int required_size = vsnprintf(buf, (size_t)buf_size, format, ap);
+
+	// Note: vsnprintf() does not include the terminating nul byte in
+	//       its return value. So 0 is valid for the empty string.
+	if (required_size >= 0)
+	{
+		++required_size;	/* Include the nul terminator. */
+
+		if (buf_size)
+		{
+			/* We have a buffer - print it. */
+			struct timeval tv;
+			(void) gettimeofday(&tv, NULL);
+
+			if (required_size <= buf_size)
+			{
+				/* Successfully formatted the buffer - output it. */
+				printf(TIMESTAMP_FMT "%s", tv.tv_sec, tv.tv_usec / 1000, buf);
+			}
+			else
+			{
+				printf(
+					TIMESTAMP_FMT
+					"ERROR: vsnprintf() required %d bytes, but only had %d\n",
+					tv.tv_sec, tv.tv_usec / 1000, required_size, buf_size);
+			}
+		}
+	}
+
+	return required_size;
+}
+
+int AAMPCLI_PRINTF(const char *format, ...)
+{
+	va_list ap;
+
+	va_start(ap, format);
+	int required_size = _local_printf(0, format, ap);
+	va_end(ap);
+
+	if (required_size > 0)
+	{
+		va_start(ap, format);
+		(void) _local_printf(required_size, format, ap);
+		va_end(ap);
+
+		// Be consistent with PRINTF(3) in case it's checked ...
+		--required_size;
+	}
+	else
+	{
+		printf("ERROR: AAMPCLI_PRINTF() failed to determine the buffer size required"
+		       " (Format string was '%s')\n", format);
+
+		required_size = -1;
+	}
+
+	return required_size;
+}

--- a/test/aampcli/AampcliPrintf.h
+++ b/test/aampcli/AampcliPrintf.h
@@ -1,0 +1,27 @@
+/*
+ *   Copyright 2025 RDK Management
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+*/
+
+/***************************************************
+ * @file AampcliPrintf.h
+ * @brief printf()-like API for aamp-cli logging.
+ ***************************************************/
+
+#ifndef AAMPCLI_PRINTF_H
+#define AAMPCLI_PRINTF_H
+
+int AAMPCLI_PRINTF(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
+
+#endif // AAMPCLI_PRINTF_H

--- a/test/aampcli/AampcliSet.cpp
+++ b/test/aampcli/AampcliSet.cpp
@@ -64,7 +64,7 @@ std::string Set::getItem(std::stringstream &command)
 
 bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 {
-	printf("cmd %s\n",cmd);
+	AAMPCLI_PRINTF("cmd %s\n",cmd);
 	char command[100];
 	int setCmd = 0;
 	int rate = 0;
@@ -89,7 +89,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 
 		if(0 == strncmp("help", command, 4))
 		{
-			printf("in help %s\n",cmd);
+			AAMPCLI_PRINTF("in help %s\n",cmd);
 			ShowHelpSet();
 		}
 		else
@@ -100,14 +100,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 					{
 						int rate;
 						double relativeTuneTime;
-						printf("[AAMPCLI] Matched Command RateAndSeek - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command RateAndSeek - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d %lf", command, &rate, &relativeTuneTime ) == 3){
 							playerInstanceAamp->SetRateAndSeek(rate, relativeTuneTime);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <rate=0,1 etc> <seek time in sec>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <rate=0,1 etc> <seek time in sec>\n", command);
 						}
 						break;
 					}
@@ -115,14 +115,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 2:
 					{
 						int x,y,w,h;
-						printf("[AAMPCLI] Matched Command VideoRectangle - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command VideoRectangle - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d %d %d %d", command, &x, &y, &w, &h) == 5){
 							playerInstanceAamp->SetVideoRectangle(x,y,w,h);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <x> <y> <w> <h>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <x> <y> <w> <h>\n", command);
 						}
 						break;
 					}
@@ -130,7 +130,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 3:
 					{
 						int videoZoom;
-						printf("[AAMPCLI] Matched Command VideoZoom - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command VideoZoom - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &videoZoom) == 2){
 							if( videoZoom>=0 && videoZoom<=VIDEO_ZOOM_GLOBAL )
 							{
@@ -138,13 +138,13 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							}
 							else
 							{
-								printf( "[AAMPCLI] invalid range (expected=%d..%d)\n", 0, (int)VIDEO_ZOOM_GLOBAL );
+								AAMPCLI_PRINTF( "[AAMPCLI] invalid range (expected=%d..%d)\n", 0, (int)VIDEO_ZOOM_GLOBAL );
 							}
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value value>0? ZOOM_FULL : ZOOM_NONE>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value value>0? ZOOM_FULL : ZOOM_NONE>\n", command);
 						}
 						break;
 					}
@@ -152,14 +152,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 4:
 					{
 						int videoMute;
-						printf("[AAMPCLI] Matched Command VideoMute - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command VideoMute - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &videoMute) == 2){
 							playerInstanceAamp->SetVideoMute((videoMute == 1 )? true : false );
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
 						}
 						break;
 					}
@@ -167,14 +167,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 5:
 					{
 						int vol;
-						printf("[AAMPCLI] Matched Command AudioVolume - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command AudioVolume - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &vol) == 2){
 							playerInstanceAamp->SetAudioVolume(vol);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value to set audio volume>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value to set audio volume>\n", command);
 						}
 						break;
 					}
@@ -182,14 +182,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 6:
 					{
 						char lang[12];
-						printf("[AAMPCLI] Matched Command Language - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command Language - %s\n", cmd);
 						if (sscanf(cmd, "set %s %s", command, lang) == 2){
 							playerInstanceAamp->SetLanguage(lang);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <lang in string>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <lang in string>\n", command);
 						}
 						break;
 					}
@@ -198,14 +198,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 					{
 						//Dummy implimentation
 						std::vector<std::string> subscribedTags;
-						printf("[AAMPCLI] Matched Command SubscribedTags - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command SubscribedTags - %s\n", cmd);
 						playerInstanceAamp->SetSubscribedTags(subscribedTags);
 						break;
 					}
 
 				case 8:
 					{
-						printf("[AAMPCLI] Matched Command LicenseServerUrl - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command LicenseServerUrl - %s\n", cmd);
 						std::istringstream iss(cmd);
 						std::vector<std::string> tokens;
 						// split input into space-delimited tokens
@@ -223,13 +223,13 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							}
 							else
 							{
-								printf( "[AAMPCLI] unsupported drmType; pass 1(eDRM_WideVine) or 2(eDRM_PlayReady)\n" );
+								AAMPCLI_PRINTF( "[AAMPCLI] unsupported drmType; pass 1(eDRM_WideVine) or 2(eDRM_PlayReady)\n" );
 							}
 						} 
 						else 
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <licenseUrl> <drmType>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <licenseUrl> <drmType>\n", command);
 						}
 						break;
 					}
@@ -237,14 +237,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 9:
 					{
 						int isAnonym;
-						printf("[AAMPCLI] Matched Command AnonymousRequest - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command AnonymousRequest - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &isAnonym) == 2){
 							playerInstanceAamp->SetAnonymousRequest((isAnonym == 1)?true:false);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
 						}
 						break;
 					}
@@ -252,14 +252,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 10:
 					{
 						int vodTFps;
-						printf("[AAMPCLI] Matched Command VodTrickplayFps - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command VodTrickplayFps - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &vodTFps) == 2){
 							playerInstanceAamp->SetVODTrickplayFPS(vodTFps);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -267,14 +267,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 11:
 					{
 						int linearTFps;
-						printf("[AAMPCLI] Matched Command LinearTrickplayFps - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command LinearTrickplayFps - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &linearTFps) == 2){
 							playerInstanceAamp->SetLinearTrickplayFPS(linearTFps);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -282,28 +282,28 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 12:
 					{
 						double liveOffset;
-						printf("[AAMPCLI] Matched Command LiveOffset - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command LiveOffset - %s\n", cmd);
 						if (sscanf(cmd, "set %s %lf", command, &liveOffset) == 2){
 							playerInstanceAamp->SetLiveOffset(liveOffset);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
 				case 56:
 					{
 						double liveOffset;
-						printf("[AAMPCLI] Matched Command LiveOffset4K - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command LiveOffset4K - %s\n", cmd);
 						if (sscanf(cmd, "set %s %lf", command, &liveOffset) == 2){
 							playerInstanceAamp->SetLiveOffset4K(liveOffset);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -311,14 +311,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 13:
 					{
 						int stallErrorCode;
-						printf("[AAMPCLI] Matched Command StallErrorCode - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command StallErrorCode - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &stallErrorCode) == 2){
 							playerInstanceAamp->SetStallErrorCode(stallErrorCode);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -326,7 +326,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 14:
 					{
 						int stallTimeout;
-						printf("[AAMPCLI] Matched Command StallTimeout - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command StallTimeout - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &stallTimeout) == 2){
 							playerInstanceAamp->SetStallTimeout(stallTimeout);
 						}
@@ -336,14 +336,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 15:
 					{
 						int reportInterval;
-						printf("[AAMPCLI] Matched Command ReportInterval - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command ReportInterval - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &reportInterval) == 2){
 							playerInstanceAamp->SetReportInterval(reportInterval);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -351,14 +351,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 16:
 					{
 						long videoBitrate;
-						printf("[AAMPCLI] Matched Command VideoBitarate - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command VideoBitarate - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &videoBitrate) == 2){
 							playerInstanceAamp->SetVideoBitrate(videoBitrate);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -366,14 +366,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 17:
 					{
 						long initialBitrate;
-						printf("[AAMPCLI] Matched Command InitialBitrate - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command InitialBitrate - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &initialBitrate) == 2){
 							playerInstanceAamp->SetInitialBitrate(initialBitrate);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -381,14 +381,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 18:
 					{
 						long initialBitrate4k;
-						printf("[AAMPCLI] Matched Command InitialBitrate4k - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command InitialBitrate4k - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &initialBitrate4k) == 2){
 							playerInstanceAamp->SetInitialBitrate4K(initialBitrate4k);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -396,14 +396,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 19:
 					{
 						double networkTimeout;
-						printf("[AAMPCLI] Matched Command NetworkTimeout - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command NetworkTimeout - %s\n", cmd);
 						if (sscanf(cmd, "set %s %lf", command, &networkTimeout) == 2){
 							playerInstanceAamp->SetNetworkTimeout(networkTimeout);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -411,14 +411,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 20:
 					{
 						double manifestTimeout;
-						printf("[AAMPCLI] Matched Command ManifestTimeout - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command ManifestTimeout - %s\n", cmd);
 						if (sscanf(cmd, "set %s %lf", command, &manifestTimeout) == 2){
 							playerInstanceAamp->SetManifestTimeout(manifestTimeout);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -426,14 +426,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 21:
 					{
 						int downloadBufferSize;
-						printf("[AAMPCLI] Matched Command DownloadBufferSize - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command DownloadBufferSize - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &downloadBufferSize) == 2){
 							playerInstanceAamp->SetDownloadBufferSize(downloadBufferSize);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -441,14 +441,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 22:
 					{
 						int preferredDrm;
-						printf("[AAMPCLI] Matched Command PreferredDrm - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command PreferredDrm - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &preferredDrm) == 2){
 							playerInstanceAamp->SetPreferredDRM((DRMSystems)preferredDrm);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -456,15 +456,15 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 23:
 					{
 						int stereoOnlyPlayback;
-						printf("[AAMPCLI] Matched Command StereoOnlyPlayback - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command StereoOnlyPlayback - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &stereoOnlyPlayback) == 2){
 							playerInstanceAamp->SetStereoOnlyPlayback(
 									(stereoOnlyPlayback == 1 )? true:false);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
 						}
 						break;
 					}
@@ -474,7 +474,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						std::string adBrkId;
 						std::string adId;
 						std::string adUrl;
-						printf("[AAMPCLI] Matched Command AlternateContents - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command AlternateContents - %s\n", cmd);
 						std::istringstream iss(cmd);
 						std::vector<std::string> tokens;
 						std::string token;
@@ -489,8 +489,8 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <adBreakId> <adId> <adUrl>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <adBreakId> <adId> <adUrl>\n", command);
 						}
 						break;
 					}
@@ -498,14 +498,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 25:
 					{
 						char networkProxy[128];
-						printf("[AAMPCLI] Matched Command NetworkProxy - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command NetworkProxy - %s\n", cmd);
 						if (sscanf(cmd, "set %s %s", command, networkProxy) == 2){
 							playerInstanceAamp->SetNetworkProxy(networkProxy);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value in string>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value in string>\n", command);
 						}
 						break;
 					}
@@ -513,14 +513,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 26:
 					{
 						char licenseReqProxy[128];
-						printf("[AAMPCLI] Matched Command LicenseReqProxy - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command LicenseReqProxy - %s\n", cmd);
 						if (sscanf(cmd, "set %s %s", command, licenseReqProxy) == 2){
 							playerInstanceAamp->SetLicenseReqProxy(licenseReqProxy);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value in string>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value in string>\n", command);
 						}
 						break;
 					}
@@ -528,14 +528,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 27:
 					{
 						long downloadStallTimeout;
-						printf("[AAMPCLI] Matched Command DownloadStallTimeout - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command DownloadStallTimeout - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &downloadStallTimeout) == 2){
 							playerInstanceAamp->SetDownloadStallTimeout((int)downloadStallTimeout);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -543,14 +543,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 28:
 					{
 						long downloadStartTimeout;
-						printf("[AAMPCLI] Matched Command DownloadStartTimeout - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command DownloadStartTimeout - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &downloadStartTimeout) == 2){
 							playerInstanceAamp->SetDownloadStartTimeout((int)downloadStartTimeout);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -558,14 +558,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 29:
 					{
 						long downloadLowBWTimeout;
-						printf("[AAMPCLI] Matched Command DownloadLowBWTimeout - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command DownloadLowBWTimeout - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &downloadLowBWTimeout) == 2){
 							playerInstanceAamp->SetDownloadLowBWTimeout((int)downloadLowBWTimeout);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -573,14 +573,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 30:
 					{
 						char preferredSubtitleLang[12];
-						printf("[AAMPCLI] Matched Command PreferredSubtitleLang - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command PreferredSubtitleLang - %s\n", cmd);
 						if (sscanf(cmd, "set %s %s", command, preferredSubtitleLang) == 2){
 							playerInstanceAamp->SetPreferredSubtitleLanguage(preferredSubtitleLang);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value in string>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value in string>\n", command);
 						}
 						break;
 					}
@@ -602,11 +602,11 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						bool prefTypePresent = false;
 						bool prefCodecPresent = false;
 						bool prefLabelPresent = false;
-						printf("[AAMPCLI] Matched Command PreferredLanguages - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command PreferredLanguages - %s\n", cmd);
 
 						if (sscanf(cmd, "set %s %s %s %s %s %s", command, preferredLanguages, rendition, type, preferredCodec, preferredLabel) == 6)
 						{
-							printf("[AAMPCLI] setting Preferred Languages (%s), rendition (%s), type (%s) , codec (%s) and label (%s)\n" ,
+							AAMPCLI_PRINTF("[AAMPCLI] setting Preferred Languages (%s), rendition (%s), type (%s) , codec (%s) and label (%s)\n" ,
 									preferredLanguages, rendition, type, preferredCodec, preferredLabel);
 							if (0 != strcasecmp(preferredLanguages, "null"))
 							{
@@ -637,7 +637,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else if (sscanf(cmd, "set %s %s %s %s %s", command, preferredLanguages, rendition, type, preferredCodec) == 5)
 						{
-							printf("[AAMPCLI] setting Preferred Languages (%s), rendition (%s), type (%s) and codec (%s)\n" ,
+							AAMPCLI_PRINTF("[AAMPCLI] setting Preferred Languages (%s), rendition (%s), type (%s) and codec (%s)\n" ,
 									preferredLanguages, rendition, type, preferredCodec);
 							if (0 != strcasecmp(preferredLanguages, "null"))
 							{
@@ -663,7 +663,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else if (sscanf(cmd, "set %s %s %s %s", command, preferredLanguages, rendition, type) == 4)
 						{
-							printf("[AAMPCLI] setting PreferredLanguages (%s) with rendition (%s) and type (%s)\n" ,
+							AAMPCLI_PRINTF("[AAMPCLI] setting PreferredLanguages (%s) with rendition (%s) and type (%s)\n" ,
 									preferredLanguages, rendition, type);
 							if (0 != strcasecmp(preferredLanguages, "null"))
 							{
@@ -683,7 +683,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else if (sscanf(cmd, "set %s %s %s", command, preferredLanguages, rendition) == 3)
 						{
-							printf("[AAMPCLI] setting PreferredLanguages (%s) with rendition (%s)\n" ,
+							AAMPCLI_PRINTF("[AAMPCLI] setting PreferredLanguages (%s) with rendition (%s)\n" ,
 									preferredLanguages, rendition);
 							if (0 != strcasecmp(preferredLanguages, "null"))
 							{
@@ -698,7 +698,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else if (sscanf(cmd, "set %s %s", command, preferredLanguages) == 2)
 						{
-							printf("[AAMPCLI] setting PreferredLanguages (%s)\n",preferredLanguages );
+							AAMPCLI_PRINTF("[AAMPCLI] setting PreferredLanguages (%s)\n",preferredLanguages );
 							if (0 != strcasecmp(preferredLanguages, "null"))
 							{
 								std::ifstream infile(preferredLanguages);
@@ -707,7 +707,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 								if(infile.good())
 								{
 									/**< If it is file get the data **/
-									printf("[AAMPCLI] File Path for Json Data (%s)\n",preferredLanguages );
+									AAMPCLI_PRINTF("[AAMPCLI] File Path for Json Data (%s)\n",preferredLanguages );
 									while ( getline (infile,line) )
 									{
 										if (!data.empty())
@@ -723,20 +723,20 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 									data = std::string(preferredLanguages);
 								}
 
-								printf("[AAMPCLI] setting PreferredLanguages (%s)\n",data.c_str());
+								AAMPCLI_PRINTF("[AAMPCLI] setting PreferredLanguages (%s)\n",data.c_str());
 								playerInstanceAamp->SetPreferredLanguages(data.c_str());
 							}
 							else
 							{
-								printf("[AAMPCLI] ERROR: Invalid arguments- %s\n", cmd);
-								printf("[AAMPCLI] set preferred languages must be set at least a language\n");
+								AAMPCLI_PRINTF("[AAMPCLI] ERROR: Invalid arguments- %s\n", cmd);
+								AAMPCLI_PRINTF("[AAMPCLI] set preferred languages must be set at least a language\n");
 							}
 
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments- %s\n", cmd);
-							printf("[AAMPCLI] set preferred languages must be run with at least 2 argument\n");
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments- %s\n", cmd);
+							AAMPCLI_PRINTF("[AAMPCLI] set preferred languages must be run with at least 2 argument\n");
 						}
 						break;
 					}
@@ -746,7 +746,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						char preferredLanguages[128];
 						if (sscanf(cmd, "set %s %s", command, preferredLanguages) == 2)
 						{
-							printf("[AAMPCLI] setting PreferredText  (%s)\n",preferredLanguages );
+							AAMPCLI_PRINTF("[AAMPCLI] setting PreferredText  (%s)\n",preferredLanguages );
 							if (0 != strcasecmp(preferredLanguages, "null"))
 							{
 								std::ifstream infile(preferredLanguages);
@@ -769,19 +769,19 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 									/**Nomal case */
 									data = std::string(preferredLanguages);
 								}
-								printf("[AAMPCLI] JSON Argument Received- %s\n", data.c_str());
+								AAMPCLI_PRINTF("[AAMPCLI] JSON Argument Received- %s\n", data.c_str());
 								playerInstanceAamp->SetPreferredTextLanguages(data.c_str());
 							}
 							else
 							{
-								printf("[AAMPCLI] ERROR: Invalid arguments- %s\n", cmd);
-								printf("[AAMPCLI] set preferred text languages must be set at least a language or json data\n");
+								AAMPCLI_PRINTF("[AAMPCLI] ERROR: Invalid arguments- %s\n", cmd);
+								AAMPCLI_PRINTF("[AAMPCLI] set preferred text languages must be set at least a language or json data\n");
 							}
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments- %s\n", cmd);
-							printf("[AAMPCLI] set preferred languages must be run with 2 argument\n");
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments- %s\n", cmd);
+							AAMPCLI_PRINTF("[AAMPCLI] set preferred languages must be run with 2 argument\n");
 						}
 						break;
 					}
@@ -789,14 +789,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 34:
 					{
 						int rampDownLimit;
-						printf("[AAMPCLI] Matched Command InitRampdownLimit - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command InitRampdownLimit - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &rampDownLimit) == 2){
 							playerInstanceAamp->SetInitRampdownLimit(rampDownLimit);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -804,14 +804,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 35:
 					{
 						int rampDownLimit;
-						printf("[AAMPCLI] Matched Command RampDownLimit - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command RampDownLimit - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &rampDownLimit) == 2){
 							playerInstanceAamp->SetRampDownLimit(rampDownLimit);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -819,14 +819,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 36:
 					{
 						long minBitrate;
-						printf("[AAMPCLI] Matched Command MinimumBitrate - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command MinimumBitrate - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &minBitrate) == 2){
 							playerInstanceAamp->SetMinimumBitrate(minBitrate);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -834,14 +834,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 37:
 					{
 						long maxBitrate;
-						printf("[AAMPCLI] Matched Command MaximumBitrate - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command MaximumBitrate - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld", command, &maxBitrate) == 2){
 							playerInstanceAamp->SetMaximumBitrate(maxBitrate);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -849,7 +849,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 					{
 						BitsPerSecond bitrate1, bitrate2, bitrate3;
 						std::vector<BitsPerSecond>bitrateList;
-						printf("[AAMPCLI] Matched Command VideoTrack - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command VideoTrack - %s\n", cmd);
 						if (sscanf(cmd, "set %s %ld %ld %ld", command, &bitrate1, &bitrate2, &bitrate3) == 4){
 							bitrateList.push_back(bitrate1);
 							bitrateList.push_back(bitrate2);
@@ -858,22 +858,22 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value1> <value2> <value3>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value1> <value2> <value3>\n", command);
 						}
 						break;
 					}
 				case 38:
 					{
 						int failCount;
-						printf("[AAMPCLI] Matched Command MaximumSegmentInjFailCount - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command MaximumSegmentInjFailCount - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &failCount) == 2){
 							playerInstanceAamp->SetSegmentInjectFailCount(failCount);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -881,14 +881,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 49:
 					{
 						int value;
-						printf("[AAMPCLI] Matched Command SslVerifyPeer - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command SslVerifyPeer - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &value) == 2){
 							playerInstanceAamp->SetSslVerifyPeerConfig(value == 1);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
 						}
 						break;
 					}
@@ -896,14 +896,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 39:
 					{
 						int failCount;
-						printf("[AAMPCLI] Matched Command MaximumDrmDecryptFailCount - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command MaximumDrmDecryptFailCount - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &failCount) == 2){
 							playerInstanceAamp->SetSegmentDecryptFailCount(failCount);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -911,7 +911,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 40:
 					{
 						int id3MetadataEventsEnabled;
-						printf("[AAMPCLI] Matched Command RegisterForID3MetadataEvents - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command RegisterForID3MetadataEvents - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &id3MetadataEventsEnabled) == 2){
 							if (id3MetadataEventsEnabled)
 							{
@@ -925,8 +925,8 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
 						}
 						break;
 					}
@@ -934,7 +934,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 53:
 					{
 						int mediaMetadataEventsEnabled;
-						printf("[AAMPCLI] Matched Command RegisterForMediaMetadata - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command RegisterForMediaMetadata - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &mediaMetadataEventsEnabled) == 2){
 							if (mediaMetadataEventsEnabled)
 							{
@@ -947,8 +947,8 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0 or 1>\n", command);
 						}
 						break;
 					}
@@ -965,8 +965,8 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value for preference> <value for track number>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value for preference> <value for track number>\n", command);
 						}
 						break;
 					}
@@ -974,15 +974,15 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 41:
 					{
 						int duration;
-						printf("[AAMPCLI] Matched Command InitialBufferDuration - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command InitialBufferDuration - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &duration) == 2)
 						{
 							playerInstanceAamp->SetInitialBufferDuration(duration);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -992,7 +992,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						int track;
 						char strTrackInfo[512];
 						memset(strTrackInfo, '\0', sizeof(strTrackInfo));
-						printf("[AAMPCLI] Matched Command AudioTrack - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command AudioTrack - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &track) == 2)
 						{
 							playerInstanceAamp->SetAudioTrack(track);
@@ -1018,7 +1018,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							}
 							label = getItem(ss);
 
-							printf("[AAMPCLI] Selecting audio track based on language  - %s rendition - %s type = %s codec = %s channel = %d label = %s\n",
+							AAMPCLI_PRINTF("[AAMPCLI] Selecting audio track based on language  - %s rendition - %s type = %s codec = %s channel = %d label = %s\n",
 									language.c_str(), rendition.c_str(), type.c_str(), codec.c_str(), channel, label.c_str());
 							playerInstanceAamp->SetAudioTrack(language, rendition, type, codec, channel,label);
 
@@ -1031,7 +1031,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						int track = 0;
 						char sidecar[128];
 
-						printf("[AAMPCLI] Matched Command TextTrack - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command TextTrack - %s\n", cmd);
 						if (sscanf(cmd, "set %s %127s", command, sidecar) == 2)
 						{
 							std::ifstream inFile(sidecar);
@@ -1044,7 +1044,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 								size_t subt_size = str.size();
 								if (subt_size > AAMPCLI_MAX_WEBVTT_SIZE)
 								{
-									printf("[AAMPCLI] ERROR: WebVTT sidecar subtitles file too big (%zu > max=%u)\n",
+									AAMPCLI_PRINTF("[AAMPCLI] ERROR: WebVTT sidecar subtitles file too big (%zu > max=%u)\n",
 										subt_size, AAMPCLI_MAX_WEBVTT_SIZE);
 								}
 								else
@@ -1064,14 +1064,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							}
 							else
 							{
-								printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-								printf("[AAMPCLI] Expected: set %s <value> OR set %s <file>\n", command, command);
+								AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+								AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value> OR set %s <file>\n", command, command);
 							}
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] set %s must be run with 1 argument\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] set %s must be run with 1 argument\n", command);
 						}
 						break;
 					}
@@ -1079,15 +1079,15 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 44:
 					{
 						int status;
-						printf("[AAMPCLI] Matched Command CCStatus - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command CCStatus - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &status) == 2)
 						{
 							playerInstanceAamp->SetCCStatus(status == 1);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -1099,7 +1099,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						char jsonFile[128];
 						char tempChar;
 
-						printf("[AAMPCLI] Matched Command CCStyle - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command CCStyle - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d %c", command, &value, &tempChar) == 2)
 						{
 							switch (value)
@@ -1114,7 +1114,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 									options = std::string(CC_OPTION_3);
 									break;
 								default:
-									printf("[AAMPCLI] Invalid option passed %d. skipping!\n", value);
+									AAMPCLI_PRINTF("[AAMPCLI] Invalid option passed %d. skipping!\n", value);
 									break;
 							}
 						}
@@ -1136,7 +1136,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							}
 							else
 							{
-								printf("[AAMPCLI] Invalid filename passed %s. skipping!\n", jsonFile);
+								AAMPCLI_PRINTF("[AAMPCLI] Invalid filename passed %s. skipping!\n", jsonFile);
 							}
 						}
 
@@ -1146,8 +1146,8 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 1,2 or 3> or json file\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 1,2 or 3> or json file\n", command);
 						}
 						break;
 					}
@@ -1155,14 +1155,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 47:
 					{
 						int propagateUriParam;
-						printf("[AAMPCLI] Matched Command PropagateUriParam - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command PropagateUriParam - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &propagateUriParam) == 2){
 							playerInstanceAamp->SetPropagateUriParameters((bool) propagateUriParam);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value>\n", command);
 						}
 						break;
 					}
@@ -1170,21 +1170,21 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 48:
 					{
 						int thumbnailTrack;
-						printf("[AAMPCLI] Matched Command ThumbnailTrack - %s\n",cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command ThumbnailTrack - %s\n",cmd);
 						if (sscanf(cmd, "set %s %d", command, &thumbnailTrack) == 2) {
-							printf("[AAMPCLI] Setting ThumbnailTrack : %s\n",playerInstanceAamp->SetThumbnailTrack(thumbnailTrack)?"Success":"Failure");
+							AAMPCLI_PRINTF("[AAMPCLI] Setting ThumbnailTrack : %s\n",playerInstanceAamp->SetThumbnailTrack(thumbnailTrack)?"Success":"Failure");
 						}
 						else
-						{	printf("[AAMPCLI] Setting ThumbnailTrack : %s\n",playerInstanceAamp->SetThumbnailTrack(-1)?"Success":"Failure");  //SetThumbnailTrack to -1 to ensure failure
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <track index>\n", command);
+						{	AAMPCLI_PRINTF("[AAMPCLI] Setting ThumbnailTrack : %s\n",playerInstanceAamp->SetThumbnailTrack(-1)?"Success":"Failure");  //SetThumbnailTrack to -1 to ensure failure
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <track index>\n", command);
 						}
 						
 						break;
 					}
 				case 50:
 					{
-						printf("[AAMPCLI] Matched Command DownloadDelayOnFetch - %s\n",cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command DownloadDelayOnFetch - %s\n",cmd);
 						sscanf(cmd, "set %s %d", command, &DownloadDelayInMs);
 						playerInstanceAamp->ApplyArtificialDownloadDelay(DownloadDelayInMs);
 						break;
@@ -1193,15 +1193,15 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 
 				case 51:
 					{
-						printf("[AAMPCLI] Matched Command PausedBehavior - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command PausedBehavior - %s\n", cmd);
 						if(sscanf(cmd, "set %s %d", command, &rate) == 2)
 						{
 							playerInstanceAamp->SetPausedBehavior(rate);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value 0,1,2 or 3>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value 0,1,2 or 3>\n", command);
 						}
 						break;
 					}
@@ -1209,15 +1209,15 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 52:
 					{
 						char lang[12];
-						printf("[AAMPCLI] Matched Command AuxiliaryAudio - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command AuxiliaryAudio - %s\n", cmd);
 						if (sscanf(cmd, "set %s %s", command, lang) == 2)
 						{
 							playerInstanceAamp->SetAuxiliaryLanguage(lang);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value in string>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value in string>\n", command);
 						}
 						break;
 					}
@@ -1227,14 +1227,14 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						int timeout;
 						if (sscanf(cmd, "set %s %d", command, &timeout) == 2)
 						{
-							printf("[AAMPCLI] Enabling AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE event registration");
+							AAMPCLI_PRINTF("[AAMPCLI] Enabling AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE event registration");
 							playerInstanceAamp->AddEventListener(AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE, lAampcli.mEventListener);
 							playerInstanceAamp->SetContentProtectionDataUpdateTimeout(timeout);
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <value in Milliseconds>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <value in Milliseconds>\n", command);
 						}
 						break;
 					}
@@ -1242,21 +1242,21 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 				case 57:
 					{
 						int enable;
-						printf("[AAMPCLI] Matched Command SubtecSimulator - %s\n", cmd);
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command SubtecSimulator - %s\n", cmd);
 						if (sscanf(cmd, "set %s %d", command, &enable) != 2)
 						{
-							printf("[AAMPCLI] ERROR: Unexpected number of arguments\n");
-							printf("[AAMPCLI] Expected: set %s <0/1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Unexpected number of arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <0/1>\n", command);
 						}
 						else if (enable == 0)
 						{
 							if (!StopSubtecSimulator())
 							{
-								printf("Subtec Simulator did not stop");
+								AAMPCLI_PRINTF("Subtec Simulator did not stop");
 							}
 							else
 							{
-								printf("Subtec Simulator stopped");
+								AAMPCLI_PRINTF("Subtec Simulator stopped");
 							}
 						}
 						else if (enable == 1)
@@ -1264,23 +1264,23 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 							// The socket path used here has to match the one used in SubtecChannel::InitComms()
 							if (!StartSubtecSimulator("/tmp/pes_data_main"))
 							{
-								printf("Subtec Simulator did not start");
+								AAMPCLI_PRINTF("Subtec Simulator did not start");
 							}
 							else
 							{
-								printf("Subtec Simulator started");
+								AAMPCLI_PRINTF("Subtec Simulator started");
 							}
 						}
 						else
 						{
-							printf("[AAMPCLI] ERROR: Mismatch in arguments\n");
-							printf("[AAMPCLI] Expected: set %s <0/1>\n", command);
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <0/1>\n", command);
 						}
 						break;
 					}
 
 				default:
-					printf("[AAMPCLI] Invalid set command %s\n", command);
+					AAMPCLI_PRINTF("[AAMPCLI] Invalid set command %s\n", command);
 					break;
 			}
 
@@ -1288,7 +1288,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 	}
 	else
 	{
-		printf("[AAMPCLI] Invalid set command = %s\n", cmd);
+		AAMPCLI_PRINTF("[AAMPCLI] Invalid set command = %s\n", cmd);
 	}
 
 	return true;
@@ -1392,10 +1392,10 @@ void Set::addCommand(int value,std::string command,std::string param,std::string
  */
 void Set::ShowHelpSet()
 {
-	printf("******************************************************************************************\n");
-	printf("*   set <command> [<arguments>]\n");
-	printf("*   Usage of Commands with arguemnts expected in ()\n");
-	printf("******************************************************************************************\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
+	AAMPCLI_PRINTF("*   set <command> [<arguments>]\n");
+	AAMPCLI_PRINTF("*   Usage of Commands with arguemnts expected in ()\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
 
 	if(!commands.empty())
 	{
@@ -1414,7 +1414,7 @@ void Set::ShowHelpSet()
 		}
 	}
 
-	printf("******************************************************************************************\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
 }
 
 char * Set::setCommandRecommender(const char *text, int state)

--- a/test/aampcli/AampcliShader.cpp
+++ b/test/aampcli/AampcliShader.cpp
@@ -120,7 +120,7 @@ void createAppWindow( int argc, char **argv )
 	glutInitWindowPosition(80, 80);
 	glutInitWindowSize(640, 480);
 	glutCreateWindow("AAMP");
-	printf("[AAMPCLI] OpenGL Version[%s] GLSL Version[%s]\n", glGetString(GL_VERSION), glGetString(GL_SHADING_LANGUAGE_VERSION));
+	AAMPCLI_PRINTF("[AAMPCLI] OpenGL Version[%s] GLSL Version[%s]\n", glGetString(GL_VERSION), glGetString(GL_SHADING_LANGUAGE_VERSION));
 #ifndef __APPLE__
 	glewInit();
 #endif
@@ -193,7 +193,7 @@ GLuint Shader::LoadShader( GLenum shader, const char *code )
 		{
 			GLchar msg[1024];
 			glGetShaderInfoLog(shaderHandle, sizeof(msg), 0, &msg[0]);
-			printf("[AAMPCLI] %s\n", msg );
+			AAMPCLI_PRINTF("[AAMPCLI] %s\n", msg );
 		}
 	}
 	return shaderHandle;
@@ -215,7 +215,7 @@ void Shader::InitShaders()
 			FILE *f = fopen( path.c_str(), "rb" );
 			if( !f )
 			{ // no more frames
-				printf( "DONE! processed %d frames\n", frameNumber-1 );
+				AAMPCLI_PRINTF( "DONE! processed %d frames\n", frameNumber-1 );
 				exit(0);
 			}
 			else
@@ -288,7 +288,7 @@ void Shader::InitShaders()
 		glGetProgramiv(mProgramID, GL_INFO_LOG_LENGTH, &logLen);
 		GLchar *msg = (GLchar *)malloc(sizeof(GLchar)*logLen);
 		glGetProgramInfoLog(mProgramID, logLen, &logLen, msg );
-		printf( "%s\n", msg );
+		AAMPCLI_PRINTF( "%s\n", msg );
 		free( msg );
 	}
 	glUseProgram(mProgramID);

--- a/test/aampcli/AampcliVirtualChannelMap.cpp
+++ b/test/aampcli/AampcliVirtualChannelMap.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "AampcliVirtualChannelMap.h"
+#include "AampcliPrintf.h"
 
 VirtualChannelMap mVirtualChannelMap;
 
@@ -76,14 +77,14 @@ bool VirtualChannelMap::isPresent(const VirtualChannelInfo& channelInfo)
 		const VirtualChannelInfo &existingChannelInfo = *it;
 		if(channelInfo.channelNumber == existingChannelInfo.channelNumber)
 		{ // forbid repeated virtual channel number!
-			printf("[AAMPCLI] duplicate channel number: %d: '%s'\n", channelInfo.channelNumber, channelInfo.uri.c_str() );
+			AAMPCLI_PRINTF("[AAMPCLI] duplicate channel number: %d: '%s'\n", channelInfo.channelNumber, channelInfo.uri.c_str() );
 			return true;
 		}
 		if(channelInfo.uri == existingChannelInfo.uri )
 		{
 			if( !didWarn )
 			{ // warn for same url appearing more than once
-				printf("[AAMPCLI] duplicate URL: %d: '%s'\n", channelInfo.channelNumber, channelInfo.uri.c_str() );
+				AAMPCLI_PRINTF("[AAMPCLI] duplicate URL: %d: '%s'\n", channelInfo.channelNumber, channelInfo.uri.c_str() );
 				didWarn = true;
 			}
 		}
@@ -179,7 +180,7 @@ void VirtualChannelMap::print(unsigned long start, unsigned long end, unsigned l
 		return;
 	}
 
-	printf("[AAMPCLI] aampcli.cfg virtual channel map:\n");
+	AAMPCLI_PRINTF("[AAMPCLI] aampcli.cfg virtual channel map:\n");
 
 	int numCols = 0;
 	unsigned long lineCount = 0;
@@ -225,9 +226,9 @@ void VirtualChannelMap::print(unsigned long start, unsigned long end, unsigned l
 		{
 			if( numCols!=0 )
 			{
-				printf( "\n" );
+				AAMPCLI_PRINTF( "\n" );
 			}
-			printf( "%s\n", channelName.c_str() );
+			AAMPCLI_PRINTF( "%s\n", channelName.c_str() );
 			numCols = 0;
 			//Increment displayed lines here & check, as the "continue" bypasses the normal check.
 			lineCount++;
@@ -237,17 +238,17 @@ void VirtualChannelMap::print(unsigned long start, unsigned long end, unsigned l
 			}			
 			continue;
 		}
-		printf("%4d: %s", pChannelInfo.channelNumber, channelName.c_str() );
+		AAMPCLI_PRINTF("%4d: %s", pChannelInfo.channelNumber, channelName.c_str() );
 		if( numCols>=4 )
 		{ // four virtual channels per row
-			printf("\n");
+			AAMPCLI_PRINTF("\n");
 			numCols = 0;
 		}
 		else
 		{
 			while( len<maxNameLen )
 			{ // pad each column to 20 characters, for clean layout
-				printf( " " );
+				AAMPCLI_PRINTF( " " );
 				len++;
 			}
 			numCols++;
@@ -259,7 +260,7 @@ void VirtualChannelMap::print(unsigned long start, unsigned long end, unsigned l
 			break;
 		}
 	}
-	printf("\n\n");
+	AAMPCLI_PRINTF("\n\n");
 }
 
 void VirtualChannelMap::setCurrentlyTunedChannel(int value)
@@ -269,9 +270,9 @@ void VirtualChannelMap::setCurrentlyTunedChannel(int value)
 
 void VirtualChannelMap::showList(unsigned long start, unsigned long end, unsigned long tail)
 {
-	printf("******************************************************************************************\n");
-	printf("*   Virtual Channel Map\n");
-	printf("******************************************************************************************\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
+	AAMPCLI_PRINTF("*   Virtual Channel Map\n");
+	AAMPCLI_PRINTF("******************************************************************************************\n");
 	print(start, end, tail);
 }
 
@@ -280,7 +281,7 @@ void VirtualChannelMap::tuneToChannel( VirtualChannelInfo &channel, PlayerInstan
 	setCurrentlyTunedChannel(channel.channelNumber);
 	const char *name = channel.name.c_str();
 	const char *locator = channel.uri.c_str();
-	printf( "TUNING to '%s' %s\n", name, locator );
+	AAMPCLI_PRINTF( "TUNING to '%s' %s\n", name, locator );
 	playerInstanceAamp->Tune(locator,bAutoPlay);
 }
 
@@ -348,7 +349,7 @@ void VirtualChannelMap::loadVirtualChannelMapFromCSV( FILE *f )
 			}
 			else
 			{ // no name, no uri, no service
-				//printf("[AAMPCLI] can not parse virtual channel '%s'\n", buf);
+				//AAMPCLI_PRINTF("[AAMPCLI] can not parse virtual channel '%s'\n", buf);
 			}
 		}
 	}

--- a/test/aampcli/aampcli_kmp.cpp
+++ b/test/aampcli/aampcli_kmp.cpp
@@ -3,6 +3,8 @@
 #include <gst/gst.h>
 #include <queue>
 
+#include "AampcliPrintf.h"
+
 static PlayerInstanceAAMP *g_kmp_player;
 static GMainLoop *main_loop;
 
@@ -10,7 +12,7 @@ static gboolean tuneFunc( gpointer arg )
 {	char *url = (char *)arg;
 	if( url )
 	{
-		printf( "tuneFunc(\"%s\")\n", url );
+		AAMPCLI_PRINTF( "tuneFunc(\"%s\")\n", url );
 		if( !g_kmp_player )
 		{ // lazily allocate player instance
 			g_kmp_player = new PlayerInstanceAAMP();

--- a/test/utests/tests/AampCliSet/CMakeLists.txt
+++ b/test/utests/tests/AampCliSet/CMakeLists.txt
@@ -38,7 +38,8 @@ set(TEST_SOURCES ExecuteTests.cpp
 
                  AampCliSetTests.cpp)
 
-set(AAMP_SOURCES ${AAMP_ROOT}/test/aampcli/AampcliSet.cpp)
+set(AAMP_SOURCES ${AAMP_ROOT}/test/aampcli/AampcliSet.cpp
+                 ${AAMP_ROOT}/test/aampcli/AampcliPrintf.cpp)
 
 add_executable(${EXEC_NAME}
                ${TEST_SOURCES}


### PR DESCRIPTION
Reason for Change:
	Allow the timing of aamp-cli log output to be accurately
	compared to the timing of aamp log output.

Test Guidance:
	Check that aamp-cli log output contains timestamps that are
	consistent with aamp's (in both the values and the formatting).

Risk: Low