### PR TITLE
VPLAY-11240: Add Coverity Test build workflow for AAMP

### DIFF
--- a/.github/workflows/Linux-build.yml
+++ b/.github/workflows/Linux-build.yml
@@ -1,0 +1,31 @@
+name: Build AAMP in Linux Environment
+
+on:
+  pull_request:
+    branches: [ develop, dev_sprint_25_2 ]
+  workflow_dispatch:
+
+jobs:
+  build-aamp-on-pr:
+    name: Build AAMP in Linux environment
+    runs-on: ubuntu-latest
+    # The docker image is used for coverity scans as well.
+    container:
+      image: ghcr.io/rdkcentral/docker-rdk-ci:latest
+
+    steps:
+      # Checkout the aamp repository
+      - name: Checkout aamp code
+        uses: actions/checkout@v3
+
+      # Install AAMP
+      # Option D builds dependencies only.
+      # Option A builds AAMP only (assuming dependencies are already installed).
+      # Option K skips Kotlin build.
+      # 'yes' is used to auto-confirm any prompts during installation
+      - name: Install AAMP
+        run: |
+          chmod +x ./install-aamp.sh
+          yes | ./install-aamp.sh -D
+          yes | ./install-aamp.sh -Ak
+

--- a/install-aamp.sh
+++ b/install-aamp.sh
@@ -118,6 +118,45 @@ if [ ! -d ${LOCAL_DEPS_BUILD_DIR} ]; then
 fi
 
 
+# Check if we're in AAMP-only mode
+if [ ${OPTION_AAMP_ONLY} = true ] ; then
+    echo ""
+    echo "*** AAMP-only mode: Skipping dependency installation ***"
+    echo "*** Assuming dependencies are already installed ***"
+
+    # Still need to create build directory and do minimal setup
+    aampcli_install_prebuild_fn ${OPTION_CLEAN}
+
+    # Set CLEAN variable for AAMP build
+    CLEAN=false
+    if [ ${OPTION_CLEAN} = true ] ; then
+        CLEAN=true
+    fi
+
+    # Jump directly to AAMP CLI build
+    subtec_install_run_script_fn
+    INSTALL_STATUS_ARR+=("subtec_install_run_script check passed.")
+
+    aampcli_install_build_fn "${CLEAN}"
+    INSTALL_STATUS_ARR+=("aampcli_install_build check passed.")
+
+    if [ ${OPTION_AAMPCLIKOTLIN_SKIP} = false ] ; then
+        cd ${AAMP_DIR}
+        build_kotlin_libraries_fn
+        build_aampcli_kotlin_bindings_fn
+        create_aampcli_kotlin_executable_fn
+        INSTALL_STATUS_ARR+=("aampcli_install_build_kotlin check passed.")
+    else
+        INSTALL_STATUS_ARR+=("aampcli_install_build_kotlin check SKIPPED.")
+    fi
+
+    aampcli_install_postbuild_fn "${CLEAN}"
+    INSTALL_STATUS_ARR+=("aampcli_install_postbuild check passed.")
+
+    tools_print_summary_fn
+    exit 0
+fi
+
 # Install prebuilt dependencies
 #
 if [ ${OPTION_QUICK} = false ] ; then
@@ -173,6 +212,14 @@ fi
 #
 rialto_install_build_fn "${OPTION_CLEAN}"
 INSTALL_STATUS_ARR+=("rialto_install_build_fn check passed.")
+
+# Check if we're in dependencies-only mode
+if [ ${OPTION_DEPS_ONLY} = true ] ; then
+    echo ""
+    echo "*** Dependencies-only mode: Skipping AAMP CLI build ***"
+    tools_print_summary_fn
+    exit 0
+fi
 
 # Install subtec-app script
 # Needs the AAMP build directory to be created by aampcli_install_build first

--- a/scripts/install_options.sh
+++ b/scripts/install_options.sh
@@ -34,13 +34,15 @@ OPTION_SUBTEC_BUILD=true
 OPTION_SUBTEC_CLEAN=false
 OPTION_CLEAN_BUILD=false
 OPTION_GOOGLETEST_REFERENCE="tags/release-1.11.0"
+OPTION_DEPS_ONLY=false
+OPTION_AAMP_ONLY=false
 
 
 
 function install_options_fn()
 {
   # Parse optional command line parameters
-  while getopts ":d:b:cf:np:r:g:qskt" OPT; do
+  while getopts ":d:b:cf:np:r:g:qsktDA" OPT; do
     case ${OPT} in
       d ) # process option d install base directory name
         OPTION_BUILD_DIR=${OPTARG}
@@ -91,6 +93,14 @@ function install_options_fn()
         OPTION_CLEAN_BUILD=true
         echo "Will remove .libs and build directories before build"
         ;;
+      D )
+        OPTION_DEPS_ONLY=true
+        echo "Dependencies only mode - will install only dependencies"
+        ;;
+      A )
+        OPTION_AAMP_ONLY=true
+        echo "AAMP only mode - will install only AAMP CLI (dependencies must be pre-installed)"
+        ;;
       * )
         echo "'Usage: No flags/options specified - build AAMP with default options
         [-b] Specify aamp branch name (default: current sprint branch)
@@ -103,8 +113,10 @@ function install_options_fn()
         [-s] Skip subtec build and installation]"
         echo "        Note:  Subtec is built by default but can be rebuilt separately with the subtec
         [-k] Skip aamp-cli Kotlin build and installation]
-        [-t] Remove .libs and build directories before build (full rebuild)"
-        
+        [-t] Remove .libs and build directories before build (full rebuild)
+        [-D] Dependencies only - install only dependencies (gstreamer, libdash, subtec, rialto, gtest)
+        [-A] AAMP only - install only AAMP CLI (requires dependencies to be pre-installed)"
+
         echo "
         [-r] Specify rialto to be built
         [-p] Specify protobuf branch name] (Linux only)"
@@ -135,6 +147,12 @@ function install_options_fn()
   if  [[ ${@:$OPTIND:1} = "rialto" ]]; then
     OPTION_RIALTO_BUILD=true
     shift
+  fi
+
+  # Validate mutually exclusive options
+  if [[ ${OPTION_DEPS_ONLY} = true && ${OPTION_AAMP_ONLY} = true ]]; then
+    echo "ERROR: -D (deps-only) and -A (aamp-only) options are mutually exclusive"
+    return 1
   fi
 
 }


### PR DESCRIPTION
Reason for change: Add a workflow to build AAMP in Linux environment with the same docker image used for coverity scans. Test Procedure: Ensure the workflow is running as expected
Risks: Low
Priority: P1