### PR TITLE
VPLAY-10409 Missing AAMP Log lines when using vethanlog

### DIFF
--- a/aamplogging.cpp
+++ b/aamplogging.cpp
@@ -95,11 +95,13 @@ void logprintf(AAMP_LogLevel logLevelIndex, const char* file, int line, const ch
 	
 	char *format_ptr = NULL;
 	int format_bytes = 0;
+	static int log_id = 0;
 	for( int pass=0; pass<2; pass++ )
 	{ // two pass: measure required bytes then populate format string
 		format_bytes = snprintf(format_ptr, format_bytes,
-							   "%s[AAMP-PLAYER][%d][%s][%zx][%s][%d]%s\n",
+							   "%s[AAMP-PLAYER][0x%08x][%d][%s][%zx][%s][%d]%s\n",
 							   timestamp,
+							   log_id,
 							   gPlayerId,
 							   mLogLevelStr[logLevelIndex],
 							   GetPrintableThreadID(),
@@ -155,6 +157,7 @@ void logprintf(AAMP_LogLevel logLevelIndex, const char* file, int line, const ch
 			va_end(args);
 		}
 	}
+	log_id++;
 }
 
 /**


### PR DESCRIPTION
Added an incrementing number to AAMP logs to help identify when line go missing