### PR TITLE
VPLAY-10807: Fix pthread_setname_np failed logs seen in AAMP

### DIFF
--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -1440,7 +1440,7 @@ void aamp_setThreadName(const char *name)
 		char truncatedThreadName[MAX_THREAD_NAME_LENGTH];
 		size_t len = strlen(name);
 		if( len>=MAX_THREAD_NAME_LENGTH )
-		{ // clamp
+		{ // clamp, avoiding ERANGE error
 			len = MAX_THREAD_NAME_LENGTH-1;
 		}
 		memcpy( truncatedThreadName, name, len );

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -46,7 +46,7 @@
 
 #define DEFER_DRM_LIC_OFFSET_FROM_START 5
 #define DEFER_DRM_LIC_OFFSET_TO_UPPER_BOUND 5
-#define MAX_THREAD_NAME_LENGTH 16
+#define MAX_THREAD_NAME_LENGTH 16 // Linux is least common denominator, with up to 15 characters + null terminator
 
 /*
  * Variable initialization for various audio formats
@@ -1433,28 +1433,27 @@ void aamp_setThreadName(const char *name)
 {
 	if (name == NULL)
 	{
-		AAMPLOG_ERR("Invalid name");
-		return;
+		AAMPLOG_ERR("invalid name");
 	}
-
-	char threadName[MAX_THREAD_NAME_LENGTH];
-	size_t nameLen = strnlen(name, MAX_THREAD_NAME_LENGTH - 1);
-
-	// Copy the name, ensuring null termination
-	memcpy(threadName, name, nameLen);
-	threadName[nameLen] = '\0';
-
-#ifdef __APPLE__
-	// Set the thread name
-	int ret = pthread_setname_np(threadName);
-#else
-	// Set the thread name
-	int ret = pthread_setname_np(pthread_self(), threadName);
-#endif
-	if (ret != 0)
+	else
 	{
-		// Not exactly an error, but log it for information
-		AAMPLOG_WARN("Error: pthread_setname_np failed with error code[%d]", ret);
+		char truncatedThreadName[MAX_THREAD_NAME_LENGTH];
+		size_t len = strlen(name);
+		if( len>=MAX_THREAD_NAME_LENGTH )
+		{ // clamp
+			len = MAX_THREAD_NAME_LENGTH-1;
+		}
+		memcpy( truncatedThreadName, name, len );
+		truncatedThreadName[len] = '\0';
+#ifdef __APPLE__
+		int ret = pthread_setname_np(truncatedThreadName); // different API signature on OSX
+#else
+		int ret = pthread_setname_np(pthread_self(), truncatedThreadName);
+#endif
+		if( ret != 0 )
+		{ // Not exactly an error, but log it for information
+			AAMPLOG_WARN( "pthread_setname_np failed with error code[%d]", ret );
+		}
 	}
 }
 

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -46,6 +46,7 @@
 
 #define DEFER_DRM_LIC_OFFSET_FROM_START 5
 #define DEFER_DRM_LIC_OFFSET_TO_UPPER_BOUND 5
+#define MAX_THREAD_NAME_LENGTH 16
 
 /*
  * Variable initialization for various audio formats
@@ -1423,6 +1424,9 @@ const char *mystrstr(const char *haystack_ptr, const char *haystack_fin, const c
 
 /**
  * @brief To set the thread name
+ * The thread name should be 16 characters or less, including null terminator.
+ * If the name is longer than 15 characters, it will be truncated.
+ * @note This function is only supported on POSIX threads.
  * @param[in] name thread name
  */
 void aamp_setThreadName(const char *name)
@@ -1430,20 +1434,27 @@ void aamp_setThreadName(const char *name)
 	if (name == NULL)
 	{
 		AAMPLOG_ERR("Invalid name");
+		return;
 	}
-	else
-	{
+
+	char threadName[MAX_THREAD_NAME_LENGTH];
+	size_t nameLen = strnlen(name, MAX_THREAD_NAME_LENGTH - 1);
+
+	// Copy the name, ensuring null termination
+	memcpy(threadName, name, nameLen);
+	threadName[nameLen] = '\0';
+
 #ifdef __APPLE__
-		// Set the thread name
-		int ret = pthread_setname_np(name);
+	// Set the thread name
+	int ret = pthread_setname_np(threadName);
 #else
-		// Set the thread name
-		int ret = pthread_setname_np(pthread_self(), name);
+	// Set the thread name
+	int ret = pthread_setname_np(pthread_self(), threadName);
 #endif
-		if (ret != 0)
-		{
-			AAMPLOG_ERR("Error: pthread_setname_np failed with error code[%d]", ret);
-		}
+	if (ret != 0)
+	{
+		// Not exactly an error, but log it for information
+		AAMPLOG_WARN("Error: pthread_setname_np failed with error code[%d]", ret);
 	}
 }
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9727,7 +9727,7 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
 void StreamAbstractionAAMP_MPD::FetcherLoop()
 {
 	UsingPlayerId playerId(aamp->mPlayerId);
-	aamp_setThreadName("aampFragmentDownloader");
+	aamp_setThreadName("aampFragDL");
 	bool exitFetchLoop = false;
 	bool trickPlay = (AAMP_NORMAL_PLAY_RATE != aamp->rate);
 


### PR DESCRIPTION
Reason for change: Enforce that thread name is limited to supported length and otherwise truncated. Also change the thread name that was causing the API to fail. The log level has been changed to prevent confusion
Test Procedure: Check for the error log during playback. Please note that log is now a warn log
Risks: None