### PR TITLE
VPLAY-9633 AAMP TSB - Changing audio track for LLD jumps to live edge…

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -2077,7 +2077,7 @@ public:
 
 	/**
 	 *   @fn ReinitializeInjection
-	 *   @brief Reintializes the injection logic
+	 *   @brief Re-Initialize the injection logic
 	 *   @param[in] rate - play rate
 	 */	
 	void ReinitializeInjection(double rate);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4621,7 +4621,7 @@ bool MediaTrack::IsInjectionFromCachedFragmentChunks()
 }
 
 /**
- *   @brief Reintializes the injection
+ *   @brief Re-initializes the injection
  *   @param[in] rate - play rate
  */	
 void StreamAbstractionAAMP::ReinitializeInjection(double rate) 


### PR DESCRIPTION
… instead of live play position

Reason for Change: spelling fix to placate godspell

Test Guidance: no godspell warning

Risk: None