### PR TITLE
VPLAY-10911 aamp_priv.h dependency removal continued

### DIFF
--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -567,12 +567,12 @@ void trim(std::string& src)
  * @brief To get the preferred iso639mapped language code
  * @retval[out] preferred iso639 mapped language.
  */
-std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferLangFormat )
+std::string Getiso639map_NormalizeLanguageCode( const std::string lang, LangCodePreference preferLangFormat )
 {
 	std::string rc;
 	if (preferLangFormat == ISO639_NO_LANGCODE_PREFERENCE)
 	{
-		rc = lang;
+		rc = std::move(lang);
 	}
 	else
 	{

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -43,6 +43,7 @@
 #include <fstream>
 #include <dirent.h>
 #include <algorithm>
+#include <inttypes.h>
 
 #define DEFER_DRM_LIC_OFFSET_FROM_START 5
 #define DEFER_DRM_LIC_OFFSET_TO_UPPER_BOUND 5
@@ -566,16 +567,22 @@ void trim(std::string& src)
  * @brief To get the preferred iso639mapped language code
  * @retval[out] preferred iso639 mapped language.
  */
-std::string Getiso639map_NormalizeLanguageCode(std::string  lang,LangCodePreference preferLangFormat )
+std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferLangFormat )
 {
-        if (preferLangFormat != ISO639_NO_LANGCODE_PREFERENCE)
-        {
-                char lang2[MAX_LANGUAGE_TAG_LENGTH];
-                strcpy(lang2, lang.c_str());
-                iso639map_NormalizeLanguageCode(lang2, preferLangFormat);
-                lang = lang2;
-        }
-	return lang;
+	std::string rc;
+	if (preferLangFormat == ISO639_NO_LANGCODE_PREFERENCE)
+	{
+		rc = lang;
+	}
+	else
+	{
+		char lang2[3+1];
+		strncpy(lang2, lang.c_str(), sizeof(lang2) );
+		lang2[sizeof(lang2)-1]=0x00; // ensure NUL termination
+		iso639map_NormalizeLanguageCode(lang2, preferLangFormat);
+		rc = lang2;
+	}
+	return rc;
 }
 
 /**

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -225,7 +225,7 @@ void trim(std::string& src);
  * @param[in] lang - Language in string format
  * @param[in] preferFormat - Preferred language format
  */
-std::string Getiso639map_NormalizeLanguageCode(std::string  lang, LangCodePreference preferFormat );
+std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferFormat );
 
 /**
  * @fn aamp_GetTimespec

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -225,7 +225,7 @@ void trim(std::string& src);
  * @param[in] lang - Language in string format
  * @param[in] preferFormat - Preferred language format
  */
-std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferFormat );
+std::string Getiso639map_NormalizeLanguageCode( const std::string lang, LangCodePreference preferFormat );
 
 /**
  * @fn aamp_GetTimespec

--- a/downloader/AampCurlStore.cpp
+++ b/downloader/AampCurlStore.cpp
@@ -25,6 +25,8 @@
 #include "AampCurlStore.h"
 #include "AampDefine.h"
 #include "AampUtils.h"
+#include "AampLogManager.h"
+#include "AampConfig.h"
 #include <mutex>
 
 // Curl callback functions

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -31,9 +31,6 @@
 #include <glib.h>
 #include <mutex>
 #include "priv_aamp.h"
-//#include "AampCurlDefine.h"
-//#include "AampMediaType.h"
-//#include "AampGrowableBuffer.h"
 
 #define eCURL_MAX_AGE_TIME			( (300) * (1000) )			/**< 5 mins - 300 secs - Max age for a connection */
 
@@ -101,7 +98,6 @@ class CurlStore
 private:
 	std::mutex mCurlInstLock{};
 	int MaxCurlSockStore;
-	bool enableCurlStore;
 
 	typedef std::unordered_map <std::string, CurlSocketStoreStruct*> CurlSockData ;
 	typedef std::unordered_map <std::string, CurlSocketStoreStruct*>::iterator CurlSockDataIter;

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -25,13 +25,15 @@
 #ifndef AAMPCURLSTORE_H
 #define AAMPCURLSTORE_H
 
-#include "AampCurlDefine.h"
-#include "priv_aamp.h"
 #include <map>
 #include <iterator>
 #include <vector>
 #include <glib.h>
 #include <mutex>
+#include "priv_aamp.h"
+//#include "AampCurlDefine.h"
+//#include "AampMediaType.h"
+//#include "AampGrowableBuffer.h"
 
 #define eCURL_MAX_AGE_TIME			( (300) * (1000) )			/**< 5 mins - 300 secs - Max age for a connection */
 
@@ -99,6 +101,7 @@ class CurlStore
 private:
 	std::mutex mCurlInstLock{};
 	int MaxCurlSockStore;
+	bool enableCurlStore;
 
 	typedef std::unordered_map <std::string, CurlSocketStoreStruct*> CurlSockData ;
 	typedef std::unordered_map <std::string, CurlSocketStoreStruct*>::iterator CurlSockDataIter;


### PR DESCRIPTION
VPLAY-10911 aamp_priv.h dependency removal continued

Reason for Change: follow-up encapsulation fixes
Test Guidance: regression only
Risk: Low