### PR TITLE
Feature/vplay 8907 guard against thread overwrite (#131)

### DIFF
--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -83,8 +83,8 @@ typedef struct HlsStreamInfo: public StreamInfo
 	HlsStreamInfo():program_id(),audio(),uri(),averageBandwidth(),closedCaptions(),subtitles(),audioFormat(){};
 
 	// Copy constructor
-    HlsStreamInfo(const HlsStreamInfo& other)
-        :
+	HlsStreamInfo(const HlsStreamInfo& other)
+		:
 		StreamInfo(other), // Initialize base class members
 		program_id(other.program_id),
 		audio(other.audio),
@@ -243,7 +243,7 @@ class TrackState : public MediaTrack
 		 *
 		 * @return void
 		 ***************************************************************************/
-		void RunFetchLoop();
+		virtual void RunFetchLoop();
 
 		/***************************************************************************
 		 * @fn FragmentCollector
@@ -482,8 +482,8 @@ class TrackState : public MediaTrack
 		void ProcessPlaylist(AampGrowableBuffer& newPlaylist, int http_error) override;
 
 		/**
-                 * @brief Get byteRangeLength and byteRangeOffset from fragmentInfo.
-                 */
+		 * @brief Get byteRangeLength and byteRangeOffset from fragmentInfo.
+		 */
 		bool IsExtXByteRange(lstring fragmentInfo, size_t *byteRangeLength, size_t *byteRangeOffset);
 
 		/**
@@ -646,7 +646,6 @@ class TrackState : public MediaTrack
 		bool refreshPlaylist;					/**< bool flag to indicate if playlist refresh required or not */
 		bool isFirstFragmentAfterABR;			/**< bool flag to indicate whether the fragment is first fragment after ABR */
 		std::thread fragmentCollectorThreadID;	/**< Thread Id for Fragment  collector Thread */
-		bool fragmentCollectorThreadStarted;	/**< Flag indicating if fragment collector thread started or not*/
 		int manifestDLFailCount;		/**< Manifest Download fail count for retry*/
 		bool firstIndexDone;					/**< Indicates if first indexing is done*/
 		std::shared_ptr<HlsDrmBase> mDrm;		/**< DRM decrypt context*/
@@ -1008,10 +1007,10 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		const std::unique_ptr<aamp::MetadataProcessorIntf> & GetMetadataProcessor(StreamOutputFormat fmt);
 
 		/***************************************************************************
-                 * @fn RefreshTrack
-                 *
-                 * @return void
-                 ***************************************************************************/
+		 * @fn RefreshTrack
+		 *
+		 * @return void
+		 ***************************************************************************/
 		void RefreshTrack(AampMediaType type) override;
 
 		/***************************************************************************
@@ -1027,10 +1026,10 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 ***************************************************************************/
 		void ConfigureAudioTrack();
 		/***************************************************************************
-                 * @fn SelectPreferredTextTrack
-                 * @param selectedTextTrack Current PreferredTextTrack Info
-                 * @return bool
-                 ***************************************************************************/
+		 * @fn SelectPreferredTextTrack
+		 * @param selectedTextTrack Current PreferredTextTrack Info
+		 * @return bool
+		 ***************************************************************************/
 		bool SelectPreferredTextTrack(TextTrackInfo& selectedTextTrack) override;
 
 	protected:
@@ -1097,8 +1096,8 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		ptsoffset_update_t mPtsOffsetUpdate;	/**< Function to use to update the PTS offset */
 
 		std::mutex mMP_mutex;  // protects mMetadataProcessor
- 		std::unique_ptr<aamp::MetadataProcessorIntf> mMetadataProcessor;
-             
+		 std::unique_ptr<aamp::MetadataProcessorIntf> mMetadataProcessor;
+			 
 };
 
 #endif // FRAGMENTCOLLECTOR_HLS_H

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -114,8 +114,8 @@ static bool IsIframeTrack(IAdaptationSet *adaptationSet);
  */
 StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *aamp, double seek_pos, float rate, id3_callback_t id3Handler)
 	: StreamAbstractionAAMP(aamp, id3Handler),
-	fragmentCollectorThreadStarted(false), mLangList(), seekPosition(seek_pos), rate(rate), fragmentCollectorThreadID(),tsbReaderThreadID(),
-	mpd(NULL), mNumberOfTracks(0), mCurrentPeriodIdx(0), mEndPosition(0), mIsLiveStream(true), mIsLiveManifest(true),mManifestDnldRespPtr(nullptr),mManifestUpdateHandleFlag(false),mUpdateManifestState(false),
+	mLangList(), seekPosition(seek_pos), rate(rate), fragmentCollectorThreadID(),tsbReaderThreadID(),
+	mpd(NULL), mNumberOfTracks(0), mCurrentPeriodIdx(0), mEndPosition(0), mIsLiveStream(true), mIsLiveManifest(true),mManifestDnldRespPtr(nullptr),mManifestUpdateHandleFlag(false), mUpdateManifestState(false),
 	mStreamInfo(NULL), mPrevStartTimeSeconds(0), mPrevLastSegurlMedia(""), mPrevLastSegurlOffset(0),
 	mPeriodEndTime(0), mPeriodStartTime(0), mPeriodDuration(0), mMinUpdateDurationMs(DEFAULT_INTERVAL_BETWEEN_MPD_UPDATES_MS),
 	mLastPlaylistDownloadTimeMs(0), mFirstPTS(0), mStartTimeOfFirstPTS(0), mAudioType(eAUDIO_UNKNOWN),
@@ -151,7 +151,7 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 	,mFcsRepresentationId(-1)
 	,mFcsSegments()
 	,isVidDiscInitFragFail(false)
-	,tsbReaderThreadStarted(false), abortTsbReader(false)
+	,abortTsbReader(false)
 	,mShortAdOffsetCalc(false)
 	,mNextPts(0.0)
 	,mPrevFirstPeriodStart(0.0f)
@@ -902,7 +902,7 @@ bool StreamAbstractionAAMP_MPD::FetchFragment(MediaStreamContext *pMediaStreamCo
 		if(!fragmentSaved)
 		{
 			AAMPLOG_WARN("StreamAbstractionAAMP_MPD: failed. fragmentUrl %s fragmentTime %f %d %d", fragmentUrl.c_str(), pMediaStreamContext->fragmentTime,isInitializationSegment, pMediaStreamContext->type);
-                  	//Added new check to avoid marking ad as failed if the http code is not worthy.
+			//Added new check to avoid marking ad as failed if the http code is not worthy.
 			if (isInitializationSegment && mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING &&
 				(pMediaStreamContext->httpErrorCode!=CURLE_WRITE_ERROR && pMediaStreamContext->httpErrorCode!= CURLE_ABORTED_BY_CALLBACK))
 			{
@@ -1053,8 +1053,8 @@ uint64_t StreamAbstractionAAMP_MPD::FindPositionInTimeline(class MediaStreamCont
 
 		/* For a timeline
 		* <SegmentTimeline>
-        *  <S d="109568" t="0"/>
-        *  <S d="107520" r="4" t="109568"/>
+		*  <S d="109568" t="0"/>
+		*  <S d="107520" r="4" t="109568"/>
 		* and a manifest update after segment 1 has been sent. Ensure one cycle of the for loop so
 		* timeLineIndex gets incremented.
 		* Without this we get a segment dropped and another repeated in server side ads
@@ -1408,18 +1408,18 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 							pMediaStreamContext->type,pMediaStreamContext->fragmentDescriptor.Time,pMediaStreamContext->fragmentDescriptor.Number,pMediaStreamContext->lastSegmentTime,duration,pMediaStreamContext->fragmentTime,endTime);
 #endif
 						retval = true;
-						if(mIsFcsRepresentation)
-                                                {
+						if (mIsFcsRepresentation)
+						{
 							fcsContent = false;
-							for(int i =0;i< mFcsSegments.size();i++)
-                                                        {
+							for (int i = 0; i < mFcsSegments.size(); i++)
+							{
 								uint64_t starttime = mFcsSegments.at(i)->GetStartTime();
-								uint64_t duration  =  mFcsSegments.at(i)->GetDuration();
+								uint64_t duration = mFcsSegments.at(i)->GetDuration();
 								// Logic  to handle the duration option missing case
-								if(!duration)
+								if (!duration)
 								{
-									//If not present, the alternative content section lasts until the start of the next FCS _element_
-									if(i+1 < mFcsSegments.size())
+									// If not present, the alternative content section lasts until the start of the next FCS _element_
+									if (i + 1 < mFcsSegments.size())
 									{
 										duration =  mFcsSegments.at(i+1)->GetStartTime();
 									}
@@ -1589,7 +1589,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 							profileIdxForBandwidthNotification = GetProfileIdxForBandwidthNotification(pMediaStreamContext->fragmentDescriptor.Bandwidth);
 							FetchAndInjectInitialization(eMEDIATYPE_VIDEO);
 							UpdateRampUpOrDownProfileReason();
-                                                        pMediaStreamContext->SetCurrentBandWidth(pMediaStreamContext->fragmentDescriptor.Bandwidth);
+							pMediaStreamContext->SetCurrentBandWidth(pMediaStreamContext->fragmentDescriptor.Bandwidth);
 							return false;
 						}
 					}
@@ -2022,13 +2022,13 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 					unsigned int nextReferencedSize;
 					float nextfragmentDuration;
 					uint64_t nextfragmentOffset;
-		                        if (ParseSegmentIndexBox(
-                                             pMediaStreamContext->IDX.GetPtr(),
-                                             pMediaStreamContext->IDX.GetLen(),
-                                             pMediaStreamContext->fragmentIndex,
-                                             &nextReferencedSize,
-                                             &nextfragmentDuration,
-                                             NULL))
+					if (ParseSegmentIndexBox(
+							pMediaStreamContext->IDX.GetPtr(),
+							pMediaStreamContext->IDX.GetLen(),
+							pMediaStreamContext->fragmentIndex,
+							&nextReferencedSize,
+							&nextfragmentDuration,
+							NULL))
 					{
 						char nextrange[MAX_RANGE_STRING_CHARS];
 						nextfragmentOffset = pMediaStreamContext->fragmentOffset+referenced_size;
@@ -2209,7 +2209,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 									index++;
 								}
 								pMediaStreamContext->fragmentIndex = index - 1;
- 								AAMPLOG_TRACE("PushNextFragment Exit : startTime %lld lastSegmentTime %" PRIu64 " index = %d", startTime, pMediaStreamContext->lastSegmentTime, pMediaStreamContext->fragmentIndex);
+								 AAMPLOG_TRACE("PushNextFragment Exit : startTime %lld lastSegmentTime %" PRIu64 " index = %d", startTime, pMediaStreamContext->lastSegmentTime, pMediaStreamContext->fragmentIndex);
 							}
 						}
 						if(rate > 0)
@@ -2444,10 +2444,10 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 					pointing to the first entry in the timeLineIndex then the duration will come from the previous
 					timeLineIndex
 					<SegmentTimeline>
-          				<S t="927972765613" d="336000" r="0" />     <-- the duration we want for rew
-          				<S t="927973101613" d="326400" r="0" />     <------timeLineIndex
-          				<S t="927973428013" d="460800" r="43" />
-			        </SegmentTimeline>
+						  <S t="927972765613" d="336000" r="0" />     <-- the duration we want for rew
+						  <S t="927973101613" d="326400" r="0" />     <------timeLineIndex
+						  <S t="927973428013" d="460800" r="43" />
+					</SegmentTimeline>
 					*/
 					uint32_t duration = timeline->GetDuration();
 					if (skipTime < 0)
@@ -3243,7 +3243,7 @@ DrmHelperPtr StreamAbstractionAAMP_MPD::CreateDrmHelper(const IAdaptationSet * a
 			{
 				contentMetadata = DrmUtils::extractWVContentMetadataFromPssh((const char*)data, (int)dataLength);
 				free(data);
-                                data = NULL;
+								data = NULL;
 			}
 			else
 			{
@@ -3539,10 +3539,10 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 	aamp->IsTuneTypeNew = newTune;
 
 	bool pushEncInitFragment = newTune || (eTUNETYPE_RETUNE == tuneType) || aamp->mbDetached;
-        if(aamp->mbDetached){
-                /* No more needed reset it **/
-                aamp->mbDetached = false;
-        }
+	if(aamp->mbDetached){
+			/* No more needed reset it **/
+			aamp->mbDetached = false;
+	}
 
 	for (int i = 0; i < AAMP_TRACK_COUNT; i++)
 	{
@@ -3699,8 +3699,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			if (!mpdDurationAvailable)
 			{
 				durationMs += periodDurationMs;
- 				AAMPLOG_INFO("Updated duration %lf seconds", ((double) durationMs/1000));
- 			}
+				 AAMPLOG_INFO("Updated duration %lf seconds", ((double) durationMs/1000));
+			 }
 
 			if(offsetFromStart >= 0 && seekPeriods)
 			{
@@ -4007,7 +4007,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 		UpdateLanguageList();
 
 		if ((eTUNETYPE_SEEK == tuneType) ||
-		    (eTUNETYPE_SEEKTOEND == tuneType))
+			(eTUNETYPE_SEEKTOEND == tuneType))
 		{
 			forceSpeedsChangedEvent = true; // Send speed change event if seek done from non-iframe period to iframe available period to inform XRE to allow trick operations.
 		}
@@ -4942,7 +4942,7 @@ void StreamAbstractionAAMP_MPD::FindTimedMetadata(MPD* mpd, Node* root, bool ini
 							if((name == "EventStream") && ("" != prdId) && !mCdaiObject->isPeriodExist(prdId))
 							{
 								bool processEventsInPeriod = ((!init || (1 < periodCnt && 0 == period->GetAdaptationSets().size())) //Take last & empty period at the MPD init AND all new periods in the MPD refresh. (No empty periods will come the middle)
-											      || (!mIsLiveManifest && init) || (mIsLiveManifest && ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive) ));
+												  || (!mIsLiveManifest && init) || (mIsLiveManifest && ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive) ));
 
 								bool modifySCTEProcessing = ISCONFIGSET(eAAMPConfig_EnableSCTE35PresentationTime);
 								if (modifySCTEProcessing)
@@ -5623,7 +5623,7 @@ void StreamAbstractionAAMP_MPD::UpdateLanguageList()
 int StreamAbstractionAAMP_MPD::GetBestAudioTrackByLanguage( int &desiredRepIdx, AudioType &CodecType,
 std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
 {
-    int bestTrack = -1;
+	int bestTrack = -1;
 	unsigned long long bestScore = 0;
 	AudioTrackInfo selectedAudioTrack; /**< Selected Audio track information */
 	IPeriod *period = mCurrentPeriod;
@@ -5862,7 +5862,7 @@ std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
  */
 bool StreamAbstractionAAMP_MPD::GetBestTextTrackByLanguage( TextTrackInfo &selectedTextTrack)
 {
-    bool bestTrack = false;
+	bool bestTrack = false;
 	unsigned long long bestScore = 0;
 	IPeriod *period = mCurrentPeriod;
 	if(!period)
@@ -6301,7 +6301,7 @@ void StreamAbstractionAAMP_MPD::SwitchSubtitleTrack(bool newTune)
 	AbortWaitForAudioTrackCatchup(true);
 
 	pMediaStreamContext->LoadNewSubtitle(true);
-    /* Flush Subtitle Fragments */
+	/* Flush Subtitle Fragments */
 	pMediaStreamContext->FlushFragments();
 	if( pMediaStreamContext->freshManifest )
 	{
@@ -7035,8 +7035,8 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	* lastsegment related params here...
 	*/
 	pMediaStreamContext->lastSegmentTime = pMediaStreamContext->fragmentDescriptor.Time - fragmentDuration;
-    pMediaStreamContext->lastSegmentDuration = pMediaStreamContext->fragmentDescriptor.Time;
-    pMediaStreamContext->lastSegmentNumber = pMediaStreamContext->fragmentDescriptor.Number - 1;
+	pMediaStreamContext->lastSegmentDuration = pMediaStreamContext->fragmentDescriptor.Time;
+	pMediaStreamContext->lastSegmentNumber = pMediaStreamContext->fragmentDescriptor.Number - 1;
 
 
 
@@ -7282,7 +7282,7 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 		if (mMultiVideoAdaptationPresent)
 		{
 			// We have multiple video adaptations in the same period and
-            // if one of them fails in license acquisition, we can skip error event
+			// if one of them fails in license acquisition, we can skip error event
 			licenseManager->SetSendErrorOnFailure(false);
 		}
 		else
@@ -7764,7 +7764,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 					{
 						// Skipping blacklist check for audio only track at the moment
 						IAdaptationSet* adaptationSet = adaptationSets.at(0);
-					    if ((mNumberOfTracks == 1) && (mMPDParseHelper->IsContentType(adaptationSet, eMEDIATYPE_AUDIO)))
+						if ((mNumberOfTracks == 1) && (mMPDParseHelper->IsContentType(adaptationSet, eMEDIATYPE_AUDIO)))
 						{
 							const auto &representations = adaptationSet->GetRepresentation();
 							for (int reprIdx = 0; reprIdx < representations.size(); reprIdx++)
@@ -7801,7 +7801,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 								mProfileMaps[idx].representationIndex = reprIdx;
 								idx++;
 							}
-					    }
+						}
 					}
 					if (0 == addedProfiles)
 					{
@@ -7901,8 +7901,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 					pMediaStreamContext->representationIndex = 0; //Fog custom mpd has single representation
 				}
 			}
-                  	//The logic is added to avoid a crash in AAMP due to stream issue in HEVC stream.
-                  	//Player will be able to end the playback gracefully with the fix.
+					  //The logic is added to avoid a crash in AAMP due to stream issue in HEVC stream.
+					  //Player will be able to end the playback gracefully with the fix.
 			if(pMediaStreamContext->representationIndex < pMediaStreamContext->adaptationSet->GetRepresentation().size())
 			{
 				pMediaStreamContext->representation = pMediaStreamContext->adaptationSet->GetRepresentation().at(pMediaStreamContext->representationIndex);
@@ -8568,22 +8568,22 @@ void StreamAbstractionAAMP_MPD::FetchAndInjectInitialization(int trackIdx, bool 
 							char temp[MAX_RANGE_STRING_CHARS];
 							snprintf( temp, sizeof(temp), "0-%" PRIu64 , s1-1 );
 							range = temp;
-							if (pMediaStreamContext->IDX.GetPtr() )
+							if (pMediaStreamContext->IDX.GetPtr())
 							{
-				                                unsigned int referenced_size;
-				                                float fragmentDuration;
-				                                if (ParseSegmentIndexBox(
-		                                                         pMediaStreamContext->IDX.GetPtr(),
-		                                                         pMediaStreamContext->IDX.GetLen(),
-		                                                         pMediaStreamContext->fragmentIndex,
-		                                                         &referenced_size,
-		                                                         &fragmentDuration,
-		                                                         NULL))
+								unsigned int referenced_size;
+								float fragmentDuration;
+								if (ParseSegmentIndexBox(
+										pMediaStreamContext->IDX.GetPtr(),
+										pMediaStreamContext->IDX.GetLen(),
+										pMediaStreamContext->fragmentIndex,
+										&referenced_size,
+										&fragmentDuration,
+										NULL))
 								{
-				                                    char temprange[MAX_RANGE_STRING_CHARS];
-				                                    snprintf(temprange, sizeof(temprange), "%" PRIu64 "-%" PRIu64 "", pMediaStreamContext->fragmentOffset, pMediaStreamContext->fragmentOffset + referenced_size - 1);
-				                                    nextrange = temprange;
-				                                 }
+									char temprange[MAX_RANGE_STRING_CHARS];
+									snprintf(temprange, sizeof(temprange), "%" PRIu64 "-%" PRIu64 "", pMediaStreamContext->fragmentOffset, pMediaStreamContext->fragmentOffset + referenced_size - 1);
+									nextrange = temprange;
+								}
 							}
 						}
 						std::string fragmentUrl;
@@ -8637,7 +8637,7 @@ void StreamAbstractionAAMP_MPD::FetchAndInjectInitialization(int trackIdx, bool 
 							else
 							{
 								string range;
-				                                string nextrange;
+												string nextrange;
 #ifdef LIBDASH_SEGMENTLIST_GET_INIT_SUPPORT
 								const ISegmentURL *segmentURL = NULL;
 								segmentURL = segmentList->Getinitialization();
@@ -9380,7 +9380,7 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 					mPrevAdaptationSetCount = adaptationSetCount;
 					periodChanged = true;
 					if ((rate == AAMP_NORMAL_PLAY_RATE) &&
-					    !mMediaStreamContext[eMEDIATYPE_VIDEO]->IsLocalTSBInjection() &&
+						!mMediaStreamContext[eMEDIATYPE_VIDEO]->IsLocalTSBInjection() &&
 						!(aamp->IsLocalAAMPTsb() && aamp->pipeline_paused))
 					{
 						aamp->SetIsPeriodChangeMarked(true);
@@ -10468,11 +10468,19 @@ void StreamAbstractionAAMP_MPD::StartFromOtherThanAampLocalTsb(void)
 {
 	aamp->mDRMLicenseManager->setSessionMgrState(SessionMgrState::eSESSIONMGR_ACTIVE);
 	// Start the worker threads for each track
-	try{
-		fragmentCollectorThreadID = std::thread(&StreamAbstractionAAMP_MPD::FetcherLoop, this);
-		fragmentCollectorThreadStarted = true;
-		AAMPLOG_INFO("Thread created for FetcherLoop [%zx]", GetPrintableThreadID(fragmentCollectorThreadID));
-	}
+	try
+	{
+		// Attempting to assign to a running thread will cause std::terminate(), not an exception
+		if(!fragmentCollectorThreadID.joinable())
+		{
+			fragmentCollectorThreadID = std::thread(&StreamAbstractionAAMP_MPD::FetcherLoop, this);
+			AAMPLOG_INFO("Thread created for FetcherLoop [%zx]", GetPrintableThreadID(fragmentCollectorThreadID));
+		}
+		else
+		{
+			AAMPLOG_INFO("FetcherLoop thread already running, not creating a new one");
+		}
+	} 
 	catch (std::exception &e)
 	{
 		AAMPLOG_ERR("Thread allocation failed for FetcherLoop : %s ", e.what());
@@ -10535,9 +10543,15 @@ void StreamAbstractionAAMP_MPD::StartFromAampLocalTsb(void)
 	try
 	{
 		abortTsbReader = false;
-		tsbReaderThreadID = std::thread(&StreamAbstractionAAMP_MPD::TsbReader, this);
-		tsbReaderThreadStarted = true;
-		AAMPLOG_INFO("Thread created for TsbReader [%zx]", GetPrintableThreadID(tsbReaderThreadID));
+		if (!tsbReaderThreadID.joinable())
+		{
+			tsbReaderThreadID = std::thread(&StreamAbstractionAAMP_MPD::TsbReader, this);
+			AAMPLOG_INFO("Thread created for TsbReader [%zx]", GetPrintableThreadID(tsbReaderThreadID));
+		}
+		else
+		{
+			AAMPLOG_WARN("Attempt to create TsbReader thread while thread is running");
+		}
 	}
 	catch(const std::exception& e)
 	{
@@ -10620,23 +10634,17 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 		AAMPLOG_INFO("Joined StartLatencyMonitorThread");
 		latencyMonitorThreadStarted = false;
 	}
-
-	if (!aamp->DownloadsAreEnabled() && (fragmentCollectorThreadStarted))
+	if (!aamp->DownloadsAreEnabled() && fragmentCollectorThreadID.joinable())
 	{
 		fragmentCollectorThreadID.join();
-		fragmentCollectorThreadStarted = false;
 	}
 
-	if(tsbReaderThreadStarted)
+	if(tsbReaderThreadID.joinable())
 	{
 		AAMPLOG_INFO("Abort TsbReader");
 		abortTsbReader = true;
-		if(tsbReaderThreadID.joinable())
-		{
-			tsbReaderThreadID.join();
-			AAMPLOG_INFO("Joined tsbReaderThreadID");
-		}
-		tsbReaderThreadStarted = false;
+		tsbReaderThreadID.join();
+		AAMPLOG_INFO("Joined tsbReaderThreadID");
 	}
 
 	for (int iTrack = 0; iTrack < mMaxTracks; iTrack++)
@@ -10679,14 +10687,10 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 			}
 		}
 		aamp->mDRMLicenseManager->setSessionMgrState(SessionMgrState::eSESSIONMGR_INACTIVE);
-		if(tsbReaderThreadStarted)
+		if(tsbReaderThreadID.joinable())
 		{
 			abortTsbReader = true;
-			if(tsbReaderThreadID.joinable())
-			{
-				tsbReaderThreadID.join();
-			}
-			tsbReaderThreadStarted = false;
+			tsbReaderThreadID.join();
 		}
 
 	}
@@ -11396,7 +11400,7 @@ std::vector<ThumbnailData> StreamAbstractionAAMP_MPD::GetThumbnailRangeData(doub
  */
 void StreamAbstractionAAMP_MPD::StopInjection(void)
 {
-    //invoked at times of discontinuity. Audio injection loop might have already exited here
+	//invoked at times of discontinuity. Audio injection loop might have already exited here
 	ReassessAndResumeAudioTrack(true);
 	for (int iTrack = 0; iTrack < mNumberOfTracks; iTrack++)
 	{
@@ -12094,7 +12098,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 					}
 					absReservationEventPosition = abObj->mAbsoluteAdBreakStartTime;
 					absPlacementEventPosition = abObj->mAbsoluteAdBreakStartTime;
-			    }
+				}
 			}
 			if(AAMP_EVENT_AD_RESERVATION_START == reservationEvt2Send || AAMP_EVENT_AD_RESERVATION_END == reservationEvt2Send)
 			{
@@ -12824,11 +12828,11 @@ double StreamAbstractionAAMP_MPD::GetEncoderDisplayLatency()
  */
 void StreamAbstractionAAMP_MPD::StartLatencyMonitorThread()
 {
-    assert(!latencyMonitorThreadStarted);
-    try
+	assert(!latencyMonitorThreadStarted);
+	try
 	{
 		latencyMonitorThreadID = std::thread(&StreamAbstractionAAMP_MPD::MonitorLatency, this);
-        latencyMonitorThreadStarted = true;
+		latencyMonitorThreadStarted = true;
 		AAMPLOG_INFO("Thread created Latency monitor [%zx]", GetPrintableThreadID(latencyMonitorThreadID));
 	}
 	catch(const std::exception& e)
@@ -12993,7 +12997,7 @@ void StreamAbstractionAAMP_MPD::MonitorLatency()
 							bufferLowHitCount = 0;
 						}
 
-					    AAMPLOG_INFO("currentLatency = %.02lf  AvailableBuffer = %.02lf minbuffer = %.02lf targetBuffer=%.02lf currentPlaybackRate = %.02lf bufferLowHitted = %d isEnoughBuffer = %d latencyCorrected = %d bufferCorrectionStarted = %d",
+						AAMPLOG_INFO("currentLatency = %.02lf  AvailableBuffer = %.02lf minbuffer = %.02lf targetBuffer=%.02lf currentPlaybackRate = %.02lf bufferLowHitted = %d isEnoughBuffer = %d latencyCorrected = %d bufferCorrectionStarted = %d",
 							currentLatency, bufferValue, minbuffer, targetBuffer, currPlaybackRate, bufferLowHit, isEnoughBuffer, latencyCorrected, bufferCorrectionStarted);
 
 						if ((currentLatency > ((double) pAampLLDashServiceData->maxLatency )) && isEnoughBuffer)
@@ -13065,7 +13069,7 @@ void StreamAbstractionAAMP_MPD::MonitorLatency()
 
 							if(sink && false == sink->SetPlayBackRate(playRate))
 							{
- 								AAMPLOG_WARN("SetPlayBackRate: failed !!!, new rate:%f curr rate: %lf", playRate, currPlaybackRate);
+								 AAMPLOG_WARN("SetPlayBackRate: failed !!!, new rate:%f curr rate: %lf", playRate, currPlaybackRate);
 							}
 							else if (reportEvent)
 							{
@@ -13147,55 +13151,55 @@ bool StreamAbstractionAAMP_MPD::CheckLLProfileAvailable(IMPD *mpd)
  */
 bool StreamAbstractionAAMP_MPD::CheckProducerReferenceTimeUTCTimeMatch(IProducerReferenceTime *pRT)
 {
-    bool bMatch = false;
-    //1. Check if UTC Time provider in <ProducerReferenceTime> _element_ is same as stored for MPD already
+	bool bMatch = false;
+	//1. Check if UTC Time provider in <ProducerReferenceTime> _element_ is same as stored for MPD already
 
-    if(pRT->GetUTCTimings().size())
-    {
-        IUTCTiming *utcTiming= pRT->GetUTCTimings().at(0);
+	if(pRT->GetUTCTimings().size())
+	{
+		IUTCTiming *utcTiming= pRT->GetUTCTimings().at(0);
 
-        // Some timeline may not have attribute for target latency , check it .
-        map<string, string> attributeMapTiming = utcTiming->GetRawAttributes();
+		// Some timeline may not have attribute for target latency , check it .
+		map<string, string> attributeMapTiming = utcTiming->GetRawAttributes();
 
-        if(attributeMapTiming.find("schemeIdUri") == attributeMapTiming.end())
-        {
-            AAMPLOG_WARN("UTCTiming@schemeIdUri attribute not available");
-        }
-        else
-        {
-            UtcTiming utcTimingType = eUTC_HTTP_INVALID;
-            AAMPLOG_TRACE("UTCTiming@schemeIdUri: %s", utcTiming->GetSchemeIdUri().c_str());
+		if(attributeMapTiming.find("schemeIdUri") == attributeMapTiming.end())
+		{
+			AAMPLOG_WARN("UTCTiming@schemeIdUri attribute not available");
+		}
+		else
+		{
+			UtcTiming utcTimingType = eUTC_HTTP_INVALID;
+			AAMPLOG_TRACE("UTCTiming@schemeIdUri: %s", utcTiming->GetSchemeIdUri().c_str());
 
-            if(!strcmp(URN_UTC_HTTP_XSDATE , utcTiming->GetSchemeIdUri().c_str()))
-            {
-                utcTimingType = eUTC_HTTP_XSDATE;
-            }
-            else if(!strcmp(URN_UTC_HTTP_ISO , utcTiming->GetSchemeIdUri().c_str()))
-            {
-                utcTimingType = eUTC_HTTP_ISO;
-            }
-            else if(!strcmp(URN_UTC_HTTP_NTP , utcTiming->GetSchemeIdUri().c_str()))
-            {
-                utcTimingType = eUTC_HTTP_NTP;
-            }
-            else
-            {
-                AAMPLOG_WARN("UTCTiming@schemeIdUri Value not proper");
-            }
-            //Check if it matches with MPD provided UTC timing
-            if(utcTimingType == aamp->GetLLDashServiceData()->utcTiming)
-            {
-                bMatch = true;
-            }
+			if(!strcmp(URN_UTC_HTTP_XSDATE , utcTiming->GetSchemeIdUri().c_str()))
+			{
+				utcTimingType = eUTC_HTTP_XSDATE;
+			}
+			else if(!strcmp(URN_UTC_HTTP_ISO , utcTiming->GetSchemeIdUri().c_str()))
+			{
+				utcTimingType = eUTC_HTTP_ISO;
+			}
+			else if(!strcmp(URN_UTC_HTTP_NTP , utcTiming->GetSchemeIdUri().c_str()))
+			{
+				utcTimingType = eUTC_HTTP_NTP;
+			}
+			else
+			{
+				AAMPLOG_WARN("UTCTiming@schemeIdUri Value not proper");
+			}
+			//Check if it matches with MPD provided UTC timing
+			if(utcTimingType == aamp->GetLLDashServiceData()->utcTiming)
+			{
+				bMatch = true;
+			}
 
-            //Adaptation set timing didnt match
-            if(!bMatch)
-            {
-                AAMPLOG_WARN("UTCTiming did not Match. !!");
-            }
-        }
-    }
-    return bMatch;
+			//Adaptation set timing didnt match
+			if(!bMatch)
+			{
+				AAMPLOG_WARN("UTCTiming did not Match. !!");
+			}
+		}
+	}
+	return bMatch;
 }
 
 /**
@@ -13204,11 +13208,11 @@ bool StreamAbstractionAAMP_MPD::CheckProducerReferenceTimeUTCTimeMatch(IProducer
  */
 void StreamAbstractionAAMP_MPD::PrintProducerReferenceTimeAttributes(IProducerReferenceTime *pRT)
 {
-    AAMPLOG_TRACE("Id: %s", pRT->GetId().c_str());
-    AAMPLOG_TRACE("Type: %s", pRT->GetType().c_str());
-    AAMPLOG_TRACE("WallClockTime %s" , pRT->GetWallClockTime().c_str());
-    AAMPLOG_TRACE("PresentationTime : %d" , pRT->GetPresentationTime());
-    AAMPLOG_TRACE("Inband : %s" , pRT->GetInband()?"true":"false");
+	AAMPLOG_TRACE("Id: %s", pRT->GetId().c_str());
+	AAMPLOG_TRACE("Type: %s", pRT->GetType().c_str());
+	AAMPLOG_TRACE("WallClockTime %s" , pRT->GetWallClockTime().c_str());
+	AAMPLOG_TRACE("PresentationTime : %d" , pRT->GetPresentationTime());
+	AAMPLOG_TRACE("Inband : %s" , pRT->GetInband()?"true":"false");
 }
 
 /**
@@ -13217,22 +13221,22 @@ void StreamAbstractionAAMP_MPD::PrintProducerReferenceTimeAttributes(IProducerRe
  */
 IProducerReferenceTime *StreamAbstractionAAMP_MPD::GetProducerReferenceTimeForAdaptationSet(IAdaptationSet *adaptationSet)
 {
-    IProducerReferenceTime *pRT = NULL;
+	IProducerReferenceTime *pRT = NULL;
 
-    if(adaptationSet != NULL)
-    {
-        const std::vector<IProducerReferenceTime *> producerReferenceTime = adaptationSet->GetProducerReferenceTime();
+	if(adaptationSet != NULL)
+	{
+		const std::vector<IProducerReferenceTime *> producerReferenceTime = adaptationSet->GetProducerReferenceTime();
 
-        if(!producerReferenceTime.size())
-            return pRT;
+		if(!producerReferenceTime.size())
+			return pRT;
 
-        pRT = producerReferenceTime.at(0);
-    }
-    else
-    {
-        AAMPLOG_WARN("adaptationSet  is null");  //CID:85233 - Null Returns
-    }
-    return pRT;
+		pRT = producerReferenceTime.at(0);
+	}
+	else
+	{
+		AAMPLOG_WARN("adaptationSet  is null");  //CID:85233 - Null Returns
+	}
+	return pRT;
 }
 
 /**
@@ -13241,7 +13245,7 @@ IProducerReferenceTime *StreamAbstractionAAMP_MPD::GetProducerReferenceTimeForAd
  */
 AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayback(const MPD* mpd)
 {
- 	 AAMPStatusType ret = eAAMPSTATUS_OK;
+	  AAMPStatusType ret = eAAMPSTATUS_OK;
 	 mLowLatencyMode	=	false;
 	/*LL DASH VERIFICATION START*/
 	//Check if LLD requested
@@ -13439,9 +13443,9 @@ bool StreamAbstractionAAMP_MPD::GetLowLatencyParams(const MPD* mpd,AampLLDashSer
 						{
 							map<string, string> attributeMap = pSegmentTemplate->GetRawAttributes();
 							if(attributeMap.find("availabilityTimeOffset") == attributeMap.end())
-    						{
-        						AAMPLOG_WARN("Latency availabilityTimeOffset attribute not available");
-    						}
+							{
+								AAMPLOG_WARN("Latency availabilityTimeOffset attribute not available");
+							}
 							else
 							{
 								LLDashData.availabilityTimeOffset = pSegmentTemplate->GetAvailabilityTimeOffset();
@@ -13508,70 +13512,70 @@ bool StreamAbstractionAAMP_MPD::GetLowLatencyParams(const MPD* mpd,AampLLDashSer
  */
 bool StreamAbstractionAAMP_MPD::ParseMPDLLData(MPD* mpd, AampLLDashServiceData &stAampLLDashServiceData)
 {
-    //check if <ServiceDescription> available->raise error if not
-    if(!mpd->GetServiceDescriptions().size())
-    {
-       AAMPLOG_TRACE("GetServiceDescriptions not available");
-    }
+	//check if <ServiceDescription> available->raise error if not
+	if(!mpd->GetServiceDescriptions().size())
+	{
+	   AAMPLOG_TRACE("GetServiceDescriptions not available");
+	}
 	else
 	{
-    	//check if <scope> _element_ is available in <ServiceDescription> _element_->raise error if not
-    	if(!mpd->GetServiceDescriptions().at(0)->GetScopes().size())
-    	{
-        	AAMPLOG_TRACE("Scope _element_ not available");
-       	}
-    	//check if <Latency> _element_ is available in <ServiceDescription> _element_->raise error if not
-    	if(!mpd->GetServiceDescriptions().at(0)->GetLatencys().size())
-    	{
-        	AAMPLOG_TRACE("Latency _element_ not available");
+		//check if <scope> _element_ is available in <ServiceDescription> _element_->raise error if not
+		if(!mpd->GetServiceDescriptions().at(0)->GetScopes().size())
+		{
+			AAMPLOG_TRACE("Scope _element_ not available");
+		}
+		//check if <Latency> _element_ is available in <ServiceDescription> _element_->raise error if not
+		if(!mpd->GetServiceDescriptions().at(0)->GetLatencys().size())
+		{
+			AAMPLOG_TRACE("Latency _element_ not available");
 		}
 		else
 		{
-    		//check if attribute @target is available in <latency> _element_->raise error if not
-    		ILatency *latency= mpd->GetServiceDescriptions().at(0)->GetLatencys().at(0);
+			//check if attribute @target is available in <latency> _element_->raise error if not
+			ILatency *latency= mpd->GetServiceDescriptions().at(0)->GetLatencys().at(0);
 
-    		// Some timeline may not have attribute for target latency , check it .
-    		map<string, string> attributeMap = latency->GetRawAttributes();
+			// Some timeline may not have attribute for target latency , check it .
+			map<string, string> attributeMap = latency->GetRawAttributes();
 
-    		if(attributeMap.find("target") == attributeMap.end())
-    		{
-        		AAMPLOG_TRACE("target Latency attribute not available");
-    		}
+			if(attributeMap.find("target") == attributeMap.end())
+			{
+				AAMPLOG_TRACE("target Latency attribute not available");
+			}
 			else
 			{
 				stAampLLDashServiceData.targetLatency = latency->GetTarget();
 				AAMPLOG_INFO("targetLatency: %d", stAampLLDashServiceData.targetLatency);
 			}
 
-    		//check if attribute @max or @min is available in <Latency> element->raise info if not
-    		if(attributeMap.find("max") == attributeMap.end())
-    		{
-        		AAMPLOG_TRACE("Latency max attribute not available");
+			//check if attribute @max or @min is available in <Latency> element->raise info if not
+			if(attributeMap.find("max") == attributeMap.end())
+			{
+				AAMPLOG_TRACE("Latency max attribute not available");
 			}
-    		else
-    		{
-        		stAampLLDashServiceData.maxLatency = latency->GetMax();
+			else
+			{
+				stAampLLDashServiceData.maxLatency = latency->GetMax();
 				AAMPLOG_INFO("maxLatency: %d", stAampLLDashServiceData.maxLatency);
-    		}
-    		if(attributeMap.find("min") == attributeMap.end())
-    		{
-        		AAMPLOG_TRACE("Latency min attribute not available");
-    		}
-    		else
-    		{
-        		stAampLLDashServiceData.minLatency = latency->GetMin();
-        		AAMPLOG_INFO("minLatency: %d", stAampLLDashServiceData.minLatency);
-    		}
+			}
+			if(attributeMap.find("min") == attributeMap.end())
+			{
+				AAMPLOG_TRACE("Latency min attribute not available");
+			}
+			else
+			{
+				stAampLLDashServiceData.minLatency = latency->GetMin();
+				AAMPLOG_INFO("minLatency: %d", stAampLLDashServiceData.minLatency);
+			}
 		}
 
-    	if(!mpd->GetServiceDescriptions().at(0)->GetPlaybackRates().size())
-    	{
-        	AAMPLOG_TRACE("Play Rate _element_ not available");
-    	}
-    	else
-    	{
-    		//check if attribute @max or @min is available in <PlaybackRate> element->raise info if not
-        	IPlaybackRate *playbackRate= mpd->GetServiceDescriptions().at(0)->GetPlaybackRates().at(0);
+		if(!mpd->GetServiceDescriptions().at(0)->GetPlaybackRates().size())
+		{
+			AAMPLOG_TRACE("Play Rate _element_ not available");
+		}
+		else
+		{
+			//check if attribute @max or @min is available in <PlaybackRate> element->raise info if not
+			IPlaybackRate *playbackRate= mpd->GetServiceDescriptions().at(0)->GetPlaybackRates().at(0);
 
 			// Some timeline may not have attribute for target latency , check it .
 			map<string, string> attributeMapRate = playbackRate->GetRawAttributes();
@@ -13598,11 +13602,11 @@ bool StreamAbstractionAAMP_MPD::ParseMPDLLData(MPD* mpd, AampLLDashServiceData &
 			}
 		}
 	}
-    //check if UTCTiming _element_ available
-    if(!mpd->GetUTCTimings().size())
-    {
-        AAMPLOG_WARN("UTCTiming _element_ not available");
-    }
+	//check if UTCTiming _element_ available
+	if(!mpd->GetUTCTimings().size())
+	{
+		AAMPLOG_WARN("UTCTiming _element_ not available");
+	}
 	else
 	{
 
@@ -13639,7 +13643,7 @@ bool StreamAbstractionAAMP_MPD::ParseMPDLLData(MPD* mpd, AampLLDashServiceData &
 
 		}
 	}
-    return true;
+	return true;
 }
 
 /***************************************************************************
@@ -13909,7 +13913,7 @@ void StreamAbstractionAAMP_MPD::NotifyFirstVideoPTS(unsigned long long pts, unsi
  */
 double StreamAbstractionAAMP_MPD::GetAvailabilityStartTime()
 {
-        return mMPDParseHelper?mMPDParseHelper->GetAvailabilityStartTime():0;
+		return mMPDParseHelper?mMPDParseHelper->GetAvailabilityStartTime():0;
 }
 
 void StreamAbstractionAAMP_MPD::UpdateMPDPeriodDetails(std::vector<PeriodInfo>& currMPDPeriodDetails,uint64_t &durMs)

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -232,8 +232,8 @@ public:
 	 */
 	double GetFirstPTS() override;
 	/**
-         * @fn GetMidSeekPosOffset
-         */
+	 * @fn GetMidSeekPosOffset
+	 */
 	double GetMidSeekPosOffset() override;
 	/**
 	 * @fn GetStartTimeOfFirstPTS
@@ -277,13 +277,13 @@ public:
 	/**
 	 * @fn GetAvailableAudioTracks
 	 * @param[in] tracks - available audio tracks in period
- 	 * @param[in] trackIndex - index of current audio track
+	 * @param[in] trackIndex - index of current audio track
 	 */
 	virtual std::vector<AudioTrackInfo> & GetAvailableAudioTracks(bool allTrack=false) override;
 	/**
-         * @brief Gets all/current available text tracks
-         * @retval vector of tracks
-         */
+		 * @brief Gets all/current available text tracks
+		 * @retval vector of tracks
+		 */
 	virtual std::vector<TextTrackInfo>& GetAvailableTextTracks(bool allTrack=false) override;
 
 	/**
@@ -295,11 +295,10 @@ public:
 	 */
 	virtual bool Is4KStream(int &height, BitsPerSecond &bandwidth) override;
 
-
 	/**
-         * @fn GetProfileCount
-         *
-         */
+	 * @fn GetProfileCount
+	 *
+	 */
 	int GetProfileCount() override;
 	/**
 	 * @fn GetProfileIndexForBandwidth
@@ -368,7 +367,7 @@ public:
 	 * @param skipTime time to skip in seconds
 	 * @param updateFirstPTS true to update first pts state variable
 	 * @param skipToEnd true to skip to the end of content
- 	 */
+	 */
 	double SkipFragments( class MediaStreamContext *pMediaStreamContext, double skipTime, bool updateFirstPTS = false, bool skipToEnd = false);
 	/**
 	 * @fn GetFirstPeriodStartTime
@@ -388,7 +387,7 @@ public:
 	 * @param[in] adaptationSet Adaptation set object
 	 * @param[out] selectedRepIdx - Selected representation index
 	 * @param[out] selectedRepBandwidth - selected audio track bandwidth
- 	 */
+	  */
 	void GetPreferredTextRepresentation(IAdaptationSet *adaptationSet, int &selectedRepIdx,	uint32_t &selectedRepBandwidth, unsigned long long &score, std::string &name, std::string &codec);
 	static Accessibility getAccessibilityNode(void *adaptationSet);
 	static Accessibility getAccessibilityNode(AampJsonObject &accessNode);
@@ -410,45 +409,45 @@ public:
 	//Apis for sidecar caption support
 
 	/**
-         * @fn InitSubtitleParser
-         * @param[in] data - subtitle data from application
-         * @return void
-         */
+	 * @fn InitSubtitleParser
+	 * @param[in] data - subtitle data from application
+	 * @return void
+	 */
 	void InitSubtitleParser(char *data) override;
 
 	/**
-         * @fn ResetSubtitle
-         * @return void
-         */
+	 * @fn ResetSubtitle
+	 * @return void
+	 */
 	void ResetSubtitle() override;
 
 	/**
-         * @fn MuteSubtitleOnPause
-         * @return void
-         */
+	 * @fn MuteSubtitleOnPause
+	 * @return void
+	 */
 	void MuteSubtitleOnPause() override;
 
 	/**
-         * @fn ResumeSubtitleOnPlay
-         * @param[in] mute - mute status
-         * @param[in] data - subtitle data from application
-         * @return void
-         */
+	 * @fn ResumeSubtitleOnPlay
+	 * @param[in] mute - mute status
+	 * @param[in] data - subtitle data from application
+	 * @return void
+	 */
 	void ResumeSubtitleOnPlay(bool mute, char *data) override;
 
 	/**
-         * @fn MuteSidecarSubtitles
-         * @param[in] mute - mute/unmute
-         * @return void
-         */
+	 * @fn MuteSidecarSubtitles
+	 * @param[in] mute - mute/unmute
+	 * @return void
+	 */
 	void MuteSidecarSubtitles(bool mute) override;
 
 	/**
-         * @fn ResumeSubtitleAfterSeek
-         * @param[in] mute - mute status
-         * @param[in] data - subtitle data from application
-         * @return void
-         */
+	 * @fn ResumeSubtitleAfterSeek
+	 * @param[in] mute - mute status
+	 * @param[in] data - subtitle data from application
+	 * @return void
+	 */
 	void ResumeSubtitleAfterSeek(bool mute, char *data) override;
 
 	/**
@@ -488,10 +487,10 @@ public:
 	 */
 	void NotifyFirstVideoPTS(unsigned long long pts, unsigned long timeScale) override;
 
-	 /**
+	/**
 	 * @fn GetAvailabilityStartTime
- 	 * @brief  Returns AvailabilityStartTime from the manifest
- 	 * @retval double . AvailabilityStartTime
+	 * @brief  Returns AvailabilityStartTime from the manifest
+	 * @retval double . AvailabilityStartTime
 	 */
 	double GetAvailabilityStartTime() override;
 
@@ -676,7 +675,7 @@ protected:
 	 * @fn TsbReader
 	 * @return void
 	 */
-	void TsbReader();
+	virtual void TsbReader();
 
 	/**
 	 * @fn GetStreamInfo
@@ -797,13 +796,13 @@ protected:
 	 * @param isInit true if its the first playlist download
 	 * @param reportBulkMeta true if bulk metadata is enabled
 	 */
-	void ProcessTrickModeRestriction(Node* node, const std::string& AdID, uint64_t startMS, bool isInit, bool reportBulkMeta);
-    	/**
+	void ProcessTrickModeRestriction(Node *node, const std::string &AdID, uint64_t startMS, bool isInit, bool reportBulkMeta);
+	/**
 	 * @fn Fragment downloader thread
 	 * @param trackIdx track index
 	 * @param initialization Initialization string
 	 */
-    	void TrackDownloader(int trackIdx, std::string initialization);
+	void TrackDownloader(int trackIdx, std::string initialization);
 	/**
 	 * @fn FetchAndInjectInitFragments
 	 * @param discontinuity number of tracks and discontinuity true if discontinuous fragment
@@ -869,11 +868,11 @@ protected:
 	/**
 	 * @fn UpdateTrackInfo
 	 */
-	AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex=false);
+	AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex = false);
 	/**
 	 * @fn SkipToEnd
 	 * @param pMediaStreamContext Track object pointer
- 	 */
+	 */
 	void SkipToEnd( class MediaStreamContext *pMediaStreamContext); //Added to support rewind in multiperiod assets
 
 	/**
@@ -884,7 +883,7 @@ protected:
 	/**
 	 * @fn ApplyLiveOffsetWorkaroundForSAP
 	 * @param seekPositionSeconds seek position in seconds.
- 	 */
+	 */
 	void ApplyLiveOffsetWorkaroundForSAP(double seekPositionSeconds);
 	/**
 	 * @fn GetFirstValidCurrMPDPeriod
@@ -984,22 +983,22 @@ protected:
 	 * @param[out] selectedRepBandwidth - selected audio track bandwidth
 	 * @param disableEC3 whether EC3 disabled by config
 	 * @param disableATMOS whether ATMOS audio disabled by config
- 	 */
+	  */
 	bool GetPreferredCodecIndex(IAdaptationSet *adaptationSet, int &selectedRepIdx, AudioType &selectedCodecType,
 	uint32_t &selectedRepBandwidth, long &bestScore, bool disableEC3, bool disableATMOS, bool disableAC4, bool disableAC3, bool &disabled);
 
 	/**
-         * @brief Get the audio track information from all period
-         * updated member variable mAudioTracksAll
-         * @return void
-         */
+		 * @brief Get the audio track information from all period
+		 * updated member variable mAudioTracksAll
+		 * @return void
+		 */
 	void PopulateAudioTracks(void);
 
 	/**
-         * @brief Get the audio track information from all preselection node of the period
-         * @param period Node ans IMPDElement
-         * @return void
-         */
+		 * @brief Get the audio track information from all preselection node of the period
+		 * @param period Node ans IMPDElement
+		 * @return void
+		 */
 	void ParseAvailablePreselections(IMPDElement *period, std::vector<AudioTrackInfo> & audioAC4Tracks);
 
 	/**
@@ -1079,8 +1078,8 @@ protected:
 	 * @param[in] immediate Flag to indicate if event(s) should be sent immediately
 	 */
 	void SendAdPlacementEvent(AAMPEventType type, const std::string& adId,
-                             uint32_t position, AampTime absolutePosition, uint32_t offset,
-                             uint32_t duration, bool immediate);
+							 uint32_t position, AampTime absolutePosition, uint32_t offset,
+							 uint32_t duration, bool immediate);
 
 	/**
 	 * @brief Send ad reservation event to listeners
@@ -1092,11 +1091,9 @@ protected:
 	 * @param[in] immediate Flag to indicate if event(s) should be sent immediately
 	 */
 	void SendAdReservationEvent(AAMPEventType type, const std::string& adBreakId,
-                               uint64_t position, AampTime absolutePosition, bool immediate);
+							   uint64_t position, AampTime absolutePosition, bool immediate);
 
 	std::mutex mStreamLock;
-	bool fragmentCollectorThreadStarted;
-	bool tsbReaderThreadStarted;
 	bool abortTsbReader;
 	std::set<std::string> mLangList;
 	double seekPosition;    // Seek offset from or position at time of tuning, in seconds.
@@ -1186,7 +1183,7 @@ protected:
 	 */
 	bool onAdEvent(AdEvent evt);
 	bool onAdEvent(AdEvent evt, double &adOffset);
- 	/**
+	 /**
 	 * @fn SetAudioTrackInfo
 	 * @param[in] tracks - available audio tracks in period
 	 * @param[in] trackIndex - index of current audio track

--- a/fragmentcollector_progressive.cpp
+++ b/fragmentcollector_progressive.cpp
@@ -37,11 +37,11 @@
 
 struct StreamWriteCallbackContext
 {
-    bool sentTunedEvent;
-    PrivateInstanceAAMP *aamp;
-    StreamWriteCallbackContext() : aamp(NULL), sentTunedEvent(false)
-    {
-    }
+	bool sentTunedEvent;
+	PrivateInstanceAAMP *aamp;
+	StreamWriteCallbackContext() : aamp(NULL), sentTunedEvent(false)
+	{
+	}
 };
 
 /**
@@ -76,31 +76,31 @@ struct StreamWriteCallbackContext
  */
 static size_t StreamWriteCallback( void *ptr, size_t size, size_t nmemb, void *userdata )
 {
-    StreamWriteCallbackContext *context = (StreamWriteCallbackContext *)userdata;
-    struct PrivateInstanceAAMP *aamp = context->aamp;
-    if( context->aamp->mDownloadsEnabled)
-    {
-       // TODO: info logging is normally only done up until first frame rendered, but even so is too noisy for below, since CURL write callback yields many small chunks
+	StreamWriteCallbackContext *context = (StreamWriteCallbackContext *)userdata;
+	struct PrivateInstanceAAMP *aamp = context->aamp;
+	if( context->aamp->mDownloadsEnabled)
+	{
+	   // TODO: info logging is normally only done up until first frame rendered, but even so is too noisy for below, since CURL write callback yields many small chunks
 		AAMPLOG_INFO("StreamWriteCallback(%zu bytes)", nmemb);
-        // throttle download speed if gstreamer isn't hungry
-        aamp->BlockUntilGstreamerWantsData( NULL/*CB*/, 0.0/*periodMs*/, eMEDIATYPE_VIDEO );
-        double fpts = 0.0;
-        double fdts = 0.0;
-        double fDuration = 2.0; // HACK!  //CID:113073 - Position variable initialized but not used
-        if( nmemb>0 )
-        {
-           aamp->SendStreamCopy( eMEDIATYPE_VIDEO, ptr, nmemb, fpts, fdts, fDuration);
-           if( !context->sentTunedEvent )
-           { // send TunedEvent after first chunk injected - this is hint for XRE to hide the "tuning overcard"
-               aamp->SendTunedEvent(false);
-               context->sentTunedEvent = true;
-           }
-       }
+		// throttle download speed if gstreamer isn't hungry
+		aamp->BlockUntilGstreamerWantsData( NULL/*CB*/, 0.0/*periodMs*/, eMEDIATYPE_VIDEO );
+		double fpts = 0.0;
+		double fdts = 0.0;
+		double fDuration = 2.0; // HACK!  //CID:113073 - Position variable initialized but not used
+		if( nmemb>0 )
+		{
+		   aamp->SendStreamCopy( eMEDIATYPE_VIDEO, ptr, nmemb, fpts, fdts, fDuration);
+		   if( !context->sentTunedEvent )
+		   { // send TunedEvent after first chunk injected - this is hint for XRE to hide the "tuning overcard"
+			   aamp->SendTunedEvent(false);
+			   context->sentTunedEvent = true;
+		   }
+	   }
    }
    else
    {
-       AAMPLOG_WARN("write_callback - interrupted");
-       nmemb = 0;
+	   AAMPLOG_WARN("write_callback - interrupted");
+	   nmemb = 0;
    }
    return nmemb;
 }
@@ -138,24 +138,24 @@ void StreamAbstractionAAMP_PROGRESSIVE::StreamFile( const char *uri, int *http_e
  */
 void StreamAbstractionAAMP_PROGRESSIVE::FetcherLoop()
 {
-    std::string contentUrl = aamp->GetManifestUrl();
-    std::string effectiveUrl;
-    int http_error;
-    
-    if(ISCONFIGSET(eAAMPConfig_UseAppSrcForProgressivePlayback))
-    {
-	    StreamFile( contentUrl.c_str(), &http_error );
-    }
-    else
-    {
-	    // send TunedEvent after first chunk injected - this is hint for XRE to hide the "tuning overcard"
-	    aamp->SendTunedEvent(false);
-    }
+	std::string contentUrl = aamp->GetManifestUrl();
+	std::string effectiveUrl;
+	int http_error;
+	
+	if(ISCONFIGSET(eAAMPConfig_UseAppSrcForProgressivePlayback))
+	{
+		StreamFile( contentUrl.c_str(), &http_error );
+	}
+	else
+	{
+		// send TunedEvent after first chunk injected - this is hint for XRE to hide the "tuning overcard"
+		aamp->SendTunedEvent(false);
+	}
 
-    while( aamp->DownloadsAreEnabled() )
-    {
-        aamp->interruptibleMsSleep( 1000 );
-    }
+	while( aamp->DownloadsAreEnabled() )
+	{
+		aamp->interruptibleMsSleep( 1000 );
+	}
 }
 
 /**
@@ -165,9 +165,9 @@ void StreamAbstractionAAMP_PROGRESSIVE::FetcherLoop()
  */
 void StreamAbstractionAAMP_PROGRESSIVE::FragmentCollector(void)
 {
-    aamp_setThreadName("aampPSFetcher");
-    FetcherLoop();
-    return;
+	aamp_setThreadName("aampPSFetcher");
+	FetcherLoop();
+	return;
 }
 
 
@@ -176,27 +176,27 @@ void StreamAbstractionAAMP_PROGRESSIVE::FragmentCollector(void)
  */
 AAMPStatusType StreamAbstractionAAMP_PROGRESSIVE::Init(TuneType tuneType)
 {
-    AAMPStatusType retval = eAAMPSTATUS_OK;
-    aamp->CurlInit(eCURLINSTANCE_VIDEO, AAMP_TRACK_COUNT,aamp->GetNetworkProxy());  //CID:110904 - newTune bool variable  initialized not used
-    aamp->IsTuneTypeNew = false;
-    std::set<std::string> mLangList; /**< empty language list */
-    std::vector<BitsPerSecond> bitrates; /**< empty bitrates */
-    for (int i = 0; i < AAMP_TRACK_COUNT; i++)
-    {
-        aamp->SetCurlTimeout(aamp->mNetworkTimeoutMs, (AampCurlInstance) i);
-    }
-    aamp->SendMediaMetadataEvent();
-    return retval;
+	AAMPStatusType retval = eAAMPSTATUS_OK;
+	aamp->CurlInit(eCURLINSTANCE_VIDEO, AAMP_TRACK_COUNT,aamp->GetNetworkProxy());  //CID:110904 - newTune bool variable  initialized not used
+	aamp->IsTuneTypeNew = false;
+	std::set<std::string> mLangList; /**< empty language list */
+	std::vector<BitsPerSecond> bitrates; /**< empty bitrates */
+	for (int i = 0; i < AAMP_TRACK_COUNT; i++)
+	{
+		aamp->SetCurlTimeout(aamp->mNetworkTimeoutMs, (AampCurlInstance) i);
+	}
+	aamp->SendMediaMetadataEvent();
+	return retval;
 }
 
 
 /*
 AAMPStatusType StreamAbstractionAAMP_PROGRESSIVE::Init(TuneType tuneType)
 {
-    AAMPStatusType retval = eAAMPSTATUS_OK;
-    bool newTune = aamp->IsNewTune();
-    aamp->IsTuneTypeNew = false;
-    return retval;
+	AAMPStatusType retval = eAAMPSTATUS_OK;
+	bool newTune = aamp->IsNewTune();
+	aamp->IsTuneTypeNew = false;
+	return retval;
 }
  */
 
@@ -204,9 +204,9 @@ AAMPStatusType StreamAbstractionAAMP_PROGRESSIVE::Init(TuneType tuneType)
  * @brief StreamAbstractionAAMP_PROGRESSIVE Constructor
  */
 StreamAbstractionAAMP_PROGRESSIVE::StreamAbstractionAAMP_PROGRESSIVE(class PrivateInstanceAAMP *aamp,double seek_pos, float rate): StreamAbstractionAAMP(aamp),
-fragmentCollectorThreadStarted(false), fragmentCollectorThreadID(), seekPosition(seek_pos)
+fragmentCollectorThreadID(), seekPosition(seek_pos)
 {
-    trickplayMode = (rate != AAMP_NORMAL_PLAY_RATE);
+	trickplayMode = (rate != AAMP_NORMAL_PLAY_RATE);
 }
 
 /**
@@ -223,15 +223,21 @@ void StreamAbstractionAAMP_PROGRESSIVE::Start(void)
 {
     try
     {
-        fragmentCollectorThreadID = std::thread(&StreamAbstractionAAMP_PROGRESSIVE::FragmentCollector, this);
-        fragmentCollectorThreadStarted = true;
-        AAMPLOG_INFO("Thread created for FragmentCollector [%zx]", GetPrintableThreadID(fragmentCollectorThreadID));
+		// Attempting to assign to a running thread will cause std::terminate(), not an exception
+		if(!fragmentCollectorThreadID.joinable())
+		{
+			fragmentCollectorThreadID = std::thread(&StreamAbstractionAAMP_PROGRESSIVE::FetcherLoop, this);
+			AAMPLOG_INFO("Thread created for FragmentCollector [%zx]", GetPrintableThreadID(fragmentCollectorThreadID));
+		}
+		else
+		{
+			AAMPLOG_WARN("FragmentCollector thread already running, not creating a new one");
+		}
     }
     catch(const std::exception& e)
     {
         AAMPLOG_ERR("Failed to create FragmentCollector thread : %s", e.what());
     }
-    
 }
 
 /**
@@ -239,11 +245,10 @@ void StreamAbstractionAAMP_PROGRESSIVE::Start(void)
  */
 void StreamAbstractionAAMP_PROGRESSIVE::Stop(bool clearChannelData)
 {
-    if(fragmentCollectorThreadStarted)
+	if(fragmentCollectorThreadID.joinable())
     {
         aamp->DisableDownloads();
         fragmentCollectorThreadID.join();
-        fragmentCollectorThreadStarted = false;
         aamp->EnableDownloads();
     }
  }
@@ -253,10 +258,10 @@ void StreamAbstractionAAMP_PROGRESSIVE::Stop(bool clearChannelData)
  */
 void StreamAbstractionAAMP_PROGRESSIVE::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &auxAudioOutputFormat, StreamOutputFormat &subtitleOutputFormat)
 {
-    primaryOutputFormat = FORMAT_ISO_BMFF;
-    audioOutputFormat = FORMAT_INVALID;
-    auxAudioOutputFormat = FORMAT_INVALID;
-    subtitleOutputFormat = FORMAT_INVALID;
+	primaryOutputFormat = FORMAT_ISO_BMFF;
+	audioOutputFormat = FORMAT_INVALID;
+	auxAudioOutputFormat = FORMAT_INVALID;
+	subtitleOutputFormat = FORMAT_INVALID;
 }
 
 /**
@@ -264,7 +269,7 @@ void StreamAbstractionAAMP_PROGRESSIVE::GetStreamFormat(StreamOutputFormat &prim
  */
 double StreamAbstractionAAMP_PROGRESSIVE::GetStreamPosition()
 {
-    return seekPosition;
+	return seekPosition;
 }
 
 /**
@@ -272,7 +277,7 @@ double StreamAbstractionAAMP_PROGRESSIVE::GetStreamPosition()
  */
 double StreamAbstractionAAMP_PROGRESSIVE::GetFirstPTS()
 {
-    return 0.0;
+	return 0.0;
 }
 
 /**
@@ -289,6 +294,6 @@ bool StreamAbstractionAAMP_PROGRESSIVE::IsInitialCachingSupported()
  */
 BitsPerSecond StreamAbstractionAAMP_PROGRESSIVE::GetMaxBitrate()
 { // STUB
-    return 0;
+	return 0;
 }
 

--- a/fragmentcollector_progressive.h
+++ b/fragmentcollector_progressive.h
@@ -37,46 +37,46 @@ using namespace std;
 class StreamAbstractionAAMP_PROGRESSIVE : public StreamAbstractionAAMP
 {
 public:
-    /**
-     * @fn StreamAbstractionAAMP_PROGRESSIVE
-     * @param aamp pointer to PrivateInstanceAAMP object associated with player
-     * @param seekpos Seek position
-     * @param rate playback rate
-     */
-    StreamAbstractionAAMP_PROGRESSIVE(class PrivateInstanceAAMP *aamp,double seekpos, float rate);
-    /**
-     * @fn ~StreamAbstractionAAMP_PROGRESSIVE
-     */
-    ~StreamAbstractionAAMP_PROGRESSIVE();
-    /**
-     * @brief Copy constructor disabled
-     *
-     */
-    StreamAbstractionAAMP_PROGRESSIVE(const StreamAbstractionAAMP_PROGRESSIVE&) = delete;
-    /**
-     * @brief assignment operator disabled
-     *
-     */
-    StreamAbstractionAAMP_PROGRESSIVE& operator=(const StreamAbstractionAAMP_PROGRESSIVE&) = delete;
-    double seekPosition;
+	/**
+	 * @fn StreamAbstractionAAMP_PROGRESSIVE
+	 * @param aamp pointer to PrivateInstanceAAMP object associated with player
+	 * @param seekpos Seek position
+	 * @param rate playback rate
+	 */
+	StreamAbstractionAAMP_PROGRESSIVE(class PrivateInstanceAAMP *aamp,double seekpos, float rate);
+	/**
+	 * @fn ~StreamAbstractionAAMP_PROGRESSIVE
+	 */
+	~StreamAbstractionAAMP_PROGRESSIVE();
+	/**
+	 * @brief Copy constructor disabled
+	 *
+	 */
+	StreamAbstractionAAMP_PROGRESSIVE(const StreamAbstractionAAMP_PROGRESSIVE&) = delete;
+	/**
+	 * @brief assignment operator disabled
+	 *
+	 */
+	StreamAbstractionAAMP_PROGRESSIVE& operator=(const StreamAbstractionAAMP_PROGRESSIVE&) = delete;
+	double seekPosition;
 	/**
 	 *   @fn Start
 	 *   @return void
 	 */
-    void Start() override;
-    /**
-     *   @fn Stop
-     *   @return void
-     */
-    void Stop(bool clearChannelData) override;
-    /**
-     *   @fn Init
-     *   @note   To be implemented by sub classes
-     *   @param  tuneType to set type of object.
-     *   @retval true on success
-     *   @retval false on failure
-     */
-    AAMPStatusType Init(TuneType tuneType) override;
+	void Start() override;
+	/**
+	 *   @fn Stop
+	 *   @return void
+	 */
+	void Stop(bool clearChannelData) override;
+	/**
+	 *   @fn Init
+	 *   @note   To be implemented by sub classes
+	 *   @param  tuneType to set type of object.
+	 *   @retval true on success
+	 *   @retval false on failure
+	 */
+	AAMPStatusType Init(TuneType tuneType) override;
 	/**
 	 * @fn GetStreamFormat
 	 * @param[out]  primaryOutputFormat - format of primary track
@@ -112,16 +112,14 @@ public:
      * @fn FetcherLoop
      * @return void
      */
-    void FetcherLoop();
+    virtual void FetcherLoop();
     /**
      * @fn FragmentCollector
-     * @retval void
      */
     void FragmentCollector();
 
 private:
     void StreamFile( const char *uri, int *http_error );
-    bool fragmentCollectorThreadStarted;
     std::thread fragmentCollectorThreadID;
 };
 
@@ -129,6 +127,4 @@ private:
 /**
  * @}
  */
- 
-
 

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -275,3 +275,11 @@ bool StreamAbstractionAAMP_MPD::UseIframeTrack(void)
 {
 	return true;
 }
+
+void StreamAbstractionAAMP_MPD::TsbReader()
+{
+    
+}
+
+bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate) { return false; }
+bool StreamAbstractionAAMP_MPD::DoStreamSinkFlushOnDiscontinuity() { return false; }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -316,6 +316,8 @@ void PrivateInstanceAAMP::ResumeDownloads()
 
 void PrivateInstanceAAMP::EnableDownloads()
 {
+	mDownloadsEnabled = true;
+	mDownloadsDisabled.notify_all(); // Signal the condition variable
 }
 
 void PrivateInstanceAAMP::AcquireStreamLock()
@@ -622,7 +624,7 @@ void PrivateInstanceAAMP::StoreLanguageList(const std::set<std::string> &langlis
 
 bool PrivateInstanceAAMP::DownloadsAreEnabled(void)
 {
-	bool retVal = false;//mDownloadsEnabled;
+	bool retVal = mDownloadsEnabled;
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
 		retVal = g_mockPrivateInstanceAAMP->DownloadsAreEnabled();
@@ -772,6 +774,13 @@ void PrivateInstanceAAMP::CurlTerm(AampCurlInstance startIdx, unsigned int insta
 
 void PrivateInstanceAAMP::DisableDownloads(void)
 {
+	std::lock_guard<std::recursive_mutex> guard(mLock);
+	mDownloadsEnabled = true;
+	if (g_mockPrivateInstanceAAMP != nullptr)
+	{
+		g_mockPrivateInstanceAAMP->DisableDownloads();
+	}
+	mDownloadsDisabled.notify_all(); // Signal the condition variable
 }
 
 int PrivateInstanceAAMP::GetInitialBufferDuration()

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -73,6 +73,7 @@ public:
 	MOCK_METHOD(double, GetLLDashCurrentPlayBackRate, ());
 	MOCK_METHOD(void, StopDownloads, ());
 	MOCK_METHOD(void, ResumeDownloads, ());
+	MOCK_METHOD(void, DisableDownloads, ());
 	MOCK_METHOD(void, TuneHelper, (TuneType tuneType, bool seekWhilePaused));
 	MOCK_METHOD(AampTSBSessionManager*, GetTSBSessionManager, ());
 	MOCK_METHOD(void, NotifyOnEnteringLive, ());

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -1027,6 +1027,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 	mStreamAbstractionAAMP_MPD->ReassessAndResumeAudioTrack(true);
 	mStreamAbstractionAAMP_MPD->AbortWaitForAudioTrackCatchup(false);
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DisableDownloads());
 	mStreamAbstractionAAMP_MPD->Stop(false);
 	/**
 	* PTS of first sample


### PR DESCRIPTION
* VPLAY-9677 Guard against fragmentCollectorThread being overwritten

Attempting to assign a thread to an existing running thread calls std::terminate() Check joinable status and only create if the thread is not already running.

Remove boolean fragmentCollectorThreadStarted from FragmentCollector classes, as it is not needed anymore; this is an intrinsic property of std::thread.

Testing:  L1 tests run (but investigating extending)

* VPLAY-9677 Guard against fragmentCollectorThread being overwritten Attempting to assign a thread to an existing running thread calls std::terminate() Check joinable status and only create if the thread is not already running.

Remove boolean fragmentCollectorThreadStarted from FragmentCollector classes, as it is not needed anymore; this is an intrinsic property of std::thread.

Testing:  L1 tests run (but investigating extending)

* VPLAY-9677 Guard against fragmentCollectorThread being overwritten Attempting to assign a thread to an existing running thread calls std::terminate() Check joinable status and only create if the thread is not already running.

Remove boolean fragmentCollectorThreadStarted from FragmentCollector classes, as it is not needed anymore; this is an intrinsic property of std::thread.

Testing:  L1 tests run (but investigating extending)

* VPLAY-9677 Guard against fragmentCollectorThread being overwritten Attempting to assign a thread to an existing running thread calls std::terminate() Check joinable status and only create if the thread is not already running.

Remove boolean fragmentCollectorThreadStarted from FragmentCollector classes, as it is not needed anymore; this is an intrinsic property of std::thread.

Testing:  L1 tests run (but investigating extending)

* VPLAY-9677 Guard against fragmentCollectorThread  & TSBreaderThread being overwritten Attempting to assign a thread to an existing running thread calls std::terminate() Check joinable status and only create if the thread is not already running.

Remove boolean fragmentCollectorThreadStarted from FragmentCollector classes, as it is not needed anymore; this is an intrinsic property of std::thread.

Testing:  L1 tests run (but investigating extending)

* VPLAY-9677 Guard against fragmentCollectorThread  & TSBreaderThread being overwritten Attempting to assign a thread to an existing running thread calls std::terminate() Check joinable status and only create if the thread is not already running.

Remove boolean fragmentCollectorThreadStarted from FragmentCollector classes, as it is not needed anymore; this is an intrinsic property of std::thread.

Testing:  L1 tests run (but investigating extending)

* Dependency injection added for testing of thread starting Fakes & mocks extended to cope with this
Incidental change to related tests using strict mocks

* Tidy formatting

* Formatting

* Fix l1 test

* Fix L1 test

* Review comments.

* WS

---------