### PR TITLE
VPLAY-10921 Getiso639map_NormalizeLanguageCode enhancements

### DIFF
--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -567,19 +567,19 @@ void trim(std::string& src)
  * @brief To get the preferred iso639mapped language code
  * @retval[out] preferred iso639 mapped language.
  */
-std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferLangFormat )
+std::string Getiso639map_NormalizeLanguageCode( const std::string lang, LangCodePreference preferLangFormat )
 {
 	std::string rc;
 	if (preferLangFormat == ISO639_NO_LANGCODE_PREFERENCE)
 	{
-		rc = lang;
+		rc = std::move(lang);
 	}
 	else
 	{
-		char lang2[3+1];
+		char lang2[3+1]; // max 3 characters, i.e. 'eng' with cstring NUL terminator
 		strncpy(lang2, lang.c_str(), sizeof(lang2) );
-		lang2[sizeof(lang2)-1]=0x00; // ensure NUL termination
-		iso639map_NormalizeLanguageCode(lang2, preferLangFormat);
+		lang2[sizeof(lang2)-1]=0x00; // ensure NUL termination (not guarenteed by strncpy)
+		iso639map_NormalizeLanguageCode(lang2, preferLangFormat); // modifies lang2
 		rc = lang2;
 	}
 	return rc;

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -43,6 +43,7 @@
 #include <fstream>
 #include <dirent.h>
 #include <algorithm>
+#include <inttypes.h>
 
 #define DEFER_DRM_LIC_OFFSET_FROM_START 5
 #define DEFER_DRM_LIC_OFFSET_TO_UPPER_BOUND 5
@@ -566,16 +567,22 @@ void trim(std::string& src)
  * @brief To get the preferred iso639mapped language code
  * @retval[out] preferred iso639 mapped language.
  */
-std::string Getiso639map_NormalizeLanguageCode(std::string  lang,LangCodePreference preferLangFormat )
+std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferLangFormat )
 {
-        if (preferLangFormat != ISO639_NO_LANGCODE_PREFERENCE)
-        {
-                char lang2[MAX_LANGUAGE_TAG_LENGTH];
-                strcpy(lang2, lang.c_str());
-                iso639map_NormalizeLanguageCode(lang2, preferLangFormat);
-                lang = lang2;
-        }
-	return lang;
+	std::string rc;
+	if (preferLangFormat == ISO639_NO_LANGCODE_PREFERENCE)
+	{
+		rc = lang;
+	}
+	else
+	{
+		char lang2[3+1];
+		strncpy(lang2, lang.c_str(), sizeof(lang2) );
+		lang2[sizeof(lang2)-1]=0x00; // ensure NUL termination
+		iso639map_NormalizeLanguageCode(lang2, preferLangFormat);
+		rc = lang2;
+	}
+	return rc;
 }
 
 /**

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -578,7 +578,7 @@ std::string Getiso639map_NormalizeLanguageCode( const std::string lang, LangCode
 	{
 		char lang2[3+1]; // max 3 characters, i.e. 'eng' with cstring NUL terminator
 		strncpy(lang2, lang.c_str(), sizeof(lang2) );
-		lang2[sizeof(lang2)-1]=0x00; // ensure NUL termination (not guarenteed by strncpy)
+		lang2[sizeof(lang2)-1]=0x00; // ensure NUL termination (not guaranteed by strncpy)
 		iso639map_NormalizeLanguageCode(lang2, preferLangFormat); // modifies lang2
 		rc = lang2;
 	}

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -225,7 +225,7 @@ void trim(std::string& src);
  * @param[in] lang - Language in string format
  * @param[in] preferFormat - Preferred language format
  */
-std::string Getiso639map_NormalizeLanguageCode(std::string  lang, LangCodePreference preferFormat );
+std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferFormat );
 
 /**
  * @fn aamp_GetTimespec

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -225,7 +225,7 @@ void trim(std::string& src);
  * @param[in] lang - Language in string format
  * @param[in] preferFormat - Preferred language format
  */
-std::string Getiso639map_NormalizeLanguageCode( const std::string  lang, LangCodePreference preferFormat );
+std::string Getiso639map_NormalizeLanguageCode( const std::string lang, LangCodePreference preferFormat );
 
 /**
  * @fn aamp_GetTimespec

--- a/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
+++ b/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
@@ -337,22 +337,52 @@ TEST(_AampUtils, trim)
 TEST(_AampUtils, Getiso639map_NormalizeLanguageCode)
 {
 	std::string result;
-	std::string lang;	
+	std::string lang;
+	
 	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_NO_LANGCODE_PREFERENCE);
 	EXPECT_STREQ(result.c_str(), "");
+	
 	lang = "aa";
 	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_3_CHAR_BIBLIOGRAPHIC_LANGCODE);
 	EXPECT_STREQ(result.c_str(), "aar");
+	
 	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_3_CHAR_TERMINOLOGY_LANGCODE);
 	EXPECT_STREQ(result.c_str(), "aar");
+	
 	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_2_CHAR_LANGCODE);
 	EXPECT_STREQ(result.c_str(), "aa");
+	
 	lang = "aar";
 	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_2_CHAR_LANGCODE);
 	EXPECT_STREQ(result.c_str(), "aa");
+	
 	lang = "";
 	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_2_CHAR_LANGCODE);
 	EXPECT_STREQ(result.c_str(), "");
+	
+	lang = "English";
+	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_3_CHAR_BIBLIOGRAPHIC_LANGCODE);
+	EXPECT_STREQ(result.c_str(), "eng");
+	
+	lang = "Xuponia";
+	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_3_CHAR_BIBLIOGRAPHIC_LANGCODE);
+	EXPECT_STREQ(result.c_str(), "xup");
+	
+	lang = "Xuponia";
+	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_3_CHAR_TERMINOLOGY_LANGCODE);
+	EXPECT_STREQ(result.c_str(), "xup");
+	
+	lang = "Xuponia";
+	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_2_CHAR_LANGCODE);
+	EXPECT_STREQ(result.c_str(), "un");
+	
+	lang = "xX";
+	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_3_CHAR_BIBLIOGRAPHIC_LANGCODE);
+	EXPECT_STREQ(result.c_str(), "und");
+	
+	lang = "xX";
+	result = Getiso639map_NormalizeLanguageCode(lang, ISO639_PREFER_2_CHAR_LANGCODE);
+	EXPECT_STREQ(result.c_str(), "xx");
 }
 
 


### PR DESCRIPTION
VPLAY-10921 Getiso639map_NormalizeLanguageCode enhancements

Reason for Change: simplifications and security fixes for aamp utility function
Test Guidance: L1 tests passing
Risk: Low