### PR TITLE
VPLAY-11271: AAMP build issue in MACOS 15.6

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -227,7 +227,8 @@ function install_pkgs_fn()
       install_pkgs_darwin_fn git glib json-glib cmake "openssl@3" libxml2 ossp-uuid cjson gnu-sed meson ninja pkg-config jsoncpp lcov gcovr jq curl
       install_pkgs_darwin_fn coreutils websocketpp "boost@1.85" jansson libxkbcommon cppunit gnu-sed fontconfig doxygen graphviz tinyxml2 openldap krb5 "openjdk@21"
 
-      if [[ "$ARCH" == "arm64" && "$CUR_MACOS_VER" == "15.5" ]]; then
+      # Check if running on arm64 with macOS 15.5 or later
+      if [[ "$ARCH" == "arm64" ]] && [[ "$(printf '%s\n' "$CUR_MACOS_VER" "15.5" | sort -V | head -n1)" == "15.5" ]]; then
           # Install downgraded version of asio for arm64.
           # This is to fix compatibility issues with websocketpp and subtec
           # "|| true" prevents the script from exiting if orc is not found, that is not an error


### PR DESCRIPTION
Reason for change: ASIO version mismatch is happening in MACOS 15.6, extend the support for building asio 1.18.2 to MACOS 15.5 onwards.
Test Procedure: Make sure AAMP builds properly in MACOS 15.6
Risks: None