### PR TITLE
VPLAY-10007: Fix for Coverity Issues (DEADCODE, DIVIDE_BY_ZERO, INTEGER_OVERFLOW, MISSING_COMMA, MISSING_BREAK)

### DIFF
--- a/downloader/AampCurlStore.cpp
+++ b/downloader/AampCurlStore.cpp
@@ -232,17 +232,7 @@ static int eas_curl_debug_callback(CURL *handle, curl_infotype type, char *data,
 		size_t len = size;
 		while( len>0 && data[len-1]<' ' ) len--;
 		std::string printable(data,len);
-		switch (type)
-		{
-		case CURLINFO_TEXT:
-			AAMPLOG_WARN("curl: %s", printable.c_str() );
-			break;
-		case CURLINFO_HEADER_IN:
-			AAMPLOG_WARN("curl header: %s", printable.c_str() );
-			break;
-		default:
-			break; //CID:94999 - Resolve deadcode
-		}
+		AAMPLOG_MIL("curl debug type:%d info:%s", type, printable.c_str() );
 	}
 	return 0;
 }

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4646,6 +4646,7 @@ static gboolean buffering_timeout (gpointer data)
 			}
 			GstMediaFormat mediaFormatRet;
 			mediaFormatRet = (GstMediaFormat)pInterfacePlayerRDK->m_gstConfigParam->media;
+			uint32_t original_buffering_timeout_cnt = privatePlayer->gstPrivateContext->buffering_timeout_cnt;
 			/* Disable re-tune on buffering timeout for DASH as unlike HLS,
 			 * DRM key acquisition can end after injection, and buffering is not expected
 			 * to be completed by the 1 second timeout
@@ -4661,7 +4662,7 @@ static gboolean buffering_timeout (gpointer data)
 			else if (frames == -1 || frames >= pInterfacePlayerRDK->m_gstConfigParam->framesToQueue || privatePlayer->gstPrivateContext->buffering_timeout_cnt-- == 0)
 			{
 				MW_LOG_MIL("Set pipeline state to %s - buffering_timeout_cnt %u  frames %i",
-				gst_element_state_get_name(privatePlayer->gstPrivateContext->buffering_target_state), (privatePlayer->gstPrivateContext->buffering_timeout_cnt+1), frames);
+				gst_element_state_get_name(privatePlayer->gstPrivateContext->buffering_target_state), original_buffering_timeout_cnt, frames);
 				SetStateWithWarnings (privatePlayer->gstPrivateContext->pipeline, privatePlayer->gstPrivateContext->buffering_target_state);
 				isRateCorrectionDefaultOnPlaying =  privatePlayer->socInterface->SetRateCorrection();
 				

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4646,7 +4646,6 @@ static gboolean buffering_timeout (gpointer data)
 			}
 			GstMediaFormat mediaFormatRet;
 			mediaFormatRet = (GstMediaFormat)pInterfacePlayerRDK->m_gstConfigParam->media;
-			uint32_t original_buffering_timeout_cnt = privatePlayer->gstPrivateContext->buffering_timeout_cnt;
 			/* Disable re-tune on buffering timeout for DASH as unlike HLS,
 			 * DRM key acquisition can end after injection, and buffering is not expected
 			 * to be completed by the 1 second timeout
@@ -4661,6 +4660,7 @@ static gboolean buffering_timeout (gpointer data)
 			}
 			else if (frames == -1 || frames >= pInterfacePlayerRDK->m_gstConfigParam->framesToQueue || privatePlayer->gstPrivateContext->buffering_timeout_cnt-- == 0)
 			{
+				uint32_t original_buffering_timeout_cnt = privatePlayer->gstPrivateContext->buffering_timeout_cnt;
 				MW_LOG_MIL("Set pipeline state to %s - buffering_timeout_cnt %u  frames %i",
 				gst_element_state_get_name(privatePlayer->gstPrivateContext->buffering_target_state), original_buffering_timeout_cnt, frames);
 				SetStateWithWarnings (privatePlayer->gstPrivateContext->pipeline, privatePlayer->gstPrivateContext->buffering_target_state);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13277,7 +13277,6 @@ long PrivateInstanceAAMP::LoadFogConfig()
 		AampJsonObject audioPreference;
 		AampJsonObject subtitlePreference;
 		bool aPrefAvail = false;
-		bool tPrefAvail = false;
 		if((preferredLanguagesList.size() > 0) || !preferredRenditionString.empty() || !preferredLabelsString.empty() || !preferredAudioAccessibilityNode.getSchemeId().empty())
 		{
 			aPrefAvail = true;
@@ -13316,11 +13315,6 @@ long PrivateInstanceAAMP::LoadFogConfig()
 		if(aPrefAvail)
 		{
 			jsondataForPreference.add("audio", audioPreference);
-			trackAdded = true;
-		}
-		if(tPrefAvail)
-		{
-			jsondataForPreference.add("text", subtitlePreference);
 			trackAdded = true;
 		}
 

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -735,6 +735,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		{
 			MonitorAVStatusEventPtr ev = std::dynamic_pointer_cast<MonitorAVStatusEvent>(e);
 			AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MONITORAV_STATUS\tstatus=%s\tvposition =%" PRId64 "\taposition=%" PRId64 "\ttimeInStateMS= %" PRIu64 "\tdroppedFrames= %" PRIu64 "\n", ev->getMonitorAVStatus().c_str(), ev->getVideoPositionMS(), ev->getAudioPositionMS(), ev->getTimeInStateMS(),ev->getDroppedFrames());
+			break;
 		}
 		case AAMP_EVENT_REPORT_ANOMALY:
 		{

--- a/test/gstTestHarness/dash_adapter.cpp
+++ b/test/gstTestHarness/dash_adapter.cpp
@@ -109,7 +109,7 @@ void unsuportedTag( const XmlNode &child, const XmlNode &parent )
 		"Accessibility",
 		"AssetIdentifier",
 		"AudioChannelConfiguration",
-		"AvailableBitrates"
+		"AvailableBitrates",
 		"body",
 		"BufferLevel",
 		"EssentialProperty",


### PR DESCRIPTION
Reason for change: Resolved More Coverity Issues caused by (DEADCODE, DIVIDE_BY_ZERO, INTEGER_OVERFLOW, MISSING_COMMA, MISSING_BREAK)
Test Procedure: Refer Jira ticket VPLAY-10007
Priority: P1