### PR TITLE
VPLAY-10424 unreliable player state event when stopping playback

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -3110,10 +3110,8 @@ void PlayerInstanceAAMP::StopInternal(bool sendStateChangeEvent)
 	if(!aamp->IsTuneCompleted())
 	{
 		aamp->TuneFail(true);
-
 	}
 	AAMPLOG_MIL("aamp_stop PlayerState=%d",state);
-	AAMPLOG_MIL("%s PLAYER[%d] Stopping Playback at Position %lld", (aamp->mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), aamp->mPlayerId, aamp->GetPositionMilliseconds());
 	aamp->Stop();
 	// Revert all custom specific setting, tune specific setting and stream specific setting , back to App/default setting
 	mConfig.RestoreConfiguration(AAMP_CUSTOM_DEV_CFG_SETTING);

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -182,10 +182,8 @@ PlayerInstanceAAMP::~PlayerInstanceAAMP()
 		mScheduler.RemoveAllTasks();
 		if (state != eSTATE_IDLE && state != eSTATE_RELEASED)
 		{
-			//Avoid stop call since already stopped
-			aamp->Stop();
+			aamp->Stop( true );
 		}
-
 		std::lock_guard<std::mutex> lock (mPrvAampMtx);
 		aamp = NULL;
 	}

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -3108,22 +3108,14 @@ void PlayerInstanceAAMP::PersistBitRateOverSeek(bool bValue)
 void PlayerInstanceAAMP::StopInternal(bool sendStateChangeEvent)
 {
 	aamp->StopPausePositionMonitoring("Stop() called");
-
 	AAMPPlayerState state = aamp->GetState();
 	if(!aamp->IsTuneCompleted())
 	{
 		aamp->TuneFail(true);
 
 	}
-
-	AAMPLOG_WARN("aamp_stop PlayerState=%d",state);
-
-	if (sendStateChangeEvent)
-	{
-		aamp->SetState(eSTATE_IDLE);
-	}
-
-	AAMPLOG_WARN("%s PLAYER[%d] Stopping Playback at Position %lld", (aamp->mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), aamp->mPlayerId, aamp->GetPositionMilliseconds());
+	AAMPLOG_MIL("aamp_stop PlayerState=%d",state);
+	AAMPLOG_MIL("%s PLAYER[%d] Stopping Playback at Position %lld", (aamp->mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), aamp->mPlayerId, aamp->GetPositionMilliseconds());
 	aamp->Stop();
 	// Revert all custom specific setting, tune specific setting and stream specific setting , back to App/default setting
 	mConfig.RestoreConfiguration(AAMP_CUSTOM_DEV_CFG_SETTING);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7427,12 +7427,15 @@ bool PrivateInstanceAAMP::IsLiveStream()
  * @brief Stop playback and release resources.
  *
  */
-void PrivateInstanceAAMP::Stop()
+void PrivateInstanceAAMP::Stop( bool isDestructing )
 {
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
 	mEventManager->FlushPendingEvents();
-	SetState(eSTATE_STOPPING);
-//	mEventManager->SetPlayerState(eSTATE_STOPPING);
+	if( !isDestructing )
+	{
+		SetState(eSTATE_STOPPING);
+	}
+	
 	{
 		std::unique_lock<std::mutex> lock(gMutex);
 		auto iter = std::find_if(std::begin(gActivePrivAAMPs), std::end(gActivePrivAAMPs), [this](const gActivePrivAAMP_t& el)
@@ -7561,9 +7564,12 @@ void PrivateInstanceAAMP::Stop()
 	mFirstFragmentTimeOffset = -1;
 	mProgressReportAvailabilityOffset = -1;
 	rate = 1;
-		
-	SetState(eSTATE_IDLE);
-
+	
+	if( !isDestructing )
+	{
+		SetState(eSTATE_IDLE);
+	}
+	
 	SetPauseOnStartPlayback(false);
 	mSeekOperationInProgress = false;
 	mTrickplayInProgress = false;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7430,8 +7430,9 @@ bool PrivateInstanceAAMP::IsLiveStream()
 void PrivateInstanceAAMP::Stop()
 {
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
-	mEventManager->SetPlayerState(eSTATE_RELEASED);
 	mEventManager->FlushPendingEvents();
+	SetState(eSTATE_STOPPING);
+//	mEventManager->SetPlayerState(eSTATE_STOPPING);
 	{
 		std::unique_lock<std::mutex> lock(gMutex);
 		auto iter = std::find_if(std::begin(gActivePrivAAMPs), std::end(gActivePrivAAMPs), [this](const gActivePrivAAMP_t& el)
@@ -7560,9 +7561,8 @@ void PrivateInstanceAAMP::Stop()
 	mFirstFragmentTimeOffset = -1;
 	mProgressReportAvailabilityOffset = -1;
 	rate = 1;
-	// Set the state to eSTATE_IDLE
-	// directly setting state variable . Calling SetState will trigger event :(
-	mState = eSTATE_IDLE;
+		
+	SetState(eSTATE_IDLE);
 
 	SetPauseOnStartPlayback(false);
 	mSeekOperationInProgress = false;

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1732,7 +1732,7 @@ public:
 	 *
 	 * @return void
 	 */
-	void Stop(void);
+	void Stop( bool isDestructing = false );
 
 	/**
 	 * @brief Checking whether TSB enabled or not

--- a/test/aampcli/AampcliPlaybackCommand.cpp
+++ b/test/aampcli/AampcliPlaybackCommand.cpp
@@ -357,7 +357,6 @@ void PlaybackCommand::HandleCommandExit( void )
 {
 	for( auto player: mAampcli.mPlayerInstances )
 	{
-		player->Stop();
 		SAFE_DELETE( player );
 	}
 	termPlayerLoop();

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -220,7 +220,7 @@ void PrivateInstanceAAMP::SendMediaMetadataEvent()
 {
 }
 
-void PrivateInstanceAAMP::Stop()
+void PrivateInstanceAAMP::Stop( bool isDestructing )
 {
 }
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -195,7 +195,7 @@ void PrivateInstanceAAMP::SetState(AAMPPlayerState state)
 	}
 }
 
-void PrivateInstanceAAMP::Stop()
+void PrivateInstanceAAMP::Stop( bool isDestructing )
 {
 }
 


### PR DESCRIPTION
VPLAY-10424 unreliable player state event when stopping playback

Reason for Change: minimally invasive patch to address race condition
Test Guidance: run l2 tests (especailly 1006) and get readout from apps
Risk: Medium