### PR TITLE
RDK-56050 patches to build scripts to make them work on OSX

### DIFF
--- a/middleware/install-middleware.sh
+++ b/middleware/install-middleware.sh
@@ -23,6 +23,10 @@ if [[ -z "${MAKEFLAGS}" ]]; then
     export MAKEFLAGS=-j$(nproc)
 fi
 
+# Set the CMAKE_POLICY_VERSION_MINIMUM to 3.5
+# Mostly required for OSX builds
+export CMAKE_POLICY_VERSION_MINIMUM=3.5
+
 # Fail the script should any step fail. To override this behavior use "|| true" on those statements
 set -eo pipefail
 


### PR DESCRIPTION
RDK-56050 patches to build scripts to make them work on OSX 

Reason for Change: build isssus after recent middleware migration

Test Guidance: below should work

cd middleware
./install-middleware.sh
cd test/utests/
./run.sh

Risk: Low (already broken)