### PR TITLE
VPLAY-11152 crash during first playback after coming out of deepsleep…

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -81,7 +81,8 @@ void getConfigs(DrmSessionManager *mDRMSessionManager , PrivateInstanceAAMP *aam
  *  @brief AampDRMLicenseManager constructor.
  */
 AampDRMLicenseManager::AampDRMLicenseManager(int maxDrmSessions, PrivateInstanceAAMP *aamp) : mMaxDRMSessions(maxDrmSessions),
-		aampInstance(aamp), mDRMSessionManager(NULL)
+		aampInstance(aamp), mDRMSessionManager(NULL),
+		accessToken(NULL), accessTokenLen(0)
 {
     aampInstance = aamp; 
     mDRMSessionManager = new DrmSessionManager(maxDrmSessions ,aampInstance);


### PR DESCRIPTION
VPLAY-11152 crash during first playback after coming out of deepsleep

Reason for change: Initialise AampDRMLicenseManager class members
Test Procedure: see ticket
Risks: Low