### PR TITLE
VPLAY-11269 FakeAampProfiler patch

### DIFF
--- a/test/utests/fakes/FakeAampProfiler.cpp
+++ b/test/utests/fakes/FakeAampProfiler.cpp
@@ -19,7 +19,7 @@
 
 #include "AampProfiler.h"
 
-ProfileEventAAMP::ProfileEventAAMP() : telemetryParam(nullptr)
+ProfileEventAAMP::ProfileEventAAMP() : telemetryParam(nullptr), mLldLowBuffObject(nullptr)
 {
 }
 


### PR DESCRIPTION
VPLAY-11269 FakeAampProfiler patch

Reason for Change: was missing pointer initialization, causing many tests to crash on OSX

Test Guidance: L1 tests passing on both Ubuntu and OSX

Risk: None