### PR TITLE
VPLAY-9810 fix typo

### DIFF
--- a/AampEvent.h
+++ b/AampEvent.h
@@ -731,8 +731,8 @@ public:
 	 * @param[in]  end      - End Position
 	 * @param[in]  speed    - Current Speed
 	 * @param[in]  pts      - Video PTS
-	 * @param[in]  videobufferedDuration - video buffered duration in milliseconds
-	 * @param[in]  audiobufferedDuration - audio buffered duration in milliseconds
+	 * @param[in]  videoBufferedDuration - video buffered duration in milliseconds
+	 * @param[in]  audioBufferedDuration - audio buffered duration in milliseconds
 	 * @param[in]  seiTimecode      - Time code
 	 * @param[in]  liveLatency      - Live latency
 	 * @param[in]  profileBandwidth - profile Bandwidth


### PR DESCRIPTION
VPLAY-9810 fix typo

Reason for Change: fix typo caught by godspell
Test Guidance: godspell no longer flagging
Risk: None