### PR TITLE
VPLAY-10331 Live latency value keeps increasing 

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -10996,7 +10996,12 @@ int PrivateInstanceAAMP::GetTextTrack()
 {
 	int idx = -1;
 	AcquireStreamLock();
-	if (PlayerCCManager::GetInstance()->GetStatus() && mpStreamAbstractionAAMP)
+	if (mpStreamAbstractionAAMP && !subtitles_muted)
+	{
+		idx = mpStreamAbstractionAAMP->GetTextTrack();
+	}
+
+	if (PlayerCCManager::GetInstance()->GetStatus() && idx == -1 && mpStreamAbstractionAAMP)
 	{
 		std::string trackId = PlayerCCManager::GetInstance()->GetTrack();
 		if (!trackId.empty())
@@ -11010,10 +11015,6 @@ int PrivateInstanceAAMP::GetTextTrack()
 				}
 			}
 		}
-	}
-	if (mpStreamAbstractionAAMP && idx == -1 && !subtitles_muted)
-	{
-		idx = mpStreamAbstractionAAMP->GetTextTrack();
 	}
 	ReleaseStreamLock();
 	return idx;
@@ -12412,11 +12413,15 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param )
 							AAMPLOG_ERR("TSB Session Manager is NULL");
 						}
 					}
-					else
+					else if(mDisableRateCorrection)
 					{
 						TuneHelper(eTUNETYPE_SEEK);
 					}
-
+					else
+					{
+						TuneHelper(eTUNETYPE_SEEKTOLIVE);
+					}
+					
 					discardEnteringLiveEvt = false;
 				}
 				ReleaseStreamLock();


### PR DESCRIPTION
Reason for change:
*fixed the issue where the trackid taken from cc to compare with the subtitle which is resulting in the teardown *Fixed the gap in SetPrefferredTextTrack where we switch between SEEK and SEEKTOLIVE based on mDisableRateCorrection Test Procedure: Test steps in ticket
Risks: Low