### PR TITLE
VPLAY-11273 video not muted correctly during pin

### DIFF
--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -65,7 +65,7 @@ void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 
 bool DefaultSocInterface::IsVideoSink(const char* name, bool isRialto)
 {
-	return (mUsingWesterosSink && StartsWith(name, "westerossink") == true);
+	return ((mUsingWesterosSink && StartsWith(name, "westerossink") == true) || (isRialto && StartsWith(name, "rialtomsevideosink") == true));
 }
 
 /**


### PR DESCRIPTION
Reason for change: video Mute isn't happening for rialo since the state change event is not reaching the bus_sync_handler
Test Procedure: Test steps in ticket
Risks: Low