### PR TITLE
VPLAY-10563 curl timeout disambiguation

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -468,8 +468,38 @@ void AampMPDDownloader::downloadMPDThread1()
 			AAMPLOG_ERR("curl request %s %s Error Code [%u]",mEffectiveUrl.c_str(), (mMPDData->mMPDDownloadResponse->iHttpRetValue < 100) ? "Curl" : "HTTP", mMPDData->mMPDDownloadResponse->iHttpRetValue);
 
 			mMPDData->mMPDStatus	=	AAMPStatusType::eAAMPSTATUS_MANIFEST_DOWNLOAD_ERROR;
+			
+			
 			if(mMPDData->mMPDDownloadResponse->iHttpRetValue != 200 && mMPDData->mMPDDownloadResponse->iHttpRetValue != 204 && mMPDData->mMPDDownloadResponse->iHttpRetValue != 206)
 			{ 
+				if (mMPDData->mMPDDownloadResponse->iHttpRetValue  == CURLE_OPERATION_TIMEDOUT)
+				{
+					double nameLookupTime = 0;
+					double connectTime = 0;
+
+					// Get the CURL handle used for the download
+					CURL* curl = mDownloader1.GetCurlHandle();
+
+					curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
+					curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
+
+					if (connectTime == 0 && nameLookupTime == 0)
+					{
+						// DNS timeout
+						AAMPLOG_WARN("Timeout: DNS resolution failed for %s", tuneUrl.c_str());
+					}
+					else if (connectTime == 0 && nameLookupTime != 0)
+					{
+						// Connection timeout (DNS succeeded)
+						AAMPLOG_WARN("Timeout: Connection to host failed for %s", tuneUrl.c_str());
+					}
+					else if (connectTime != 0 && nameLookupTime != 0)
+					{
+						// Data transfer timeout (connection established)
+						AAMPLOG_WARN("Timeout: Data transfer failed for %s", tuneUrl.c_str());
+					}
+				}
+			
 				AampLogManager::LogNetworkError (mEffectiveUrl.c_str(), AAMPNetworkErrorHttp, mMPDData->mMPDDownloadResponse->iHttpRetValue, eMEDIATYPE_MANIFEST);
 				//Use DownloadResponse Show call instead of printheaderresponse fn -since it is not scope
 				mMPDData->mMPDDownloadResponse->show();

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -669,3 +669,7 @@ size_t AampCurlDownloader::GetDataString(std::string &dataStr)
 	return ret;
 }
 
+CURL* AampCurlDownloader::GetCurlHandle()
+{
+	return mCurl;
+}

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -246,6 +246,8 @@ public:
 	*/	
 	size_t GetDataString(std::string &dataStr);
 
+	CURL* GetCurlHandle();
+
 private:
 	void updateCurlParams();
 	void updateResponseParams();

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4295,6 +4295,34 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 					}
 					if (res == CURLE_COULDNT_CONNECT || res == CURLE_OPERATION_TIMEDOUT || (isDownloadStalled && (eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT != abortReason)))
 					{
+						AAMPLOG_INFO("Connection/Timeout error %d for url %s", res, remoteUrl.c_str());
+						
+						//Curl error to be differentiated
+						double nameLookupTime = 0;
+    					double connectTime = 0;
+
+						// Get the CURL handle used for the download
+						//CURL* curl = mDownloader1.GetCurlHandle();
+
+						curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
+						curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
+
+						if (connectTime == 0 && nameLookupTime == 0)
+						{
+							// DNS timeout
+							AAMPLOG_WARN("Timeout: DNS resolution failed for %s", remoteUrl.c_str());
+						}
+						else if (connectTime == 0 && nameLookupTime != 0)
+						{
+							// Connection timeout (DNS succeeded)
+							AAMPLOG_WARN("Timeout: Connection to host failed for %s", remoteUrl.c_str());
+						}
+						else if (connectTime != 0 && nameLookupTime != 0)
+						{
+							// Data transfer timeout (connection established)
+							AAMPLOG_WARN("Timeout: Data transfer failed for %s", remoteUrl.c_str());
+						}
+
 						if(mpStreamAbstractionAAMP)
 						{
 							switch (mediaType)


### PR DESCRIPTION
Reason for change: Distinguished the curl error 28, into DNS timeout error, connection with the host timeout and data transfer timeout
Risks: Low
Test Procedure: Refer jira ticket
Priority: P1