### PR TITLE
VPLAY-10820: Observing Technical fault after waking from Deepsleep

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1160,7 +1160,7 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 		int32_t statusCode;
 		int32_t reasonCode;
 		int32_t businessStatus;
-		bool videoMuteState = mIsVideoOnMute.load();
+		bool videoMuteState = mDrmSessionManager->mIsVideoOnMute.load();
 		if (!mAampSecManagerSession.isSessionValid())
 		{
 			// if we're about to get a licence and are not re-using a session, then we have not seen the first video frame yet. Do not allow watermarking to get enabled yet.

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1161,11 +1161,11 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 		int32_t reasonCode;
 		int32_t businessStatus;
 		bool videoMuteState = mDrmSessionManager->mIsVideoOnMute.load();
-		if (!mAampSecManagerSession.isSessionValid())
+		if (!mDrmSessionManager->mAampSecManagerSession.isSessionValid())
 		{
 			// if we're about to get a licence and are not re-using a session, then we have not seen the first video frame yet. Do not allow watermarking to get enabled yet.
 			AAMPLOG_WARN("First frame flag cleared before AcquireLicense, with mIsVideoOnMute=%d", videoMuteState);
-			mFirstFrameSeen.store(false);
+			mDrmSessionManager->mFirstFrameSeen.store(false);
 		}
 
 		tStartTime = NOW_STEADY_TS_MS;
@@ -1177,7 +1177,7 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 																 keySystem,
 																 mediaUsage,
 																 secclientSessionToken, challengeInfo.accessToken.length(),
-																 mAampSecManagerSession,
+																 mDrmSessionManager->mAampSecManagerSession,
 																 &licenseResponseStr, &licenseResponseLength,
 																 &statusCode, &reasonCode, &businessStatus, videoMuteState);
 		tEndTime = NOW_STEADY_TS_MS;

--- a/drm/AampDRMLicManager.h
+++ b/drm/AampDRMLicManager.h
@@ -56,12 +56,6 @@ public:
 	AampCurlDownloader mAccessTokenConnector;
 	AampLicensePreFetcher* mLicensePrefetcher; /**< DRM license prefetcher instance */
 	PrivateInstanceAAMP *aampInstance; /** AAMP instance **/
-#ifdef USE_SECMANAGER
-	AampSecManagerSession mAampSecManagerSession;
-	std::atomic<bool> mIsVideoOnMute;
-	std::atomic<int> mCurrentSpeed;
-	std::atomic<bool> mFirstFrameSeen;
-#endif
 	/**
 	 * @fn          setLicenseRequestAbort
 	 * @param       isAbort bool flag to curl abort

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -127,6 +127,12 @@ class DrmSessionManager
 
 	DrmSessionContext *drmSessionContexts;
 	configs *m_drmConfigParam;
+#ifdef USE_SECMANAGER
+        AampSecManagerSession mAampSecManagerSession;
+        std::atomic<bool> mIsVideoOnMute;
+        std::atomic<int> mCurrentSpeed;
+        std::atomic<bool> mFirstFrameSeen;
+#endif
 private:
 	KeyID *cachedKeyIDs;
 	char* accessToken;
@@ -137,12 +143,6 @@ private:
 	std::mutex mDrmSessionLock;
 	bool mEnableAccessAttributes;
 	int mMaxDrmSessions;
-#ifdef USE_SECMANAGER
-	AampSecManagerSession mAampSecManagerSession;
-	std::atomic<bool> mIsVideoOnMute;
-	std::atomic<int> mCurrentSpeed;
-	std::atomic<bool> mFirstFrameSeen;
-#endif
 	/**     
      	 * @brief Copy constructor disabled
      	 *


### PR DESCRIPTION
Reason for change: Maintained the single secmanager session in
middleware component to resolve the closesession failure - feature/VPLAY-10820_2.6.1
Test Procedure: Refer Jira
Risks: NA