### PR TITLE
VPLAY-11009 aamp cli logs seekablerange as "seekablerangen/a" when not applicable

### DIFF
--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -536,7 +536,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 					auto end = ev->getEnd();
 					if( start<0 && end<0 )
 					{
-						snprintf( seekableRange, sizeof(seekableRange), "n/a" );
+						snprintf( seekableRange, sizeof(seekableRange), "(n/a)" );
 					}
 					else
 					{


### PR DESCRIPTION
VPLAY-11009 aamp cli logs seekablerange as "seekablerangen/a" when not applicable

Reason for Change: seekable range logged in confusing manner when tsb not available

Test Guidance: play linear stream in aampcli without use of local TSB and check AAMP_EVENT_PROGRESS logs

Risk: none