### PR TITLE
VPLAY-10447: Negative Buffer value seen While long playback of SLE co…

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1175,7 +1175,11 @@ void AAMPGstPlayer::StopBuffering(bool forceStop)
 		bool sendEndEvent = playerInstance->StopBuffering(forceStop, isPlaying);
 		if(!sendEndEvent && isPlaying)
 		{
-			sendEndEvent = aamp->PausePipeline(false, false);
+			if (aamp->PausePipeline(false, false))
+			{
+				aamp->NotifyPlaybackPaused(false); 		/* Notify that playback has resumed (unpaused) */
+				sendEndEvent = true;
+			}
 			aamp->UpdateSubtitleTimestamp();
 		}
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8036,12 +8036,21 @@ void PrivateInstanceAAMP::ScheduleRetune(PlaybackErrorType errorType, AampMediaT
 		)
 		{
 			SendBufferChangeEvent(true);  // Buffer state changed, buffer Under flow started
-			if (!pipeline_paused &&  !PausePipeline(true, true))
+			if (!pipeline_paused)
 			{
-					AAMPLOG_ERR("Failed to pause the Pipeline");
+				if(!PausePipeline(true, true))
+				{
+						AAMPLOG_ERR("Failed to pause the Pipeline");
+				}
+				else
+				{
+					if (mpStreamAbstractionAAMP)
+					{
+						mpStreamAbstractionAAMP->NotifyPlaybackPaused(true);
+					}
+				}
 			}
 		}
-
 
 		SendAnomalyEvent(ANOMALY_WARNING, "%s %s", GetMediaTypeName(trackType), getStringForPlaybackError(errorType));
 		bool activeAAMPFound = false;


### PR DESCRIPTION
…ntent

Reason for change: Invoke NotifyPlaybackPaused() when pausing due to underflow and when resuming after the buffer recovers. This ensures the paused timestamp and duration are updated for buffer calculations.
Test Procedure: Refer Jira
Risks: Low