### PR TITLE
VPLAY-10434:Crash (37983920-lstring::atof) during ad break of SLE

### DIFF
--- a/lstring.hpp
+++ b/lstring.hpp
@@ -239,7 +239,13 @@ public:
 			}
 			else if( c=='.' )
 			{
-				assert( afterDecimal == false );
+				if (afterDecimal)
+				{
+					throw std::runtime_error(
+						std::string("lstring::atof: multiple decimal points in string '") +
+						std::string(ptr, len) + "'"
+					);
+				}
 				afterDecimal = true;
 			}
 			else if( c==',' )
@@ -248,7 +254,10 @@ public:
 			}
 			else
 			{
-				assert(0);
+				throw std::runtime_error(
+					std::string("lstring::atof: unexpected character '") + c +
+					"' in string '" + std::string(ptr, len) + "'"
+				);
 			}
 		}
 		return ival/(double)precision;


### PR DESCRIPTION
Reason for change: Replaced assert() with throw std::runtime_error() exception.
Test Procedure: Refer Jira
Risks: No