### PR TITLE
VPLAY-11380 restoring stomped follow-up threshold change for abr

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2643,8 +2643,8 @@ bool StreamAbstractionAAMP::RampDownProfile(int http_error)
 	else if (video)
 	{
 		double bufferValue = GetBufferValue(video);
-		if (bufferValue <= FLOATING_POINT_EPSILON)
-		{
+		if (bufferValue <= 2.0 )
+		{ // panic mode - jump directly to lowest profile
 			AAMPLOG_WARN("rampdown to lowest profile as buffer near zero");
 			desiredProfileIndex = aamp->mhAbrManager.getProfileIndexForLowestBandwidth();
 		}


### PR DESCRIPTION
VPLAY-11380 restoring stomped follow-up threshold change for abr

Reason for Change: relaxed epsilon threshold for panic mode to instead be 2.0s

Test Guidance: see ticket

Risk: Low - restoring change to sprint