### PR TITLE
VPLAY-10605 [VIPA] CC is not displayed in VOD assets with pre-roll ads

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10973,6 +10973,10 @@ void StreamAbstractionAAMP_MPD::GetStreamFormat(StreamOutputFormat &primaryOutpu
 				subtitleOutputFormat = FORMAT_SUBTITLE_MP4;
 			}
 		}
+		else
+		{
+			subtitleOutputFormat = FORMAT_INVALID;
+		}
 
 		// If subtitles are not enabled, we need to have an init fragment to inject otherwise
 		// a complete pipeline cannot be created; and Rialto will not start playing video


### PR DESCRIPTION
VPLAY-10605 Fix value of subtitle format returned

Reason for Change: Fix made to StreamAbstractionAAMP_MPD::GetStreamFormat which was missing in original delivery, and caused regression in non-Rialto L3 tests

Testing Guidance: Re-ran failed L3 tests

Risk: Low
