### PR TITLE
VPLAY-10741 address new compilation warnings while building utests

### DIFF
--- a/test/utests/fakes/FakeContentSecurityManager.cpp
+++ b/test/utests/fakes/FakeContentSecurityManager.cpp
@@ -49,13 +49,6 @@ void ContentSecurityManager::DestroyInstance()
 {
 }
 
-static std::size_t getInputSummaryHash(const char* moneyTraceMetdata[][2], const char* contentMetdata,
-					size_t contMetaLen, const char* licenseRequest, const char* keySystemId,
-					const char* mediaUsage, const char* accessToken, bool isVideoMuted)
-{
-	return 0;
-}
-
 bool ContentSecurityManager::AcquireLicense( std::string clientId, std::string appId, const char* licenseUrl, const char* moneyTraceMetdata[][2],
 					const char* accessAttributes[][2], const char* contentMetdata, size_t contMetaLen,
 					const char* licenseRequest, size_t licReqLen, const char* keySystemId,

--- a/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
@@ -77,12 +77,12 @@ protected:
 		MockMediaTrack *mMockAudioTrack;
 		MockMediaTrack *mMockVideoTrack;
 
-		virtual AAMPStatusType Init(TuneType tuneType){return eAAMPSTATUS_OK;}
-		virtual void Start(){}
-		virtual void Stop(bool clearChannelData){}
-		virtual void GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &auxAudioOutputFormat, StreamOutputFormat &subtitleOutputFormat){}
+		virtual AAMPStatusType Init(TuneType tuneType) override {return eAAMPSTATUS_OK;}
+		virtual void Start() override {}
+		virtual void Stop(bool clearChannelData) override {}
+		virtual void GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &auxAudioOutputFormat, StreamOutputFormat &subtitleOutputFormat) override {}
 
-		virtual MediaTrack* GetMediaTrack(TrackType type)
+		virtual MediaTrack* GetMediaTrack(TrackType type) override
 		{
 			if (type == eTRACK_AUDIO)
 				return mMockAudioTrack;


### PR DESCRIPTION
VPLAY-10741 address new compilation warnings while building utests

Reason for Change: address compilation warnings i.e. overrides a member function but is not marked 'override'
Also removes an unused static fake function
Test Guidance: build l1 tests and confirm warnings no longer emitted
Risk: Low