### PR TITLE
VPLAY-10694: Add rpath to AAMP binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ if(APPLE)
 	# add the automatically determined parts of the RPATH
 	# which point to directories outside the build tree to the install RPATH
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+else()
+	# For Linux builds, use the origin of the executable as the RPATH
+	set(CMAKE_INSTALL_RPATH "$ORIGIN")
 endif()
 
 #update XCode scheme flags, harmless for non Darwin builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(APPLE)
 	# which point to directories outside the build tree to the install RPATH
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 else()
-	# For Linux builds, use the origin of the executable as the RPATH
+	# For other builds, use the origin of the executable as the RPATH
 	set(CMAKE_INSTALL_RPATH "$ORIGIN")
 endif()
 


### PR DESCRIPTION
Reason for change: Add RPATH=$ORIGIN to AAMP binaries for VIPA widget
Test Procedure: Validate DRM playback with VIPA
Risks: Low