### PR TITLE
VPLAY-9990 avoid double std::move use with drmHelperToUse

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -477,7 +477,7 @@ void StreamAbstractionAAMP_HLS::InitiateDrmProcess()
 			/** Queue protection event to the pipeline **/
 			licenseManager->QueueProtectionEvent(drmHelperToUse, "1", 0, eMEDIATYPE_VIDEO);
 			/** Queue content protection in DRM license fetcher **/
-			licenseManager->QueueContentProtection(drmHelperToUse, "1", 0, eMEDIATYPE_VIDEO);
+			licenseManager->QueueContentProtection(std::move(drmHelperToUse), "1", 0, eMEDIATYPE_VIDEO);
 		}
 	}
 }

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -475,9 +475,9 @@ void StreamAbstractionAAMP_HLS::InitiateDrmProcess()
 		{
 			AampDRMLicenseManager *licenseManager = aamp->mDRMLicenseManager;
 			/** Queue protection event to the pipeline **/
-			licenseManager->QueueProtectionEvent(std::move(drmHelperToUse), "1", 0, eMEDIATYPE_VIDEO);
+			licenseManager->QueueProtectionEvent(drmHelperToUse, "1", 0, eMEDIATYPE_VIDEO);
 			/** Queue content protection in DRM license fetcher **/
-			licenseManager->QueueContentProtection(std::move(drmHelperToUse), "1", 0, eMEDIATYPE_VIDEO);
+			licenseManager->QueueContentProtection(drmHelperToUse, "1", 0, eMEDIATYPE_VIDEO);
 		}
 	}
 }


### PR DESCRIPTION
VPLAY-9990 avoid double std::move use with drmHelperToUse

Reason for Change: avoid xcode-flagged warning from static code analysis

Test Guidance: no more warning in xcode

Risk: Low