### PR TITLE
VPLAY-10820: Observing Technical fault after waking from Deepsleep

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1156,13 +1156,12 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 		int32_t statusCode;
 		int32_t reasonCode;
 		int32_t businessStatus;
-
-		if (!mAampSecManagerSession.isSessionValid())
+		bool videoMuteState = mDrmSessionManager->mIsVideoOnMute.load();
+		if (!mDrmSessionManager->mAampSecManagerSession.isSessionValid())
 		{
 			// if we're about to get a licence and are not re-using a session, then we have not seen the first video frame yet. Do not allow watermarking to get enabled yet.
-			bool videoMuteState = mIsVideoOnMute;
 			AAMPLOG_WARN("First frame flag cleared before AcquireLicense, with mIsVideoOnMute=%d", videoMuteState);
-			mFirstFrameSeen = false;
+			mDrmSessionManager->mFirstFrameSeen.store(false);
 		}
 
 		tStartTime = NOW_STEADY_TS_MS;
@@ -1174,9 +1173,9 @@ DrmData * AampDRMLicenseManager::getLicenseSec(const LicenseRequest &licenseRequ
 																 keySystem,
 																 mediaUsage,
 																 secclientSessionToken, challengeInfo.accessToken.length(),
-																 mAampSecManagerSession,
+																 mDrmSessionManager->mAampSecManagerSession,
 																 &licenseResponseStr, &licenseResponseLength,
-																 &statusCode, &reasonCode, &businessStatus, mIsVideoOnMute);
+																 &statusCode, &reasonCode, &businessStatus, videoMuteState);
 		tEndTime = NOW_STEADY_TS_MS;
 		downloadTimeMS = tEndTime - tStartTime;
 		if (res)

--- a/drm/AampDRMLicManager.h
+++ b/drm/AampDRMLicManager.h
@@ -56,12 +56,6 @@ public:
 	AampCurlDownloader mAccessTokenConnector;
 	AampLicensePreFetcher* mLicensePrefetcher; /**< DRM license prefetcher instance */
 	PrivateInstanceAAMP *aampInstance; /** AAMP instance **/
-#ifdef USE_SECMANAGER
-	AampSecManagerSession mAampSecManagerSession;
-	std::atomic<bool> mIsVideoOnMute;
-	std::atomic<int> mCurrentSpeed;
-	std::atomic<bool> mFirstFrameSeen;
-#endif
 	/**
 	 * @fn          setLicenseRequestAbort
 	 * @param       isAbort bool flag to curl abort

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -127,6 +127,12 @@ class DrmSessionManager
 
 	DrmSessionContext *drmSessionContexts;
 	configs *m_drmConfigParam;
+#ifdef USE_SECMANAGER
+        AampSecManagerSession mAampSecManagerSession;
+        std::atomic<bool> mIsVideoOnMute;
+        std::atomic<int> mCurrentSpeed;
+        std::atomic<bool> mFirstFrameSeen;
+#endif
 private:
 	KeyID *cachedKeyIDs;
 	char* accessToken;
@@ -137,12 +143,6 @@ private:
 	std::mutex mDrmSessionLock;
 	bool mEnableAccessAttributes;
 	int mMaxDrmSessions;
-#ifdef USE_SECMANAGER
-	AampSecManagerSession mAampSecManagerSession;
-	std::atomic<bool> mIsVideoOnMute;
-	std::atomic<int> mCurrentSpeed;
-	std::atomic<bool> mFirstFrameSeen;
-#endif
 	/**     
      	 * @brief Copy constructor disabled
      	 *


### PR DESCRIPTION
Reason for change: Maintained the single secmanager session in middleware component to resolve the closesession failure Test Procedure: Refer Jira
Risks: NA



VPLAY-10820: Observing Technical fault after waking from Deepsleep

Reason for change: Maintained the single secmanager session in middleware component to resolve the closesession failure Test Procedure: Refer Jira
Risks: NA