### PR TITLE
VPLAY-10434:Crash (37983920-lstring::atof) during ad break of SLE

### DIFF
--- a/lstring.hpp
+++ b/lstring.hpp
@@ -248,6 +248,7 @@ public:
 			}
 			else
 			{
+				AAMPLOG_WARN("lstring::atof: unexpected character '%c' in string '%.*s'", c, (int)len, ptr);
 				assert(0);
 			}
 		}


### PR DESCRIPTION
Reason for change: Added warning log to print unexpected character before asserting
Test Procedure: Refer Jira
Risks: No