### PR TITLE
VPLAY-11062 revert

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7718,8 +7718,6 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		SetState(eSTATE_IDLE);
 	}
 
-	// Set EventManager State to RELEASED as no events beyond this point
-	mEventManager->SetPlayerState(eSTATE_RELEASED);
 	SetPauseOnStartPlayback(false);
 	mSeekOperationInProgress = false;
 	mTrickplayInProgress = false;


### PR DESCRIPTION
VPLAY-11062 revert

Reason for Change: this broke l2 tests 1006 and 1018; player state not changing after stop

Test Guidance: l2 tests again passing

Risk: Low