### PR TITLE
VPLAY-11245 RialtoCCManager build fix

### DIFF
--- a/middleware/closedcaptions/rialto/PlayerRialtoCCManager.cpp
+++ b/middleware/closedcaptions/rialto/PlayerRialtoCCManager.cpp
@@ -25,6 +25,7 @@
  */
 #include "PlayerRialtoCCManager.h"
 #include "PlayerLogManager.h" // Included for MW_LOG
+#include <glib-object.h>  // Included for g_object_set
 
 /**
  * @brief stores Handle


### PR DESCRIPTION
Reason For Change:

Adding missing header file from original delivery https://github.com/rdkcentral/aamp/pull/590

Risk: Low