### PR TITLE
VPLAY-10918 more use of const keyword for AampConfig and MediaStreamContext

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -865,7 +865,7 @@ void AampConfig::ApplyDeviceCapabilities()
 	SetConfigValue(AAMP_DEFAULT_SETTING, eAAMPConfig_UseSecManager, isSecMgr);
 }
 
-std::string AampConfig::GetUserAgentString()
+std::string AampConfig::GetUserAgentString() const
 {
 	return std::string(configValueString[eAAMPConfig_UserAgent].value);
 }
@@ -873,7 +873,7 @@ std::string AampConfig::GetUserAgentString()
 /**
  * @brief Gets the boolean configuration value
  */
-bool AampConfig::IsConfigSet(AAMPConfigSettingBool cfg)
+bool AampConfig::IsConfigSet(AAMPConfigSettingBool cfg) const
 {	if (cfg < AAMPCONFIG_BOOL_COUNT)
 	{
 		return configValueBool[cfg].value;
@@ -881,7 +881,7 @@ bool AampConfig::IsConfigSet(AAMPConfigSettingBool cfg)
 	return false;
 }
 
-bool AampConfig::GetConfigValue( AAMPConfigSettingBool cfg )
+bool AampConfig::GetConfigValue( AAMPConfigSettingBool cfg ) const
 {
 	if(cfg < AAMPCONFIG_BOOL_COUNT)
 	{
@@ -893,7 +893,7 @@ bool AampConfig::GetConfigValue( AAMPConfigSettingBool cfg )
  * @brief GetConfigValue - Gets configuration for integer data type
  *
  */
-int AampConfig::GetConfigValue(AAMPConfigSettingInt cfg)
+int AampConfig::GetConfigValue(AAMPConfigSettingInt cfg) const
 {
 	if(cfg < AAMPCONFIG_INT_COUNT)
 	{
@@ -905,7 +905,7 @@ int AampConfig::GetConfigValue(AAMPConfigSettingInt cfg)
  * @brief GetConfigValue - Gets configuration for double data type
  *
  */
-double AampConfig::GetConfigValue(AAMPConfigSettingFloat cfg)
+double AampConfig::GetConfigValue(AAMPConfigSettingFloat cfg) const
 {
 	if(cfg < AAMPCONFIG_FLOAT_COUNT)
 	{
@@ -918,7 +918,7 @@ double AampConfig::GetConfigValue(AAMPConfigSettingFloat cfg)
  * @brief GetConfigValue - Gets configuration for string data type
  *
  */
-std::string AampConfig::GetConfigValue(AAMPConfigSettingString cfg)
+std::string AampConfig::GetConfigValue(AAMPConfigSettingString cfg) const
 {
 	if(cfg < AAMPCONFIG_STRING_COUNT)
 	{
@@ -932,19 +932,19 @@ std::string AampConfig::GetConfigValue(AAMPConfigSettingString cfg)
  *
  * @return ConfigPriority - owner of the config
  */
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingBool cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingBool cfg) const
 {
 	return configValueBool[cfg].owner;
 }
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingInt cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingInt cfg) const
 {
 	return configValueInt[cfg].owner;
 }
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingFloat cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingFloat cfg) const
 {
 	return configValueFloat[cfg].owner;
 }
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingString cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingString cfg) const
 {
 	return configValueString[cfg].owner;
 }
@@ -954,13 +954,13 @@ ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingString cfg)
  *
  * @return true - if valid return
  */
-const char * AampConfig::GetChannelOverride(const std::string manifestUrl)
+const char * AampConfig::GetChannelOverride(const std::string manifestUrl) const
 {
 	if(mChannelOverrideMap.size() && manifestUrl.size())
 	{
 		for (auto it = mChannelOverrideMap.begin(); it != mChannelOverrideMap.end(); ++it)
 		{
-			ConfigChannelInfo &pChannelInfo = *it;
+			const ConfigChannelInfo &pChannelInfo = *it;
 			if (manifestUrl.find(pChannelInfo.name) != std::string::npos)
 			{
 				return pChannelInfo.uri.c_str();
@@ -975,13 +975,13 @@ const char * AampConfig::GetChannelOverride(const std::string manifestUrl)
  *
  * @return true - if valid return
  */
-const char * AampConfig::GetChannelLicenseOverride(const std::string manifestUrl)
+const char * AampConfig::GetChannelLicenseOverride(const std::string manifestUrl) const
 {
     if(mChannelOverrideMap.size() && manifestUrl.size())
     {
         for (auto it = mChannelOverrideMap.begin(); it != mChannelOverrideMap.end(); ++it)
         {
-            ConfigChannelInfo &pChannelInfo = *it;
+            const ConfigChannelInfo &pChannelInfo = *it;
             if (manifestUrl.find(pChannelInfo.uri) != std::string::npos)
             {
                 if(!pChannelInfo.licenseUri.empty())

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -1347,7 +1347,7 @@ bool AampConfig::CustomSearch( std::string url, int playerId , std::string appna
  *
  * @return true
  */
-bool AampConfig::GetAampConfigJSONStr(std::string &str)
+bool AampConfig::GetAampConfigJSONStr(std::string &str) const
 {
 	AampJsonObject jsondata;
 
@@ -1911,19 +1911,19 @@ void AampConfig::DoCustomSetting(ConfigPriority owner)
 	ConfigureLogSettings();
 }
 
-const char * AampConfig::GetConfigName(AAMPConfigSettingBool cfg )
+const char * AampConfig::GetConfigName(AAMPConfigSettingBool cfg ) const
 {
 	return mConfigLookupTableBool[cfg].cmdString;
 }
-const char * AampConfig::GetConfigName(AAMPConfigSettingInt cfg )
+const char * AampConfig::GetConfigName(AAMPConfigSettingInt cfg ) const
 {
 	return mConfigLookupTableInt[cfg].cmdString;
 }
-const char * AampConfig::GetConfigName(AAMPConfigSettingFloat cfg )
+const char * AampConfig::GetConfigName(AAMPConfigSettingFloat cfg ) const
 {
 	return mConfigLookupTableFloat[cfg].cmdString;
 }
-const char *AampConfig::GetConfigName(AAMPConfigSettingString cfg )
+const char *AampConfig::GetConfigName(AAMPConfigSettingString cfg ) const
 {
 	return mConfigLookupTableString[cfg].cmdString;
 }

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -676,7 +676,7 @@ public:
      	 * @fn GetAampConfigJSONStr
      	 * @param[in] str  - input string where config json will be stored
      	 */
-	bool GetAampConfigJSONStr(std::string &str);
+	bool GetAampConfigJSONStr(std::string &str) const;
 	/**
      	 * @fn DoCustomSetting 
      	 *
@@ -722,10 +722,10 @@ private:
 		 */
 	void CustomArrayRead( cJSON *customArray,ConfigPriority owner );
 
-	const char * GetConfigName(AAMPConfigSettingBool cfg );
-	const char * GetConfigName(AAMPConfigSettingInt cfg );
-	const char * GetConfigName(AAMPConfigSettingFloat cfg );
-	const char * GetConfigName(AAMPConfigSettingString cfg );
+	const char * GetConfigName(AAMPConfigSettingBool cfg ) const;
+	const char * GetConfigName(AAMPConfigSettingInt cfg ) const;
+	const char * GetConfigName(AAMPConfigSettingFloat cfg ) const;
+	const char * GetConfigName(AAMPConfigSettingString cfg ) const;
 	
 	std::vector<struct customJson>vCustom;
 	std::vector<struct customJson>::iterator vCustomIt;

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -599,27 +599,27 @@ public:
      	 * @param[in] cfg - Configuration enum
      	 * @return true / false 
      	 */
-	bool IsConfigSet(AAMPConfigSettingBool cfg);
-	bool GetConfigValue( AAMPConfigSettingBool cfg );
-	int GetConfigValue( AAMPConfigSettingInt cfg );
-	double GetConfigValue( AAMPConfigSettingFloat cfg );
-	std::string GetConfigValue( AAMPConfigSettingString cfg );
+	bool IsConfigSet(AAMPConfigSettingBool cfg) const;
+	bool GetConfigValue( AAMPConfigSettingBool cfg ) const;
+	int GetConfigValue( AAMPConfigSettingInt cfg ) const;
+	double GetConfigValue( AAMPConfigSettingFloat cfg ) const;
+	std::string GetConfigValue( AAMPConfigSettingString cfg ) const;
 	
-	ConfigPriority GetConfigOwner(AAMPConfigSettingBool cfg);
-	ConfigPriority GetConfigOwner(AAMPConfigSettingInt cfg);
-	ConfigPriority GetConfigOwner(AAMPConfigSettingFloat cfg);
-	ConfigPriority GetConfigOwner(AAMPConfigSettingString cfg);
+	ConfigPriority GetConfigOwner(AAMPConfigSettingBool cfg) const;
+	ConfigPriority GetConfigOwner(AAMPConfigSettingInt cfg) const;
+	ConfigPriority GetConfigOwner(AAMPConfigSettingFloat cfg) const;
+	ConfigPriority GetConfigOwner(AAMPConfigSettingString cfg) const;
 	
  	/**
      	 * @fn GetChannelOverride
      	 * @param[in] chName - channel name to search
      	 */
-	const char * GetChannelOverride(const std::string chName);    
+	const char * GetChannelOverride(const std::string chName) const;
  	/**
      	 * @fn GetChannelLicenseOverride
      	 * @param[in] chName - channel Name to override
      	 */
- 	const char * GetChannelLicenseOverride(const std::string chName);
+ 	const char * GetChannelLicenseOverride(const std::string chName) const;
 
 	/**
          * @fn ProcessConfigJson
@@ -693,7 +693,7 @@ public:
      	 */
 	bool CustomSearch( std::string url, int playerId , std::string appname);
 
-	std::string GetUserAgentString();
+	std::string GetUserAgentString() const;
 private:
 
 	/**

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -466,7 +466,7 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 /**
  *  @brief Cache Fragment Chunk
  */
-bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, char *ptr, size_t size, std::string remoteUrl, long long dnldStartTime)
+bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, long long dnldStartTime)
 {
 	AAMPLOG_DEBUG("[%s] Chunk Buffer Length %zu Remote URL %s", name, size, remoteUrl.c_str());
 

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -131,7 +131,7 @@ public:
      * @param remoteUrl url of fragment
      * @param dnldStartTime of the download
      */
-    bool CacheFragmentChunk(AampMediaType actualType, char *ptr, size_t size, std::string remoteUrl,long long dnldStartTime);
+    bool CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl,long long dnldStartTime);
 
     /**
      * @fn ABRProfileChanged

--- a/test/utests/fakes/FakeAampConfig.cpp
+++ b/test/utests/fakes/FakeAampConfig.cpp
@@ -53,7 +53,7 @@ void AampConfig::SetConfigValue(ConfigPriority owner, AAMPConfigSettingFloat cfg
 void AampConfig::SetConfigValue(ConfigPriority owner, AAMPConfigSettingString cfg , const std::string &value){}
 
 
-bool AampConfig::IsConfigSet(AAMPConfigSettingBool cfg)
+bool AampConfig::IsConfigSet(AAMPConfigSettingBool cfg) const
 {
     if (g_mockAampConfig != nullptr)
     {
@@ -65,7 +65,7 @@ bool AampConfig::IsConfigSet(AAMPConfigSettingBool cfg)
     }
 }
 
-int AampConfig::GetConfigValue(AAMPConfigSettingInt cfg)
+int AampConfig::GetConfigValue(AAMPConfigSettingInt cfg) const
 {
     if (g_mockAampConfig != nullptr)
     {
@@ -77,7 +77,7 @@ int AampConfig::GetConfigValue(AAMPConfigSettingInt cfg)
     }
 }
 
-double AampConfig::GetConfigValue(AAMPConfigSettingFloat cfg)
+double AampConfig::GetConfigValue(AAMPConfigSettingFloat cfg) const
 {
     if (g_mockAampConfig != nullptr)
     {
@@ -89,7 +89,7 @@ double AampConfig::GetConfigValue(AAMPConfigSettingFloat cfg)
     }
 }
 
-std::string AampConfig::GetConfigValue(AAMPConfigSettingString cfg)
+std::string AampConfig::GetConfigValue(AAMPConfigSettingString cfg) const
 {
     if (g_mockAampConfig != nullptr)
     {
@@ -145,7 +145,7 @@ bool AampConfig::ProcessConfigJson(const cJSON *cfgdata, ConfigPriority owner )
     return false;
 }
 
-void AampConfig::DoCustomSetting(ConfigPriority owner) const
+void AampConfig::DoCustomSetting(ConfigPriority owner)
 {
 }
 

--- a/test/utests/fakes/FakeAampConfig.cpp
+++ b/test/utests/fakes/FakeAampConfig.cpp
@@ -145,11 +145,11 @@ bool AampConfig::ProcessConfigJson(const cJSON *cfgdata, ConfigPriority owner )
     return false;
 }
 
-void AampConfig::DoCustomSetting(ConfigPriority owner)
+void AampConfig::DoCustomSetting(ConfigPriority owner) const
 {
 }
 
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingBool cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingBool cfg) const
 {
 	if (g_mockAampConfig != nullptr)
 	{
@@ -160,7 +160,7 @@ ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingBool cfg)
 		return AAMP_DEFAULT_SETTING;
 	}
 }
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingInt cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingInt cfg) const
 {
 	if (g_mockAampConfig != nullptr)
 	{
@@ -171,7 +171,7 @@ ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingInt cfg)
 		return AAMP_DEFAULT_SETTING;
 	}
 }
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingFloat cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingFloat cfg) const
 {
 	if (g_mockAampConfig != nullptr)
 	{
@@ -182,7 +182,7 @@ ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingFloat cfg)
 		return AAMP_DEFAULT_SETTING;
 	}
 }
-ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingString cfg)
+ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingString cfg) const
 {
 	if (g_mockAampConfig != nullptr)
 	{
@@ -194,22 +194,22 @@ ConfigPriority AampConfig::GetConfigOwner(AAMPConfigSettingString cfg)
 	}
 }
 
-bool AampConfig::GetAampConfigJSONStr(std::string &str)
+bool AampConfig::GetAampConfigJSONStr(std::string &str) const
 {
     return false;
 }
 
-std::string AampConfig::GetUserAgentString()
+std::string AampConfig::GetUserAgentString() const
 {
 	return "";
 }
 
-const char * AampConfig::GetChannelOverride(const std::string manifestUrl)
+const char * AampConfig::GetChannelOverride(const std::string manifestUrl) const
 {
     return nullptr;
 }
 
-const char * AampConfig::GetChannelLicenseOverride(const std::string manifestUrl)
+const char * AampConfig::GetChannelLicenseOverride(const std::string manifestUrl) const
 {
     return nullptr;
 }

--- a/test/utests/fakes/FakeMediaStreamContext.cpp
+++ b/test/utests/fakes/FakeMediaStreamContext.cpp
@@ -22,7 +22,7 @@
 
 MockMediaStreamContext *g_mockMediaStreamContext = nullptr;
 
-bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, char *ptr, size_t size, std::string remoteUrl,long long dnldStartTime)
+bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl,long long dnldStartTime)
 {
     return false;
 }


### PR DESCRIPTION
VPLAY-10918 more use of const keyword for AampConfig and MediaStreamContext

Reason for Change: various parameters/methods can/should be safely declared constant, for better compile time protection of invariants.

Test Guidance: no compilation issues and light regression testing for good measure

Risk: None - no functional change other than new const declarations