### PR TITLE
VPLAY-10785 Anti piracy Watermarking not detected

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1160,13 +1160,12 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 		int32_t statusCode;
 		int32_t reasonCode;
 		int32_t businessStatus;
-
+		bool videoMuteState = mIsVideoOnMute.load();
 		if (!mAampSecManagerSession.isSessionValid())
 		{
 			// if we're about to get a licence and are not re-using a session, then we have not seen the first video frame yet. Do not allow watermarking to get enabled yet.
-			bool videoMuteState = mIsVideoOnMute;
 			AAMPLOG_WARN("First frame flag cleared before AcquireLicense, with mIsVideoOnMute=%d", videoMuteState);
-			mFirstFrameSeen = false;
+			mFirstFrameSeen.store(false);
 		}
 
 		tStartTime = NOW_STEADY_TS_MS;
@@ -1180,7 +1179,7 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 																 secclientSessionToken, challengeInfo.accessToken.length(),
 																 mAampSecManagerSession,
 																 &licenseResponseStr, &licenseResponseLength,
-																 &statusCode, &reasonCode, &businessStatus, mIsVideoOnMute);
+																 &statusCode, &reasonCode, &businessStatus, videoMuteState);
 		tEndTime = NOW_STEADY_TS_MS;
 		downloadTimeMS = tEndTime - tStartTime;
 		if (res)

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -205,17 +205,17 @@ void DrmSessionManager::setVideoMute(bool live, double currentLatency, bool live
 #ifdef USE_SECMANAGER
 	MW_LOG_WARN("Video mute status (new): %d, state changed: %.1s, pos: %f", isVideoOnMute, (isVideoOnMute == mIsVideoOnMute) ? "N":"Y", positionMs);
 
-	mIsVideoOnMute = isVideoOnMute;
+	mIsVideoOnMute.store(isVideoOnMute);
 	auto localSession = mAampSecManagerSession; //Remove potential isSessionValid(), getSessionID() race by using a local copy
 	if(localSession.isSessionValid())
 	{
-		AampSecManager::GetInstance()->UpdateSessionState(localSession.getSessionID(), !mIsVideoOnMute);
-		if(!mIsVideoOnMute)
+		AampSecManager::GetInstance()->UpdateSessionState(localSession.getSessionID(), !mIsVideoOnMute.load());
+		if(!mIsVideoOnMute.load())
 		{
 			//this is required as secmanager waits for speed update to show wm once session is active
-			int speed=mCurrentSpeed;
+			int speed=mCurrentSpeed.load();
 			MW_LOG_INFO("Setting speed after video unmute %d ", speed);
-			setPlaybackSpeedState(live, currentLatency, livepoint, liveOffsetMs,mCurrentSpeed, positionMs);
+			setPlaybackSpeedState(live, currentLatency, livepoint, liveOffsetMs, speed, positionMs);
 		}
 	}
 #endif
@@ -233,7 +233,7 @@ void DrmSessionManager::hideWatermarkOnDetach(void)
 	{
 		AampSecManager::GetInstance()->UpdateSessionState(localSession.getSessionID(), false);
 	}
-	mFirstFrameSeen = false;
+	mFirstFrameSeen.store(false);
 #endif
 }
 
@@ -241,21 +241,21 @@ void DrmSessionManager::hideWatermarkOnDetach(void)
 void DrmSessionManager::setPlaybackSpeedState(bool live, double currentLatency, bool livepoint , double liveOffsetMs, int speed, double positionMs, bool firstFrameSeen)
 {
 #ifdef USE_SECMANAGER
-	bool isVideoOnMute=mIsVideoOnMute;
+	bool isVideoOnMute=mIsVideoOnMute.load();
 	auto localSession = mAampSecManagerSession; //Remove potential isSessionValid(), getSessionID() race by using a local copy
 	MW_LOG_WARN("In DrmSessionManager::after calling setPlaybackSpeedState speed=%d position=%f sessionID=[%" PRId64 "], mute: %d",speed, positionMs, localSession.getSessionID(), isVideoOnMute);
-	mCurrentSpeed = speed;
+	mCurrentSpeed.store(speed);
 	if(firstFrameSeen)
 	{
 		MW_LOG_INFO("First frame seen - latched");
-		mFirstFrameSeen = true;
+		mFirstFrameSeen.store(true);
 	}
-	else if (mFirstFrameSeen)
+	else if (mFirstFrameSeen.load())
 	{
 		MW_LOG_INFO("First frame has previously been seen, we will send speed updates");
 	}
 
-	if(localSession.isSessionValid() && !mIsVideoOnMute && mFirstFrameSeen)
+	if(localSession.isSessionValid() && !mIsVideoOnMute.load() && mFirstFrameSeen.load())
 	{
 		MW_LOG_INFO("calling AampSecManager::setPlaybackSpeedState()");
 
@@ -279,8 +279,8 @@ void DrmSessionManager::setPlaybackSpeedState(bool live, double currentLatency, 
 	}
 	else
 	{
-		bool firstFrameSeenCopy=mFirstFrameSeen;
-		isVideoOnMute=mIsVideoOnMute;
+		bool firstFrameSeenCopy=mFirstFrameSeen.load();
+		isVideoOnMute=mIsVideoOnMute.load();
 		MW_LOG_INFO("Not calling AampSecManager::setPlaybackSpeedState(), sessionID=[%" PRId64 "], mIsVideoOnMute=%d, firstFrameSeen=%d", localSession.getSessionID(), isVideoOnMute, firstFrameSeenCopy);
 	}
 #endif
@@ -658,7 +658,7 @@ KeyState DrmSessionManager::getDrmSession(int &err, std::shared_ptr<DrmHelper> d
 				{
 					// Set the drmSession's ID as mAampSecManagerSession so that this code will not be repeated for multiple calls for createDrmSession					
 					mAampSecManagerSession = slotSession;
-					bool videoMuteState = mIsVideoOnMute;
+					bool videoMuteState = mIsVideoOnMute.load();
 					MW_LOG_WARN("Activating re-used DRM, sessionId[%" PRId64 "], with video mute = %d", slotSession.getSessionID(), videoMuteState);
 					AampSecManager::GetInstance()->UpdateSessionState(slotSession.getSessionID(), true);
 				}
@@ -773,8 +773,8 @@ void DrmSessionManager::notifyCleanup()
 		AampSecManager::GetInstance()->UpdateSessionState(localSession.getSessionID(), false);
 		// Reset the session ID, the session ID is preserved within DrmSession instances
 		mAampSecManagerSession.setSessionInvalid();	//note this doesn't necessarily close the session as the session ID is also saved in the slot
-		mCurrentSpeed = 0;
-		mFirstFrameSeen = false;
+		mCurrentSpeed.store(0);
+		mFirstFrameSeen.store(false);
 	}
 #endif
 }


### PR DESCRIPTION
Reason for change: The parameter mIsVideonMute is an atomic variable. Directly assigning a value to an atomic variable might have caused this unexpected behaviour.
Test Procedure: test steps in ticket
Risks: Low