### PR TITLE
VPLAY-10851: AS component takes more than 2 seconds to stop / L2 Fix

### DIFF
--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -1120,6 +1120,8 @@ bool PrivateCDAIObjectMPD::FulFillAdObject()
 						break;
 					}
 				}
+				// Resolve the full adbreak object, this is used for conditional wait if it was primarily waiting on this ad
+				adbreakObj.resolved = true;
 			}
 			else
 			{
@@ -1482,8 +1484,8 @@ bool PrivateCDAIObjectMPD::WaitForNextAdResolved(int timeoutMs)
 			if (!it->resolved)
 			{
 				AAMPLOG_INFO("Waiting for next ad placement to complete with timeout %d ms.", timeoutMs);
-				completed = mAdPlacementCV.wait_for(lock, std::chrono::milliseconds(timeoutMs), [it] {
-					return it->resolved;
+				completed = mAdPlacementCV.wait_for(lock, std::chrono::milliseconds(timeoutMs), [this, &it] {
+					return it->resolved || !mAamp->DownloadsAreEnabled();
 				});
 			}
 			else
@@ -1507,18 +1509,24 @@ bool PrivateCDAIObjectMPD::WaitForNextAdResolved(int timeoutMs, std::string peri
 	std::unique_lock<std::mutex> lock(mAdPlacementMtx);
 	bool completed = false;
 	AAMPLOG_INFO("Waiting for next ad placement in %s to complete with timeout %d ms.", periodId.c_str(), timeoutMs);
-	if (mAdPlacementCV.wait_for(lock, std::chrono::milliseconds(timeoutMs)) == std::cv_status::no_timeout)
+	if (isAdBreakObjectExist(periodId))
 	{
-		completed = true;
-	}
-	else
-	{
-		AAMPLOG_INFO("Timed out waiting for next ad placement.");
-		if(isAdBreakObjectExist(periodId))
+		if (mAdPlacementCV.wait_for(lock, std::chrono::milliseconds(timeoutMs), [this, periodId] {
+			return !mAamp->DownloadsAreEnabled() || mAdBreaks[periodId].resolved;
+		}))
 		{
+			completed = true;
+		}
+		else
+		{
+			AAMPLOG_INFO("Timed out waiting for next ad placement.");
 			// Mark the ad break as invalid
 			mAdBreaks[periodId].invalid = true;
 		}
+	}
+	else
+	{
+		AAMPLOG_INFO("AdBreakId[%s] not existing while waiting. Returning false.", periodId.c_str());
 	}
 	return completed;
 }

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -189,12 +189,14 @@ struct AdBreakObject{
 	bool                                 mSplitPeriod;    /**< To identify whether the ad is split period ad or not */
 	bool                                 invalid;         /**< flag marks if the adbreak is invalid or not */
 	AampTime                             mAbsoluteAdBreakStartTime; /**< Period start time */
+	bool                                 resolved;       /**< flag marks if the adbreak is resolved or not */
+	
 	/**
 	* @brief AdBreakObject default constructor
 	*/
 	AdBreakObject()
 		: brkDuration(0), ads(), endPeriodId(), endPeriodOffset(0), adsDuration(0), adjustEndPeriodOffset(false),
-		mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), mAbsoluteAdBreakStartTime(0.0)
+		mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), mAbsoluteAdBreakStartTime(0.0), resolved(false)
 	{
 	}
 
@@ -210,7 +212,7 @@ struct AdBreakObject{
 	AdBreakObject(uint32_t _duration, AdNodeVectorPtr _ads, std::string _endPeriodId,
 		uint64_t _endPeriodOffset, uint32_t _adsDuration)
 		: brkDuration(_duration), ads(_ads), endPeriodId(_endPeriodId), endPeriodOffset(_endPeriodOffset),
-		adsDuration(_adsDuration), adjustEndPeriodOffset(false), mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), mAbsoluteAdBreakStartTime(0.0)
+		adsDuration(_adsDuration), adjustEndPeriodOffset(false), mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), mAbsoluteAdBreakStartTime(0.0), resolved(false)
 	{
 	}
 };

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -3583,4 +3583,231 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodId, "testPeriodId1");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodOffset, 0);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodId, "testPeriodId3");
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodOffset, 0);
+}
+
+/**
+ * @brief Tests the functionality of the PlaceAds method,periodDurationAvailable where ad of base period duration is greater than the next period ad duration .
+ * P1(30s), (SCTE 30s)P2(16s), P3(12s), P4(2s)
+ * .........AD1(15s),AD2(15s)         ........*/
+TEST_F(AdManagerMPDTests, PlaceAdsTests_22)
+{
+  // not adding scte35 markers. These are mocked in PrivateObjectMPD instance
+  static const char *manifest1 =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="dynamic">
+  <Period id="testPeriodId0" start="PT0S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p0_init.mp4" media="video_p0_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="0" d="5000" r="14" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="testPeriodId1" start="PT30S">
+    <AdaptationSet id="1" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="75000" d="5000" r="7" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+
+</MPD>
+)";
+
+  static const char *manifest2 =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="dynamic">
+  <Period id="testPeriodId0" start="PT0S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p0_init.mp4" media="video_p0_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="0" d="5000" r="14" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="testPeriodId1" start="PT30S">
+    <AdaptationSet id="1" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="75000" d="5000" r="7" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="testPeriodId2" start="PT46S">
+    <AdaptationSet id="1" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="110000" d="5000" r="5" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="testPeriodId3" start="PT58S">
+    <AdaptationSet id="1" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="150000" d="5000" r="0" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>
+)";
+  std::string periodId1 = "testPeriodId1";
+  std::string periodId2 = "testPeriodId2";
+  std::string periodId3 = "testPeriodId3";
+
+  InitializeAdMPDObject(manifest1);
+  mPrivateCDAIObjectMPD->mPlacementObj = PlacementObj(periodId1, periodId1, 6, 0, 12000, 0, false);
+
+  // Add ads to the adBreak
+  mPrivateCDAIObjectMPD->mAdBreaks = {
+    {periodId1, AdBreakObject(30000, std::make_shared<std::vector<AdNode>>(), "", 0, 30000)}
+  };
+  // 1 - to - 2 mapping of ad and adbreak
+  mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->emplace_back(false, false, true, "adId1", "url1", 15000, periodId1, 0, nullptr);
+  // Second ad doesn't have basePeriodId and basePeriodOffset set
+  mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->emplace_back(false, false, true, "adId2", "url2", 15000, "", -1, nullptr);
+
+  // Add ads to mPeriodMap. mPeriodMap[periodId].adBreakId is non-empty for live at the beginning as per SetAlternateContents
+  mPrivateCDAIObjectMPD->mPeriodMap[periodId1] = Period2AdData(false, periodId1, 12000 /*in ms*/,
+    {
+      std::make_pair (0, AdOnPeriod(0, 0)), // for adId1 idx=0, offset=0s
+    });
+  mPrivateCDAIObjectMPD->PlaceAds(mAdMPDParseHelper);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mSplitPeriod, false);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, true);
+  EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak not placed
+
+  InitializeAdMPDObject(manifest2);
+  mPrivateCDAIObjectMPD->PlaceAds(mAdMPDParseHelper);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 2); // periodId2 map created
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,16000); //periodmap of periodid1 duration
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.openPeriodId, periodId2); // open period changed to periodId2
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adNextOffset, 13000);
+
+  mPrivateCDAIObjectMPD->PlaceAds(mAdMPDParseHelper);//place ads called again to make periodDelta = 0
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak placed
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].endPeriodId, periodId3);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].endPeriodOffset, 0);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, true);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).placed, true);
+
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodId, "testPeriodId1");
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodOffset, 0);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodId, "testPeriodId1");
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodOffset, 15000);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration,12000);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId1);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 1);
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 1000);
+}
+
+TEST_F(AdManagerMPDTests, WaitForNextAdResolved_NoAdFulfillObj)
+{
+  // Nothing set in mAdFulfillObj, should return false immediately
+  EXPECT_FALSE(mPrivateCDAIObjectMPD->WaitForNextAdResolved(50));
+}
+
+TEST_F(AdManagerMPDTests, WaitForNextAdResolved_ResolvedImmediately)
+{
+  std::string periodId = "p1";
+  std::string adId = "ad1";
+
+  // Add ads to the adBreak
+  mPrivateCDAIObjectMPD->mAdBreaks = {
+      {periodId, AdBreakObject(30000, std::make_shared<std::vector<AdNode>>(), "", 0, 30000)}};
+  // Create ad break and insert resolved ad
+  mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->emplace_back(false, false, true, adId, "", 0, "", 0, nullptr);
+  mPrivateCDAIObjectMPD->mAdFulfillObj = AdFulfillObj(periodId, adId, "dummy");
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->WaitForNextAdResolved(100));
+}
+
+TEST_F(AdManagerMPDTests, WaitForNextAdResolved_TimesOut)
+{
+    std::string periodId = "p1";
+    std::string adId = "ad1";
+
+      // Add ads to the adBreak
+    mPrivateCDAIObjectMPD->mAdBreaks = {
+      {periodId, AdBreakObject(30000, std::make_shared<std::vector<AdNode>>(), "", 0, 30000)}};
+    mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->emplace_back(false, false, false, adId, "", 0, "", 0, nullptr);
+    mPrivateCDAIObjectMPD->mAdFulfillObj = AdFulfillObj(periodId, adId, "dummy");
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->WaitForNextAdResolved(50));
+}
+
+TEST_F(AdManagerMPDTests, WaitForNextAdResolved_SignalledBeforeTimeout)
+{
+    std::string periodId = "p1";
+    std::string adId = "ad1";
+
+      // Add ads to the adBreak
+    mPrivateCDAIObjectMPD->mAdBreaks = {
+      {periodId, AdBreakObject(30000, std::make_shared<std::vector<AdNode>>(), "", 0, 30000)}};
+    mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->emplace_back(false, false, false, adId, "", 0, "", 0, nullptr);
+    mPrivateCDAIObjectMPD->mAdFulfillObj = AdFulfillObj(periodId, adId, "dummy");
+
+    // Run wait in a thread
+    bool completed = false;
+    std::thread waiter([&]{
+        completed = mPrivateCDAIObjectMPD->WaitForNextAdResolved(500);
+    });
+
+    // Give some time then resolve and notify
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    {
+        std::lock_guard<std::mutex> lock(mPrivateCDAIObjectMPD->mAdPlacementMtx);
+        mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).resolved = true;
+        mPrivateCDAIObjectMPD->mAdPlacementCV.notify_one();
+    }
+
+    waiter.join();
+    EXPECT_TRUE(completed);
+}
+
+TEST_F(AdManagerMPDTests, WaitForNextAdResolved_DisableDownloadsBeforeWait)
+{
+  std::string periodId = "p1";
+  std::string adId = "ad1";
+
+  // Add ads to the adBreak
+  mPrivateCDAIObjectMPD->mAdBreaks = {
+    {periodId, AdBreakObject(30000, std::make_shared<std::vector<AdNode>>(), "", 0, 30000)}};
+  mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->emplace_back(false, false, false, adId, "", 0, "", 0, nullptr);
+  mPrivateCDAIObjectMPD->mAdFulfillObj = AdFulfillObj(periodId, adId, "dummy");
+
+  // Abort before waiting
+  EXPECT_CALL(*g_mockPrivateInstanceAAMP ,DownloadsAreEnabled()).WillRepeatedly(Return(false));
+
+  auto start = std::chrono::steady_clock::now();
+  bool result = mPrivateCDAIObjectMPD->WaitForNextAdResolved(5000);
+  auto end = std::chrono::steady_clock::now();
+  auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+
+  // Should return false immediately
+  EXPECT_TRUE(result);
+  // Fail if it actually waited for more than 100ms (indicating it did not abort immediately)
+  EXPECT_LT(elapsedMs, 500) << "WaitForNextAdResolved did not abort immediately, waited for " << elapsedMs << " ms";
 }


### PR DESCRIPTION
Reason for change: Adding a download disabled check inside ad resolved wait This helps stop to finish playback gracefully if ad resolution is in progress in Fetcher thread
Risks: Low
Test Procedure: Test with Linear channel change in devices Priority: P1

Change-Id: I584e9a4e2a13a0014a0fa692dae3a58689304629