### PR TITLE
RDKAAMP-3639 : review and eliminate runtime behaviors dependent

### DIFF
--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -177,14 +177,18 @@ set(SOURCES
 	PlayerScheduler.cpp
 	gstplayertaskpool.cpp
 	PlayerUtils.cpp
-	vendor/SocInterface.cpp
-	vendor/amlogic/AmlogicSocInterface.cpp
-	vendor/realtek/RealtekSocInterface.cpp
-	vendor/brcm/BrcmSocInterface.cpp
-	vendor/default/DefaultSocInterface.cpp
 	drm/processProtectionHls.cpp
 	ProcessHandler.cpp
 	)
+if(NOT CMAKE_PLATFORM_UBUNTU AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    list(APPEND SOURCES vendor/amlogic/AmlogicSocInterface.cpp
+						vendor/realtek/RealtekSocInterface.cpp
+						vendor/brcm/BrcmSocInterface.cpp
+						vendor/default/DefaultSocInterface.cpp
+						vendor/SocInterface.cpp)
+else()
+	list(APPEND SOURCES test/utests/fakes/FakeSocInterface.cpp)
+endif()
 set(LIBPLAYERGSTINTERFACE_DRM_SOURCES drm/PlayerHlsDrmSessionInterface.cpp
 	drm/DrmSessionManager.cpp
 	drm/DrmSession.cpp
@@ -365,6 +369,10 @@ target_link_libraries(playergstinterface ${LIBPLAYERGSTINTERFACE_DEPENDS})
 target_link_libraries(playergstinterface ${GST_LINK_LIBRARIES} ${GSTREAMER_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES})
 
 target_link_libraries(playergstinterface ${GSTVIDEO_LIBRARIES} ${LIBPLAYERGSTINTERFACE_DEPENDS})
+
+if (NOT CMAKE_PLATFORM_UBUNTU AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+	target_link_libraries(playergstinterface gstsvpext)
+endif()
 
 set_target_properties(playergstinterface PROPERTIES COMPILE_FLAGS "${LIBPLAYERGSTINTERFACE_DEFINES} ${OS_CXX_FLAGS}")
 

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -3808,7 +3808,7 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 	}
 	else if (eGST_MEDIATYPE_AUDIO == mediaType)
 	{
-		MW_LOG_MIL("OnAudioFirstFrame. got First Audio Frame");
+		MW_LOG_MIL("OnFirstAudioFrame. got First Audio Frame");
 		if (audioOnly)
 		{
 			if (!interfacePlayerPriv->gstPrivateContext->decoderHandleNotified)

--- a/middleware/gst-plugins/CMakeLists.txt
+++ b/middleware/gst-plugins/CMakeLists.txt
@@ -95,11 +95,6 @@ target_include_directories (gstaamp PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../ $
 
 set(LIBPLUGIN_DEFINES "${PLUGIN_DEFINES}")
 
-if (CMAKE_AMLOGIC_SOC)
-        message("CMAKE_AMLOGIC_SOC set")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DAMLOGIC")
-	target_link_libraries (gstaamp gstsvpext)
-endif()
 
 #TODO Remove once PrivateInstance_Player is compilation flag independent.
 #if(CMAKE_USE_SECCLIENT)

--- a/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
@@ -22,12 +22,11 @@
 #include "gstcdmidecryptor.h"
 #include <open_cdm.h>
 #include <open_cdm_adapter.h>
-#if defined(AMLOGIC)
-#include <gst_svp_meta.h>
-#endif
 #include <dlfcn.h>
 #include <stdio.h>
 #include "DrmConstants.h"
+#include "SocInterface.h"
+#include "gst_svp_meta.h"
 
 GST_DEBUG_CATEGORY_STATIC ( gst_cdmidecryptor_debug_category);
 #define GST_CAT_DEFAULT  gst_cdmidecryptor_debug_category
@@ -166,6 +165,8 @@ static void gst_cdmidecryptor_class_init(
 		GstCDMIDecryptorClass *klass)
 {
 	DEBUG_FUNC();
+
+	std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
 	GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
 	GstBaseTransformClass *base_transform_class = GST_BASE_TRANSFORM_CLASS(klass);
 
@@ -190,10 +191,11 @@ static void gst_cdmidecryptor_class_init(
 	base_transform_class->transform_ip = GST_DEBUG_FUNCPTR(
 			gst_cdmidecryptor_transform_ip);
 
-#if !defined(AMLOGIC)
-	base_transform_class->accept_caps = GST_DEBUG_FUNCPTR(
-			gst_cdmidecryptor_accept_caps);
-#endif
+	if (socInterface)
+	{
+		socInterface->ConfigureAcceptCaps(base_transform_class, gst_cdmidecryptor_accept_caps);
+	}
+
 	base_transform_class->transform_ip_on_passthrough = FALSE;
 
 	gst_element_class_set_static_metadata(GST_ELEMENT_CLASS(klass),
@@ -300,6 +302,8 @@ gst_cdmidecryptor_transform_caps(GstBaseTransform * trans,
 		GstPadDirection direction, GstCaps * caps, GstCaps * filter)
 {
 	DEBUG_FUNC();
+
+	std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
 	GstCDMIDecryptor *cdmidecryptor = GST_CDMI_DECRYPTOR(trans);
 	g_return_val_if_fail(direction != GST_PAD_UNKNOWN, NULL);
 	unsigned size = gst_caps_get_size(caps);
@@ -432,10 +436,12 @@ gst_cdmidecryptor_transform_caps(GstBaseTransform * trans,
 
 		gst_cdmicapsappendifnotduplicate(transformedCaps, out);
 
-#if defined(AMLOGIC)
-	if (direction == GST_PAD_SINK && !gst_caps_is_empty(transformedCaps) && OCDMGstTransformCaps)
-		OCDMGstTransformCaps(&transformedCaps);
-#endif
+		if (socInterface && socInterface->IsTransformCapsRequired())
+		{
+			if (direction == GST_PAD_SINK && !gst_caps_is_empty(transformedCaps) && OCDMGstTransformCaps)
+				OCDMGstTransformCaps(&transformedCaps);
+		}
+
 	}
 
 	if (filter)
@@ -473,6 +479,7 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 {
 	DEBUG_FUNC();
 
+	std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
 	GstCDMIDecryptor *cdmidecryptor =
 			GST_CDMI_DECRYPTOR(trans);
 
@@ -508,17 +515,18 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 	{
 		GST_DEBUG_OBJECT(cdmidecryptor,
 				"Failed to get GstProtection metadata from buffer %p, could be clear buffer",buffer);
-#if defined(AMLOGIC)
-		// call decrypt even for clear samples in order to copy it to a secure buffer. If secure buffers are not supported
-		// decrypt() call will return without doing anything
-		if (cdmidecryptor->drmSession != NULL)
-		   errorCode = cdmidecryptor->drmSession->decrypt(keyIDBuffer, ivBuffer, buffer, subSampleCount, subsamplesBuffer, cdmidecryptor->sinkCaps);
-		else
-		{ /* If drmSession creation failed, then the call will be aborted here */
-			result = GST_FLOW_NOT_SUPPORTED;
-			GST_ERROR_OBJECT(cdmidecryptor, "drmSession is **** NULL ****, returning GST_FLOW_NOT_SUPPORTED");
+		if (socInterface && socInterface->IsDecryptRequired())
+		{
+			// call decrypt even for clear samples in order to copy it to a secure buffer. If secure buffers are not supported
+			// decrypt() call will return without doing anything
+			if (cdmidecryptor->drmSession != NULL)
+			   errorCode = cdmidecryptor->drmSession->decrypt(keyIDBuffer, ivBuffer, buffer, subSampleCount, subsamplesBuffer, cdmidecryptor->sinkCaps);
+			else
+			{ /* If drmSession creation failed, then the call will be aborted here */
+				result = GST_FLOW_NOT_SUPPORTED;
+				GST_ERROR_OBJECT(cdmidecryptor, "drmSession is **** NULL ****, returning GST_FLOW_NOT_SUPPORTED");
+			}
 		}
-#endif
 		goto free_resources;
 	}
 
@@ -962,6 +970,7 @@ static GstStateChangeReturn gst_cdmidecryptor_changestate(
 	
 	DEBUG_FUNC();
 
+	std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
 	GstStateChangeReturn ret = GST_STATE_CHANGE_SUCCESS;
 	GstCDMIDecryptor* cdmidecryptor =
 			GST_CDMI_DECRYPTOR(element);
@@ -981,20 +990,18 @@ static GstStateChangeReturn gst_cdmidecryptor_changestate(
 		g_cond_signal(&cdmidecryptor->condition);
 		g_mutex_unlock(&cdmidecryptor->mutex);
 		break;
-#if defined(AMLOGIC)
 	case GST_STATE_CHANGE_NULL_TO_READY:
 		GST_DEBUG_OBJECT(cdmidecryptor, "NULL->READY");
 		if (cdmidecryptor->svpCtx == NULL)
-		 gst_svp_ext_get_context(&cdmidecryptor->svpCtx, Server, 0);
+		 socInterface->SvpGetContext(&cdmidecryptor->svpCtx, Server, 0);
 		break;
 	case GST_STATE_CHANGE_READY_TO_NULL:
 		GST_DEBUG_OBJECT(cdmidecryptor, "READY->NULL");
 		if (cdmidecryptor->svpCtx) {
-  	        	gst_svp_ext_free_context(cdmidecryptor->svpCtx);
+			socInterface->SvpFreeContext(cdmidecryptor->svpCtx);
 			cdmidecryptor->svpCtx = NULL;	
 		}
 		break;
-#endif
 	default:
 		break;
 	}

--- a/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
@@ -26,7 +26,6 @@
 #include <stdio.h>
 #include "DrmConstants.h"
 #include "SocInterface.h"
-#include "gst_svp_meta.h"
 
 GST_DEBUG_CATEGORY_STATIC ( gst_cdmidecryptor_debug_category);
 #define GST_CAT_DEFAULT  gst_cdmidecryptor_debug_category
@@ -993,7 +992,7 @@ static GstStateChangeReturn gst_cdmidecryptor_changestate(
 	case GST_STATE_CHANGE_NULL_TO_READY:
 		GST_DEBUG_OBJECT(cdmidecryptor, "NULL->READY");
 		if (cdmidecryptor->svpCtx == NULL)
-		 socInterface->SvpGetContext(&cdmidecryptor->svpCtx, Server, 0);
+		 socInterface->SvpGetContext(&cdmidecryptor->svpCtx, 0);
 		break;
 	case GST_STATE_CHANGE_READY_TO_NULL:
 		GST_DEBUG_OBJECT(cdmidecryptor, "READY->NULL");

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -251,3 +251,18 @@ bool DefaultSocInterface::SetPlaybackRate(const std::vector<GstElement*>& source
 {
 	return false;
 }
+
+/**
+ * @brief Configure Capability Acceptance for GStreamer Transform
+ *
+ * Sets up the accept_caps function pointer for a GStreamer base transform class.
+ * This allows the transform element to decide whether it can accept a given set of capabilities (caps),
+ * which is essential for negotiating media formats during pipeline setup.
+ *
+ * @param base_transform_class Pointer to the GStreamer base transform class to configure.
+ * @param accept_caps_func Function used to determine if the transform accepts specific caps.
+ */
+void SocInterface::ConfigureAcceptCaps(GstBaseTransformClass* base_transform_class ,
+													AcceptCapsFunc accept_caps_func)
+{
+}

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -231,3 +231,20 @@ void SocInterface::SetWesterosSinkState(bool status)
 {
 	mUsingWesterosSink = status;
 }
+
+/**
+ * @brief Configure Capability Acceptance for GStreamer Transform
+ *
+ * Sets up the accept_caps function pointer for a GStreamer base transform class.
+ * This allows the transform element to decide whether it can accept a given set of capabilities (caps),
+ * which is essential for negotiating media formats during pipeline setup.
+ *
+ * @param base_transform_class Pointer to the GStreamer base transform class to configure.
+ * @param accept_caps_func Function used to determine if the transform accepts specific caps.
+ */
+void SocInterface::ConfigureAcceptCaps(GstBaseTransformClass* base_transform_class ,
+													AcceptCapsFunc accept_caps_func) {
+    if (accept_caps_func) {
+        base_transform_class->accept_caps = GST_DEBUG_FUNCPTR(accept_caps_func);
+    }
+}

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -25,9 +25,13 @@
 #include <vector>
 #include <memory>
 #include <gst/base/gstbasesink.h>
+#include <gst/base/gstbasetransform.h>
 #include "PlayerLogManager.h"
 
 #define REQUIRED_QUEUED_FRAMES_DEFAULT (5+1)
+
+typedef gboolean (*AcceptCapsFunc)(GstBaseTransform *, GstPadDirection, GstCaps *);
+
 /**
  * @brief Enumeration for play flags.
  *
@@ -100,6 +104,16 @@ public:
 	 * @param status Set to `true` if Westeros Sink is enabled, `false` otherwise.
 	 */
 	void SetWesterosSinkState(bool status);
+
+	/**
+	 * @brief Get SVP Context
+	 */
+	virtual void SvpGetContext(void **svpCtx, int server, int flags){};
+
+	/**
+	 * @brief Free SVP Context
+	 */
+	virtual void SvpFreeContext(void *svpCtx){};
 	
 	/*@brief returns true if video stats required from sink otherwise false*/
 	virtual bool IsPlaybackQualityFromSink(){return false;}
@@ -125,6 +139,27 @@ public:
 	 * @return A pointer to the created SocInterface object.
 	 */
 	static std::shared_ptr<SocInterface> CreateSocInterface();
+
+	/**
+	 * @brief Configure the accept caps
+	 * @return void
+	 */
+	virtual void ConfigureAcceptCaps( GstBaseTransformClass* base_transform_class,
+						 AcceptCapsFunc accept_caps_func);
+
+	/**
+	 * @brief Indicates whether transform capabilities are required.
+	 * @return true if transform capabilities are required; otherwise, false
+	 */
+	virtual bool IsTransformCapsRequired() const {
+		return false; }
+
+	/**
+	 * @brief Indicates whether decryption is required.
+	 * @return true if decryption are required; otherwise, false
+	 */
+	virtual bool IsDecryptRequired() const {
+		return false; }
 	
 	/**
 	 * @brief Check if AppSrc should be used.

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -108,7 +108,7 @@ public:
 	/**
 	 * @brief Get SVP Context
 	 */
-	virtual void SvpGetContext(void **svpCtx, int server, int flags){};
+	virtual void SvpGetContext(void **svpCtx, int flags){};
 
 	/**
 	 * @brief Free SVP Context

--- a/middleware/vendor/amlogic/AmlogicSocInterface.cpp
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "AmlogicSocInterface.h"
+#include "gst_svp_meta.h"
 
 /**
  * @brief AmlogicSocInterface constructor.
@@ -183,6 +184,26 @@ bool AmlogicSocInterface::IsVideoSink(const char* name, bool isRialto)
 	}
 
 	return false;
+}
+
+/**
+ * @brief Get SVP Context
+ * @param svpCtx svp context
+ * @param server To identify server/client
+ * @param flags SVP Flag
+ */
+void AmlogicSocInterface::SvpGetContext(void **svpCtx, int server, int flags)
+{
+	gst_svp_ext_get_context(svpCtx, static_cast<context_type>(server), flags);
+}
+
+/**
+ * @brief Free SVP Context
+ * @param svpCtx svp context
+ */
+void AmlogicSocInterface::SvpFreeContext(void *svpCtx)
+{
+	gst_svp_ext_free_context(svpCtx);
 }
 
 /**

--- a/middleware/vendor/amlogic/AmlogicSocInterface.cpp
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.cpp
@@ -192,9 +192,9 @@ bool AmlogicSocInterface::IsVideoSink(const char* name, bool isRialto)
  * @param server To identify server/client
  * @param flags SVP Flag
  */
-void AmlogicSocInterface::SvpGetContext(void **svpCtx, int server, int flags)
+void AmlogicSocInterface::SvpGetContext(void **svpCtx, int flags)
 {
-	gst_svp_ext_get_context(svpCtx, static_cast<context_type>(server), flags);
+	gst_svp_ext_get_context(svpCtx, Server, flags);
 }
 
 /**

--- a/middleware/vendor/amlogic/AmlogicSocInterface.h
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.h
@@ -92,6 +92,38 @@ class AmlogicSocInterface : public SocInterface
 		void SetAC4Tracks(GstElement *src, int trackId) override;
 
 		/**
+		 * @brief Get SVP Context
+		 */
+		void SvpGetContext(void **svpCtx, int server, int flags)override;
+
+		/**
+		 * @brief Free SVP Context
+		 */
+		void SvpFreeContext(void *svpCtx)override;
+
+		/**
+		 * @brief Configure the accept caps
+		 * @return void
+		 */
+		void ConfigureAcceptCaps( GstBaseTransformClass* base_transform_class,
+                         AcceptCapsFunc accept_caps_func)override {
+			return;	 }
+
+		/**
+		 * @brief Indicates whether transform capabilities are required.
+		 * @return true if transform capabilities are required; otherwise, false
+		 */
+		bool IsTransformCapsRequired() const override {
+			return true; }
+
+		/**
+		 * @brief Indicates whether decryption is required.
+		 * @return true if decryption are required; otherwise, false
+		 */
+		bool IsDecryptRequired() const override {
+			return true; }
+
+		/**
 		 * @brief Set rate correction.
 		 * @return True on success, false otherwise.
 		 */

--- a/middleware/vendor/amlogic/AmlogicSocInterface.h
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.h
@@ -94,7 +94,7 @@ class AmlogicSocInterface : public SocInterface
 		/**
 		 * @brief Get SVP Context
 		 */
-		void SvpGetContext(void **svpCtx, int server, int flags)override;
+		void SvpGetContext(void **svpCtx, int flags)override;
 
 		/**
 		 * @brief Free SVP Context


### PR DESCRIPTION
Reason for change: Moving the SOC related code changes to vendor layer from GST RDK plugins
Test Procedure: Need to ensure the playback in SOC specific devices
Risks: Low