### PR TITLE
VPLAY-10563 curl timeout disambiguation

### DIFF
--- a/AampEvent.h
+++ b/AampEvent.h
@@ -153,7 +153,10 @@ typedef enum
 	AAMP_TUNE_INVALID_MANIFEST_FAILURE,		   /**< Manifest is invalid */
 	AAMP_TUNE_FAILED_PTS_ERROR,			   /**< Playback failed due to PTS error */
 	AAMP_TUNE_MP4_INIT_FRAGMENT_MISSING,		   /**< Init fragments missing in playlist */
-	AAMP_TUNE_FAILURE_UNKNOWN			   /**<  Unknown failure */
+	AAMP_TUNE_DNS_RESOLVE_TIMEOUT,
+	AAMP_TUNE_CURL_CONNECTION_TIMEOUT,
+	AAMP_TUNE_DATA_TRANSFER_TIMEOUT,
+	AAMP_TUNE_FAILURE_UNKNOWN		   /**<  Unknown failure */
 } AAMPTuneFailure;
 
 /**

--- a/AampLogManager.h
+++ b/AampLogManager.h
@@ -199,7 +199,7 @@ public:
 	 * @param[in] type - media type
 	 * @return void
 	 */
-	static void LogNetworkError(const char* url, AAMPNetworkErrorType errorType, int errorCode, AampMediaType type)
+	static void LogNetworkError(const char* url, AAMPNetworkErrorType errorType, int errorCode, AampMediaType type, const char* failureReason = nullptr)
 	{
 		std::string location;
 		std::string symptom;
@@ -221,8 +221,17 @@ public:
 			{
 				if(errorCode > 0)
 				{
-					logprintf( eLOGLEVEL_ERROR, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='timeout %d' type='%s' location='%s' symptom='%s' url='%s'",
+					if( failureReason != nullptr )
+					{
+						logprintf( eLOGLEVEL_ERROR, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='timeout %d(%s)' type='%s' location='%s' symptom='%s' url='%s'",
+							  errorCode,failureReason, GetMediaTypeName(type), location.c_str(), symptom.c_str(), url );
+			
+					}
+					else
+					{
+						logprintf( eLOGLEVEL_ERROR, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='timeout %d' type='%s' location='%s' symptom='%s' url='%s'",
 							  errorCode, GetMediaTypeName(type), location.c_str(), symptom.c_str(), url );
+					}
 				}
 			}
 				break; /*AAMPNetworkErrorTimeout*/

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -471,29 +471,15 @@ void AampMPDDownloader::downloadMPDThread1()
 			
 			if(mMPDData->mMPDDownloadResponse->iHttpRetValue != 200 && mMPDData->mMPDDownloadResponse->iHttpRetValue != 204 && mMPDData->mMPDDownloadResponse->iHttpRetValue != 206)
 			{ 
-				double nameLookupTime = 0;
-				double connectTime = 0;
-				// Get the CURL handle used for the download
-				CURL* curl = mDownloader1.GetCurlHandle();
-				curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
-				curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
-				//Curl timeout error analysis
-				if (connectTime == 0 && nameLookupTime == 0)
-				{
-					// DNS timeout
-					AAMPLOG_WARN("Timeout: DNS resolution failed for %s", tuneUrl.c_str());
+				if( mMPDData->mMPDDownloadResponse->iHttpRetValue == CURLE_OPERATION_TIMEDOUT && ( nullptr != GetCurlTimeoutFailureReason(mDownloader1.GetCurlHandle()) ) )
+				{ 
+					mMPDData->mMPDDownloadResponse->failureReasonString = GetCurlTimeoutFailureReason(mDownloader1.GetCurlHandle());
+					AampLogManager::LogNetworkError (mEffectiveUrl.c_str(), AAMPNetworkErrorTimeout, mMPDData->mMPDDownloadResponse->iHttpRetValue, eMEDIATYPE_MANIFEST,mMPDData->mMPDDownloadResponse->failureReasonString);
 				}
-				else if (connectTime == 0 && nameLookupTime != 0)
+				else
 				{
-					// Connection timeout (DNS succeeded)
-					AAMPLOG_WARN("Timeout: Connection to host failed for %s", tuneUrl.c_str());
+					AampLogManager::LogNetworkError (mEffectiveUrl.c_str(), AAMPNetworkErrorHttp, mMPDData->mMPDDownloadResponse->iHttpRetValue, eMEDIATYPE_MANIFEST);
 				}
-				else if (connectTime != 0 && nameLookupTime != 0)
-				{
-					// Data transfer timeout (connection established)
-					AAMPLOG_WARN("Timeout: Data transfer failed for %s", tuneUrl.c_str());
-				}
-				AampLogManager::LogNetworkError (mEffectiveUrl.c_str(), AAMPNetworkErrorHttp, mMPDData->mMPDDownloadResponse->iHttpRetValue, eMEDIATYPE_MANIFEST);
 				//Use DownloadResponse Show call instead of printheaderresponse fn -since it is not scope
 				mMPDData->mMPDDownloadResponse->show();
 			}
@@ -705,6 +691,21 @@ ManifestDownloadResponsePtr AampMPDDownloader::GetManifest(bool bWait, int iWait
 			{
 				// Timed out
 				respPtr->mMPDDownloadResponse->iHttpRetValue = CURLE_OPERATION_TIMEDOUT;
+
+				CURL *curlHandle = nullptr;
+
+				// If you have a getter or if mCurl is public/protected:
+				curlHandle = mDownloader1.GetCurlHandle(); // or mDownloader1->mCurl if it's a pointer
+
+				// Optionally, log or use the handle
+				if (curlHandle)
+				{
+					respPtr->mMPDDownloadResponse->failureReasonString = GetCurlTimeoutFailureReason(curlHandle);
+				}
+				else
+				{
+					AAMPLOG_WARN("GetManifest: CURL handle is null");
+				}
 				AAMPLOG_INFO("GetManifest timer exited after timeout ...%d",iWaitDurationMs);
 				return respPtr;
 			}

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -468,8 +468,31 @@ void AampMPDDownloader::downloadMPDThread1()
 			AAMPLOG_ERR("curl request %s %s Error Code [%u]",mEffectiveUrl.c_str(), (mMPDData->mMPDDownloadResponse->iHttpRetValue < 100) ? "Curl" : "HTTP", mMPDData->mMPDDownloadResponse->iHttpRetValue);
 
 			mMPDData->mMPDStatus	=	AAMPStatusType::eAAMPSTATUS_MANIFEST_DOWNLOAD_ERROR;
+			
 			if(mMPDData->mMPDDownloadResponse->iHttpRetValue != 200 && mMPDData->mMPDDownloadResponse->iHttpRetValue != 204 && mMPDData->mMPDDownloadResponse->iHttpRetValue != 206)
 			{ 
+				double nameLookupTime = 0;
+				double connectTime = 0;
+				// Get the CURL handle used for the download
+				CURL* curl = mDownloader1.GetCurlHandle();
+				curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
+				curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
+				//Curl timeout error analysis
+				if (connectTime == 0 && nameLookupTime == 0)
+				{
+					// DNS timeout
+					AAMPLOG_WARN("Timeout: DNS resolution failed for %s", tuneUrl.c_str());
+				}
+				else if (connectTime == 0 && nameLookupTime != 0)
+				{
+					// Connection timeout (DNS succeeded)
+					AAMPLOG_WARN("Timeout: Connection to host failed for %s", tuneUrl.c_str());
+				}
+				else if (connectTime != 0 && nameLookupTime != 0)
+				{
+					// Data transfer timeout (connection established)
+					AAMPLOG_WARN("Timeout: Data transfer failed for %s", tuneUrl.c_str());
+				}
 				AampLogManager::LogNetworkError (mEffectiveUrl.c_str(), AAMPNetworkErrorHttp, mMPDData->mMPDDownloadResponse->iHttpRetValue, eMEDIATYPE_MANIFEST);
 				//Use DownloadResponse Show call instead of printheaderresponse fn -since it is not scope
 				mMPDData->mMPDDownloadResponse->show();

--- a/AampMPDDownloader.h
+++ b/AampMPDDownloader.h
@@ -63,6 +63,7 @@
 #include "dash/mpd/MPDSegmenter.h"
 #include "AampLLDASHData.h"
 #include "AampMPDUtils.h"
+#include "AampUtils.h"
 
 typedef void (*ManifestUpdateCallbackFunc)(void *);
 

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -36,7 +36,7 @@
 #include <assert.h>
 #include <ctime>
 #include <cctype>
-#include <curl/curl.h>
+//#include <curl/curl.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1449,4 +1449,24 @@ bool aamp_isTuneScheme( const char *cmdBuf )
     }
     return isTuneScheme;
 }
+const char* GetCurlTimeoutFailureReason(CURL* curl)
+{
+    double nameLookupTime = 0;
+    double connectTime = 0;
+    curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
+    curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
 
+    if (connectTime == 0 && nameLookupTime == 0)
+    {
+        return "DNS";
+    }
+    else if (connectTime == 0 && nameLookupTime != 0)
+    {
+        return "Connect";
+    }
+    else if (connectTime != 0 && nameLookupTime != 0)
+    {
+        return "Data transfer";
+    }
+    return nullptr;
+}

--- a/AampUtils.h
+++ b/AampUtils.h
@@ -33,6 +33,7 @@
 #include "iso639map.h"
 #include <string>
 #include <sstream>
+#include <curl/curl.h>
 #include <chrono>
 #include "TsbApi.h"
 
@@ -421,5 +422,7 @@ int aamp_SetThreadSchedulingParameters(int policy, int priority);
  * @retval true iff uri starts with a recognized protocol representing an IP Video Locator
  */
 bool aamp_isTuneScheme( const char *cmdBuf );
+
+const char* GetCurlTimeoutFailureReason(CURL* curl);
 
 #endif  /* __AAMP_UTILS_H__ */

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -302,7 +302,6 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 						AAMPLOG_ERR("%s Not able to download init fragments; reached failure threshold sending tune failed event",name);
 						abortWaitForVideoPTS();
 						aamp->SetFlushFdsNeededInCurlStore(true);
-
 						aamp->SendDownloadErrorEvent(AAMP_TUNE_INIT_FRAGMENT_DOWNLOAD_FAILURE, httpErrorCode);
 					}
 				}

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -669,3 +669,7 @@ size_t AampCurlDownloader::GetDataString(std::string &dataStr)
 	return ret;
 }
 
+CURL* AampCurlDownloader::GetCurlHandle()
+{
+	return mCurl;
+}

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -176,6 +176,7 @@ typedef struct _downloadResponse
 	std::string sEffectiveUrl;
 	std::vector<std::string>  mResponseHeader;
 	std::vector<std::uint8_t> mDownloadData;
+	const char* failureReasonString = nullptr;
 	
 	_downloadResponse() : curlRetValue(0), iHttpRetValue(0), mAbortReason(eCURL_ABORT_REASON_NONE), downloadCompleteMetrics(),progressMetrics(), sEffectiveUrl(""), mResponseHeader(), mDownloadData() {}
 

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -246,6 +246,8 @@ public:
 	*/	
 	size_t GetDataString(std::string &dataStr);
 
+	CURL* GetCurlHandle();
+
 private:
 	void updateCurlParams();
 	void updateResponseParams();

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4521,6 +4521,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::FetchDashManifest()
 	double downloadTime;
 	bool updateVideoEndMetrics = false;
 	int http_error = 0;
+	const char* failureReason = nullptr;
 
 	{
 		mManifestDnldRespPtr = MakeSharedManifestDownloadResponsePtr();
@@ -4532,6 +4533,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::FetchDashManifest()
 		gotManifest		=	(mManifestDnldRespPtr->mMPDStatus == AAMPStatusType::eAAMPSTATUS_OK);
 		http_error		=	mManifestDnldRespPtr->mMPDDownloadResponse->iHttpRetValue;
 		downloadTime	=	mManifestDnldRespPtr->mMPDDownloadResponse->downloadCompleteMetrics.total;
+		failureReason   =   mManifestDnldRespPtr->mMPDDownloadResponse->failureReasonString;
 		//update videoend info
 		updateVideoEndMetrics = true;
 		if (gotManifest)
@@ -4586,7 +4588,31 @@ AAMPStatusType StreamAbstractionAAMP_MPD::FetchDashManifest()
 			{
 				aamp->UpdateDuration(0);
 				aamp->SetFlushFdsNeededInCurlStore(true);
-				aamp->SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, http_error);
+
+				if( http_error == CURLE_OPERATION_TIMEDOUT && failureReason != nullptr )
+				{
+					if( strcmp(failureReason,"DNS")==0)
+					{	
+						aamp->SendDownloadErrorEvent(AAMP_TUNE_DNS_RESOLVE_TIMEOUT, http_error);
+					}
+					else if ( strcmp(failureReason,"Connect")==0 )
+					{
+						aamp->SendDownloadErrorEvent(AAMP_TUNE_CURL_CONNECTION_TIMEOUT, http_error);
+					}
+					else if( strcmp(failureReason,"Data transfer" )==0 )
+					{
+						aamp->SendDownloadErrorEvent(AAMP_TUNE_DATA_TRANSFER_TIMEOUT, http_error);
+					}
+					else
+					{
+						aamp->SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, http_error);
+					}
+				}
+				else
+				{
+					aamp->SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, http_error);
+				} 
+
 				AAMPLOG_ERR("StreamAbstractionAAMP_MPD: manifest download failed");
 				ret = AAMPStatusType::eAAMPSTATUS_MANIFEST_DOWNLOAD_ERROR;
 			}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4288,12 +4288,37 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						{
 							effectiveUrl.assign(remoteUrl);
 						}
+						//Curl error to be differentiated
+						AAMPLOG_INFO("Connection/Timeout error %d for url %s", res, remoteUrl.c_str());
+						//Curl error to be differentiated
+						double nameLookupTime = 0;
+    					double connectTime = 0;
+						// Get the CURL handle used for the download
+						//CURL* curl = mDownloader1.GetCurlHandle();
+						curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
+						curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
+						if (connectTime == 0 && nameLookupTime == 0)
+						{
+							// DNS timeout
+							AAMPLOG_WARN("Timeout: DNS resolution failed for %s", remoteUrl.c_str());
+						}
+						else if (connectTime == 0 && nameLookupTime != 0)
+						{
+							// Connection timeout (DNS succeeded)
+							AAMPLOG_WARN("Timeout: Connection to host failed for %s", remoteUrl.c_str());
+						}
+						else if (connectTime != 0 && nameLookupTime != 0)
+						{
+							// Data transfer timeout (connection established)
+							AAMPLOG_WARN("Timeout: Data transfer failed for %s", remoteUrl.c_str());
+						}
 						AampLogManager::LogNetworkError (effectiveUrl.c_str(), // Effective URL could be different than remoteURL
 						AAMPNetworkErrorCurl, (int)(progressCtx.abortReason == eCURL_ABORT_REASON_NONE ? res : CURLE_PARTIAL_FILE), mediaType);
 						print_headerResponse(context.allResponseHeaders, mediaType);
 					}
 					if (res == CURLE_COULDNT_CONNECT || res == CURLE_OPERATION_TIMEDOUT || (isDownloadStalled && (eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT != abortReason)))
 					{
+						
 						if(mpStreamAbstractionAAMP)
 						{
 							switch (mediaType)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -213,6 +213,9 @@ static TuneFailureMap tuneFailureMap[] =
 	{AAMP_TUNE_INVALID_MANIFEST_FAILURE, 10, "AAMP: Invalid Manifest, parse failed"},
 	{AAMP_TUNE_FAILED_PTS_ERROR, 80, "AAMP: Playback failed due to PTS error"},
 	{AAMP_TUNE_MP4_INIT_FRAGMENT_MISSING, 10, "AAMP: init fragments missing in playlist"},
+	{AAMP_TUNE_DNS_RESOLVE_TIMEOUT, 10, "AAMP: Manifest download failed due to DNS resolve timeout"},
+	{AAMP_TUNE_CURL_CONNECTION_TIMEOUT, 10, "AAMP: Manifest download failed due to connection timeout"},
+	{AAMP_TUNE_DATA_TRANSFER_TIMEOUT, 10, "AAMP: Manifest download failed due to data transfer timeout"},
 	{AAMP_TUNE_FAILURE_UNKNOWN, 100, "AAMP: Unknown Failure"}
 };
 
@@ -2671,7 +2674,6 @@ void PrivateInstanceAAMP::SendDownloadErrorEvent(AAMPTuneFailure tuneFailure, in
 		{
 			strcat(description, "(FOG)");
 		}
-
 		SendErrorEvent(actualFailure, description, retryStatus);
 	}
 	else
@@ -3561,7 +3563,6 @@ void PrivateInstanceAAMP::LogTuneComplete(void)
 				playbackType.append(":TSB=false");
 			}
 		}
-
 		SendAnomalyEvent(eMsgType, "Tune attempt#%d. %s:%s URL:%s", mTuneAttempts,playbackType.c_str(),getStreamTypeString().c_str(),GetTunedManifestUrl());
 	}
 	AampLogManager::setLogLevel(eLOGLEVEL_WARN);
@@ -3967,6 +3968,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 	struct curl_slist* httpHeaders = NULL;
 	CURLcode res = CURLE_OK;
 	int fragmentDurationMs = (int)(fragmentDurationS*1000);
+	const char* failureReason = nullptr;
 
 	int maxDownloadAttempt = 1;
 	switch( mediaType )
@@ -4288,33 +4290,18 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						{
 							effectiveUrl.assign(remoteUrl);
 						}
-						//Curl error to be differentiated
-						AAMPLOG_INFO("Connection/Timeout error %d for url %s", res, remoteUrl.c_str());
-						//Curl error to be differentiated
-						double nameLookupTime = 0;
-    					double connectTime = 0;
-						// Get the CURL handle used for the download
-						//CURL* curl = mDownloader1.GetCurlHandle();
-						curl_easy_getinfo(curl, CURLINFO_NAMELOOKUP_TIME, &nameLookupTime);
-						curl_easy_getinfo(curl, CURLINFO_CONNECT_TIME, &connectTime);
-						if (connectTime == 0 && nameLookupTime == 0)
+						if(res == CURLE_OPERATION_TIMEDOUT && GetCurlTimeoutFailureReason(curl) != nullptr)
 						{
-							// DNS timeout
-							AAMPLOG_WARN("Timeout: DNS resolution failed for %s", remoteUrl.c_str());
+							AampLogManager::LogNetworkError (effectiveUrl.c_str(), // Effective URL could be different than remoteURL
+							AAMPNetworkErrorCurl, (int)(progressCtx.abortReason == eCURL_ABORT_REASON_NONE ? res : CURLE_PARTIAL_FILE), mediaType,GetCurlTimeoutFailureReason(curl));
 						}
-						else if (connectTime == 0 && nameLookupTime != 0)
+						else
 						{
-							// Connection timeout (DNS succeeded)
-							AAMPLOG_WARN("Timeout: Connection to host failed for %s", remoteUrl.c_str());
+							AampLogManager::LogNetworkError (effectiveUrl.c_str(), // Effective URL could be different than remoteURL
+							AAMPNetworkErrorCurl, (int)(progressCtx.abortReason == eCURL_ABORT_REASON_NONE ? res : CURLE_PARTIAL_FILE), mediaType);
 						}
-						else if (connectTime != 0 && nameLookupTime != 0)
-						{
-							// Data transfer timeout (connection established)
-							AAMPLOG_WARN("Timeout: Data transfer failed for %s", remoteUrl.c_str());
-						}
-						AampLogManager::LogNetworkError (effectiveUrl.c_str(), // Effective URL could be different than remoteURL
-						AAMPNetworkErrorCurl, (int)(progressCtx.abortReason == eCURL_ABORT_REASON_NONE ? res : CURLE_PARTIAL_FILE), mediaType);
 						print_headerResponse(context.allResponseHeaders, mediaType);
+
 					}
 					if (res == CURLE_COULDNT_CONNECT || res == CURLE_OPERATION_TIMEDOUT || (isDownloadStalled && (eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT != abortReason)))
 					{
@@ -4587,8 +4574,17 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 			// these are generated after trick play options,
 			if( !(http_code == CURLE_ABORTED_BY_CALLBACK || http_code == CURLE_WRITE_ERROR || http_code == 204))
 			{
-				SendAnomalyEvent(ANOMALY_WARNING, "%s:%s,%s-%d url:%s", (mFogTSBEnabled ? "FOG" : "CDN"),
+				if(failureReason != nullptr)
+				{
+									SendAnomalyEvent(ANOMALY_WARNING, "%s:%s,%s-%d url:%s reason: %s", (mFogTSBEnabled ? "FOG" : "CDN"),
+								 GetMediaTypeName(mediaType), (http_code < 100) ? "Curl" : "HTTP", http_code, remoteUrl.c_str(),failureReason);
+				}
+				else
+				{
+					SendAnomalyEvent(ANOMALY_WARNING, "%s:%s,%s-%d url:%s", (mFogTSBEnabled ? "FOG" : "CDN"),
 								 GetMediaTypeName(mediaType), (http_code < 100) ? "Curl" : "HTTP", http_code, remoteUrl.c_str());
+				}
+
 			}
 
 			if ( (httpRespHeaders[curlInstance].type == eHTTPHEADERTYPE_XREASON) && (httpRespHeaders[curlInstance].data.length() > 0) )
@@ -8172,7 +8168,6 @@ void PrivateInstanceAAMP::ScheduleRetune(PlaybackErrorType errorType, AampMediaT
 					AAMPLOG_ERR("Failed to pause the Pipeline");
 			}
 		}
-
 
 		SendAnomalyEvent(ANOMALY_WARNING, "%s %s", GetMediaTypeName(trackType), getStringForPlaybackError(errorType));
 		bool activeAAMPFound = false;

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2386,7 +2386,7 @@ void StreamAbstractionAAMP::GetDesiredProfileOnBuffer(int currProfileIndex, int 
 	else
 	{
 		AAMPLOG_WARN("Switch to index 0; buffer is about to drain :Buffer %lf !!",bufferValue);
-		newProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
+		newProfileIndex = 0;
 	}
 }
 
@@ -2544,7 +2544,7 @@ int StreamAbstractionAAMP::GetDesiredProfileBasedOnCache(void)
 		{
 			//InsufficientBufferRule: Buffer is empty
 			AAMPLOG_WARN("Switch to index 0; buffer is about to drain :Buffer %lf !!",bufferValue);
-			desiredProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
+			desiredProfileIndex = 0;
 			if(currentProfileIndex != desiredProfileIndex)
 			{
 				mBitrateReason = eAAMP_BITRATE_CHANGE_BY_BUFFER_EMPTY;
@@ -2650,12 +2650,7 @@ bool StreamAbstractionAAMP::RampDownProfile(int http_error)
 		// 1. Rampdown to the lowest profile directly (if this also fails, will lead to playback failure or skipped content)
 		// 2. Rampdown in single steps (here we're already rebuffering or not yet streaming)
 		// Recommend option 2, unless good reason is found to rampdown to lowest profile directly.
-		if (bufferValue <= FLOATING_POINT_EPSILON)
-		{
-			AAMPLOG_WARN("Attempting rampdown to lowest profile as buffer is 0");
-			desiredProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
-		}
-		else if (bufferValue > mABRMaxBuffer)
+		if (bufferValue == 0 || bufferValue > mABRMaxBuffer)
 		{
 			// Rampdown in single steps
 			desiredProfileIndex = aamp->mhAbrManager.getRampedDownProfileIndex(currentProfileIndex);

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -24,7 +24,6 @@
 #include <cstdarg>
 #include <sys/time.h>
 #include <cstring>
-#include <algorithm>
 
 #if !defined(__APPLE__)
 #if defined(USE_SYSTEMD_JOURNAL_PRINT)
@@ -712,21 +711,4 @@ void ABRManager::setLogDirectory(char driveName) {
  */
 void ABRManager::setDefaultIframeBitrate(long defaultIframeBitrate) {
   mDefaultIframeBitrate = defaultIframeBitrate;
-}
-
-/**
- *  @brief Get the lowest bitrate pointing index
- */
-int  ABRManager::getProfileIndexForLowestBandwidth()
-{
-	std::lock_guard<std::mutex> lock(mProfileLock);
-	int profileCount = getProfileCountUnlocked();
-	PROFILES_EMPTY_CHECK_RET(profileCount, 0);
-	int index = 0;
-	auto &profileMap = mSortedBWProfileList.begin()->second;
-	if (!profileMap.empty()) 
-	{
-		index = profileMap.begin()->second;
-	}
-	return index;
 }

--- a/support/aampabr/ABRManager.h
+++ b/support/aampabr/ABRManager.h
@@ -184,13 +184,6 @@ public:
    * @return int index of the max bandwidth
    */
   int getMaxBandwidthProfile(const std::string& periodId = std::string());
-
-  /**
-   * @fn getProfileIndexForLowestBandwidth
-   *
-   * @return int index for lowest bitrate
-   */
-  int getProfileIndexForLowestBandwidth();
 public:
   // Getters/Setters
   /**

--- a/test/utests/fakes/FakeABRManager.cpp
+++ b/test/utests/fakes/FakeABRManager.cpp
@@ -111,8 +111,3 @@ int ABRManager::removeProfiles(std::vector<BitsPerSecond> profileBPS, int curren
 {
     return 0;
 }
-
-int  ABRManager::getProfileIndexForLowestBandwidth()
-{
-    return 0;
-}

--- a/test/utests/fakes/FakeAampUtils.cpp
+++ b/test/utests/fakes/FakeAampUtils.cpp
@@ -607,5 +607,10 @@ int aamp_SetThreadSchedulingParameters(int policy, int priority)
 
 bool aamp_isTuneScheme( const char *cmdBuf ){ return false; }
 
+const char* GetCurlTimeoutFailureReason(CURL* curl)
+{
+	return "";
+}
+
 // aamp_ApplyPageHttpHeaders not actually part of AampUtils.cpp, but fake declared here for convenience
 extern "C" void aamp_ApplyPageHttpHeaders(PlayerInstanceAAMP *aamp){}


### PR DESCRIPTION
Reason for change: Distinguished the curl error 28, into DNS timeout error, connection with the host timeout and data transfer timeout
Risks: Low
Test Procedure: Refer jira ticket
Priority: P1