### PR TITLE
VPLAY-9810 Add droppedFrames to MonitorAV event

### DIFF
--- a/AampEvent.h
+++ b/AampEvent.h
@@ -731,8 +731,8 @@ public:
 	 * @param[in]  end      - End Position
 	 * @param[in]  speed    - Current Speed
 	 * @param[in]  pts      - Video PTS
-	 * @param[in]  videobufferedDuration - video buffered duration in milliseconds
-	 * @param[in]  audiobufferedDuration - audio buffered duration in milliseconds
+	 * @param[in]  videoBufferedDuration - video buffered duration in milliseconds
+	 * @param[in]  audioBufferedDuration - audio buffered duration in milliseconds
 	 * @param[in]  seiTimecode      - Time code
 	 * @param[in]  liveLatency      - Live latency
 	 * @param[in]  profileBandwidth - profile Bandwidth

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9106,6 +9106,7 @@ void StreamAbstractionAAMP_MPD::AdvanceTrack(int trackIdx, bool trickPlay, doubl
 	}
 	else
 	{
+		std::lock_guard<std::mutex> lock(mutex);
 		// Important DEBUG area, live downloader is delayed due to some external factors (Injector or Gstreamer)
 		if (pMediaStreamContext->IsInjectionFromCachedFragmentChunks())
 		{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7487,8 +7487,8 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		inpData->bIgnoreResponseHeader	= true;
 		inpData->eRequestType = eCURL_DELETE;
 		inpData->proxyName        = GetNetworkProxy();
-		T1.Initialize(inpData);
-		T1.Download(remoteUrl, respData );
+		T1.Initialize(std::move(inpData));
+		T1.Download(remoteUrl, std::move(respData) );
 	}
 
 	UnblockWaitForDiscontinuityProcessToComplete();
@@ -10038,7 +10038,11 @@ std::string PrivateInstanceAAMP::GetAvailableAudioTracks(bool allTrack)
 			{
 				if (IsLocalAAMPTsb())
 				{
-					mpStreamAbstractionAAMP->GetCurrentAudioTrack(currentTrackInfo);
+					bool trackAvailable = mpStreamAbstractionAAMP->GetCurrentAudioTrack(currentTrackInfo);
+					if( !trackAvailable )
+					{
+						AAMPLOG_WARN( "GetCurrentAudioTrack returned false" );
+					}
 				}
 				for (auto iter = trackInfo.begin(); iter != trackInfo.end(); iter++)
 				{
@@ -10158,7 +10162,11 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 			{
 				if (IsLocalAAMPTsb())
 				{
-					mpStreamAbstractionAAMP->GetCurrentTextTrack(currentTrackInfo);
+					bool trackInfoAvailable = mpStreamAbstractionAAMP->GetCurrentTextTrack(currentTrackInfo);
+					if( !trackInfoAvailable )
+					{
+						AAMPLOG_WARN( "GetCurrentTextTrack returned false" );
+					}
 				}
 				for (auto iter = trackInfo.begin(); iter != trackInfo.end(); iter++)
 				{

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1836,14 +1836,19 @@ CachedFragment* MediaTrack::GetFetchChunkBuffer(bool initialize)
  */
 bool MediaTrack::IsFragmentCacheFull()
 {
+	bool rc = false;
+	std::lock_guard<std::mutex> guard(mutex);
 	if(IsInjectionFromCachedFragmentChunks())
 	{
 		AAMPLOG_DEBUG("[%s] numberOfFragmentChunksCached %d mCachedFragmentChunksSize %zu", name, numberOfFragmentChunksCached, mCachedFragmentChunksSize);
-		return numberOfFragmentChunksCached == mCachedFragmentChunksSize;
+		rc = (numberOfFragmentChunksCached == mCachedFragmentChunksSize);
 	}
-
-	AAMPLOG_DEBUG("[%s] numberOfFragmentsCached %d maxCachedFragmentsPerTrack %d", name, numberOfFragmentsCached, maxCachedFragmentsPerTrack);
-	return numberOfFragmentsCached == maxCachedFragmentsPerTrack;
+	else
+	{
+		AAMPLOG_DEBUG("[%s] numberOfFragmentsCached %d maxCachedFragmentsPerTrack %d", name, numberOfFragmentsCached, maxCachedFragmentsPerTrack);
+		rc = numberOfFragmentsCached == maxCachedFragmentsPerTrack;
+	}
+	return rc;
 }
 
 /**
@@ -4047,7 +4052,7 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 				track->playContext->setRate(aamp->rate, PlayMode_normal);
 				if(eMEDIATYPE_AUDIO == i)
 				{
-					peerAudioProcessor = processor;
+					peerAudioProcessor = std::move(processor);
 				}
 				else if (eMEDIATYPE_VIDEO == i && subtitleESProcessor)
 				{


### PR DESCRIPTION
VPLAY-9810 Add droppedFrames to MonitorAV event

Reason for Change: fix typo in AampEvent.h (flagged by godspell)
Test Guidance: no godspell warnings
Risk: None (typo was in comment)