### PR TITLE
VPLAY-10764 CC Visible when parental control at tune time

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7153,7 +7153,7 @@ void PrivateInstanceAAMP::SetSubtitleMute(bool muted)
 	StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 	if (sink)
 	{
-		sink->SetSubtitleMute(video_muted || muted);
+		sink->SetSubtitleMute(video_muted | muted);
 	}
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7153,7 +7153,7 @@ void PrivateInstanceAAMP::SetSubtitleMute(bool muted)
 	StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 	if (sink)
 	{
-		sink->SetSubtitleMute(muted);
+		sink->SetSubtitleMute((video_muted) ? video_muted : muted);
 	}
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7153,7 +7153,7 @@ void PrivateInstanceAAMP::SetSubtitleMute(bool muted)
 	StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 	if (sink)
 	{
-		sink->SetSubtitleMute((video_muted) ? video_muted : muted);
+		sink->SetSubtitleMute(video_muted | muted);
 	}
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7153,7 +7153,7 @@ void PrivateInstanceAAMP::SetSubtitleMute(bool muted)
 	StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 	if (sink)
 	{
-		sink->SetSubtitleMute(video_muted | muted);
+		sink->SetSubtitleMute(video_muted || muted);
 	}
 }
 

--- a/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
@@ -42,79 +42,104 @@ class SubtitleMuteTests : public testing::TestWithParam< std::pair<bool, bool> >
 {
 protected:
 
-    PrivateInstanceAAMP *mPrivateInstanceAAMP{};
+	PrivateInstanceAAMP *mPrivateInstanceAAMP{};
 
-    void SetUp() override
-    {
+	void SetUp() override
+	{
 
-        if(gpGlobalConfig == nullptr)
-        {
-            gpGlobalConfig =  new AampConfig();
-        }
+		if(gpGlobalConfig == nullptr)
+		{
+			gpGlobalConfig =  new AampConfig();
+		}
 
-        mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
-        g_mockAampGstPlayer = new MockAAMPGstPlayer( mPrivateInstanceAAMP);
-        g_mockStreamAbstractionAAMP = new MockStreamAbstractionAAMP(mPrivateInstanceAAMP);
+		mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
+		g_mockAampGstPlayer = new MockAAMPGstPlayer( mPrivateInstanceAAMP);
+		g_mockStreamAbstractionAAMP = new MockStreamAbstractionAAMP(mPrivateInstanceAAMP);
 		g_mockAampStreamSinkManager = new NiceMock<MockAampStreamSinkManager>();
 
-        mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+		mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 
    		EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
-    }
+	}
 
-    void TearDown() override
-    {
-        delete mPrivateInstanceAAMP;
-        mPrivateInstanceAAMP = nullptr;
+	void TearDown() override
+	{
+		delete mPrivateInstanceAAMP;
+		mPrivateInstanceAAMP = nullptr;
 
-        delete g_mockStreamAbstractionAAMP;
-        g_mockStreamAbstractionAAMP = nullptr;
+		delete g_mockStreamAbstractionAAMP;
+		g_mockStreamAbstractionAAMP = nullptr;
 
-        delete g_mockAampGstPlayer;
-        g_mockAampGstPlayer = nullptr;
+		delete g_mockAampGstPlayer;
+		g_mockAampGstPlayer = nullptr;
 
-        delete gpGlobalConfig;
-        gpGlobalConfig = nullptr;
+		delete gpGlobalConfig;
+		gpGlobalConfig = nullptr;
 
 		delete g_mockAampStreamSinkManager;
 		g_mockAampStreamSinkManager = nullptr;
-    }
+	}
 
 public:
-    void CacheAndMuteSubtitles(bool currState, bool inputState)
-    {
-        mPrivateInstanceAAMP->subtitles_muted = currState;
-        // Confirm operation works as expected
-        // If input = unmute, subtitles should be set to currState (mute/un-mute)
-        bool finalState = inputState ? inputState : currState;
-        EXPECT_CALL(*g_mockStreamAbstractionAAMP, MuteSubtitles(finalState)).Times(1);
-        EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(finalState)).Times(1);
+	void CacheAndMuteSubtitles(bool currState, bool inputState)
+	{
+		mPrivateInstanceAAMP->subtitles_muted = currState;
+		// Confirm operation works as expected
+		// If input = unmute, subtitles should be set to currState (mute/un-mute)
+		bool finalState = inputState ? inputState : currState;
+		EXPECT_CALL(*g_mockStreamAbstractionAAMP, MuteSubtitles(finalState)).Times(1);
+		EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(finalState)).Times(1);
 
-        mPrivateInstanceAAMP->AcquireStreamLock();
-        mPrivateInstanceAAMP->CacheAndApplySubtitleMute(inputState);
-        mPrivateInstanceAAMP->ReleaseStreamLock();
+		mPrivateInstanceAAMP->AcquireStreamLock();
+		mPrivateInstanceAAMP->CacheAndApplySubtitleMute(inputState);
+		mPrivateInstanceAAMP->ReleaseStreamLock();
 
-        // Confirm original state is preserved
-        EXPECT_EQ(mPrivateInstanceAAMP->subtitles_muted, currState);
-    }
+		// Confirm original state is preserved
+		EXPECT_EQ(mPrivateInstanceAAMP->subtitles_muted, currState);
+	}
+
+	void TestSetSubtitleMute(bool videoMuted, bool subtitleMuteParam)
+	{
+		// Set the video_muted state
+		mPrivateInstanceAAMP->video_muted = videoMuted;
+		
+		// Expected result should be logical OR of video_muted and subtitleMuteParam
+		// This tests the core logic: sink->SetSubtitleMute(video_muted | muted);
+		bool expectedMuteState = videoMuted | subtitleMuteParam;
+		
+		// Expect SetSubtitleMute to be called on the sink with the ORed result
+		EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(expectedMuteState)).Times(1);
+		
+		// Call the method under test
+		mPrivateInstanceAAMP->SetSubtitleMute(subtitleMuteParam);
+	}
 
 };
 
 TEST_P(SubtitleMuteTests, CacheSubtitleMuteTests)
 {
-    auto param = GetParam();
-    bool currState = param.first;
-    bool inputState = param.second;
-    CacheAndMuteSubtitles(currState, inputState);
+	auto param = GetParam();
+	bool currState = param.first;
+	bool inputState = param.second;
+	CacheAndMuteSubtitles(currState, inputState);
+}
+
+TEST_P(SubtitleMuteTests, SetSubtitleMuteTests)
+{
+	auto param = GetParam();
+	bool videoMuted = param.first;
+	bool subtitleMuteParam = param.second;
+	TestSetSubtitleMute(videoMuted, subtitleMuteParam);
 }
 
 // Run PlaybackSpeedTests tests at various speeds
 INSTANTIATE_TEST_SUITE_P(TestSubtitleMute,
-                         SubtitleMuteTests,
-                         testing::Values(
-                            std::pair<bool, bool>(true, true), // subtitle muted, video mute
-                            std::pair<bool, bool>(true, false),// subtitle muted, video unmute
-                            std::pair<bool, bool>(false, true),// subtitle unmuted, video mute
-                            std::pair<bool, bool>(false, false)// subtitle unmuted, video unmute
-                            ));
+						 SubtitleMuteTests,
+						 testing::Values(
+							std::pair<bool, bool>(true, true), // subtitle muted, video mute
+							std::pair<bool, bool>(true, false),// subtitle muted, video unmute
+							std::pair<bool, bool>(false, true),// subtitle unmuted, video mute
+							std::pair<bool, bool>(false, false)// subtitle unmuted, video unmute
+							));
+
 

--- a/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
@@ -59,7 +59,7 @@ protected:
 
 		mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 
-   		EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+		EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
 	}
 
 	void TearDown() override

--- a/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
@@ -118,18 +118,18 @@ public:
 
 TEST_P(SubtitleMuteTests, CacheSubtitleMuteTests)
 {
-	auto param = GetParam();
-	bool currState = param.first;
-	bool inputState = param.second;
+	auto param {GetParam()};
+	bool currState {param.first};
+	bool inputState {param.second};
 	CacheAndMuteSubtitles(currState, inputState);
 }
 
 TEST_P(SubtitleMuteTests, SetSubtitleMuteTests)
 {
-	auto param = GetParam();
-	bool videoMuted = param.first;
-	bool subtitleMuteParam = param.second;
-	TestSetSubtitleMute(videoMuted, subtitleMuteParam);
+	auto param {GetParam()};
+	bool subtitleMuted {param.first};
+	bool videoMuted {param.second};
+	TestSetSubtitleMute(videoMuted, subtitleMuted);
 }
 
 // Run PlaybackSpeedTests tests at various speeds

--- a/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/SubtitleMuteTests.cpp
@@ -132,7 +132,6 @@ TEST_P(SubtitleMuteTests, SetSubtitleMuteTests)
 	TestSetSubtitleMute(videoMuted, subtitleMuted);
 }
 
-// Run PlaybackSpeedTests tests at various speeds
 INSTANTIATE_TEST_SUITE_P(TestSubtitleMute,
 						 SubtitleMuteTests,
 						 testing::Values(


### PR DESCRIPTION
Reason for change: When the video is muted the subtitles get reenabled if the aamp interface is called to unmute the subtitles. This can result in PIN protected content having the AV muted but subtitles present.

Risks: Low
Test Procedure: Refer Jira ticket