### PR TITLE
VPLAY-11269: Fix mem leak in AampProfiler

### DIFF
--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -211,6 +211,10 @@ void ProfileEventAAMP::TuneBegin(void)
 	{
 		cJSON_Delete(telemetryParam);
 	}
+	if (mLldLowBuffObject)
+	{
+		cJSON_Delete(mLldLowBuffObject);
+	}
 	mLldLowBuffObject = NULL;
 	telemetryParam = cJSON_CreateObject();
 }
@@ -648,9 +652,14 @@ void ProfileEventAAMP::GetTelemetryParam()
 	std::lock_guard<std::mutex> lock(discontinuityParamMutex);
 	if(telemetryParam != NULL)
 	{
-		std::string jsonStr = cJSON_PrintUnformatted(telemetryParam);
-		AAMPLOG_MIL("Telemetry values %s", jsonStr.c_str());
+		char *jsonStr = cJSON_PrintUnformatted(telemetryParam);
+		AAMPLOG_MIL("Telemetry values %s", jsonStr);
+		cJSON_free(jsonStr);
 		cJSON_Delete(telemetryParam);
+		if (mLldLowBuffObject)
+		{
+			cJSON_Delete(mLldLowBuffObject);
+		}
 		mLldLowBuffObject = NULL;
 		telemetryParam = cJSON_CreateObject();
 	}

--- a/AampProfiler.h
+++ b/AampProfiler.h
@@ -259,11 +259,15 @@ public:
 	/**
 	 * @brief ProfileEventAAMP Destructor
 	 */
-	~ProfileEventAAMP(){
+	~ProfileEventAAMP()
+	{
 		if(telemetryParam != NULL)
 		{
 			cJSON_Delete(telemetryParam);
-			mLldLowBuffObject = NULL;
+		}
+		if (mLldLowBuffObject)
+		{
+			cJSON_Delete(mLldLowBuffObject);
 		}
 	}
 	/**


### PR DESCRIPTION
Reason for change: Release the memory allocated to convert json to string. Also handle mLldLowBuffObject properly
Test Procedure: Make sure no mem leaks observed on tune tests. Refer ticket for some cases
Risks: Low
Priority: P0