### PR TITLE
VPLAY-10406: Fix L2 2024 failure due to empty buffer check

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4173,7 +4173,8 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						print_headerResponse(context.allResponseHeaders, mediaType);
 					}
 
-					if (buffer->GetPtr() == NULL || buffer->GetLen() == 0)
+					// Do the empty buffer check only for successful downloads
+					if ((http_code == 200 || http_code == 204 || http_code == 206) && (buffer->GetPtr() == NULL || buffer->GetLen() == 0))
 					{
 #if LIBCURL_VERSION_NUM >= 0x073700 // CURL version >= 7.55.0
 						double dlSize = aamp_CurlEasyGetinfoOffset(curl, CURLINFO_SIZE_DOWNLOAD_T);


### PR DESCRIPTION
Reason for change: Check for zero-byte buffer in successful downloads
Test Procedure: 2024 L2 should pass
Risks: Low