### PR TITLE
VPLAY-10523 : [AAMP] Sprint release version is displayed as 7.06 inst…

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -30,7 +30,7 @@
 #define AAMP_CFG_PATH "/opt/aamp.cfg"
 #define AAMP_JSON_PATH "/opt/aampcfg.json"
 
-#define AAMP_VERSION "7.06"
+#define AAMP_VERSION "7.07"
 #define AAMP_TUNETIME_VERSION 5
 
 //Stringification of Macro : use two levels of macros


### PR DESCRIPTION
…ead of 7.07

Reason for change: Changed AAMP version to 7.07
Test Procedure: Refer Jira
Risks: No