### PR TITLE
VPLAY-10709 - [VIPA] A/V played for 1-2 second when Trickmode attempted whilst Paused within TSB

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -804,6 +804,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					// Resuming payback from pause
 					// If have local TSB, but playing from Live then seek into the TSB
 					// Otherwise unpause the pipeline
+					AAMPLOG_WARN("ANJ: aamp->IsLocalAAMPTsb() = %d, aamp->IsLocalAAMPTsbInjection( = %d", aamp->IsLocalAAMPTsb(), aamp->IsLocalAAMPTsbInjection());
 					if(aamp->IsLocalAAMPTsb() && !aamp->IsLocalAAMPTsbInjection())
 					{
 						retValue = false;
@@ -812,11 +813,14 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 						aamp->rate = AAMP_NORMAL_PLAY_RATE;
 						aamp->pipeline_paused = false;
 						aamp->AcquireStreamLock();
+						AAMPLOG_WARN("ANJ:Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate set to AAMP_NORMAL_PLAY_RATE");
 						aamp->TuneHelper(eTUNETYPE_SEEK, false);
+						AAMPLOG_WARN("ANJ:After Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate = %f", aamp->rate);
 						aamp->ReleaseStreamLock();
 					}
 					else
 					{
+						AAMPLOG_WARN("ANJ: else case. unpause flow ====");
 						// check if unpausing in the middle of fragments caching
 						if(!aamp->SetStateBufferingIfRequired())
 						{
@@ -824,6 +828,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
 							if (sink)
 							{
+								AAMPLOG_WARN("ANJ:Calling sink->Pause(false, false)");
 								retValue = sink->Pause(false, false);
 							}
 							// required since buffers are already cached in paused state
@@ -883,6 +888,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					tuneTypePlay = eTUNETYPE_SEEKTOLIVE;
 					aamp->mJumpToLiveFromPause = false;
 				}
+# if 0//anj:to try
 				/* if Gstreamer pipeline set to paused state by user, change it to playing state */
 				if (playAlreadyEnabled && aamp->pipeline_paused == true)
 				{
@@ -890,6 +896,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
 					if (sink)
 					{
+						AAMPLOG_WARN("ANJ:2: Calling sink->Pause(false, false)");
 						(void)sink->Pause(false, false);
 					}
 				}
@@ -897,6 +904,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				{
 					AAMPLOG_INFO("Play was not already enabled(%d) or pipeline not paused(%d)", playAlreadyEnabled, aamp->pipeline_paused);
 				}
+#endif//anj: to try
 				aamp->rate = rate;
 				aamp->pipeline_paused = false;
 				aamp->mSeekFromPausedState = false;
@@ -906,7 +914,9 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				aamp->EnableDownloads();
 				aamp->ResumeDownloads();
 				aamp->AcquireStreamLock();
+				AAMPLOG_WARN("ANJ:Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->TuneHelper(tuneTypePlay); // this unpauses pipeline as side effect
+				AAMPLOG_WARN("ANJ:After Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->ReleaseStreamLock();
 			}
 

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -804,6 +804,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					// Resuming payback from pause
 					// If have local TSB, but playing from Live then seek into the TSB
 					// Otherwise unpause the pipeline
+					AAMPLOG_WARN("ANJ: aamp->IsLocalAAMPTsb() = %d, aamp->IsLocalAAMPTsbInjection( = %d", aamp->IsLocalAAMPTsb(), aamp->IsLocalAAMPTsbInjection());
 					if(aamp->IsLocalAAMPTsb() && !aamp->IsLocalAAMPTsbInjection())
 					{
 						retValue = false;
@@ -812,11 +813,14 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 						aamp->rate = AAMP_NORMAL_PLAY_RATE;
 						aamp->pipeline_paused = false;
 						aamp->AcquireStreamLock();
+						AAMPLOG_WARN("ANJ:Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate set to AAMP_NORMAL_PLAY_RATE");
 						aamp->TuneHelper(eTUNETYPE_SEEK, false);
+						AAMPLOG_WARN("ANJ:After Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate = %f", aamp->rate);
 						aamp->ReleaseStreamLock();
 					}
 					else
 					{
+						AAMPLOG_WARN("ANJ: else case. unpause flow ====");
 						// check if unpausing in the middle of fragments caching
 						if(!aamp->SetStateBufferingIfRequired())
 						{
@@ -824,6 +828,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
 							if (sink)
 							{
+								AAMPLOG_WARN("ANJ:Calling sink->Pause(false, false)");
 								retValue = sink->Pause(false, false);
 							}
 							// required since buffers are already cached in paused state
@@ -883,7 +888,23 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					tuneTypePlay = eTUNETYPE_SEEKTOLIVE;
 					aamp->mJumpToLiveFromPause = false;
 				}
-
+# if 1//anj:to try
+				/* if Gstreamer pipeline set to paused state by user, change it to playing state */
+				if (playAlreadyEnabled && aamp->pipeline_paused == true)
+				{
+					AAMPLOG_INFO("Play was already enabled, and pipeline paused - unpause");
+					StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
+					if (sink)
+					{
+						AAMPLOG_WARN("ANJ:2: commented Calling sink->Pause(false, false)");
+//						(void)sink->Pause(false, false);
+					}
+				}
+				else
+				{
+					AAMPLOG_INFO("Play was not already enabled(%d) or pipeline not paused(%d)", playAlreadyEnabled, aamp->pipeline_paused);
+				}
+#endif//anj: to try
 				aamp->rate = rate;
 				aamp->pipeline_paused = false;
 				aamp->mSeekFromPausedState = false;
@@ -893,7 +914,9 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				aamp->EnableDownloads();
 				aamp->ResumeDownloads();
 				aamp->AcquireStreamLock();
+				AAMPLOG_WARN("ANJ:Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->TuneHelper(tuneTypePlay); // this unpauses pipeline as side effect
+				AAMPLOG_WARN("ANJ:After Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->ReleaseStreamLock();
 			}
 

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -804,7 +804,6 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					// Resuming payback from pause
 					// If have local TSB, but playing from Live then seek into the TSB
 					// Otherwise unpause the pipeline
-					AAMPLOG_WARN("ANJ: aamp->IsLocalAAMPTsb() = %d, aamp->IsLocalAAMPTsbInjection( = %d", aamp->IsLocalAAMPTsb(), aamp->IsLocalAAMPTsbInjection());
 					if(aamp->IsLocalAAMPTsb() && !aamp->IsLocalAAMPTsbInjection())
 					{
 						retValue = false;
@@ -813,14 +812,11 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 						aamp->rate = AAMP_NORMAL_PLAY_RATE;
 						aamp->pipeline_paused = false;
 						aamp->AcquireStreamLock();
-						AAMPLOG_WARN("ANJ:Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate set to AAMP_NORMAL_PLAY_RATE");
 						aamp->TuneHelper(eTUNETYPE_SEEK, false);
-						AAMPLOG_WARN("ANJ:After Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate = %f", aamp->rate);
 						aamp->ReleaseStreamLock();
 					}
 					else
 					{
-						AAMPLOG_WARN("ANJ: else case. unpause flow ====");
 						// check if unpausing in the middle of fragments caching
 						if(!aamp->SetStateBufferingIfRequired())
 						{
@@ -828,7 +824,6 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
 							if (sink)
 							{
-								AAMPLOG_WARN("ANJ:Calling sink->Pause(false, false)");
 								retValue = sink->Pause(false, false);
 							}
 							// required since buffers are already cached in paused state
@@ -888,23 +883,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					tuneTypePlay = eTUNETYPE_SEEKTOLIVE;
 					aamp->mJumpToLiveFromPause = false;
 				}
-# if 1//anj:to try
-				/* if Gstreamer pipeline set to paused state by user, change it to playing state */
-				if (playAlreadyEnabled && aamp->pipeline_paused == true)
-				{
-					AAMPLOG_INFO("Play was already enabled, and pipeline paused - unpause");
-					StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
-					if (sink)
-					{
-						AAMPLOG_WARN("ANJ:2: commented Calling sink->Pause(false, false)");
-//						(void)sink->Pause(false, false);
-					}
-				}
-				else
-				{
-					AAMPLOG_INFO("Play was not already enabled(%d) or pipeline not paused(%d)", playAlreadyEnabled, aamp->pipeline_paused);
-				}
-#endif//anj: to try
+
 				aamp->rate = rate;
 				aamp->pipeline_paused = false;
 				aamp->mSeekFromPausedState = false;
@@ -914,9 +893,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				aamp->EnableDownloads();
 				aamp->ResumeDownloads();
 				aamp->AcquireStreamLock();
-				AAMPLOG_WARN("ANJ:Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->TuneHelper(tuneTypePlay); // this unpauses pipeline as side effect
-				AAMPLOG_WARN("ANJ:After Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->ReleaseStreamLock();
 			}
 

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -620,7 +620,6 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 
 		if (aamp->mpStreamAbstractionAAMP && !(aamp->mbUsingExternalPlayer))
 		{
-			bool playAlreadyEnabled = aamp->mbPlayEnabled;
 			if ( AAMP_SLOWMOTION_RATE != rate && !aamp->mIsIframeTrackPresent && rate != AAMP_NORMAL_PLAY_RATE && rate != 0 && aamp->mMediaFormat != eMEDIAFORMAT_PROGRESSIVE)
 			{
 				AAMPLOG_WARN("Ignoring trickplay. No iframe tracks in stream");

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -804,7 +804,6 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					// Resuming payback from pause
 					// If have local TSB, but playing from Live then seek into the TSB
 					// Otherwise unpause the pipeline
-					AAMPLOG_WARN("ANJ: aamp->IsLocalAAMPTsb() = %d, aamp->IsLocalAAMPTsbInjection( = %d", aamp->IsLocalAAMPTsb(), aamp->IsLocalAAMPTsbInjection());
 					if(aamp->IsLocalAAMPTsb() && !aamp->IsLocalAAMPTsbInjection())
 					{
 						retValue = false;
@@ -813,14 +812,11 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 						aamp->rate = AAMP_NORMAL_PLAY_RATE;
 						aamp->pipeline_paused = false;
 						aamp->AcquireStreamLock();
-						AAMPLOG_WARN("ANJ:Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate set to AAMP_NORMAL_PLAY_RATE");
 						aamp->TuneHelper(eTUNETYPE_SEEK, false);
-						AAMPLOG_WARN("ANJ:After Calling TuneHelper with eTUNETYPE_SEEK. aamp->rate = %f", aamp->rate);
 						aamp->ReleaseStreamLock();
 					}
 					else
 					{
-						AAMPLOG_WARN("ANJ: else case. unpause flow ====");
 						// check if unpausing in the middle of fragments caching
 						if(!aamp->SetStateBufferingIfRequired())
 						{
@@ -828,7 +824,6 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
 							if (sink)
 							{
-								AAMPLOG_WARN("ANJ:Calling sink->Pause(false, false)");
 								retValue = sink->Pause(false, false);
 							}
 							// required since buffers are already cached in paused state
@@ -888,23 +883,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					tuneTypePlay = eTUNETYPE_SEEKTOLIVE;
 					aamp->mJumpToLiveFromPause = false;
 				}
-# if 0//anj:to try
-				/* if Gstreamer pipeline set to paused state by user, change it to playing state */
-				if (playAlreadyEnabled && aamp->pipeline_paused == true)
-				{
-					AAMPLOG_INFO("Play was already enabled, and pipeline paused - unpause");
-					StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(aamp);
-					if (sink)
-					{
-						AAMPLOG_WARN("ANJ:2: Calling sink->Pause(false, false)");
-						(void)sink->Pause(false, false);
-					}
-				}
-				else
-				{
-					AAMPLOG_INFO("Play was not already enabled(%d) or pipeline not paused(%d)", playAlreadyEnabled, aamp->pipeline_paused);
-				}
-#endif//anj: to try
+
 				aamp->rate = rate;
 				aamp->pipeline_paused = false;
 				aamp->mSeekFromPausedState = false;
@@ -914,9 +893,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				aamp->EnableDownloads();
 				aamp->ResumeDownloads();
 				aamp->AcquireStreamLock();
-				AAMPLOG_WARN("ANJ:Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->TuneHelper(tuneTypePlay); // this unpauses pipeline as side effect
-				AAMPLOG_WARN("ANJ:After Calling TuneHelper with tuneTypePlay = %d, aamp->rate = %f", tuneTypePlay, aamp->rate);
 				aamp->ReleaseStreamLock();
 			}
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -261,6 +261,10 @@ void PrivateInstanceAAMP::detach()
 
 void PrivateInstanceAAMP::NotifySpeedChanged(float rate, bool changeState)
 {
+	if (g_mockPrivateInstanceAAMP != nullptr)
+	{
+		g_mockPrivateInstanceAAMP->NotifySpeedChanged(rate, changeState);
+	}
 }
 
 void PrivateInstanceAAMP::LogPlayerPreBuffered(void)

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -88,6 +88,7 @@ public:
 	MOCK_METHOD(double, GetLivePlayPosition, ());
 	MOCK_METHOD(bool, GetLLDashChunkMode, ());
 	MOCK_METHOD(void, SetLLDashChunkMode, (bool enable));
+	MOCK_METHOD(void, NotifySpeedChanged, (float rate, bool changeState));
 };
 
 extern MockPrivateInstanceAAMP *g_mockPrivateInstanceAAMP;

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2462,9 +2462,12 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_TrickPlayWhenPausedFromTSB)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(_)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifySpeedChanged(2.0,_)).Times(1);
+	//calling AAMPGstPlayer::Pause(false,false) would cause the pipeline to play at x1
+	// before changing the speed to x2. Make sure that it is not happening.
 	EXPECT_CALL(*g_mockAampGstPlayer, Pause(false, false)).Times(0);
 
 	mPlayerInstance->SetRate(2.0);
 	EXPECT_EQ(mPrivateInstanceAAMP->pipeline_paused, false);
+	EXPECT_EQ(mPrivateInstanceAAMP->rate, 2.0);
 
 }

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2444,3 +2444,27 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_ResumeFromTSB) {
 
     EXPECT_EQ(mPrivateInstanceAAMP->pipeline_paused, false);
 }
+
+// Test forward 2x from being paused in local TSB playback
+TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_TrickPlayWhenPausedFromTSB) {
+
+	mPlayerInstance->aamp = mPrivateInstanceAAMP;
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mPrivateInstanceAAMP->pipeline_paused = true;
+	mPrivateInstanceAAMP->mbPlayEnabled = true;
+	mPrivateInstanceAAMP->mIsIframeTrackPresent = true;
+	mPrivateInstanceAAMP->SetLocalAAMPTsb(true);
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_PLAYING));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, StopDownloads()).Times(0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(true));
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(_)).Times(0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, _)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifySpeedChanged(2.0,_)).Times(1);
+	EXPECT_CALL(*g_mockAampGstPlayer, Pause(false, false)).Times(0);
+
+	mPlayerInstance->SetRate(2.0);
+	EXPECT_EQ(mPrivateInstanceAAMP->pipeline_paused, false);
+
+}


### PR DESCRIPTION
This is because SetRateInternal is explicitly making an unpause call to the sink before calling TuneHelper, thus unpausing the playback first, and then applying the trick mode rate. This results in AV to play for few seconds before starting trick play.
Removing the unpause code from SetRateInternal.