### PR TITLE
VPLAY-11395 L2 Test AAMP-TUNE-1012_ManifestPreProcess failing

### DIFF
--- a/test/aampcli/AampcliPlaybackCommand.cpp
+++ b/test/aampcli/AampcliPlaybackCommand.cpp
@@ -1183,20 +1183,22 @@ char * PlaybackCommand::commandRecommender(const char *text, int state)
 
 size_t WriteCallback(void* contents, size_t size, size_t nmemb, std::string* userp)
 {
-    userp->append((char*)contents, size * nmemb);
-    return size * nmemb;
+	size_t n = size * nmemb;
+    userp->append( (char*)contents, n );
+    return n;
 }
 
 std::string PlaybackCommand::getManifestData(std::string& url)
 {
-	CURL* curl;
 	std::string manifestData;
 	if( url.substr(0, 7) == "http://" || url.substr(0, 8) == "https://" )
 	{
 		auto delim = url.find('@');
-		curl = curl_easy_init();
+		CURL* curl = curl_easy_init();
 		if(curl)
 		{
+			CURL_EASY_SETOPT_STRING(curl, CURLOPT_USERAGENT, "aamp-getManifestData/1.0");
+			
 			if( delim != std::string::npos )
 			{
 				std::string range = url.substr(delim+1);
@@ -1212,9 +1214,12 @@ std::string PlaybackCommand::getManifestData(std::string& url)
 			(void)curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 			(void)curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
 			(void)curl_easy_setopt(curl, CURLOPT_WRITEDATA, &manifestData);
-			(void)curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
 			CURLcode rc = curl_easy_perform(curl);
-			if (CURLE_OK == rc)
+			if (CURLE_OK != rc)
+			{
+				AAMPCLI_PRINTF("[AAMPCLI] %s curl error: %u", __FUNCTION__, rc);
+			}
+			else
 			{
 				long response_code = 0;
 				(void)curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
@@ -1225,8 +1230,7 @@ std::string PlaybackCommand::getManifestData(std::string& url)
 					case 206:
 						break;
 					default:
-						// http error
-						AAMPCLI_PRINTF("[AAMPCLI] %s curl error code : %ld",__FUNCTION__,response_code);
+						AAMPCLI_PRINTF("[AAMPCLI] %s http error: %ld", __FUNCTION__,response_code);
 						break;
 				}
 			}


### PR DESCRIPTION
VPLAY-11395 L2 Test AAMP-TUNE-1012_ManifestPreProcess failing

Reason for Change: fixes for aampcli-getManifestData utility function used in l2 test Corrections to logging
Filled out user agent (avoids 403 on S3 server)

Test Guidance: L2 1012 passing
Risk: Low