### PR TITLE
VPLAY-10605 fix unused var

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9007,7 +9007,6 @@ bool StreamAbstractionAAMP_MPD::GetEncryptedHeaders(std::map<int, std::string>& 
 bool StreamAbstractionAAMP_MPD::ExtractAndAddSubtitleMediaHeader()
 {
 	bool ret = false;
-	size_t numPeriods = mMPDParseHelper->GetNumberOfPeriods();  //CID:96576 - Removed the  headerCount variable which is initialized but not used
 	bool subtitleFound = false;
 
 	for (auto &period: mpd->GetPeriods())


### PR DESCRIPTION
VPLAY-10605 fix unused var

Reason for Change: resolve compiler warning in new ExtractAndAddSubtitleMediaHeader method

Test Guidance: static code analysis

Risk: None