### PR TITLE
Revert "VPLAY-11125 [AAMP-TSB] Fragments not skipped when ff to live at high rate"

### DIFF
--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -778,125 +778,64 @@ AAMPStatusType AampTSBSessionManager::InvokeTsbReaders(double &startPosSec, floa
 }
 
 /**
- * @brief Calculate delta value for fragment skipping based on rate and FPS
- */
-AampTime AampTSBSessionManager::CalculateSkipDelta(float rate, int vodTrickplayFPS)
-{
-	AampTime delta = 0.0;
-
-	if (mAamp->playerStartedWithTrickPlay)
-	{
-		AAMPLOG_WARN("Played switched in trickplay, delta set to zero");
-		mAamp->playerStartedWithTrickPlay = false;
-	}
-	else if (vodTrickplayFPS == 0)
-	{
-		AAMPLOG_WARN("vodTrickplayFPS is zero, delta set to zero");
-	}
-	else
-	{
-		delta = static_cast<AampTime>(std::abs(static_cast<double>(rate))) / static_cast<double>(vodTrickplayFPS);
-	}
-
-	return delta;
-}
-
-/**
- * @brief Navigate to next fragment based on playback rate
- */
-bool AampTSBSessionManager::NavigateToNextFragment(TsbFragmentDataPtr& fragment, float rate)
-{
-	bool success = false;
-
-	if (rate > AAMP_RATE_PAUSE)		// Fast forward
-	{
-		if (fragment->GetAbsolutePosition().inSeconds() >= mAamp->mTrickModePositionEOS)
-		{
-			// It is not guaranteed that this INFO will be printed when the live play position is reached,
-			// as the reader may reach EOS before this function is called.
-			// But if this INFO is printed, it confirms that the live play position was reached.
-			AAMPLOG_INFO("Reached live play position during fast forward");
-			success = false;
-		}
-		else
-		{
-			fragment = fragment->next;
-			success = true;
-		}
-	}
-	else							// Rewind
-	{
-		if (fragment->prev)
-		{
-			fragment = fragment->prev;
-			success = true;
-		}
-		if (!(fragment->prev))
-		{
-			// Don't skip the first fragment in the TSB so BoS is detected correctly
-			AAMPLOG_INFO("Reached beginning of TSB during rewind");
-			success = false;
-		}
-	}
-
-	return success;
-}
-
-/**
- * @brief Check if fragment skipping should be performed
- */
-bool AampTSBSessionManager::ShouldSkipFragments(std::shared_ptr<AampTsbReader>& reader, float rate)
-{
-	return (eMEDIATYPE_VIDEO == reader->GetMediaType() &&
-			((AAMP_NORMAL_PLAY_RATE < rate) || (AAMP_RATE_PAUSE > rate)));
-}
-
-/**
  * @brief Skip the frames based on playback rate on trickplay
  */
 void AampTSBSessionManager::SkipFragment(std::shared_ptr<AampTsbReader>& reader, TsbFragmentDataPtr& nextFragmentData)
 {
-	// Early validation check
 	if (nextFragmentData && reader && !reader->IsEos())
 	{
-		float rate = reader->GetPlaybackRate();
-
-		if (ShouldSkipFragments(reader, rate))
+		AampTime skippedDuration{};
+		if(eMEDIATYPE_VIDEO == reader->GetMediaType())
 		{
 			AampTime startPos = nextFragmentData->GetAbsolutePosition();
 			const int vodTrickplayFPS = mAamp->mConfig->GetConfigValue(eAAMPConfig_VODTrickPlayFPS);
-			AampTime skippedDuration{};
-			AampTime delta = CalculateSkipDelta(rate, vodTrickplayFPS);
-
+			float rate = reader->GetPlaybackRate();
+			AampTime delta = 0.0;
+			if(mAamp->playerStartedWithTrickPlay)
+			{
+				AAMPLOG_WARN("Played switched in trickplay, delta set to zero");
+				delta = 0.0;
+				mAamp->playerStartedWithTrickPlay = false;
+			}
+			else if (vodTrickplayFPS == 0)
+			{
+				AAMPLOG_WARN("vodTrickplayFPS is zero, delta set to zero");
+			}
+			else
+			{
+				delta = static_cast<AampTime>(std::abs(static_cast<double>(rate))) / static_cast<double>(vodTrickplayFPS);
+			}
+			
 			// Only skip fragments when delta is larger than fragment duration
-			while (nextFragmentData && (delta > 0.0))
+			while (delta > 0.0)
 			{
 				AampTime fragDuration = nextFragmentData->GetDuration();
 				if (delta <= fragDuration)
-				{
 					break;
-				}
 
 				delta -= fragDuration;
 				skippedDuration += fragDuration;
-
-				if (!NavigateToNextFragment(nextFragmentData, rate))
+				TsbFragmentDataPtr tmp{};
+				if (rate > 0.0)
+				{
+					tmp = nextFragmentData->next;
+				}
+				else if (rate < 0.0)
+				{
+					tmp = nextFragmentData->prev;
+				}
+				if (!tmp)
 				{
 					break;
 				}
+				nextFragmentData = std::move(tmp);
 			}
-
-			// Only print this INFO if the next fragment to inject is available.
-			// This function is always called with the next fragment to the last one read, so the skipped duration includes all fragments skipped
-			if (nextFragmentData)
-			{
-				AAMPLOG_INFO("Skipped frames [rate=%.02f] from %.02lf to %.02lf delta = %.02lf, total duration = %.02lf",
-						rate, startPos.inSeconds(), nextFragmentData->GetAbsolutePosition().inSeconds(), delta.inSeconds(), skippedDuration.inSeconds());
-			}
+			AAMPLOG_INFO("Skipped frames [rate=%.02f] from %.02lf to %.02lf total duration = %.02lf",
+					rate, startPos.inSeconds(), nextFragmentData->GetAbsolutePosition().inSeconds(), skippedDuration.inSeconds());
 		}
 	}
+	return;
 }
-
 /**
  * @brief Read next fragment from the TSB and push it to the injector loop via the fragment cache
  *
@@ -920,7 +859,11 @@ bool AampTSBSessionManager::PushNextTsbFragment(MediaStreamContext *pMediaStream
 	{
 		TsbFragmentDataPtr nextFragmentData = reader->FindNext();
 		AampTime rate = reader->GetPlaybackRate();
-		SkipFragment(reader, nextFragmentData);
+		// Slow motion is handled in GST layer with SetPlaybackRate
+		if(AAMP_NORMAL_PLAY_RATE !=  rate && AAMP_RATE_PAUSE != rate && AAMP_SLOWMOTION_RATE != rate && eMEDIATYPE_VIDEO == mediaType)
+		{
+			SkipFragment(reader, nextFragmentData);
+		}
 
 		if (nextFragmentData)
 		{

--- a/AampTSBSessionManager.h
+++ b/AampTSBSessionManager.h
@@ -296,34 +296,10 @@ protected:
 	std::shared_ptr<CachedFragment> Read(TsbFragmentDataPtr fragmentdata, double &pts);
 	/**
 	 * @brief Skip Fragment based on rate
-	 * @param[in] reader - Reader object
-	 * @param[in,out] nextFragmentData - Fragment Data to be potentially skipped
+	 * @param reader Reader object
+	 * @param nextFragmentData Fragment Data
 	 */
 	void SkipFragment(std::shared_ptr<AampTsbReader> &reader, TsbFragmentDataPtr& nextFragmentData);
-
-	/**
-	 * @brief Calculate delta value for fragment skipping based on rate and FPS
-	 * @param[in] rate - Playback rate
-	 * @param[in] vodTrickplayFPS - Trickplay frames per second
-	 * @return Calculated delta value
-	 */
-	AampTime CalculateSkipDelta(float rate, int vodTrickplayFPS);
-
-	/**
-	 * @brief Navigate to next fragment based on playback rate
-	 * @param[in,out] fragment - Fragment data to navigate from; updated to next fragment if successful
-	 * @param[in] rate - Playback rate
-	 * @return true if navigation was successful, false if reached boundary
-	 */
-	bool NavigateToNextFragment(TsbFragmentDataPtr& fragment, float rate);
-
-	/**
-	 * @brief Check if fragment skipping should be performed
-	 * @param[in] reader - Reader object
-	 * @param[in] rate - Playback rate
-	 * @return true if fragments should be skipped
-	 */
-	bool ShouldSkipFragments(std::shared_ptr<AampTsbReader>& reader, float rate);
 
 	/**
 	 * @brief Process ad metadata events for the current fragment

--- a/test/utests/tests/AampTsbSessionManagerTests_Mocked/FunctionalTests.cpp
+++ b/test/utests/tests/AampTsbSessionManagerTests_Mocked/FunctionalTests.cpp
@@ -30,6 +30,7 @@
 #include "MockTSBStore.h"
 #include "MockTSBDataManager.h"
 #include "MockMediaStreamContext.h"
+#include "MockAampUtils.h"
 #include <memory>
 
 using ::testing::_;
@@ -40,8 +41,7 @@ using ::testing::StrictMock;
 AampConfig *gpGlobalConfig{nullptr};
 
 // Test fixture.  Set up mocks here.
-class AampTsbSessionManagerTests : public ::testing::Test
-{
+class AampTsbSessionManagerTests : public ::testing::Test {
 protected:
 	static constexpr const char *TEST_BASE_URL = "http://server/";
 	static constexpr const char *TEST_DATA = "This is a dummy data";
@@ -58,10 +58,12 @@ protected:
 
 		// Create mocks for the AAMP objects
 		g_mockPrivateInstanceAAMP = new NiceMock<MockPrivateInstanceAAMP>();
-		g_mockTSBReader = std::make_shared<StrictMock<MockTSBReader>>();
+		// Note: g_mockTSBReader is not used in these tests due to architecture limitations
+		// g_mockTSBReader = std::make_shared<StrictMock<MockTSBReader>>();
 		g_mockTSBDataManager = new NiceMock<MockTSBDataManager>();
 		g_mockTSBStore = new NiceMock<MockTSBStore>();
 		g_mockMediaStreamContext = new NiceMock<MockMediaStreamContext>();
+		g_mockAampUtils = new NiceMock<MockAampUtils>();
 
 		// Create a TSBDataManager object with the mock data
 		mTsbDataManager = std::make_shared<AampTsbDataManager>();
@@ -84,14 +86,18 @@ protected:
 	void TearDown() override
 	{
 		// reset all the shared pointers in Setup() in the reverse order they were created
-		g_mockTSBReader.reset();
+		delete g_mockAampUtils;
+		g_mockAampUtils = nullptr;
+		// g_mockTSBReader.reset(); // Not used anymore
 		delete (g_mockTSBDataManager);
 		g_mockTSBDataManager = nullptr;
 		mMediaStreamContext.reset();
 		mAampTSBSessionManager.reset();
+		//g_mockTsbFragmentData.reset();
 		mAamp.reset();
 		delete (g_mockTSBStore);
 		g_mockTSBStore = nullptr;
+		//g_mockTsbInitData.reset();
 		delete (g_mockMediaStreamContext);
 		g_mockMediaStreamContext = nullptr;
 		mTsbDataManager.reset();
@@ -113,16 +119,29 @@ protected:
 	constexpr static double kDefaultBandwidth{1000000}; // 1Mbps
 };
 
+// Test calling PushNextTsbFragment() for a track that is disabled
+TEST_F(AampTsbSessionManagerTests, TrackDisabled)
+{
+	const uint32_t numFreeFragments = 2;
+
+	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = false;
+
+	EXPECT_FALSE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
+}
+
 // Test the behaviour when reading the next fragment returns nullptr
 TEST_F(AampTsbSessionManagerTests, FindNextNull)
 {
 	const uint32_t numFreeFragments = 2;
 
 	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(nullptr));
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillOnce(Return(AAMP_NORMAL_PLAY_RATE));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(0);
 
+	// Since we can't easily mock the TSB reader (methods aren't virtual and mTsbReaders is private),
+	// this test verifies the behavior when a real reader doesn't find fragments.
+	// In a real scenario with empty TSB, FindNext() would return nullptr and PushNextTsbFragment should return false.
+	// The real implementation will try to find fragments from TSB data manager.
+	// Since no fragments are set up in the test data manager, it should return false.
+	
 	EXPECT_FALSE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
 }
 
@@ -136,448 +155,146 @@ TEST_F(AampTsbSessionManagerTests, NoFreeFragments)
 	// When numFreeFragments is 0, PushNextTsbFragment should return false immediately
 	// without calling FindNext or ReadNext on the TSB reader
 	// The real implementation checks: if (numFreeFragments) before proceeding
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).Times(0);
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(0);
-
+	
 	EXPECT_FALSE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
 }
+
+/**
+ * NOTE: Many of the following tests were originally designed to use mocks,
+ * but the current AampTSBSessionManager architecture doesn't support easy mocking because:
+ * 1. mTsbReaders is private and can't be easily injected
+ * 2. AampTsbReader methods aren't virtual, so inheritance-based mocking doesn't work
+ * 3. The session manager creates real AampTsbReader objects in InitializeTsbReaders()
+ * 
+ * These tests have been converted to integration-style tests that verify behavior
+ * with real objects rather than mocked expectations.
+ */
 
 // Test the behaviour when reading the init fragment fails
 TEST_F(AampTsbSessionManagerTests, ReadInitFragmentFailure)
 {
 	const uint32_t numFreeFragments = 2;
 
-	// Create a dummy TsbInitData object (needed for the constructor)
-	std::shared_ptr<TsbInitData> mockInitData = std::make_shared<TsbInitData>(
-		"dummyInitUrl", eMEDIATYPE_VIDEO, 0.0, StreamInfo{}, "dummyPeriodId", 0
-	);
-
-	// Create dummy parameters
-	std::string dummyUrl = "dummyUrl";
-	AampMediaType dummyMediaType = eMEDIATYPE_VIDEO;
-	double dummyPosition = 0.0;
-	double dummyDuration = 1.0;
-	double dummyPts = 0.0;
-	bool dummyDisc = false;
-	std::string dummyPrId = "dummyPeriodId";
-	uint32_t dummyTimeScale = 1000;
-	double dummyPTSOffsetSec = 0.0;
-
-
-	// Create a TsbFragmentData object with the dummy parameters
-	auto mockFragmentData{std::make_shared<TsbFragmentData>(
-		dummyUrl, dummyMediaType, dummyPosition, dummyDuration, dummyPts, dummyDisc,
-		dummyPrId, mockInitData, dummyTimeScale, dummyPTSOffsetSec)};
-
 	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
 
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(AAMP_NORMAL_PLAY_RATE));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(mockFragmentData));
-
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(1);
-
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).WillRepeatedly(Return(10));
-	// Simulate Read failure for init fragment
-	EXPECT_CALL(*g_mockTSBStore, Read(_, _, _)).WillOnce(Return(TSB::Status::FAILED));
-
+	// Without setting up actual TSB data, the reader won't find any fragments
+	// and PushNextTsbFragment should return false
 	EXPECT_FALSE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
 }
 
 // Test that the init fragment is not injected if it has not changed
-TEST_F(AampTsbSessionManagerTests, SameInitFragment)
+// DISABLED: This test requires complex mock setup that doesn't work with current architecture
+TEST_F(AampTsbSessionManagerTests, DISABLED_SameInitFragment)
 {
-	const uint32_t numFreeFragments = 2;
-	std::string dummyUrl = "dummyUrl";
-	AampMediaType dummyMediaType = eMEDIATYPE_VIDEO;
-	double dummyPosition = 0.0;
-	double dummyDuration = 1.0;
-	double dummyPts = 0.0;
-	bool dummyDisc = false;
-	std::string dummyPrId = "dummyPeriodId";
-	uint32_t dummyTimeScale = 1000;
-	double dummyPTSOffsetSec = 0.0;
-
-	auto mockInitData = std::make_shared<TsbInitData>("dummyInitUrl", eMEDIATYPE_VIDEO, 0.0, StreamInfo{}, "dummyPeriodId", 0);
-	// Create a TsbFragmentData object with the dummy parameters
-	auto mockFragmentData{std::make_shared<TsbFragmentData>(
-		dummyUrl, dummyMediaType, dummyPosition, dummyDuration, dummyPts, dummyDisc,
-		dummyPrId, mockInitData, dummyTimeScale, dummyPTSOffsetSec
-	)};
-
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-	// Last init fragment data is set to the same value as the init fragment data for mockFragmentData
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mLastInitFragmentData = mockInitData;
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(AAMP_NORMAL_PLAY_RATE));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(mockFragmentData));
-
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(mockFragmentData)).Times(1);
-
-	// Called by AampTSBSessionManager::Read(). It should be called only once
-	// for the media fragment. It has to return a value > 0
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).WillOnce(Return(10));
-
-	// Called only once for the media fragment injection
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).WillOnce(Return(true));
-
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
+	// This test was originally designed to verify init fragment reuse logic,
+	// but requires mocking that isn't compatible with the current design.
 }
 
 // Test that the init fragment is injected if it has changed
-TEST_F(AampTsbSessionManagerTests, FirstDownload_Success)
+// DISABLED: This test requires complex mock setup that doesn't work with current architecture
+TEST_F(AampTsbSessionManagerTests, DISABLED_FirstDownload_Success)
 {
-	const uint32_t numFreeFragments = 2;
-	std::string dummyUrl = "dummyUrl";
-	AampMediaType dummyMediaType = eMEDIATYPE_VIDEO;
-	double dummyPosition = 0.0;
-	double dummyDuration = 1.0;
-	double dummyPts = 0.0;
-	bool dummyDisc = false;
-	std::string dummyPrId = "dummyPeriodId";
-	uint32_t dummyTimeScale = 1000;
-	double dummyPTSOffsetSec = 0.0;
-
-	auto mockInitData = std::make_shared<TsbInitData>("dummyInitUrl", eMEDIATYPE_VIDEO, 0.0, StreamInfo{}, "dummyPeriodId", 0);
-	// Create a TsbFragmentData object with the dummy parameters
-	auto mockFragmentData{std::make_shared<TsbFragmentData>(
-		dummyUrl, dummyMediaType, dummyPosition, dummyDuration, dummyPts, dummyDisc,
-		dummyPrId, mockInitData, dummyTimeScale, dummyPTSOffsetSec
-	)};
-
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(AAMP_NORMAL_PLAY_RATE));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(mockFragmentData));
-
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(mockFragmentData)).Times(1);
-
-	// Called by AampTSBSessionManager::Read(), once for the init fragment and
-	// once for the first media fragment. It has to return a value > 0
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).Times(2).WillRepeatedly(Return(10));
-
-	// Called for the init fragment injection followed by the first media fragment
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).Times(2).WillRepeatedly(Return(true));
-
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
+	// This test was originally designed to verify init fragment injection logic,
+	// but requires mocking that isn't compatible with the current design.
 }
 
 // Test that the init fragment is injected but the fragment is not
-TEST_F(AampTsbSessionManagerTests, OnlyFreeFragmentForInit)
+// DISABLED: This test requires complex mock setup that doesn't work with current architecture
+TEST_F(AampTsbSessionManagerTests, DISABLED_OnlyFreeFragmentForInit)
 {
-	const uint32_t numFreeFragments = 2;
-	std::string dummyUrl = "dummyUrl";
-	AampMediaType dummyMediaType = eMEDIATYPE_VIDEO;
-	double dummyPosition = 0.0;
-	double dummyDuration = 1.0;
-	double dummyPts = 0.0;
-	bool dummyDisc = false;
-	std::string dummyPrId = "dummyPeriodId";
-	uint32_t dummyTimeScale = 1000;
-	double dummyPTSOffsetSec = 0.0;
-
-	auto mockInitData = std::make_shared<TsbInitData>("dummyInitUrl", eMEDIATYPE_VIDEO, dummyPosition, StreamInfo{}, "dummyPeriodId", 0);
-	// Create a TsbFragmentData object with the dummy parameters
-	auto mockFragmentData{std::make_shared<TsbFragmentData>(
-		dummyUrl, dummyMediaType, dummyPosition, dummyDuration, dummyPts, dummyDisc,
-		dummyPrId, mockInitData, dummyTimeScale, dummyPTSOffsetSec
-	)};
-
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(AAMP_NORMAL_PLAY_RATE));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(mockFragmentData));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(0);
-	// CacheFragment not called because need space for both init and media fragments
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).Times(0);
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).Times(0);
-	EXPECT_FALSE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), 1));
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(mockFragmentData));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(1);
-	// Called twice for init and media fragments
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).Times(2).WillRepeatedly(Return(10));
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).Times(2).WillRepeatedly(Return(true));
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
+	// This test was originally designed to verify space management logic,
+	// but requires mocking that isn't compatible with the current design.
 }
 
 // Test that when skip fragments is called, the next fragment is read
 // and the init fragment for the 2nd test fragment is injected
-TEST_F(AampTsbSessionManagerTests, SkipFragments)
+// DISABLED: This test requires complex mock setup that doesn't work with current architecture
+TEST_F(AampTsbSessionManagerTests, DISABLED_SkipFragments)
 {
-	const uint32_t numFreeFragments = 2;
-	std::string dummyUrl = "dummyUrl";
-	AampMediaType dummyMediaType = eMEDIATYPE_VIDEO;
-	AampTime dummyPosition = 0.0;
-	AampTime dummyDuration = 1.0;
-	AampTime dummyPts = 0.0;
-	bool dummyDisc = false;
-	std::string dummyPrId = "dummyPeriodId";
-	uint32_t dummyTimeScale = 1000;
-	AampTime dummyPTSOffsetSec = 0.0;
-	StreamInfo dummyStreamInfo;
-	dummyStreamInfo.bandwidthBitsPerSecond = kDefaultBandwidth;
-
-	auto mockInitData = std::make_shared<TsbInitData>("dummyInitUrl", eMEDIATYPE_VIDEO, 0.0, dummyStreamInfo, "dummyPeriodId", 0);
-
-	std::shared_ptr<AampTsbReader> tsbReader = mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO);
-	// Set the bandwidth of the reader to the same value as the init fragment to ensure that the new init fragment is
-	// injected, even if the bandwidth does not change.
-	tsbReader->mCurrentBandwidth = kDefaultBandwidth;
-	tsbReader->mTrackEnabled = true;
-
-	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_VODTrickPlayFPS)).WillRepeatedly(Return(4));
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(30.0));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillRepeatedly([=]() mutable {
-		static AampTime currentPosition = dummyPosition;
-		TsbFragmentDataPtr fragmentData = std::make_shared<TsbFragmentData>(
-			dummyUrl, dummyMediaType, currentPosition, dummyDuration, dummyPts, dummyDisc,
-			dummyPrId, mockInitData, dummyTimeScale, dummyPTSOffsetSec
-		);
-		currentPosition += dummyDuration;
-		return fragmentData;
-	});
-
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(1);
-
-	// Called by AampTSBSessionManager::Read(), once for the init fragment and
-	// once for the first media fragment. It has to return a value > 0
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).Times(2).WillRepeatedly(Return(10));
-
-	// Called for the init fragment injection followed by the first media fragment
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).Times(2).WillRepeatedly(Return(true));
-
-	// Call PushNextTsbFragment, expect the init fragment to be read and injected
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
+	// This test was originally designed to verify skip fragment logic with trickplay,
+	// but requires mocking that isn't compatible with the current design.
 }
 
-// Test that EnqueueWrite does not call RecalculatePTS when TSBWrite is called with the wrong media type
-TEST_F(AampTsbSessionManagerTests, TSBWriteTests_WrongMediaType)
+// Test SkipFragment logic with rates up to +/-64.0
+TEST_F(AampTsbSessionManagerTests, SkipFragment_TrickplayRates)
 {
-	std::shared_ptr<CachedFragment> cachedFragment = std::make_shared<CachedFragment>();
-	double FRAG_DURATION = 3.0;
-
-	cachedFragment->initFragment = true;
-	cachedFragment->duration = 0;
-	cachedFragment->position = 0;
-	cachedFragment->fragment.AppendBytes(TEST_DATA, strlen(TEST_DATA));
-	// Valid media types are only VIDEO, AUDIO, SUBTITLE, AUX_AUDIO and INIT fragments
-	cachedFragment->type = eMEDIATYPE_DEFAULT;
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, RecalculatePTS(_,_,_)).Times(0);
-	mAampTSBSessionManager->EnqueueWrite(TEST_BASE_URL, cachedFragment, TEST_PERIOD_ID);
-}
-
-// Test EnqueueWrite behaviour for a video init fragment
-TEST_F(AampTsbSessionManagerTests, TSBWriteTests_InitFragmentSuccess)
-{
-	std::shared_ptr<CachedFragment> cachedFragment = std::make_shared<CachedFragment>();
-	double FRAG_DURATION = 3.0;
-
-	cachedFragment->initFragment = true;
-	cachedFragment->duration = 0;
-	cachedFragment->position = 0;
-	cachedFragment->fragment.AppendBytes(TEST_DATA, strlen(TEST_DATA));
-	cachedFragment->type = eMEDIATYPE_INIT_VIDEO;
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, RecalculatePTS(eMEDIATYPE_INIT_VIDEO, _, _)).Times(1).WillOnce(Return(0.0));
-	mAampTSBSessionManager->EnqueueWrite(TEST_BASE_URL, cachedFragment, TEST_PERIOD_ID);
-}
-
-// Test the behaviour when reading from TSB at high rates
-// and skipping fragments is required
-// This test uses fragments of 2 seconds duration, maximum 4 frames per second and rate of 20.0
-// 20 / 4 = 5 seconds, so we expect 2 fragments to be skipped
-TEST_F(AampTsbSessionManagerTests, PushNextTsbFragment_SkipFragment)
-{
-	const uint32_t numFreeFragments = 2;
-	int trickplayFPS = 4;
+	// Create a chain of 5 fragments
 	std::string url = "http://example.com";
 	AampMediaType media = eMEDIATYPE_VIDEO;
 	double position = 1000.0;
 	double duration = 2.0;
 	double pts = 0.0;
-	bool discont = false;
 	std::string periodId = "testPeriodId";
 	StreamInfo streamInfo;
 	int profileIdx = 0;
 	uint32_t timeScale = 240000;
 	double PTSOffsetSec = 0.0;
 
-	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_VODTrickPlayFPS))
-		.WillRepeatedly(Return(trickplayFPS));
-
-	// Create init data and fragments
 	TsbInitDataPtr initFragment = std::make_shared<TsbInitData>(url, media, position, streamInfo, periodId, profileIdx);
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mLastInitFragmentData = initFragment;
 
-	// Mock data manager
-	TsbFragmentDataPtr firstFragment = std::make_shared<TsbFragmentData>(url, media, position, duration, pts, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	TsbFragmentDataPtr secondFragment = std::make_shared<TsbFragmentData>(url, media, position + duration, duration, pts + duration, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	secondFragment->prev = firstFragment;
-	firstFragment->next = secondFragment;
-	TsbFragmentDataPtr thirdFragment = std::make_shared<TsbFragmentData>(url, media, position + 2 * duration, duration, pts + 2 * duration, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	secondFragment->next = thirdFragment;
-	thirdFragment->prev = secondFragment;
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(firstFragment));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(thirdFragment));
+	std::vector<TsbFragmentDataPtr> fragments;
+	for (int i = 0; i < 5; ++i)
+	{
+		fragments.push_back(std::make_shared<TsbFragmentData>(
+			url, media, position + i * duration, duration, pts + i * duration, false, periodId, initFragment, timeScale, PTSOffsetSec));
+		if (i > 0)
+		{
+			fragments[i-1]->next = fragments[i];
+			fragments[i]->prev = fragments[i-1];
+		}
+	}
 
-	// Set live play position after the third fragment
-	mAamp->mTrickModePositionEOS = position + 3 * duration;
+	// Simulate the skip logic inline, as in AampTSBSessionManager::SkipFragment
+	auto callSkipFragment = [](TsbFragmentDataPtr& frag, float rate, int vodTrickplayFPS) {
+		AampTime skippedDuration = 0.0;
+		AampTime delta = 0.0;
+		if (vodTrickplayFPS == 0)
+		{
+			delta = 0.0;
+		}
+		else
+		{
+			delta = static_cast<AampTime>(std::abs(static_cast<double>(rate))) / static_cast<double>(vodTrickplayFPS);
+		}
+		while (delta > 0.0 && frag)
+		{
+			AampTime fragDuration = frag->GetDuration();
+			if (delta <= fragDuration)
+				break;
+			delta -= fragDuration;
+			skippedDuration += fragDuration;
+			TsbFragmentDataPtr tmp = nullptr;
+			if (rate > 0.0)
+				tmp = frag->next;
+			else if (rate < 0.0)
+				tmp = frag->prev;
+			if (!tmp)
+				break;
+			frag = tmp;
+		}
+	};
 
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(20.0f));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
+	int vodTrickplayFPS = 25;
 
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).WillRepeatedly(Return(sizeof(url)));
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).WillOnce(Return(true));
+	// Test forward skip with various positive rates
+	std::vector<float> forwardRates = {64.0f, 32.0f, 16.0f, 8.0f, 4.0f, 2.0f, 1.0f};
+	std::vector<size_t> expectedForwardIdx = {1, 0, 0, 0, 0, 0, 0}; // Only 64.0 skips one fragment
 
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
-}
+	for (size_t i = 0; i < forwardRates.size(); ++i)
+	{
+		TsbFragmentDataPtr frag = fragments[0];
+		callSkipFragment(frag, forwardRates[i], vodTrickplayFPS);
+		EXPECT_EQ(frag, fragments[expectedForwardIdx[i]]) << "Failed for rate " << forwardRates[i];
+	}
 
-// Test the behaviour when reading from TSB at high positive rates,
-// skipping fragments is required but the next fragment is not available.
-// This is a normal scenario when fast-forwarding to live.
-// This test uses fragments of 2 seconds duration, maximum 4 frames per second and rate of 20.0
-// 20 / 4 = 5 seconds, so we expect 2 fragments to be skipped
-TEST_F(AampTsbSessionManagerTests, PushNextTsbFragment_SkipFragment_NotAvailable)
-{
-	const uint32_t numFreeFragments = 2;
-	int trickplayFPS = 4;
-	std::string url = "http://example.com";
-	AampMediaType media = eMEDIATYPE_VIDEO;
-	double position = 1000.0;
-	double duration = 2.0;
-	double pts = 0.0;
-	bool discont = false;
-	std::string periodId = "testPeriodId";
-	StreamInfo streamInfo;
-	int profileIdx = 0;
-	uint32_t timeScale = 240000;
-	double PTSOffsetSec = 0.0;
+	// Test backward skip with various negative rates
+	std::vector<float> backwardRates = {-1.0f, -2.0f, -4.0f, -8.0f, -16.0f, -32.0f, -64.0f};
+	std::vector<size_t> expectedBackwardIdx = {4, 4, 4, 4, 4, 4, 3}; // Only -64.0 skips one fragment
 
-	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_VODTrickPlayFPS))
-		.WillRepeatedly(Return(trickplayFPS));
-
-	// Create init data and fragments
-	TsbInitDataPtr initFragment = std::make_shared<TsbInitData>(url, media, position, streamInfo, periodId, profileIdx);
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mLastInitFragmentData = initFragment;
-
-	// Mock data manager
-	TsbFragmentDataPtr firstFragment = std::make_shared<TsbFragmentData>(url, media, position, duration, pts, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	firstFragment->next = nullptr;
-
-	// Set live play position after the fragment
-	mAamp->mTrickModePositionEOS = position + duration;
-
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(firstFragment));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(_)).Times(0);
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(20.0f));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).Times(0);
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).Times(0);
-
-	EXPECT_FALSE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
-}
-
-// Test the behaviour when reading from TSB at high positive rates and reaching the live play position.
-// If a fragment position is greater than or equal to the live play position, it should not be skipped.
-// This is a normal scenario when fast-forwarding to live.
-// This test uses fragments of 2 seconds duration, maximum 4 frames per second and rate of 20.0
-// 20 / 4 = 5 seconds, so we expect 2 fragments to be skipped
-TEST_F(AampTsbSessionManagerTests, PushNextTsbFragment_SkipFragment_LivePlayPosition)
-{
-	const uint32_t numFreeFragments = 2;
-	int trickplayFPS = 4;
-	std::string url = "http://example.com";
-	AampMediaType media = eMEDIATYPE_VIDEO;
-	double position = 1000.0;
-	double duration = 2.0;
-	double pts = 0.0;
-	bool discont = false;
-	std::string periodId = "testPeriodId";
-	StreamInfo streamInfo;
-	int profileIdx = 0;
-	uint32_t timeScale = 240000;
-	double PTSOffsetSec = 0.0;
-
-	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_VODTrickPlayFPS))
-		.WillRepeatedly(Return(trickplayFPS));
-
-	// Create init data and fragments
-	TsbInitDataPtr initFragment = std::make_shared<TsbInitData>(url, media, position, streamInfo, periodId, profileIdx);
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mLastInitFragmentData = initFragment;
-
-	// Mock data manager
-	TsbFragmentDataPtr firstFragment = std::make_shared<TsbFragmentData>(url, media, position, duration, pts, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	firstFragment->next = nullptr;
-	mAamp->mTrickModePositionEOS = position;	// Live play position matches the position of the first fragment
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(firstFragment));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(firstFragment));
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(20.0f));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).WillRepeatedly(Return(sizeof(url)));
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).WillOnce(Return(true));
-
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
-}
-
-// Test the behaviour when reading from TSB at high negative rates,
-// skipping fragments is required but the next fragment is not available.
-// This is a normal scenario when rewinding to the beginning of the TSB.
-// This test uses fragments of 2 seconds duration, maximum 4 frames per second and rate of 20.0
-// 20 / 4 = 5 seconds, so we expect 2 fragments to be skipped
-TEST_F(AampTsbSessionManagerTests, PushNextTsbFragment_SkipFragment_BoS)
-{
-	const uint32_t numFreeFragments = 2;
-	int trickplayFPS = 4;
-	std::string url = "http://example.com";
-	AampMediaType media = eMEDIATYPE_VIDEO;
-	double position = 1000.0;
-	double duration = 2.0;
-	double pts = 0.0;
-	bool discont = false;
-	std::string periodId = "testPeriodId";
-	StreamInfo streamInfo;
-	int profileIdx = 0;
-	uint32_t timeScale = 240000;
-	double PTSOffsetSec = 0.0;
-
-    EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_VODTrickPlayFPS))
-      .WillRepeatedly(Return(trickplayFPS));
-
-	// Create init data and fragments
-	TsbInitDataPtr initFragment = std::make_shared<TsbInitData>(url, media, position, streamInfo, periodId, profileIdx);
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mTrackEnabled = true;
-	mAampTSBSessionManager->GetTsbReader(eMEDIATYPE_VIDEO)->mLastInitFragmentData = initFragment;
-
-	// Mock data manager
-	TsbFragmentDataPtr firstFragment = std::make_shared<TsbFragmentData>(url, media, position, duration, pts, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	firstFragment->prev = nullptr;
-	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(firstFragment));
-	EXPECT_CALL(*g_mockTSBReader, ReadNext(firstFragment));
-
-	EXPECT_CALL(*g_mockTSBReader, GetPlaybackRate()).WillRepeatedly(Return(-20.0f));
-	EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(false));
-
-	EXPECT_CALL(*g_mockTSBStore, GetSize(_)).WillRepeatedly(Return(sizeof(url)));
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheTsbFragment(_)).WillOnce(Return(true));
-
-	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
+	for (size_t i = 0; i < backwardRates.size(); ++i)
+	{
+		TsbFragmentDataPtr frag = fragments[4];
+		callSkipFragment(frag, backwardRates[i], vodTrickplayFPS);
+		EXPECT_EQ(frag, fragments[expectedBackwardIdx[i]]) << "Failed for rate " << backwardRates[i];
+	}
 }


### PR DESCRIPTION
Reverts rdkcentral/aamp#502

test to see if this cause l2 failures