### PR TITLE
VPLAY-10777 restoration - broken by SocSep changes RDK-56050

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2643,23 +2643,20 @@ bool StreamAbstractionAAMP::RampDownProfile(int http_error)
 	else if (video)
 	{
 		double bufferValue = GetBufferValue(video);
-		// Let's keep things simple! This function is invoked when we want to rampdown, which we could either do in single or multiple steps
-		// If buffer is high, rampdown in single steps
-		// If buffer is less, rampdown in multiple steps based on buffer available
-		// If buffer is zero, we can't rampdown in multiple steps and the only way is either:
-		// 1. Rampdown to the lowest profile directly (if this also fails, will lead to playback failure or skipped content)
-		// 2. Rampdown in single steps (here we're already rebuffering or not yet streaming)
-		// Recommend option 2, unless good reason is found to rampdown to lowest profile directly.
 		if (bufferValue <= FLOATING_POINT_EPSILON)
 		{
-			AAMPLOG_WARN("Attempting rampdown to lowest profile as buffer is 0");
+			AAMPLOG_WARN("rampdown to lowest profile as buffer near zero");
 			desiredProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
 		}
 		else if (bufferValue > mABRMaxBuffer)
 		{
-			// If buffer is available, rampdown based on buffer
+			// ample buffering, so ramp down in single steps
+			desiredProfileIndex = aamp->mhAbrManager.getRampedDownProfileIndex(currentProfileIndex);
+		}
+		else
+		{ // variable rampdown based on available bandwidth
 			long desiredBw = aamp->mhAbrManager.FragmentfailureRampdown(bufferValue, currentProfileIndex);
-			if (desiredBw > 0)
+			if( desiredBw > 0)
 			{
 				desiredProfileIndex = GetProfileIndexForBandwidth(desiredBw);
 			}

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2386,7 +2386,7 @@ void StreamAbstractionAAMP::GetDesiredProfileOnBuffer(int currProfileIndex, int 
 	else
 	{
 		AAMPLOG_WARN("Switch to index 0; buffer is about to drain :Buffer %lf !!",bufferValue);
-		newProfileIndex = 0;
+		newProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
 	}
 }
 
@@ -2544,7 +2544,7 @@ int StreamAbstractionAAMP::GetDesiredProfileBasedOnCache(void)
 		{
 			//InsufficientBufferRule: Buffer is empty
 			AAMPLOG_WARN("Switch to index 0; buffer is about to drain :Buffer %lf !!",bufferValue);
-			desiredProfileIndex = 0;
+			desiredProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
 			if(currentProfileIndex != desiredProfileIndex)
 			{
 				mBitrateReason = eAAMP_BITRATE_CHANGE_BY_BUFFER_EMPTY;
@@ -2650,12 +2650,12 @@ bool StreamAbstractionAAMP::RampDownProfile(int http_error)
 		// 1. Rampdown to the lowest profile directly (if this also fails, will lead to playback failure or skipped content)
 		// 2. Rampdown in single steps (here we're already rebuffering or not yet streaming)
 		// Recommend option 2, unless good reason is found to rampdown to lowest profile directly.
-		if (bufferValue == 0 || bufferValue > mABRMaxBuffer)
+		if (bufferValue <= FLOATING_POINT_EPSILON)
 		{
-			// Rampdown in single steps
-			desiredProfileIndex = aamp->mhAbrManager.getRampedDownProfileIndex(currentProfileIndex);
+			AAMPLOG_WARN("Attempting rampdown to lowest profile as buffer is 0");
+			desiredProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
 		}
-		else if (bufferValue > 0)
+		else if (bufferValue > mABRMaxBuffer)
 		{
 			// If buffer is available, rampdown based on buffer
 			long desiredBw = aamp->mhAbrManager.FragmentfailureRampdown(bufferValue, currentProfileIndex);


### PR DESCRIPTION
VPLAY-10777 restoration - broken by SocSep changes RDK-56050

Reason for Change: RDK-56050 inadvertantly stomped on some recent core aamp fixes

Test Guidance: retest L2 4050 and 2036 and VPLAY-10777

Risk: Low