### PR TITLE
VPLAY-11152 crash during first playback after coming out of deepsleep…

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -79,7 +79,8 @@ void getConfigs(DrmSessionManager *mDrmSessionManager , PrivateInstanceAAMP *aam
  *  @brief AampDRMLicenseManager constructor.
  */
 AampDRMLicenseManager::AampDRMLicenseManager(int maxDrmSessions, PrivateInstanceAAMP *aamp) : mMaxDRMSessions(maxDrmSessions),
-		aampInstance(aamp), mDrmSessionManager(NULL)
+		aampInstance(aamp), mDrmSessionManager(NULL),
+		accessToken(NULL), accessTokenLen(0)
 {
     aampInstance = aamp; 
 	std::function<void(uint32_t,uint32_t,const std::string&)> waterMarkSessionUpdateCB = std::bind(&PrivateInstanceAAMP::SendWatermarkSessionUpdateEvent, aampInstance, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);


### PR DESCRIPTION
VPLAY-11152 crash during first playback after coming out of deepsleep 

Reason for change: Initialise AampDRMLicenseManager class members
Test Procedure: see ticket
Risks: Low