### PR TITLE
VPLAY-10142: Observed Crash with fingerprint "42622052"

### DIFF
--- a/AampGrowableBuffer.cpp
+++ b/AampGrowableBuffer.cpp
@@ -64,7 +64,7 @@ void AampGrowableBuffer::Free( void )
 void AampGrowableBuffer::ReserveBytes( size_t numBytes )
 {
 	assert( ptr==NULL && avail == 0 );
-	ptr = (char *)g_malloc( numBytes );
+	ptr = (char *)g_try_malloc( numBytes );
 	if( ptr )
 	{
 		NETMEMORY_PLUS();
@@ -86,7 +86,7 @@ void AampGrowableBuffer::AppendBytes( const void *srcPtr, size_t srcLen )
 		{ // if still not enough, reallocate based on required
 			numBytes = required*2;
 		}
-		gpointer mem = g_realloc(ptr, numBytes );
+		gpointer mem = g_try_realloc(ptr, numBytes );
 		if( mem )
 		{
 			if( !ptr )

--- a/test/utests/fakes/FakeGLib.cpp
+++ b/test/utests/fakes/FakeGLib.cpp
@@ -242,24 +242,24 @@ void g_usleep(gulong microseconds)
 
 }
 
-gpointer g_malloc(gsize	 n_bytes)
+gpointer g_try_malloc(gsize	 n_bytes)
 {
 	gpointer ptr = NULL;
 
 	if (g_mockGLib != nullptr)
 	{
-		ptr = g_mockGLib->g_malloc(n_bytes);
+		ptr = g_mockGLib->g_try_malloc(n_bytes);
 	}
 	return ptr;
 }
 
-gpointer g_realloc (gpointer mem, gsize n_bytes)
+gpointer g_try_realloc (gpointer mem, gsize n_bytes)
 {
 	gpointer ptr = NULL;
 
 	if (g_mockGLib != nullptr)
 	{
-		ptr = g_mockGLib->g_realloc(mem, n_bytes);
+		ptr = g_mockGLib->g_try_realloc(mem, n_bytes);
 	}
 	return ptr;
 

--- a/test/utests/mocks/MockGLib.h
+++ b/test/utests/mocks/MockGLib.h
@@ -32,9 +32,9 @@ public:
 	MOCK_METHOD(GParamSpec*, g_object_class_find_property, (GObjectClass* oclass, const gchar* property_name));
 	MOCK_METHOD(guint, g_timeout_add, (guint interval, GSourceFunc function, gpointer data));
 	MOCK_METHOD(gboolean, g_source_remove, (guint tag));
-	MOCK_METHOD(gpointer, g_malloc, (gsize n_bytes));
+	MOCK_METHOD(gpointer, g_try_malloc, (gsize n_bytes));
 	MOCK_METHOD(void, g_free, (gpointer mem));
-	MOCK_METHOD(gpointer, g_realloc, (gpointer mem, gsize n_bytes));
+	MOCK_METHOD(gpointer, g_try_realloc, (gpointer mem, gsize n_bytes));
 
 	MOCK_METHOD(void, g_object_set, (gpointer object, const gchar *property_name, int value));
 	MOCK_METHOD(void, g_object_set, (gpointer object, const gchar *property_name, char * value));

--- a/test/utests/tests/AampGrowableBuffer/ConstructorsTests.cpp
+++ b/test/utests/tests/AampGrowableBuffer/ConstructorsTests.cpp
@@ -72,10 +72,10 @@ TEST_F(ConstructorsTests, Copy)
 {
 	AampGrowableBuffer buf("buf-copyctor");
 
-	EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillRepeatedly(callMalloc);
+	EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillRepeatedly(callMalloc);
 	buf.ReserveBytes(data_len);
 
-	EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillRepeatedly(callRealloc);
+	EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillRepeatedly(callRealloc);
 	buf.AppendBytes(data_buf.data(), data_buf.size());
 
 	auto tester = [this, &buf](AampGrowableBuffer & test_buf)
@@ -127,10 +127,10 @@ TEST_F(ConstructorsTests, Move)
 {
 	AampGrowableBuffer buf("buf-move-ctor");
 
-	EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillRepeatedly(callMalloc);
+	EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillRepeatedly(callMalloc);
 	buf.ReserveBytes(data_len);
 
-	EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillRepeatedly(callRealloc);
+	EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillRepeatedly(callRealloc);
 	buf.AppendBytes(&data_buf[0], data_buf.size());
 
 	auto tester = [this](const AampGrowableBuffer & src_buf, AampGrowableBuffer & test_buf)

--- a/test/utests/tests/AampGrowableBuffer/FunctionalTests.cpp
+++ b/test/utests/tests/AampGrowableBuffer/FunctionalTests.cpp
@@ -72,7 +72,7 @@ TEST_F(FunctionalTests, FreeTest)
 {
     AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
 
-    EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+    EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
 
     // Arrange: Allocate memory for the buffer and add some data
     buffer.ReserveBytes(10);
@@ -94,7 +94,7 @@ TEST_F(FunctionalTests, ReserveBytesTest)
     // Arrange: The buffer is set up in the fixture's SetUp()
     // Act: Call the ReserveBytes function
 
-    EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+    EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
 
     size_t numBytesToReserve = 10;
     buffer.ReserveBytes(numBytesToReserve);
@@ -115,7 +115,7 @@ TEST_F(FunctionalTests, AppendBytesTest)
     const char* srcData = "Hello, World!";
     size_t srcLen = strlen(srcData);
 
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillOnce(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillOnce(callRealloc);
 
     // Act: Call the AppendBytes function
     buffer.AppendBytes(srcData, srcLen);
@@ -138,7 +138,7 @@ TEST_F(FunctionalTests, MoveBytesTest)
     const char* srcData = "Hello, World!";
     size_t srcLen = strlen(srcData);
 
-    EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+    EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
  
     buffer.ReserveBytes(srcLen); // Make sure the buffer has enough space
 
@@ -160,7 +160,7 @@ TEST_F(FunctionalTests, AppendNulTerminatorTest)
 {
     AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
 
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillOnce(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillOnce(callRealloc);
 
     // Act: Call the AppendNulTerminator function
     buffer.AppendNulTerminator();
@@ -195,7 +195,7 @@ TEST_F(FunctionalTests, ReplaceTest)
     // Arrange: Set up two buffers - the source buffer and the destination buffer
     AampGrowableBuffer sourceBuffer("buffer");
 
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillOnce(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillOnce(callRealloc);
 
     sourceBuffer.AppendBytes("Hello", 5);
 
@@ -221,7 +221,7 @@ TEST_F(FunctionalTests, TransferNonEmptyTest)
     // Create a new buffer for this test
     AampGrowableBuffer buffer("buffer");
 
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillOnce(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillOnce(callRealloc);
 
     // Arrange: Add some data to the buffer
     buffer.AppendBytes("Test Data", 9);
@@ -259,7 +259,7 @@ TEST_F(FunctionalTests, Reserve1KBytesTest)
     AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
     size_t numBytesToReserve = 1024; // 1K
 
-    EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+    EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
 
     // Act: Call the ReserveBytes function
     buffer.ReserveBytes(numBytesToReserve);
@@ -277,7 +277,7 @@ TEST_F(FunctionalTests, Reserve8KBytesTest)
     AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
     size_t numBytesToReserve = 8192; // 8K
 
-    EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+    EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
 
     // Act: Call the ReserveBytes function
     buffer.ReserveBytes(numBytesToReserve);
@@ -296,7 +296,7 @@ TEST_F(FunctionalTests, Reserve32KBytesTest)
     AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
     size_t numBytesToReserve = 32768; // 32K
 
-    EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+    EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
 
     // Act: Call the ReserveBytes function
     buffer.ReserveBytes(numBytesToReserve);
@@ -316,7 +316,7 @@ TEST_F(FunctionalTests, SeriesOfAppendsTest)
     const char srcData[8192] = "Hello, World!";
     size_t srcLen = strlen(srcData);
 
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillRepeatedly(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillRepeatedly(callRealloc);
 
 
     // Arrange: Reserve a large initial space
@@ -343,7 +343,7 @@ TEST_F(FunctionalTests, SetLenPositiveTest)
     size_t srcNewLen = srcLen / 2;          // Reduce the length to half
 
     // Expectation for AppendBytes()
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillOnce(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillOnce(callRealloc);
 
     // Expectation for the destructor ~AampGrowableBuffer()
     EXPECT_CALL(*g_mockGLib, g_free(_)).WillOnce(callFree);
@@ -370,7 +370,7 @@ TEST_F(FunctionalTests, SetLenAfterReserveBytesTest)
 
     {
         AampGrowableBuffer testBuf("testBuf");
-        EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillOnce(callMalloc);
+        EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillOnce(callMalloc);
         testBuf.ReserveBytes(10);
         testBuf.SetLen(9);
         EXPECT_EQ(testBuf.GetLen(), 9);
@@ -391,7 +391,7 @@ TEST_F(FunctionalTests, SetLenAfterAppendBytesTest)
     size_t srcLen = strlen(srcData);
 
     // Expectation for AppendBytes()
-    EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillOnce(callRealloc);
+    EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillOnce(callRealloc);
 
     // Expectation for the destructor ~AampGrowableBuffer()
     EXPECT_CALL(*g_mockGLib, g_free(_)).WillOnce(callFree);

--- a/test/utests/tests/IsoBmffConvertToKeyFrameTests/IsoBmffConvertToKeyFrameTests.cpp
+++ b/test/utests/tests/IsoBmffConvertToKeyFrameTests/IsoBmffConvertToKeyFrameTests.cpp
@@ -122,8 +122,8 @@ TEST_P(IsoBmffConvertToKeyFrameTestsP, converToIFrame)
 {
 	AampGrowableBuffer src_data{"srcData"};
 
-	EXPECT_CALL(*g_mockGLib, g_malloc(_)).WillRepeatedly(callMalloc);
-	EXPECT_CALL(*g_mockGLib, g_realloc(_,_)).WillRepeatedly(callRealloc);
+	EXPECT_CALL(*g_mockGLib, g_try_malloc(_)).WillRepeatedly(callMalloc);
+	EXPECT_CALL(*g_mockGLib, g_try_realloc(_,_)).WillRepeatedly(callRealloc);
 
 	test_data_t td = GetParam();
 	src_data.AppendBytes(td.input_data,  td.input_data_len);


### PR DESCRIPTION
Reason for change: Replaced the current glib malloc calls with non-aborting versions to avoid crash on malloc failure. Updated L1 tests accordingly
Test Procedure: Refer Jira
Risks: No