### PR TITLE
VPLAY-11442 : [Update UVE Doc] Ability to configure + / - av sync thr…

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -210,6 +210,10 @@ Configuration options are passed to AAMP using the UVE initConfig method. This a
 | tsbLength | Number | 3600 (1 hour) or 1500 (25 min) | Max duration (seconds) of Local TSB to build up before culling  (not recommended for apps to change). Refer to [TSB Feature](#tsb-feature) for complete details. |
 | monitorAV | Boolean | False | Enable background monitoring of audio/video positions to infer video freeze, audio drop, or av sync issues |
 | monitorAVReportingInterval | Number | 1000 | Timeout in milliseconds for reporting MonitorAV events |
+| monitorAVSyncThresholdPositive | Number | 100 | configures threshold for pair of mismatched audio,video positions(positive) to be reported as avsync in milliseconds |
+
+| monitorAVSyncThresholdNegative | Number | 100 | configures threshold for pair of mismatched audio,video positions(negative) to be reported as avsync in milliseconds |
+| monitorAVJumpThreshold  | Number | 100 | configures threshold aligned audio,video positions advancing together by unexpectedly large delta to be reported as jump in milliseconds |
 
 Example:
 ```js


### PR DESCRIPTION
…eshold values for MonitorAV.

Reason for change: added documentation for monitorAV sync
Test Procedure: No Test required
Priority: P1