### PR TITLE
VPLAY-10641 rate correction

### DIFF
--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -226,7 +226,7 @@ public:
 	 * @param rate The desired playback rate.
 	 * @param video_dec The video decoder element.
 	 * @param audio_dec The audio decoder element.
-	 * @param isRialto True if rialtosink is used.
+	 * @param isRialto True if rialto sink is used.
 	 * @return True if the playback rate was set successfully, false otherwise.
 	 */
 	virtual bool SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto) = 0;

--- a/middleware/vendor/amlogic/AmlogicSocInterface.cpp
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.cpp
@@ -78,7 +78,7 @@ bool AmlogicSocInterface::AudioOnlyMode(GstElement *sinkbin)
  * @param rate The desired playback rate.
  * @param video_dec The video decoder element.
  * @param audio_dec The audio decoder element.
- * @param isRialto True if rialtosink is used.
+ * @param isRialto True if rialto sink is used.
  * @return True if the playback rate was set successfully, false otherwise.
  */
 bool AmlogicSocInterface::SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto)

--- a/middleware/vendor/amlogic/AmlogicSocInterface.h
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.h
@@ -70,7 +70,7 @@ class AmlogicSocInterface : public SocInterface
 		 * @param rate The desired playback rate.
 		 * @param video_dec The video decoder element.
 		 * @param audio_dec The audio decoder element.
-		 * @param isRialto True if rialtosink is used.
+		 * @param isRialto True if rialto sink is used.
 		 * @return True if the playback rate was set successfully, false otherwise.
 		 */
 		bool SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto) override;

--- a/middleware/vendor/brcm/BrcmSocInterface.cpp
+++ b/middleware/vendor/brcm/BrcmSocInterface.cpp
@@ -42,12 +42,12 @@ void BrcmSocInterface::SetAudioProperty(const char * &volume, const char * &mute
  * @param rate The desired playback rate.
  * @param video_dec The video decoder element.
  * @param audio_dec The audio decoder element.
- * @param isRialto True if rialtosink is used.
+ * @param isRialto True if rialto sink is used.
  * @return True if the playback rate was set successfully, false otherwise.
  */
 bool BrcmSocInterface::SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto)
 {
-	//For rialto sinks default soc routine will be called, BCM platform changes has to be verified
+	//For rialto sinks default soc routine will be called
 	bool status = true;
 	MW_LOG_MIL("send custom-instant-rate-change : %f ...", rate);
 	GstStructure *structure = gst_structure_new("custom-instant-rate-change", "rate", G_TYPE_DOUBLE, rate, NULL);

--- a/middleware/vendor/brcm/BrcmSocInterface.h
+++ b/middleware/vendor/brcm/BrcmSocInterface.h
@@ -64,7 +64,7 @@ class BrcmSocInterface : public SocInterface
 		 * @param rate The desired playback rate.
 		 * @param video_dec The video decoder element.
 		 * @param audio_dec The audio decoder element.
-		 * @param isRialto True if rialtosink is used.
+		 * @param isRialto True if rialto sink is used.
 		 * @return True if the playback rate was set successfully, false otherwise.
 		 */
 		bool SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto) override;

--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -277,7 +277,7 @@ bool DefaultSocInterface::IsVideoMaster(GstElement *videoSink, bool isRialto)
  * @param rate The desired playback rate.
  * @param video_dec The video decoder element.
  * @param audio_dec The audio decoder element.
- * @param isRialto True if rialtosink is used.
+ * @param isRialto True if rialto sink is used.
  * @return True if the playback rate was set successfully, false otherwise.
  */
 bool DefaultSocInterface::SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto)

--- a/middleware/vendor/realtek/RealtekSocInterface.cpp
+++ b/middleware/vendor/realtek/RealtekSocInterface.cpp
@@ -67,7 +67,7 @@ void RealtekSocInterface::SetAudioProperty(const char * &volume, const char * &m
  * @param rate The desired playback rate.
  * @param video_dec The video decoder element.
  * @param audio_dec The audio decoder element.
- * @param isRialto True if rialtosink is used.
+ * @param isRialto True if rialto sink is used.
  * @return True if the playback rate was set successfully, false otherwise.
  */
 bool RealtekSocInterface::SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto)

--- a/middleware/vendor/realtek/RealtekSocInterface.h
+++ b/middleware/vendor/realtek/RealtekSocInterface.h
@@ -110,7 +110,7 @@ class RealtekSocInterface : public SocInterface
 		 * @param rate The desired playback rate.
 		 * @param video_dec The video decoder element.
 		 * @param audio_dec The audio decoder element.
-		 * @param isRialto True if rialtosink is used.
+		 * @param isRialto True if rialto sink is used.
 		 * @return True if the playback rate was set successfully, false otherwise.
 		 */
 		bool SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec, bool isRialto) override;


### PR DESCRIPTION
VPLAY-10641 rate correction follow-up fix

Reason for Change: change comment "rialtosink" to "rialto sink" to avoid godspell warning; remove a forbidden keyword

Test Guidance: no godspell or forbidden word warnings

Risk: None