### PR TITLE
VPLAY-10489: Fix L2 8006 failures due to VPLAY-9299

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3118,7 +3118,7 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 					{
 						profiler.ProfileBegin(PROFILE_BUCKET_DISCO_FLUSH);
 					}
-					sink->Flush(mpStreamAbstractionAAMP->GetFirstPTS(), rate);
+					sink->Flush(mpStreamAbstractionAAMP->GetFirstPTS(), rate, false);
 					if(mDiscontinuityFound)
 					{
 						profiler.ProfileEnd(PROFILE_BUCKET_DISCO_FLUSH);


### PR DESCRIPTION
Reason for change: Set shouldTearDown flag to false in Flush() call to avoid pipeline teardown and crash. Earlier the order was different and hence the pipeline teared down by Flush would be recreated by Configure() This is not happening anymore.
Test Procedure: Test 8006 should pass
Risks: None