### PR TITLE
VPLAY-10590 gst test harness segfault on device

### DIFF
--- a/test/gstTestHarness/gst-port.cpp
+++ b/test/gstTestHarness/gst-port.cpp
@@ -167,7 +167,7 @@ public:
 	
 	void enough_data( GstElement *appSrc )
 	{
-		g_print( "MediaStream::enough_data %s", GetMediaTypeAsString() );
+		g_print( "MediaStream::enough_data %s\n", GetMediaTypeAsString() );
 		context->EnoughData( mediaType );
 	}
 	

--- a/test/gstTestHarness/gst-port.cpp
+++ b/test/gstTestHarness/gst-port.cpp
@@ -32,7 +32,7 @@ static void found_source_cb(GObject * object, GObject * orig, GParamSpec * pspec
 class MediaStream
 {
 public:
-	MediaStream( MediaType mediaType, class PipelineContext *context ) : isConfigured(false), playbin(NULL), appsrc(NULL), injectedSeconds(), context(context), mediaType(mediaType), pad(NULL)
+	MediaStream( MediaType mediaType, class PipelineContext *context ) : isConfigured(false), playbin(NULL), appsrc(NULL), injectedSeconds(), context(context), mediaType(mediaType)//, pad(NULL)
 	{
 	}
 	
@@ -189,8 +189,22 @@ public:
 	
 	void Seek( const SeekParam &param )
 	{
+		g_print( "Seek: start=%f stop=%f flags=%d\n",
+				param.start_s, param.stop_s, param.flags );
+		
 		gint64 start = (gint64)(param.start_s*GST_SECOND);
-		gint64 stop = (gint64)(param.stop_s*GST_SECOND);
+		GstSeekType stop_type;
+		gint64 stop;
+		if( param.stop_s < 0 )
+		{
+			stop_type = GST_SEEK_TYPE_NONE;
+			stop = GST_CLOCK_TIME_NONE;
+		}
+		else
+		{
+			stop_type = GST_SEEK_TYPE_SET;
+			stop = (gint64)(param.stop_s*GST_SECOND);
+		}
 		g_print( "MediaStream::Seek %s flags=%d start=%" GST_TIME_FORMAT " stop=%" GST_TIME_FORMAT "\n",
 				GetMediaTypeAsString(),
 				param.flags,
@@ -201,7 +215,7 @@ public:
 									   1.0, // rate
 									   GST_FORMAT_TIME,
 									   param.flags,
-									   GST_SEEK_TYPE_SET, start,
+									   stop_type, start,
 									   GST_SEEK_TYPE_SET, stop );
 		assert( rc );
 	}
@@ -212,17 +226,21 @@ public:
 		g_object_get( orig, pspec->name, &appsrc, NULL );
 		
 		// configuration to drive need-data and enough-data signaling
+		int max_bytes = 0;
 		switch( mediaType )
 		{
 			case eMEDIATYPE_VIDEO:
-				g_object_set(appsrc, "max-bytes", 12582912, NULL ); // default = 200000
+				max_bytes = 12582912;
 				break;
 			case eMEDIATYPE_AUDIO:
-				g_object_set(appsrc, "max-bytes", 1536000, NULL ); // default = 200000
+				max_bytes = 1536000;
 				break;
 			default:
+				assert(0);
 				break;
 		}
+		g_print( "max-bytes=%d\n", max_bytes );
+		g_object_set(appsrc, "max-bytes", max_bytes, NULL ); // default = 200000
 		g_object_set(appsrc, "min-percent", 50, NULL ); // default = 0
 		
 		g_signal_connect(appsrc, "need-data", G_CALLBACK(need_data_cb), this );
@@ -241,22 +259,30 @@ public:
 		}
 		else
 		{
+			g_print( "using typefind\n" );
 			g_object_set(appsrc, "typefind", TRUE, NULL);
 		}
-		pad = gst_element_get_static_pad(appsrc, "src");
+		//pad = gst_element_get_static_pad(appsrc, "src");
 		
 		// seek here avoids freeze at start for non-zero first_pts
-		assert( context->mSegmentEndSeekQueue.size()>0 );
-		SeekParam param = context->mSegmentEndSeekQueue.front();
-		context->mSegmentEndSeekQueue.pop();
-		Seek( param );
+		if( context->mSegmentEndSeekQueue.size()>0 )
+		{
+			SeekParam param = context->mSegmentEndSeekQueue.front();
+			context->mSegmentEndSeekQueue.pop();
+			Seek( param );
+		}
+		else
+		{
+			g_print("empty mSegmentEndSeekQueue\n");
+		}
+		g_print( "exiting found_source\n" );
 	}
 	
 	MediaStream(const MediaStream&)=delete; // copy constructor
 	MediaStream& operator=(const MediaStream&)=delete; // copy assignment operator
 	
 private:
-	GstPad * pad;
+	//GstPad * pad;
 	bool isConfigured; // avoid double configure
 	double injectedSeconds;
 	class PipelineContext *context;

--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -35,7 +35,7 @@
 #include <arpa/inet.h>
 #include <sys/time.h>
 
-#define STOP_NEVER 9999
+#define STOP_NEVER -1
 
 static std::mutex mCommandMutex;
 
@@ -49,7 +49,7 @@ static enum ContentFormat
 	eCONTENTFORMAT_QTDEMUX,
 	eCONTENTFORMAT_TS_ES,
 	eCONTENTFORMAT_TSDEMUX,
-} mContentFormat = eCONTENTFORMAT_QTDEMUX;
+} mContentFormat;
 
 static Mp4Demux *gMp4Demux[2]; // TODO: move these mp4demux instances inside classes
 
@@ -212,6 +212,7 @@ private:
 public:
 	TrackFragment( MediaType mediaType, const char *path, double duration, double pts_offset=0 ):len(), ptr(), tsDemux(),  pts_offset(pts_offset), duration(duration), url(path), mediaType(mediaType)
 	{
+		printf( "new TrackFragment mediaType=%d pts_offset=%f\n", mediaType, pts_offset );
 	}
 	
 	~TrackFragment()
@@ -1579,7 +1580,7 @@ static void NetworkCommandServer( struct AppContext *appContext )
 
 int my_main(int argc, char **argv)
 {
-	setenv( "GST_DEBUG", "*:4", 1 ); // programatically override gstreamer log level:
+	// setenv( "GST_DEBUG", "*:4", 1 ); // programatically override gstreamer log level:
 	// refer https://gstreamer.freedesktop.org/documentation/tutorials/basic/debugging-tools.html?gi-language=c
 	gst_init(&argc, &argv);
 	g_print( "gstreamer test harness\n" );

--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -49,7 +49,7 @@ static enum ContentFormat
 	eCONTENTFORMAT_QTDEMUX,
 	eCONTENTFORMAT_TS_ES,
 	eCONTENTFORMAT_TSDEMUX,
-} mContentFormat = eCONTENTFORMAT_MP4_ES;
+} mContentFormat = eCONTENTFORMAT_QTDEMUX;
 
 static Mp4Demux *gMp4Demux[2]; // TODO: move these mp4demux instances inside classes
 
@@ -1579,7 +1579,7 @@ static void NetworkCommandServer( struct AppContext *appContext )
 
 int my_main(int argc, char **argv)
 {
-	// setenv( "GST_DEBUG", "*:4", 1 ); // programatically override gstreamer log level:
+	setenv( "GST_DEBUG", "*:4", 1 ); // programatically override gstreamer log level:
 	// refer https://gstreamer.freedesktop.org/documentation/tutorials/basic/debugging-tools.html?gi-language=c
 	gst_init(&argc, &argv);
 	g_print( "gstreamer test harness\n" );

--- a/test/gstTestHarness/stream_utils.cpp
+++ b/test/gstTestHarness/stream_utils.cpp
@@ -61,8 +61,8 @@ double GetPeriodFirstPts( const Timeline &timeline, std::string contentType, Per
 	{
 		auto representation = adaptationSet.representation[0];
 		if( representation.data.presentationTimeOffset )
-		{
-			pts = representation.data.presentationTimeOffset/(double)representation.data.timescale;
+		{ // FIXME
+			// pts = representation.data.presentationTimeOffset/(double)representation.data.timescale;
 		}
 		else if( timeline.type == "dynamic" )
 		{
@@ -73,8 +73,8 @@ double GetPeriodFirstPts( const Timeline &timeline, std::string contentType, Per
 			}
 			else if( representation.data.duration.size()>1 )
 			{
-				auto dt = (baseTime - period.start);
-				pts += dt;
+				auto delta = (baseTime - period.start);
+				pts += delta;
 			}
 			else
 			{


### PR DESCRIPTION
VPLAY-10590 gst test harness segfault on device

Reason for Change: debug crash on device with gst test harness

add missing newline under enough_data callback
change default to using qtdemux (instead of mp4demux)
enable gstreamer logging by default
Test Guidance: refer ticket

Risk: Low (test only, not to merge as-is)