### PR TITLE
VPLAY-9904: Support PTO for DASH SegmentTimeline format

### DIFF
--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -1277,6 +1277,7 @@ protected:
 	bool mShortAdOffsetCalc;
 	AampTime mNextPts;					/*For PTS restamping*/
 	std::vector<std::unique_ptr<aamp::AampTrackWorker>> mTrackWorkers;	/**< Track workers for fetching fragments*/
+	bool mIsFinalFirstPTS; /**< Flag to indicate if the first PTS is final or not */
 };
 
 #endif //FRAGMENTCOLLECTOR_MPD_H_

--- a/test/utests/tests/AampGrowableBuffer/FunctionalTests.cpp
+++ b/test/utests/tests/AampGrowableBuffer/FunctionalTests.cpp
@@ -400,4 +400,3 @@ TEST_F(FunctionalTests, SetLenAfterAppendBytesTest)
     EXPECT_DEATH(buffer.SetLen(100), _);
     EXPECT_EQ(buffer.GetLen(), srcLen);     // Check that length has not changed
 }
-


### PR DESCRIPTION
Reason for change: Handle PTO in SegmentTimeline. Add PTO offset from timelineStart to skipTime to skip to the right fragment. This also adjusts for seekMidFragment config. Use a new flag mIsFinalFirstPTS to determine if we should update PTS in NotifyFirstVideoPTS which is most likely the firstPTS of fragment and doesn't include PTO Test Procedure: Test with streams in VPLAY-10064 and also validate with the app as in ticket description
Risks: Low