### PR TITLE
VPLAY-11379 address compiler warnings from tip of dev_sprint_25_2

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -2880,7 +2880,6 @@ bool InterfacePlayerRDK::StopBuffering(bool forceStop, bool &isPlaying)
  */
 unsigned long InterfacePlayerRDK::GetCCDecoderHandle()
 {
-	gst_media_stream* stream = &interfacePlayerPriv->gstPrivateContext->stream[eGST_MEDIATYPE_SUBTITLE];
 	gpointer dec_handle = NULL;
 
 	if (interfacePlayerPriv->gstPrivateContext->usingClosedCaptionsControl)

--- a/test/gstTestHarness/mp4demux.hpp
+++ b/test/gstTestHarness/mp4demux.hpp
@@ -126,7 +126,7 @@ private:
 	uint32_t width_fixed;
 	uint32_t height_fixed;
 	uint16_t language;
-	uint32_t sampleOffset;
+	size_t sampleOffset;
 	bool sencPresent;
 	bool verbose;
 	
@@ -282,9 +282,9 @@ private:
 		if (sample_count && got_auxiliary_information_offset)
 		{
 			ptr = moof_ptr + auxiliary_information_offset;
-			uint32_t maxSampleCount = sampleOffset + sample_count;
-			assert (samples.size() == maxSampleCount);
-			for (int i = sampleOffset; i < maxSampleCount; i++)
+			size_t maxSampleCount = sampleOffset + sample_count;
+			assert(samples.size() == maxSampleCount);
+			for( auto i = sampleOffset; i < maxSampleCount; i++ )
 			{
 				// Skip IV data if present (comes before subsample data in auxiliary info)
 				if( iv_size )
@@ -309,7 +309,7 @@ private:
 				{
 					// Read subsample data
 					uint16_t n_subsamples = ReadU16();
-					PRINTF( "%sSample %d: %d subsamples\n", INDENT(), i, n_subsamples );
+					PRINTF( "%sSample %zu: %d subsamples\n", INDENT(), i, n_subsamples );
 					size_t subsamples_size = n_subsamples * 6;
 					samples[i].subsamples = std::string((char *)ptr, subsamples_size);
 					if( verbose )
@@ -411,7 +411,7 @@ private:
 	{
 		ReadHeader();
 		uint32_t sampleCount = ReadU32();
-		u_int32_t maxSampleCount = sampleOffset + sampleCount;
+		size_t maxSampleCount = sampleOffset + sampleCount;
 		assert( samples.size() == maxSampleCount );
 		// Start from sampleOffset to map samples from mdat
 		for( auto iSample=sampleOffset; iSample<maxSampleCount; iSample++ )

--- a/tsDemuxer.cpp
+++ b/tsDemuxer.cpp
@@ -42,10 +42,6 @@
 
 #define MAX_FIRST_PTS_OFFSET (uint33_t{45000}) /*500 ms*/
 
-/** Maximum PTS value */
-// #define MAX_PTS (uint33_t::max_value().value)
-constexpr uint64_t max_pts_value = uint33_t::max_value().value;
-
 /**
  * @brief std::exchange for pre-c++14 compiler
  * @param obj	-	object whose value to replace


### PR DESCRIPTION
VPLAY-11379 address compiler warnings from tip of dev_sprint_25_2

Reason for Change: address various xcode warnings

Test Guidance: refer ticket - the cited warnings should no longer be seen

Risk: Low