### PR TITLE
VPLAY-10403 Fix IsVideoSink() when using Rialto

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4491,7 +4491,7 @@ void InterfacePlayerRDK::SetVideoMute(bool muted)
 	}
 	else
 	{
-		MW_LOG_WARN("InterfacePlayerRDK not setting video mute");
+		MW_LOG_INFO("InterfacePlayerRDK not setting video mute");
 	}
 }
 
@@ -4574,8 +4574,6 @@ static GstBusSyncReply bus_sync_handler(GstBus * bus, GstMessage * msg, Interfac
 		case GST_MESSAGE_STATE_CHANGED:
 			GstState old_state, new_state;
 			gst_message_parse_state_changed(msg, &old_state, &new_state, NULL);
-			MW_LOG_MIL("InterfacePlayerRDK - using %s, old state %d new state %d",
-						GST_OBJECT_NAME(msg->src), old_state, new_state);
 
 			if (GST_MESSAGE_SRC(msg) == GST_OBJECT(pInterfacePlayerRDK->gstPrivateContext->pipeline))
 			{

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4491,7 +4491,7 @@ void InterfacePlayerRDK::SetVideoMute(bool muted)
 	}
 	else
 	{
-		MW_LOG_INFO("InterfacePlayerRDK not setting video mute");
+		MW_LOG_WARN("InterfacePlayerRDK not setting video mute");
 	}
 }
 

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4574,6 +4574,8 @@ static GstBusSyncReply bus_sync_handler(GstBus * bus, GstMessage * msg, Interfac
 		case GST_MESSAGE_STATE_CHANGED:
 			GstState old_state, new_state;
 			gst_message_parse_state_changed(msg, &old_state, &new_state, NULL);
+			MW_LOG_MIL("InterfacePlayerRDK - using %s, old state %d new state %d",
+						GST_OBJECT_NAME(msg->src), old_state, new_state);
 
 			if (GST_MESSAGE_SRC(msg) == GST_OBJECT(pInterfacePlayerRDK->gstPrivateContext->pipeline))
 			{

--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -65,7 +65,6 @@ void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 
 bool DefaultSocInterface::IsVideoSink(const char* name, bool isRialto)
 {
-	//return (mUsingWesterosSink && StartsWith(name, "westerossink") == true);
 	bool isVideoSink = false;
 
 	// Check for Westeros sink

--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -65,7 +65,22 @@ void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 
 bool DefaultSocInterface::IsVideoSink(const char* name, bool isRialto)
 {
-	return (mUsingWesterosSink && StartsWith(name, "westerossink") == true);
+	//return (mUsingWesterosSink && StartsWith(name, "westerossink") == true);
+	bool isVideoSink = false;
+
+	// Check for Westeros sink
+	if (mUsingWesterosSink && StartsWith(name, "westerossink"))
+	{
+		isVideoSink = true;
+	}
+
+	// Check for Rialto sink
+	if (isRialto && StartsWith(name, "rialtomsevideosink"))
+	{
+		isVideoSink = true;
+	}
+
+	return isVideoSink;
 }
 
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5507,6 +5507,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			if (sink)
 			{
 				sink->SetVideoZoom(zoom_mode);
+				AAMPLOG_MIL("SetVideoMute video_muted %d mApplyCachedVideoMute %d", video_muted, mApplyCachedVideoMute);
 				sink->SetVideoMute(video_muted);
 				if (mApplyCachedVideoMute)
 				{
@@ -5518,6 +5519,10 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 				{
 					sink->Configure(mVideoFormat, mAudioFormat, mAuxFormat, mSubtitleFormat, mpStreamAbstractionAAMP->GetESChangeStatus(), mpStreamAbstractionAAMP->GetAudioFwdToAuxStatus());
 				}
+			}
+			else
+			{
+				AAMPLOG_ERR("GetStreamSink() returned NULL");
 			}
 		}
 
@@ -6105,6 +6110,10 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 			//There two fns are being called in PlayerInstanceAAMP::SetVideoMute
 			SetVideoMute(video_muted);
 			CacheAndApplySubtitleMute(video_muted);
+		}
+		else
+		{
+			AAMPLOG_ERR("mpStreamAbstractionAAMP is NULL, cannot apply cached video mute");
 		}
 	}
 	ReleaseStreamLock();
@@ -7047,6 +7056,10 @@ void PrivateInstanceAAMP::SetVideoMute(bool muted)
 	if (sink)
 	{
 		sink->SetVideoMute(muted);
+	}
+	else
+	{
+		AAMPLOG_WARN("StreamSink not available, muted %d", muted);
 	}
 	if(ISCONFIGSET_PRIV(eAAMPConfig_UseSecManager) || ISCONFIGSET_PRIV(eAAMPConfig_UseFireboltSDK))
 	{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5507,7 +5507,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			if (sink)
 			{
 				sink->SetVideoZoom(zoom_mode);
-				AAMPLOG_MIL("SetVideoMute video_muted %d mApplyCachedVideoMute %d", video_muted, mApplyCachedVideoMute);
+				AAMPLOG_INFO("SetVideoMute video_muted %d mApplyCachedVideoMute %d", video_muted, mApplyCachedVideoMute);
 				sink->SetVideoMute(video_muted);
 				if (mApplyCachedVideoMute)
 				{


### PR DESCRIPTION
Reason for Change: Mute video when PIN is required
Test Procedure: Verify that video is not displayed when PIN is required
Priority: P1
Risks: Low

Signed-off-by: Jose Fagundez [jfagunde@synamedia.com](mailto:jfagunde@synamedia.com)