### PR TITLE
VPLAY-10894 eliminate inappropriate dependencies on main_aamp.h & priv_aamp.h

### DIFF
--- a/AampCacheHandler.h
+++ b/AampCacheHandler.h
@@ -28,9 +28,13 @@
 #include <memory>
 #include <unordered_map>
 #include <exception>
-#include "priv_aamp.h"
 #include <mutex>
 #include <condition_variable>
+#include "AampGrowableBuffer.h"
+#include "AampMediaType.h"
+#include "AampUtils.h"
+#include "AampLogManager.h"
+#include "AampDefine.h"
 
 #define PLAYLIST_CACHE_SIZE_UNLIMITED -1
 

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -1406,7 +1406,7 @@ void AampConfig::ProcessConfigText(std::string &cfg, ConfigPriority owner )
 				while (getline(iss, token, ' '))
 				{
 					const char *uri = token.c_str();
-					if( PlayerInstanceAAMP::isTuneScheme(uri) )
+					if( aamp_isTuneScheme(uri) )
 					{
 						AAMPLOG_INFO("Override %s", uri );
 						channelInfo.uri = token;

--- a/AampTSBSessionManager.h
+++ b/AampTSBSessionManager.h
@@ -31,7 +31,6 @@
 #include <uuid/uuid.h>
 #include <map>
 #include "tsb/api/TsbApi.h"
-#include "priv_aamp.h"
 #include "AampMediaType.h"
 #include "AampTsbDataManager.h"
 #include "AampTsbMetaDataManager.h"

--- a/AampTsbDataManager.h
+++ b/AampTsbDataManager.h
@@ -32,7 +32,6 @@
 #include <exception>
 #include <mutex>
 #include <utility>
-#include "priv_aamp.h"
 #include "StreamAbstractionAAMP.h"
 #include "ABRManager.h" // For BitsPerSecond
 #include "AampTime.h"

--- a/AampTsbReader.h
+++ b/AampTsbReader.h
@@ -26,7 +26,6 @@
 #define AAMP_TSBREADER_H
 
 #include "AampTsbDataManager.h"
-#include "priv_aamp.h"
 #include "AampMediaType.h"
 #include "AampTime.h"
 

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -1425,7 +1425,21 @@ int aamp_SetThreadSchedulingParameters(int policy, int priority)
 	AAMPLOG_INFO("Thread scheduling parameters set successfully.");
 	return result; // Success
 }
-/*
- * EOF
- */
+
+bool aamp_isTuneScheme( const char *cmdBuf )
+{
+    size_t cmdLen = strlen(cmdBuf);
+    bool isTuneScheme = false;
+    static const char *protocol[]  = { "http:","https:","live:","hdmiin:","file:","mr:","tune:" };
+    for( int i=0; i<sizeof(protocol)/sizeof(protocol[0]); i++ )
+    {
+        size_t protocolLen = strlen(protocol[i]);
+        if( cmdLen>=protocolLen && memcmp( cmdBuf, protocol[i], protocolLen )==0 )
+        {
+            isTuneScheme=true;
+            break;
+        }
+    }
+    return isTuneScheme;
+}
 

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -413,5 +413,13 @@ void aamp_setThreadName(const char *name);
  */
 int aamp_SetThreadSchedulingParameters(int policy, int priority);
 
+/**
+ * @fn isTuneScheme
+ *
+ * @param[in] uri
+ *
+ * @retval true iff uri starts with a recognized protocol representing an IP Video Locator
+ */
+bool aamp_isTuneScheme( const char *cmdBuf );
 
 #endif  /* __AAMP_UTILS_H__ */

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ set(LIBAAMP_SOURCES
 	streamabstraction.cpp
 	priv_aamp.cpp priv_aamp.h
 	main_aamp.cpp main_aamp.h
-	LangCodePreference.h StreamOutputFormat.h VideoZoomMode.h StreamSink.h AudioTrackInfo.h TextTrackInfo.h
+	LangCodePreference.h StreamOutputFormat.h VideoZoomMode.h StreamSink.h AudioTrackInfo.h TextTrackInfo.h TimedMetadata.h
 	drm/AampDRMLicManager.cpp drm/AampDRMLicManager.h
 	drm/DrmInterface.cpp drm/DrmInterface.h
 	aampgstplayer.cpp aampgstplayer.h
@@ -703,7 +703,7 @@ install(FILES
 	middleware/SocUtils.h
 	middleware/closedcaptions/PlayerCCManager.h
 	middleware/PlayerUtils.h
-	LangCodePreference.h StreamOutputFormat.h VideoZoomMode.h StreamSink.h
+	LangCodePreference.h StreamOutputFormat.h VideoZoomMode.h StreamSink.h TimedMetadata.h
 	DESTINATION include
 )
 

--- a/TimedMetadata.h
+++ b/TimedMetadata.h
@@ -1,0 +1,51 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2023 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TIMED_METADATA_H
+#define TIMED_METADATA_H
+
+/**
+ * @brief Class for Timed Metadata
+ */
+class TimedMetadata
+{
+public:
+	/**
+	 * @brief TimedMetadata Constructor
+	 */
+	TimedMetadata() : _timeMS(0), _name(""), _content(""), _id(""), _durationMS(0) {}
+	
+	/**
+	 * @brief TimedMetadata Constructor
+	 *
+	 * @param[in] timeMS - Time in milliseconds
+	 * @param[in] name - Metadata name
+	 * @param[in] content - Metadata content
+	 */
+	TimedMetadata(long long timeMS, std::string name, std::string content, std::string id, double durMS) : _timeMS(timeMS), _name(name), _content(content), _id(id), _durationMS(durMS) {}
+	
+public:
+	long long _timeMS;       /**< Time in milliseconds */
+	std::string _name;       /**< Metadata name */
+	std::string _content;    /**< Metadata content */
+	std::string _id;         /**< Id of the timedMetadata. If not available an Id will bre created */
+	double _durationMS;      /**< Duration in milliseconds */
+};
+
+#endif // TIMED_METADATA_H

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -23,7 +23,9 @@
 */
 
 #include "isobmffbuffer.h"
-#include "priv_aamp.h" //Required for AAMPLOG_WARN1
+#include "AampUtils.h"
+#include "AampLogManager.h"
+#include <inttypes.h>
 #include <string.h>
 
 static Box *findBoxInVector(const char * box_type, const std::vector<Box*> *boxes);

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -28,7 +28,6 @@
 #include "jsbindings-version.h"
 #include "jsutils.h"
 #include "main_aamp.h"
-#include "priv_aamp.h"
 #include <mutex>
 #include "PlayerCCManager.h"
 
@@ -351,20 +350,19 @@ static JSValueRef AAMP_getProperty_timedMetadata(JSContextRef context, JSObjectR
 		return JSValueMakeUndefined(context);
 	}
 
-	PrivateInstanceAAMP* privAAMP = (pAAMP->_aamp != NULL) ? pAAMP->_aamp->aamp : NULL;
-	if (privAAMP == NULL)
+	if (pAAMP->_aamp == NULL)
 	{
                 LOG_ERROR_EX("privAAMP not initialized");
 		*exception = aamp_GetException(context, AAMPJS_INVALID_ARGUMENT, "AAMP.timedMetadata - initialization error");
 		return JSValueMakeUndefined(context);
 	}
-
-	int32_t length = (int32_t)privAAMP->timedMetadata.size();
+	auto timedMetadata = pAAMP->_aamp->GetTimedMetadata();
+	int32_t length = (int32_t)timedMetadata.size();
 
 	JSValueRef* array = new JSValueRef[length];
 	for (int32_t i = 0; i < length; i++)
 	{
-		TimedMetadata item = privAAMP->timedMetadata.at(i);
+		TimedMetadata item = timedMetadata.at(i);
 		JSObjectRef ref = aamp_CreateTimedMetadataJSObject(context, item._timeMS, item._name.c_str(), item._content.c_str(), item._id.c_str(), item._durationMS);
 		array[i] = ref;
 	}

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -47,6 +47,11 @@ AampConfig *gpGlobalConfig=NULL;
 
 std::mutex PlayerInstanceAAMP::mPrvAampMtx;
 
+const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) const
+{
+	return aamp->GetTimedMetadata();
+}
+
 /**
  *  @brief PlayerInstanceAAMP Constructor.
  */

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -58,6 +58,7 @@
 #include "StreamOutputFormat.h"
 #include "VideoZoomMode.h"
 #include "StreamSink.h"
+#include "TimedMetadata.h"
 
 /*! \mainpage
  *
@@ -69,10 +70,6 @@
 
 #define PrivAAMPState AAMPPlayerState // backwards compatibility for apps using native interface
 
-#if 0
-using AdObject = std::pair<std::string, std::string>;
-#endif
-
 /**
  * @class PlayerInstanceAAMP
  * @brief Player interface class for the JS plugin.
@@ -81,6 +78,7 @@ class PlayerInstanceAAMP
 {
 public: // FIXME: this should be private, but some tests access it
 	class PrivateInstanceAAMP *aamp;  		  /**< AAMP player's private instance */
+	const std::vector<TimedMetadata> & GetTimedMetadata( void ) const;
 
 private:
 	std::shared_ptr<PrivateInstanceAAMP> sp_aamp; 	  /**< shared pointer for aamp resource */
@@ -114,31 +112,7 @@ public:
 	 *   @param other object to copy
 	 */
 	PlayerInstanceAAMP& operator=(const PlayerInstanceAAMP& other) = delete;
-
-	/**
-	 * @fn isTuneScheme
-	 *
-	 * @param[in] uri
-	 *
-	 * @retval true iff uri starts with a recognized protocol representing an IP Video Locator
-	 */
-	static bool isTuneScheme( const char *cmdBuf )
-	{
-		size_t cmdLen = strlen(cmdBuf);
-		bool isTuneScheme = false;
-		static const char *protocol[]  = { "http:","https:","live:","hdmiin:","file:","mr:","tune:" };
-		for( int i=0; i<sizeof(protocol)/sizeof(protocol[0]); i++ )
-		{
-			size_t protocolLen = strlen(protocol[i]);
-			if( cmdLen>=protocolLen && memcmp( cmdBuf, protocol[i], protocolLen )==0 )
-			{
-				isTuneScheme=true;
-				break;
-			}
-		}
-		return isTuneScheme;
-	}
-
+    
 	/**
 	 *   @fn Tune
 	 *
@@ -1491,6 +1465,7 @@ protected:
 	 *   @return void
 	 */
 	void SetTextTrackInternal(int trackId, char *data);
+	
 private:
 
 	/**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7731,6 +7731,10 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 	AampStreamSinkManager::GetInstance().DeactivatePlayer(this, true);
 }
 
+const std::vector<TimedMetadata> & PrivateInstanceAAMP::GetTimedMetadata( void ) const
+{
+	return timedMetadata;
+}
 /**
  * @brief SaveTimedMetadata Function to store Metadata for bulk reporting during Initialization
  */

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -25,11 +25,16 @@
 #ifndef PRIVAAMP_H
 #define PRIVAAMP_H
 
+#include "Accessibility.hpp"
+#include "VideoZoomMode.h"
+#include "AampScheduler.h"
+#include "StreamSink.h"
+#include "TimedMetadata.h"
+
 #include "AampProfiler.h"
 #include "DrmHelper.h"
 #include "DrmMediaFormat.h"
 #include "DrmCallbacks.h"
-#include "main_aamp.h"
 #include <IPVideoStat.h>
 #include "AampGrowableBuffer.h"
 #include "CCTrackInfo.h"
@@ -248,7 +253,7 @@ struct AsyncEventDescriptor
 	AsyncEventDescriptor& operator=(const AsyncEventDescriptor& other) = delete;
 
 	AAMPEventPtr event;
-	std::shared_ptr<PrivateInstanceAAMP> aamp;
+	std::shared_ptr<class PrivateInstanceAAMP> aamp;
 };
 
 /**
@@ -280,35 +285,6 @@ struct DynamicDrmInfo {
 };
 
 class Id3CallbackData;
-
-/**
- * @brief Class for Timed Metadata
- */
-class TimedMetadata
-{
-public:
-
-	/**
-	 * @brief TimedMetadata Constructor
-	 */
-	TimedMetadata() : _timeMS(0), _name(""), _content(""), _id(""), _durationMS(0) {}
-
-	/**
-	 * @brief TimedMetadata Constructor
-	 *
-	 * @param[in] timeMS - Time in milliseconds
-	 * @param[in] name - Metadata name
-	 * @param[in] content - Metadata content
-	 */
-	TimedMetadata(long long timeMS, std::string name, std::string content, std::string id, double durMS) : _timeMS(timeMS), _name(name), _content(content), _id(id), _durationMS(durMS) {}
-
-public:
-	long long _timeMS;       /**< Time in milliseconds */
-	std::string _name;       /**< Metadata name */
-	std::string _content;    /**< Metadata content */
-	std::string _id;         /**< Id of the timedMetadata. If not available an Id will bre created */
-	double      _durationMS; /**< Duration in milliseconds */
-};
 
 
 /**
@@ -1826,6 +1802,8 @@ public:
 	 * @return void
 	 */
 	void SaveNewTimedMetadata(long long timeMS, const char* szName, const char* szContent, int nb, const char* id = "", double durationMS = -1);
+
+	const std::vector<TimedMetadata> & GetTimedMetadata( void ) const;
 
 	/**
 	 * @fn SaveTimedMetadata

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -24,7 +24,6 @@
 
 #include "Aampcli.h"
 #include "scte35/AampSCTE35.h"
-//#include "AampcliShader.h"
 
 Aampcli mAampcli;
 const char *gApplicationPath = NULL;

--- a/test/aampcli/AampcliCommand.h
+++ b/test/aampcli/AampcliCommand.h
@@ -23,7 +23,7 @@
  */
 #pragma once
 
-#include "priv_aamp.h"
+#include "main_aamp.h"
 
 class Command
 {

--- a/test/aampcli/AampcliGet.h
+++ b/test/aampcli/AampcliGet.h
@@ -27,7 +27,6 @@
 
 #include <cstring>
 #include "main_aamp.h"
-//#include "priv_aamp.h"
 #include "AampcliCommand.h"
 
 typedef struct GetCommandInfo{

--- a/test/aampcli/AampcliGet.h
+++ b/test/aampcli/AampcliGet.h
@@ -26,7 +26,8 @@
 #define AAMPCLIGET_H
 
 #include <cstring>
-#include "priv_aamp.h"
+#include "main_aamp.h"
+//#include "priv_aamp.h"
 #include "AampcliCommand.h"
 
 typedef struct GetCommandInfo{

--- a/test/aampcli/AampcliPlaybackCommand.cpp
+++ b/test/aampcli/AampcliPlaybackCommand.cpp
@@ -506,7 +506,7 @@ void PlaybackCommand::HandleCommandFog( const char *cmd, PlayerInstanceAAMP *pla
 	else
 	{
 		//Should be a cmd of "fog url". Create fogified URL & try & tune to that.
-		if((strlen(cmd) > 4) && playerInstanceAamp->isTuneScheme(&cmd[4]))
+		if((strlen(cmd) > 4) && aamp_isTuneScheme(&cmd[4]))
 		{
 			std::string fogUrl;
 			buildFogUrl(mFogHostPrefix, &cmd[4], fogUrl);
@@ -675,7 +675,7 @@ void PlaybackCommand::HandleCommandTuneData( const char *cmd, PlayerInstanceAAMP
 	if (std::getline(str,url, ' '))
 	{
 		mAampcli.mManifestDataUrl = url;
-		if (playerInstanceAamp->isTuneScheme(url.c_str()))
+		if (aamp_isTuneScheme(url.c_str()))
 		{
 			AAMPCLI_PRINTF("[AAMPCLI] Player: url : %s \n",url.c_str());
 			manifestData = getManifestData(url);
@@ -761,7 +761,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 	{
 		HandleCommandRelease(cmd, playerInstanceAamp );
 	}
-	else if( playerInstanceAamp->isTuneScheme(cmd) )
+	else if( aamp_isTuneScheme(cmd) )
 	{
 		HandleCommandTuneLocator( cmd, playerInstanceAamp );
 	}

--- a/test/aampcli/AampcliSet.cpp
+++ b/test/aampcli/AampcliSet.cpp
@@ -23,8 +23,8 @@
  */
 
 #include <iomanip>
-#include"Aampcli.h"
-#include"AampcliSet.h"
+#include "Aampcli.h"
+#include "AampcliSet.h"
 #include "AampcliSubtecSimulator.h"
 
 #define AAMPCLI_MAX_WEBVTT_SIZE	(500 * 1024)

--- a/test/aampcli/AampcliVirtualChannelMap.h
+++ b/test/aampcli/AampcliVirtualChannelMap.h
@@ -27,7 +27,7 @@
 
 #include <stdlib.h>
 #include <sstream>
-#include <priv_aamp.h>
+#include <main_aamp.h>
 
 #define VIRTUAL_CHANNEL_VALID(x) ((x) > 0)
 #define MAX_BUFFER_LENGTH 4096

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -783,6 +783,12 @@ void PrivateInstanceAAMP::ResumeTrackInjection(AampMediaType type)
 {
 }
 
+const std::vector<TimedMetadata> & PrivateInstanceAAMP::GetTimedMetadata( void ) const
+{
+	static std::vector<TimedMetadata> timedMetadata;
+	return timedMetadata;
+}
+
 void PrivateInstanceAAMP::SaveTimedMetadata(long long timeMilliseconds, const char *szName,
 											const char *szContent, int nb, const char *id,
 											double durationMS)

--- a/test/utests/fakes/FakeAampCCManager.cpp
+++ b/test/utests/fakes/FakeAampCCManager.cpp
@@ -18,7 +18,7 @@
  */
 #include <string>
 #include <vector>
-#include "main_aamp.h"
+#include "priv_aamp.h"
 #include "AampLogManager.h"
 #include "PlayerCCManager.h"
 

--- a/test/utests/fakes/FakeAampUtils.cpp
+++ b/test/utests/fakes/FakeAampUtils.cpp
@@ -605,5 +605,7 @@ int aamp_SetThreadSchedulingParameters(int policy, int priority)
 	return 0;
 }
 
+bool aamp_isTuneScheme( const char *cmdBuf ){ return false; }
+
 // aamp_ApplyPageHttpHeaders not actually part of AampUtils.cpp, but fake declared here for convenience
 extern "C" void aamp_ApplyPageHttpHeaders(PlayerInstanceAAMP *aamp){}

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -22,6 +22,13 @@
 
 MockPlayerInstanceAAMP *g_mockPlayerInstanceAAMP = nullptr;
 
+const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) const
+{
+	static std::vector<TimedMetadata> rc;
+	return rc;
+}
+
+
 	PlayerInstanceAAMP::PlayerInstanceAAMP(StreamSink* streamSink, std::function< void(const unsigned char *, int, int, int) > exportFrames) {  }
 	PlayerInstanceAAMP::~PlayerInstanceAAMP() {  }
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1712,3 +1712,10 @@ double PrivateInstanceAAMP::GetFormatPositionOffsetInMSecs()
 {
 	return 0;
 }
+
+const std::vector<TimedMetadata> & PrivateInstanceAAMP::GetTimedMetadata( void ) const
+{
+	static std::vector<TimedMetadata> rc;
+	return rc;
+}
+

--- a/test/utests/fakes/FakeTsProcessor.cpp
+++ b/test/utests/fakes/FakeTsProcessor.cpp
@@ -17,7 +17,6 @@
 * limitations under the License.
 */
 #include <string>
-#include "main_aamp.h"
 #include "AampLogManager.h"
 #include "tsprocessor.h"
 #include "ID3Metadata.hpp"

--- a/test/utests/tests/AampCacheHandlerTests/AampCacheHandlerTests.cpp
+++ b/test/utests/tests/AampCacheHandlerTests/AampCacheHandlerTests.cpp
@@ -20,7 +20,7 @@
 #include <gtest/gtest.h>
 #include "AampCacheHandler.h"
 #include "AampMediaType.h"
-
+#include "AampConfig.h"
 #include "MockAampGrowableBuffer.h"
 
 using namespace testing;

--- a/test/utests/tests/PlayerInstanceAAMP/PauseOnPlaybackTests.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PauseOnPlaybackTests.cpp
@@ -22,7 +22,7 @@
 #include "MockAampConfig.h"
 #include "MockAampScheduler.h"
 #include "MockPrivateInstanceAAMP.h"
-#include "main_aamp.h" // FIXME?
+#include "main_aamp.h"
 #include "MockStreamAbstractionAAMP.h"
 
 using ::testing::_;

--- a/test/utests/tests/PlayerInstanceAAMP/PauseOnPlaybackTests.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PauseOnPlaybackTests.cpp
@@ -22,9 +22,8 @@
 #include "MockAampConfig.h"
 #include "MockAampScheduler.h"
 #include "MockPrivateInstanceAAMP.h"
-#include "main_aamp.h"
+#include "main_aamp.h" // FIXME?
 #include "MockStreamAbstractionAAMP.h"
-#include "priv_aamp.h"
 
 using ::testing::_;
 using ::testing::Return;

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -26,7 +26,6 @@
 #include "MockStreamAbstractionAAMP.h"
 #include "MockAampStreamSinkManager.h"
 #include "main_aamp.h"
-#include "priv_aamp.h"
 
 using ::testing::_;
 using ::testing::Return;


### PR DESCRIPTION
VPLAY-10894 eliminate inappropriate dependencies on main_aamp.h & priv_aamp.h

Reason for Change: better encapsulation

Test Guidance: basic regression (L1, L2, L3)

Risk: Low