### PR TITLE
VPLAY-10805: Fix build errors due to missing headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,6 +703,7 @@ install(FILES
 	middleware/SocUtils.h
 	middleware/closedcaptions/PlayerCCManager.h
 	middleware/PlayerUtils.h
+	LangCodePreference.h StreamOutputFormat.h VideoZoomMode.h StreamSink.h
 	DESTINATION include
 )
 


### PR DESCRIPTION
Reason for change: Fix device build errors observed with the initial patchset
Test Procedure: Make sure device builds are completed successfully
Risks: None