### PR TITLE
VPLAY-9124: Hold off removing event handler until Event is sent

### DIFF
--- a/AampEventManager.h
+++ b/AampEventManager.h
@@ -68,6 +68,7 @@ private:
 	typedef std::map<guint, bool> AsyncEventList;		  /**< Collection of Async tasks pending */
 	typedef std::map<guint, bool>::iterator AsyncEventListIter;
 	AsyncEventList	mPendingAsyncEvents;
+	AAMPEventType mEventInProgress;
 
 protected:
 	int mPlayerId;
@@ -207,6 +208,8 @@ public:
          *
          */
 	AampEventManager& operator=(const AampEventManager&) = delete;
+
+	AAMPEventType IsEventInProgress() { return mEventInProgress; }
 };
 
 

--- a/jsbindings/jsbindings.h
+++ b/jsbindings/jsbindings.h
@@ -23,6 +23,7 @@
 #include <JavaScriptCore/JavaScript.h>
 #include "main_aamp.h"
 #include <map>
+#include <vector>
 /*
  * @file jsbindings.h
  * @brief APIs exposed by the AAMP JS to inject different bindings.
@@ -33,7 +34,7 @@
  * @brief Private data structure for JS binding object
  */
 struct PrivAAMPStruct_JS {
-	PrivAAMPStruct_JS() : _ctx(), _aamp(NULL), _listeners()
+	PrivAAMPStruct_JS() : _ctx(), _aamp(NULL), _listeners(), _ex_listeners()
 	{
 	}
 	virtual ~PrivAAMPStruct_JS()
@@ -49,6 +50,7 @@ struct PrivAAMPStruct_JS {
 	PlayerInstanceAAMP* _aamp;
 
 	std::multimap<AAMPEventType, void*> _listeners;
+	std::vector<void*> _ex_listeners;  // Expired event listeners which were removed during an event transmission
 };
 
 /**

--- a/jsbindings/jseventlistener.cpp
+++ b/jsbindings/jseventlistener.cpp
@@ -1755,6 +1755,7 @@ void AAMP_JSEventListener::Event(const AAMPEventPtr& e)
 	JSObjectRef event = createNewAAMPJSEvent(p_obj->_ctx, aampPlayer_getNameFromEventType(evtType), false, false);
 	if (event)
 	{
+		// We copy p_obj->_ctx locally here, since aamp_dispatchEventToJS() below can result in this event handler being deleted, invalidating 'p_obj'
 		JSGlobalContextRef ctx = p_obj->_ctx;
 		JSValueProtect(ctx, event);
 
@@ -1767,6 +1768,12 @@ void AAMP_JSEventListener::Event(const AAMPEventPtr& e)
 			AdResolvedEventPtr evt = std::dynamic_pointer_cast<AdResolvedEvent>(e);
 			std::string adId = evt->getAdId();
 			JSObjectRef cbObj = p_obj->getCallbackForAdId(adId);
+
+			// ***************** WARNING (future extensions) *******************
+			// Extending the code to use "p_obj" after aamp_dispatchEventToJS() may result in a crash if JS callback calls RemoveEventHandler or Deletes the Player instance!
+			// Note: RemoveEventHandler has been see to be called from the EOS JS callback.
+			// *****************************************************************
+
 			if (cbObj != NULL)
 			{
 				aamp_dispatchEventToJS(ctx, cbObj, event);

--- a/jsbindings/jsmediaplayer.cpp
+++ b/jsbindings/jsmediaplayer.cpp
@@ -69,7 +69,7 @@ struct AAMPMediaPlayer_JS : public PrivAAMPStruct_JS
 	 */
 	JSObjectRef getCallbackForAdId(std::string id) override
 	{
-         	LOG_TRACE("Enter, id: %s",id);
+		LOG_TRACE("Enter, id: %s",id.c_str());
 		std::map<std::string, JSObjectRef>::const_iterator it = _promiseCallbacks.find(id);
 		if (it != _promiseCallbacks.end())
 		{

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1661,6 +1661,19 @@ void PlayerInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListe
 }
 
 /**
+ *  @brief Check which event is currently processed
+ */
+AAMPEventType PlayerInstanceAAMP::IsEventInProgress()
+{
+	AAMPEventType type = AAMP_MAX_NUM_EVENTS;
+	if(aamp)
+	{
+		type = aamp->IsEventInProgress();
+	}
+	return type;
+}
+
+/**
  *  @brief To check whether the asset is live or not.
  */
 bool PlayerInstanceAAMP::IsLive()

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -1070,6 +1070,13 @@ public:
 	void RemoveEventListener(AAMPEventType eventType, EventListener* eventListener);
 
 	/**
+	 * @fn IsEventInProgress
+	 *
+	 * @return Returns the type of event that is currently in process
+	 */
+	AAMPEventType IsEventInProgress();
+
+	/**
 	 *   @fn IsLive
 	 *
 	 *   @return bool - True if live content, false otherwise

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2479,6 +2479,14 @@ void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventList
 }
 
 /**
+ *  @brief Check which event is currently processed
+ */
+AAMPEventType PrivateInstanceAAMP::IsEventInProgress()
+{
+	return mEventManager->IsEventInProgress();
+}
+
+/**
  * @brief IsEventListenerAvailable Check if Event is registered
  */
 bool PrivateInstanceAAMP::IsEventListenerAvailable(AAMPEventType eventType)

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1388,6 +1388,14 @@ public:
 	 * @return void
 	 */
 	void RemoveEventListener(AAMPEventType eventType, EventListener* eventListener);
+
+	/**
+	 * @fn IsEventInProgress
+	 *
+	 * @return Returns the type of event that is currently in process
+	 */
+	AAMPEventType IsEventInProgress();
+
 	/**
 	 * @fn IsEventListenerAvailable
 	 *

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -67,6 +67,7 @@ MockPlayerInstanceAAMP *g_mockPlayerInstanceAAMP = nullptr;
 	void PlayerInstanceAAMP::UnloadJS(void* context) {  }
 	void PlayerInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListener* eventListener) {  }
 	void PlayerInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener) {  }
+	AAMPEventType PlayerInstanceAAMP::IsEventInProgress() { return AAMP_MAX_NUM_EVENTS; }
 	void PlayerInstanceAAMP::InsertAd(const char *url, double  positionSeconds) {  }
 	void PlayerInstanceAAMP::AddPageHeaders(std::map<std::string, std::string> customHttpHeaders) {  }
 	void PlayerInstanceAAMP::AddCustomHTTPHeader(std::string headerName, std::vector<std::string> headerValue, bool isLicenseHeader) {  }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -376,6 +376,11 @@ void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventList
 {
 }
 
+AAMPEventType PrivateInstanceAAMP::IsEventInProgress(void)
+{
+	return AAMP_MAX_NUM_EVENTS;
+}
+
 DrmHelperPtr PrivateInstanceAAMP::GetCurrentDRM(void)
 {
 	return nullptr;


### PR DESCRIPTION
Reason for change: Defer removal of event handlers where Event is in progress. This prevents AAMP_JS deletion during Event() processing. Also protect jsContext class object from any garbage collection. Note: This undoes a workaround that stored a js ctx variable locally to avoid a crash.

Signed-off-by: gavin_parry@comcast.com