### PR TITLE
VPLAY-10507: [AAMP]Port Admanager changes to 8.0_p1v

### DIFF
--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -537,7 +537,13 @@ void  PrivateCDAIObjectMPD::PlaceAds(dash::mpd::IMPD *mpd)
 					if (diff <  OFFSET_ALIGN_FACTOR)
 					{
 						//check if next period available
-						iter++;
+						for (iter = iter+1; iter < periods.size(); iter++)
+						{
+							if (adMPDParseHelper->aamp_GetPeriodDuration(iter, 0) > 0)
+							{
+								break;
+							}
+						}
 						if( iter < periods.size() && adMPDParseHelper->aamp_GetPeriodDuration(iter, 0) > 0)
 						{
 							auto nextPeriod = periods.at(iter);


### PR DESCRIPTION
Reason for change: Ticket is created to port the empty period ad changes to 8.0_p1v branch.
Risks: Low
Test Procedure: Test with Fog TSB
Priority: P1