### PR TITLE
VPLAY-11352: Crash Observed while Playback of linear LLD HD/UHD

### DIFF
--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -212,10 +212,7 @@ void ProfileEventAAMP::TuneBegin(void)
 	{
 		cJSON_Delete(telemetryParam);
 	}
-	if (mLldLowBuffObject)
-	{
-		cJSON_Delete(mLldLowBuffObject);
-	}
+	// mLldLowBuffObject is a child of telemetryParam, so it's automatically deleted above
 	mLldLowBuffObject = NULL;
 	telemetryParam = cJSON_CreateObject();
 }
@@ -603,10 +600,7 @@ void ProfileEventAAMP::GetTelemetryParam()
 		AAMPLOG_MIL("Telemetry values %s", jsonStr);
 		cJSON_free(jsonStr);
 		cJSON_Delete(telemetryParam);
-		if (mLldLowBuffObject)
-		{
-			cJSON_Delete(mLldLowBuffObject);
-		}
+		// mLldLowBuffObject is a child of telemetryParam, so it's automatically deleted above
 		mLldLowBuffObject = NULL;
 		telemetryParam = cJSON_CreateObject();
 	}

--- a/AampProfiler.h
+++ b/AampProfiler.h
@@ -252,7 +252,7 @@ private:
 public:
 
 	/**
-	 * @fn ProfileEventAAMP
+	 * @fn ProfileEventAAMP Constructor
 	 */
 	ProfileEventAAMP();
 
@@ -264,21 +264,20 @@ public:
 		if(telemetryParam != NULL)
 		{
 			cJSON_Delete(telemetryParam);
-		}
-		if (mLldLowBuffObject)
-		{
-			cJSON_Delete(mLldLowBuffObject);
+			// mLldLowBuffObject is a child of telemetryParam, so it's automatically deleted above
 		}
 	}
+
 	/**
-         * @brief Copy constructor disabled
-         *
-         */
+	 * @brief Copy constructor disabled
+	 *
+	 */
 	ProfileEventAAMP(const ProfileEventAAMP&) = delete;
+
 	/**
-         * @brief assignment operator disabled
-         *
-         */
+	 * @brief assignment operator disabled
+	 *
+	 */
 	ProfileEventAAMP& operator=(const ProfileEventAAMP&) = delete;
 
 	/**


### PR DESCRIPTION
Reason for change: mLldLowBuffObject is a child of telemetryParam, so it's automatically deleted.
Test Procedure: As mentioned in ticket
Risks: None