### PR TITLE
VPLAY-11527 [VIPA] SoC support for ac4 audio track selection

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -854,8 +854,8 @@ void AampConfig::ApplyDeviceCapabilities()
 	bool IsWifiCurlHeader = pInstance->IsConfigWifiCurlHeader();	
 
 	configValueBool[eAAMPConfig_UseAppSrcForProgressivePlayback].value = SocUtils::UseAppSrcForProgressivePlayback();
-	configValueBool[eAAMPConfig_DisableAC4].value = SocUtils::IsSupportedAC4();
-	configValueBool[eAAMPConfig_DisableAC3].value = SocUtils::IsSupportedAC3();
+	configValueBool[eAAMPConfig_DisableAC4].value = SocUtils::IsDisabledAC4();
+	configValueBool[eAAMPConfig_DisableAC3].value = SocUtils::IsDisabledAC3();
 	configValueBool[eAAMPConfig_UseWesterosSink].value = SocUtils::UseWesterosSink();
 	configValueBool[eAAMPConfig_SyncAudioFragments].value = SocUtils::IsAudioFragmentSyncSupported();
 	SetConfigValue(AAMP_DEFAULT_SETTING, eAAMPConfig_WifiCurlHeader, IsWifiCurlHeader);

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -283,7 +283,7 @@ static bool IsAtmosAudio(const IMPDElement *nodePtr)
  * @param[in] rep - representation node for atmos audio check
  * @retval audio type as per aamp code from string value
  */
-static AudioType getCodecType( const string & codecValue, const IMPDElement *rep)
+static AudioType getCodecType(string & codecValue, const IMPDElement *rep)
 {
 	AudioType audioType = eAUDIO_UNSUPPORTED;
 	if (codecValue == "ec+3")
@@ -292,7 +292,7 @@ static AudioType getCodecType( const string & codecValue, const IMPDElement *rep
 		audioType = eAUDIO_ATMOS;
 #endif
 	}
-	if( codecValue.rfind("ac-4",0)==0 )
+	else if ( codecValue.rfind("ac-4",0)==0 )
 	{
 		audioType = eAUDIO_DOLBYAC4;
 	}
@@ -332,8 +332,10 @@ static AudioType getCodecType( const string & codecValue, const IMPDElement *rep
  * @brief Get representation index from preferred codec list
  * @retval whether track selected or not
  */
-bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptationSet, int &selectedRepIdx, AudioType &selectedCodecType, uint32_t &selectedRepBandwidth, long &bestScore, bool disableEC3, bool disableATMOS, bool disableAC4, bool disableAC3, bool& disabled)
+bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptationSet, int &selectedRepIdx, AudioType &selectedCodecType,
+	uint32_t &selectedRepBandwidth, long &bestScore, bool disableEC3, bool disableATMOS, bool disableAC4, bool disableAC3, bool& disabled)
 {
+	printf( "entering StreamAbstractionAAMP_MPD::GetPreferredCodecIndex\n" );
 	bool isTrackSelected = false;
 	if( aamp->preferredCodecList.size() > 0 )
 	{
@@ -361,6 +363,7 @@ bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptatio
 				{
 					codecValue = adapCodecs.at(0);
 				}
+				printf( "codecValue=%s\n", codecValue.c_str() );
 				auto iter = std::find(aamp->preferredCodecList.begin(), aamp->preferredCodecList.end(), codecValue);
 				if(iter != aamp->preferredCodecList.end())
 				{  /* track is in preferred codec list */
@@ -443,21 +446,11 @@ void StreamAbstractionAAMP_MPD::GetPreferredTextRepresentation(IAdaptationSet *a
 	AAMPLOG_INFO("StreamAbstractionAAMP_MPD: SelectedRepIndex : %d selectedRepBandwidth: %d", selectedRepIdx, selectedRepBandwidth);
 }
 
-/**
- * @brief
- * @param adaptationSet
- * @param in/out selectedCodecType
- * @param in/out selectedRepBandwidth
- * @param disableEC3 EC3 support disabled via config or SoC capabilities
- * @param disableATMOS ATMOS support disabled via config or SoC capabilities
- * @param disableAC4 AC4 support disabled via config or SoC capabilities
- * @param disableAC3 AC3 support disabled via config or SoC capabilities
- * @param disabled
- */
-static int GetDesiredCodecIndex( const IAdaptationSet *adaptationSet, AudioType &selectedCodecType, uint32_t &selectedRepBandwidth, bool disableEC3 ,bool disableATMOS, bool disableAC4, bool disableAC3, bool &disabled)
+static int GetDesiredCodecIndex(IAdaptationSet *adaptationSet, AudioType &selectedCodecType, uint32_t &selectedRepBandwidth,
+				bool disableEC3,bool disableATMOS, bool disableAC4,bool disableAC3,  bool &disabled)
 {
 	int selectedRepIdx = -1;
-	if( adaptationSet!=NULL )
+	if(adaptationSet != NULL)
 	{
 		const std::vector<IRepresentation *> representation = adaptationSet->GetRepresentation();
 		// check for codec defined in Adaptation Set
@@ -468,23 +461,17 @@ static int GetDesiredCodecIndex( const IAdaptationSet *adaptationSet, AudioType 
 			uint32_t bandwidth = rep->GetBandwidth();
 			const std::vector<string> codecs = rep->GetCodecs();
 			AudioType audioType = eAUDIO_UNKNOWN;
-			string codecValue;
+			string codecValue="";
+			// check if Representation includec codec
 			if(codecs.size())
-			{ // check if Representation includes codec
-				codecValue = codecs.at(0);
-			}
-			else if(adapCodecs.size())
-			{ // else check if Adaptation has codec defn
+				codecValue=codecs.at(0);
+			else if(adapCodecs.size()) // else check if Adaptation has codec defn
 				codecValue = adapCodecs.at(0);
-			}
-			else
-			{ // else no codec defined, go with unknown
-				codecValue.clear();
-				audioType = getCodecType(codecValue, rep);
-			}
-			
+			// else no codec defined , go with unknown
+			audioType = getCodecType(codecValue, rep);
+
 			/*
-			* By default the audio profile selection priority is set as AC4 > ATMOS > DD+ > AAC
+			* By default the audio profile selection priority is set as ATMOS then DD+ then AAC
 			* Note that this check comes after the check of selected language.
 			* disableATMOS: avoid use of ATMOS track
 			* disableEC3: avoid use of DDPLUS and ATMOS tracks
@@ -508,7 +495,7 @@ static int GetDesiredCodecIndex( const IAdaptationSet *adaptationSet, AudioType 
 	}
 	else
 	{
-		AAMPLOG_WARN("adaptationSet is null");  //CID:85233 - Null Returns
+		AAMPLOG_WARN("adaptationSet  is null");  //CID:85233 - Null Returns
 	}
 	return selectedRepIdx;
 }
@@ -4306,10 +4293,10 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			}
 		}
 
-		// Rialto does not support dynamic streams, so we need to extract and save the 
+		// Rialto does not support dynamic streams, so we need to extract and save the
 		// subtitle init fragment from the main vod asset, so that it can be injected
 		// later if a pre-roll advert is played that does not contain subtitles.
-		if (ISCONFIGSET(eAAMPConfig_useRialtoSink) && 
+		if (ISCONFIGSET(eAAMPConfig_useRialtoSink) &&
 		   !mIsLiveStream &&
 		   (!(AampStreamSinkManager::GetInstance().GetMediaHeader(eMEDIATYPE_SUBTITLE))))
 		{
@@ -5700,6 +5687,7 @@ void StreamAbstractionAAMP_MPD::UpdateLanguageList()
 int StreamAbstractionAAMP_MPD::GetBestAudioTrackByLanguage( int &desiredRepIdx, AudioType &CodecType,
 std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
 {
+	printf( "entering StreamAbstractionAAMP_MPD::GetBestAudioTrackByLanguage\n" );
 	int bestTrack = -1;
 	unsigned long long bestScore = 0;
 	AudioTrackInfo selectedAudioTrack; /**< Selected Audio track information */
@@ -5797,10 +5785,10 @@ std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
 			bool disableATMOS = (disableEC3) ? true : ISCONFIGSET(eAAMPConfig_DisableATMOS);
 			bool disableAC3 = ISCONFIGSET(eAAMPConfig_DisableAC3);
 			bool disableAC4 = ISCONFIGSET(eAAMPConfig_DisableAC4);
-
 			int audioRepresentationIndex = -1;
 			long codecScore = 0;
 			bool disabled = false;
+			printf( "disableAC4=%d\n", disableAC4 );
 			if(!GetPreferredCodecIndex(adaptationSet, audioRepresentationIndex, selectedCodecType, selRepBandwidth, codecScore, disableEC3 , disableATMOS, disableAC4, disableAC3, disabled))
 			{
 				audioRepresentationIndex = GetDesiredCodecIndex(adaptationSet, selectedCodecType, selRepBandwidth, disableEC3 , disableATMOS, disableAC4, disableAC3, disabled);
@@ -10979,7 +10967,7 @@ void StreamAbstractionAAMP_MPD::GetStreamFormat(StreamOutputFormat &primaryOutpu
 	//TODO - check whether the ugly hack above is in operation
 	// This is again a dirty hack, the check for PTS restamp enabled. TODO: We need to remove this in future
 	// For cases where subtitles is enabled mid-playback, we need to configure the pipeline at the beginning. FORMAT_SUBTITLE_MP4 will be set
-	if (mMediaStreamContext[eMEDIATYPE_SUBTITLE] && 
+	if (mMediaStreamContext[eMEDIATYPE_SUBTITLE] &&
 		mMediaStreamContext[eMEDIATYPE_SUBTITLE]->type != eTRACK_AUX_AUDIO)
 	{
 		if (mMediaStreamContext[eMEDIATYPE_SUBTITLE]->enabled || ISCONFIGSET(eAAMPConfig_EnablePTSReStamp))

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -283,17 +283,16 @@ static bool IsAtmosAudio(const IMPDElement *nodePtr)
  * @param[in] rep - representation node for atmos audio check
  * @retval audio type as per aamp code from string value
  */
-static AudioType getCodecType(string & codecValue, const IMPDElement *rep)
+static AudioType getCodecType( const string & codecValue, const IMPDElement *rep)
 {
 	AudioType audioType = eAUDIO_UNSUPPORTED;
-	std::string ac4 = "ac-4";
 	if (codecValue == "ec+3")
 	{
 #ifndef __APPLE__
 		audioType = eAUDIO_ATMOS;
 #endif
 	}
-	else if (!codecValue.compare(0, ac4.size(), ac4))
+	if( codecValue.rfind("ac-4",0)==0 )
 	{
 		audioType = eAUDIO_DOLBYAC4;
 	}
@@ -333,8 +332,7 @@ static AudioType getCodecType(string & codecValue, const IMPDElement *rep)
  * @brief Get representation index from preferred codec list
  * @retval whether track selected or not
  */
-bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptationSet, int &selectedRepIdx, AudioType &selectedCodecType,
-	uint32_t &selectedRepBandwidth, long &bestScore, bool disableEC3, bool disableATMOS, bool disableAC4, bool disableAC3, bool& disabled)
+bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptationSet, int &selectedRepIdx, AudioType &selectedCodecType, uint32_t &selectedRepBandwidth, long &bestScore, bool disableEC3, bool disableATMOS, bool disableAC4, bool disableAC3, bool& disabled)
 {
 	bool isTrackSelected = false;
 	if( aamp->preferredCodecList.size() > 0 )
@@ -445,11 +443,21 @@ void StreamAbstractionAAMP_MPD::GetPreferredTextRepresentation(IAdaptationSet *a
 	AAMPLOG_INFO("StreamAbstractionAAMP_MPD: SelectedRepIndex : %d selectedRepBandwidth: %d", selectedRepIdx, selectedRepBandwidth);
 }
 
-static int GetDesiredCodecIndex(IAdaptationSet *adaptationSet, AudioType &selectedCodecType, uint32_t &selectedRepBandwidth,
-				bool disableEC3,bool disableATMOS, bool disableAC4,bool disableAC3,  bool &disabled)
+/**
+ * @brief
+ * @param adaptationSet
+ * @param in/out selectedCodecType
+ * @param in/out selectedRepBandwidth
+ * @param disableEC3 EC3 support disabled via config or SoC capabilities
+ * @param disableATMOS ATMOS support disabled via config or SoC capabilities
+ * @param disableAC4 AC4 support disabled via config or SoC capabilities
+ * @param disableAC3 AC3 support disabled via config or SoC capabilities
+ * @param disabled
+ */
+static int GetDesiredCodecIndex( const IAdaptationSet *adaptationSet, AudioType &selectedCodecType, uint32_t &selectedRepBandwidth, bool disableEC3 ,bool disableATMOS, bool disableAC4, bool disableAC3, bool &disabled)
 {
 	int selectedRepIdx = -1;
-	if(adaptationSet != NULL)
+	if( adaptationSet!=NULL )
 	{
 		const std::vector<IRepresentation *> representation = adaptationSet->GetRepresentation();
 		// check for codec defined in Adaptation Set
@@ -460,17 +468,23 @@ static int GetDesiredCodecIndex(IAdaptationSet *adaptationSet, AudioType &select
 			uint32_t bandwidth = rep->GetBandwidth();
 			const std::vector<string> codecs = rep->GetCodecs();
 			AudioType audioType = eAUDIO_UNKNOWN;
-			string codecValue="";
-			// check if Representation includec codec
+			string codecValue;
 			if(codecs.size())
-				codecValue=codecs.at(0);
-			else if(adapCodecs.size()) // else check if Adaptation has codec defn
+			{ // check if Representation includes codec
+				codecValue = codecs.at(0);
+			}
+			else if(adapCodecs.size())
+			{ // else check if Adaptation has codec defn
 				codecValue = adapCodecs.at(0);
-			// else no codec defined , go with unknown
-			audioType = getCodecType(codecValue, rep);
-
+			}
+			else
+			{ // else no codec defined, go with unknown
+				codecValue.clear();
+				audioType = getCodecType(codecValue, rep);
+			}
+			
 			/*
-			* By default the audio profile selection priority is set as ATMOS then DD+ then AAC
+			* By default the audio profile selection priority is set as AC4 > ATMOS > DD+ > AAC
 			* Note that this check comes after the check of selected language.
 			* disableATMOS: avoid use of ATMOS track
 			* disableEC3: avoid use of DDPLUS and ATMOS tracks
@@ -494,7 +508,7 @@ static int GetDesiredCodecIndex(IAdaptationSet *adaptationSet, AudioType &select
 	}
 	else
 	{
-		AAMPLOG_WARN("adaptationSet  is null");  //CID:85233 - Null Returns
+		AAMPLOG_WARN("adaptationSet is null");  //CID:85233 - Null Returns
 	}
 	return selectedRepIdx;
 }

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -288,9 +288,7 @@ static AudioType getCodecType(string & codecValue, const IMPDElement *rep)
 	AudioType audioType = eAUDIO_UNSUPPORTED;
 	if (codecValue == "ec+3")
 	{
-#ifndef __APPLE__
 		audioType = eAUDIO_ATMOS;
-#endif
 	}
 	else if ( codecValue.rfind("ac-4",0)==0 )
 	{
@@ -324,7 +322,6 @@ static AudioType getCodecType(string & codecValue, const IMPDElement *rep)
 	{
 		audioType = eAUDIO_AAC;
 	}
-
 	return audioType;
 }
 
@@ -335,7 +332,6 @@ static AudioType getCodecType(string & codecValue, const IMPDElement *rep)
 bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptationSet, int &selectedRepIdx, AudioType &selectedCodecType,
 	uint32_t &selectedRepBandwidth, long &bestScore, bool disableEC3, bool disableATMOS, bool disableAC4, bool disableAC3, bool& disabled)
 {
-	printf( "entering StreamAbstractionAAMP_MPD::GetPreferredCodecIndex\n" );
 	bool isTrackSelected = false;
 	if( aamp->preferredCodecList.size() > 0 )
 	{
@@ -363,7 +359,6 @@ bool StreamAbstractionAAMP_MPD::GetPreferredCodecIndex(IAdaptationSet *adaptatio
 				{
 					codecValue = adapCodecs.at(0);
 				}
-				printf( "codecValue=%s\n", codecValue.c_str() );
 				auto iter = std::find(aamp->preferredCodecList.begin(), aamp->preferredCodecList.end(), codecValue);
 				if(iter != aamp->preferredCodecList.end())
 				{  /* track is in preferred codec list */
@@ -5687,7 +5682,6 @@ void StreamAbstractionAAMP_MPD::UpdateLanguageList()
 int StreamAbstractionAAMP_MPD::GetBestAudioTrackByLanguage( int &desiredRepIdx, AudioType &CodecType,
 std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
 {
-	printf( "entering StreamAbstractionAAMP_MPD::GetBestAudioTrackByLanguage\n" );
 	int bestTrack = -1;
 	unsigned long long bestScore = 0;
 	AudioTrackInfo selectedAudioTrack; /**< Selected Audio track information */
@@ -5788,7 +5782,6 @@ std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
 			int audioRepresentationIndex = -1;
 			long codecScore = 0;
 			bool disabled = false;
-			printf( "disableAC4=%d\n", disableAC4 );
 			if(!GetPreferredCodecIndex(adaptationSet, audioRepresentationIndex, selectedCodecType, selRepBandwidth, codecScore, disableEC3 , disableATMOS, disableAC4, disableAC3, disabled))
 			{
 				audioRepresentationIndex = GetDesiredCodecIndex(adaptationSet, selectedCodecType, selRepBandwidth, disableEC3 , disableATMOS, disableAC4, disableAC3, disabled);

--- a/middleware/SocUtils.cpp
+++ b/middleware/SocUtils.cpp
@@ -47,12 +47,11 @@ namespace SocUtils
 	 * This function checks the SOC interface for AC-4 support and also verifies
 	 * if the codec is supported at the InterfacePlayerRDK level.
 	 *
-	 * @return true if AC-4 is supported, false otherwise.
+	 * @return true if AC-4 is not supported
 	 */
 	bool IsDisabledAC4( void )
 	{
-		bool disableAc = socInterface->IsDisabledAC4();
-		return (disableAc || (!InterfacePlayerRDK::IsCodecSupported("ac-4")));
+		return !InterfacePlayerRDK::IsCodecSupported("ac-4");
 	}
 
 	/**
@@ -60,11 +59,11 @@ namespace SocUtils
 	 *
 	 * This function checks whether the AC-3 codec is supported by InterfacePlayerRDK.
 	 *
-	 * @return true if AC-3 is supported, false otherwise.
+	 * @return true if AC-3 is not supported
 	 */
 	bool IsDisabledAC3( void )
 	{
-		return (!InterfacePlayerRDK::IsCodecSupported("ac-3"));
+		return !InterfacePlayerRDK::IsCodecSupported("ac-3");
 	}
 
 	/**

--- a/middleware/SocUtils.cpp
+++ b/middleware/SocUtils.cpp
@@ -49,9 +49,9 @@ namespace SocUtils
 	 *
 	 * @return true if AC-4 is supported, false otherwise.
 	 */
-	bool IsSupportedAC4( void )
+	bool IsDisabledAC4( void )
 	{
-		bool disableAc = socInterface->IsSupportedAC4();
+		bool disableAc = socInterface->IsDisabledAC4();
 		return (disableAc || (!InterfacePlayerRDK::IsCodecSupported("ac-4")));
 	}
 
@@ -62,7 +62,7 @@ namespace SocUtils
 	 *
 	 * @return true if AC-3 is supported, false otherwise.
 	 */
-	bool IsSupportedAC3( void )
+	bool IsDisabledAC3( void )
 	{
 		return (!InterfacePlayerRDK::IsCodecSupported("ac-3"));
 	}

--- a/middleware/SocUtils.h
+++ b/middleware/SocUtils.h
@@ -42,9 +42,9 @@ namespace SocUtils
 	 * This function checks the SOC interface for AC-4 support and also verifies
 	 * if the codec is supported at the InterfacePlayerRDK level.
 	 *
-	 * @return true if AC-4 is supported, false otherwise.
+	 * @return true if AC-4 is not supported
 	 */
-	bool IsSupportedAC4( void );
+	bool IsDisabledAC4( void );
 
 	/**
 	 * @brief Checks if Westeros sink is used.
@@ -80,9 +80,9 @@ namespace SocUtils
 	 *
 	 * This function checks whether the AC-3 codec is supported by InterfacePlayerRDK.
 	 *
-	 * @return true if AC-3 is supported, false otherwise.
+	 * @return true if AC-3 is not supported.
 	 */
-	bool IsSupportedAC3( void );
+	bool IsDisabledAC3( void );
 
 	/**
 	 * @brief Retrieves the number of required queued frames.

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -136,15 +136,6 @@ public:
 	virtual bool UseAppSrc(){return false;}
 	
 	/**
-	 * @brief Check if AC4 should be disabled.
-	 *
-	 * Determines whether AC4 support should be disabled.
-	 *
-	 * @return True if AC4 should be disabled, false otherwise.
-	 */
-	virtual bool IsDisabledAC4(){return false;}
-	
-	/**
 	 * @brief Check if Westeros sink should be used.
 	 *
 	 * Determines whether the Westeros sink should be used in the current context.

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -142,7 +142,7 @@ public:
 	 *
 	 * @return True if AC4 should be disabled, false otherwise.
 	 */
-	virtual bool IsSupportedAC4(){return false;}
+	virtual bool IsDisabledAC4(){return false;}
 	
 	/**
 	 * @brief Check if Westeros sink should be used.

--- a/middleware/vendor/brcm/BrcmSocInterface.h
+++ b/middleware/vendor/brcm/BrcmSocInterface.h
@@ -39,7 +39,9 @@ class BrcmSocInterface : public SocInterface
 		 *
 		 * @return True if AC4 should be disabled, false otherwise.
 		 */
-		bool IsSupportedAC4()override{return true;}
+		bool IsDisabledAC4()override{
+			return true; // FIXME! available on devices with MS12 v2 support
+		}
 		
 		/**
 		 * @brief Check if PTS restamping is supported by the platform.

--- a/middleware/vendor/brcm/BrcmSocInterface.h
+++ b/middleware/vendor/brcm/BrcmSocInterface.h
@@ -31,17 +31,6 @@ class BrcmSocInterface : public SocInterface
 {
 	public:
 		BrcmSocInterface();
-
-		/**
-		 * @brief Check if AC4 should be disabled.
-		 *
-		 * Determines whether AC4 support should be disabled.
-		 *
-		 * @return True if AC4 should be disabled, false otherwise.
-		 */
-		bool IsDisabledAC4()override{
-			return true; // FIXME! available on devices with MS12 v2 support
-		}
 		
 		/**
 		 * @brief Check if PTS restamping is supported by the platform.

--- a/test/utests/fakes/FakeSocUtils.cpp
+++ b/test/utests/fakes/FakeSocUtils.cpp
@@ -44,10 +44,6 @@ namespace SocUtils
 	{
 		return false;
 	}
-	bool DisableAC3( void )
-	{
-		return false;
-	}
 
 	bool IsDisabledAC3()
 	{

--- a/test/utests/fakes/FakeSocUtils.cpp
+++ b/test/utests/fakes/FakeSocUtils.cpp
@@ -28,7 +28,7 @@ namespace SocUtils
 	{
 		return false;
 	}
-	bool IsSupportedAC4( void )
+	bool IsDisabledAC4( void )
 	{
 		return false;
 	}
@@ -49,7 +49,7 @@ namespace SocUtils
 		return false;
 	}
 
-	bool IsSupportedAC3()
+	bool IsDisabledAC3()
 	{
 		return false;
 	}

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -128,7 +128,7 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 			{eAAMPConfig_EnableClientDai, false},
 			{eAAMPConfig_MatchBaseUrl, false},
 			{eAAMPConfig_UseAbsoluteTimeline, false},
-			{eAAMPConfig_DisableAC4, true},
+			{eAAMPConfig_DisableAC4, false},
 			{eAAMPConfig_LimitResolution, false},
 			{eAAMPConfig_Disable4K, false},
 			{eAAMPConfig_PersistHighNetworkBandwidth, false},

--- a/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
+++ b/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
@@ -298,7 +298,7 @@ protected:
 			{eAAMPConfig_EnableClientDai, true},
 			{eAAMPConfig_MatchBaseUrl, false},
 			{eAAMPConfig_UseAbsoluteTimeline, false},
-			{eAAMPConfig_DisableAC4, true},
+			{eAAMPConfig_DisableAC4, false},
 			{eAAMPConfig_AudioOnlyPlayback, false},
 			{eAAMPConfig_LimitResolution, false},
 			{eAAMPConfig_Disable4K, false},

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioOnlyTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioOnlyTests.cpp
@@ -75,7 +75,7 @@ protected:
 		{eAAMPConfig_EnableClientDai, false},
 		{eAAMPConfig_MatchBaseUrl, false},
 		{eAAMPConfig_UseAbsoluteTimeline, false},
-		{eAAMPConfig_DisableAC4, true},
+		{eAAMPConfig_DisableAC4, false},
 		{eAAMPConfig_LimitResolution, false},
 		{eAAMPConfig_Disable4K, false},
 		{eAAMPConfig_PersistHighNetworkBandwidth, false},

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
@@ -440,5 +440,82 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 
 	std::vector<AudioTrackInfo> audioTracks = mStreamAbstractionAAMP_MPD->GetAvailableAudioTracks();
 	EXPECT_EQ(audioTracks.size(), 1);
-	EXPECT_EQ(audioTracks[0].codec, "ac-4.02.01.00"); // should this be normalized to ac-4?
+	EXPECT_EQ(audioTracks[0].codec, "ac-4.02.01.00");
+}
+
+TEST_F(SelectAudioTrackTests, MultiAudio)
+{
+	AAMPStatusType status;
+	std::string fragmentUrl;
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT2M0.0S" minBufferTime="PT4.0S">
+  <Period id="0" start="PT0.0S">
+	<AdaptationSet id="0" contentType="audio">
+	  <Representation id="0" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="64000" audioSamplingRate="48000">
+		<SegmentTemplate timescale="48000" initialization="aac/audio_init.mp4" media="aac/audio_$Number$.mp4" startNumber="1">
+		  <SegmentTimeline>
+			<S t="0" d="96000" r="59"/>
+		  </SegmentTimeline>
+		</SegmentTemplate>
+	  </Representation>
+	</AdaptationSet>
+	<AdaptationSet id="1" contentType="audio">
+	  <Representation id="1" mimeType="audio/mp4" codecs="ac-3" bandwidth="64000" audioSamplingRate="48000">
+		<SegmentTemplate timescale="48000" initialization="ac3/audio_init.mp4" media="ac3/audio_$Number$.mp4" startNumber="1">
+		  <SegmentTimeline>
+			<S t="0" d="96000" r="59"/>
+		  </SegmentTimeline>
+		</SegmentTemplate>
+	  </Representation>
+	</AdaptationSet>
+	<AdaptationSet id="2" contentType="audio">
+	  <Representation id="2" mimeType="audio/mp4" codecs="ec-3" bandwidth="64000" audioSamplingRate="48000">
+		<SegmentTemplate timescale="48000" initialization="ec3/audio_init.mp4" media="ec3/audio_$Number$.mp4" startNumber="1">
+		  <SegmentTimeline>
+			<S t="0" d="96000" r="59"/>
+		  </SegmentTimeline>
+		</SegmentTemplate>
+	  </Representation>
+	</AdaptationSet>
+	<AdaptationSet id="3" contentType="audio">
+	  <Representation id="3" mimeType="audio/mp4" codecs="ec+3" bandwidth="64000" audioSamplingRate="48000">
+		<SegmentTemplate timescale="48000" initialization="atmos/audio_init.mp4" media="atmos/audio_$Number$.mp4" startNumber="1">
+		  <SegmentTimeline>
+			<S t="0" d="96000" r="59"/>
+		  </SegmentTimeline>
+		</SegmentTemplate>
+	  </Representation>
+	</AdaptationSet>
+	<AdaptationSet id="4" contentType="audio">
+	  <Representation id="4" mimeType="audio/mp4" codecs="ac-4.02.01.00" bandwidth="64000" audioSamplingRate="48000">
+		<SegmentTemplate timescale="48000" initialization="ac4/audio_init.mp4" media="ac4/audio_$Number$.mp4" startNumber="1">
+		  <SegmentTimeline>
+			<S t="0" d="96000" r="59"/>
+		  </SegmentTimeline>
+		</SegmentTemplate>
+	  </Representation>
+	</AdaptationSet>
+  </Period>
+</MPD>)";
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("ac4/audio_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _, _, _))
+		.WillOnce(Return(true));
+	status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+	
+	std::vector<AudioTrackInfo> audioTracks = mStreamAbstractionAAMP_MPD->GetAvailableAudioTracks();
+	EXPECT_EQ(audioTracks.size(), 5);
+	const char *expected_codec[5] =
+	{
+		"mp4a.40.2",
+		"ac-3",
+		"ec-3",
+		"ec+3",
+		"ac-4.02.01.00"
+	};
+	for( int i=0; i<audioTracks.size(); i++ )
+	{
+		EXPECT_EQ( audioTracks[i].codec, expected_codec[i] );
+	}
 }

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
@@ -421,7 +421,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT2M0.0S" minBufferTime="PT4.0S">
 	<Period id="0" start="PT0.0S">
 			<AdaptationSet id="3" contentType="audio">
-					<Representation id="0" mimeType="audio/mp4" codecs="ac-4" bandwidth="64000" audioSamplingRate="48000">
+					<Representation id="0" mimeType="audio/mp4" codecs="ac-4.02.01.00" bandwidth="64000" audioSamplingRate="48000">
 							<SegmentTemplate timescale="48000" initialization="ac4/audio_init.mp4" media="ac4/audio_$Number$.mp4" startNumber="1">
 									<SegmentTimeline>
 											<S t="0" d="96000" r="59" />
@@ -440,5 +440,5 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 
 	std::vector<AudioTrackInfo> audioTracks = mStreamAbstractionAAMP_MPD->GetAvailableAudioTracks();
 	EXPECT_EQ(audioTracks.size(), 1);
-	EXPECT_EQ(audioTracks[0].codec, "ac-4");
+	EXPECT_EQ(audioTracks[0].codec, "ac-4.02.01.00"); // should this be normalized to ac-4?
 }

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -236,7 +236,7 @@ protected:
 			{eAAMPConfig_EnableClientDai, true},
 			{eAAMPConfig_MatchBaseUrl, false},
 			{eAAMPConfig_UseAbsoluteTimeline, false},
-			{eAAMPConfig_DisableAC4, true},
+			{eAAMPConfig_DisableAC4, false},
 			{eAAMPConfig_AudioOnlyPlayback, false},
 			{eAAMPConfig_LimitResolution, false},
 			{eAAMPConfig_Disable4K, false},

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -82,7 +82,7 @@ protected:
 		{eAAMPConfig_EnableClientDai, false},
 		{eAAMPConfig_MatchBaseUrl, false},
 		{eAAMPConfig_UseAbsoluteTimeline, false},
-		{eAAMPConfig_DisableAC4, true},
+		{eAAMPConfig_DisableAC4, false},
 		{eAAMPConfig_AudioOnlyPlayback, false},
 		{eAAMPConfig_LimitResolution, false},
 		{eAAMPConfig_Disable4K, false},

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/LinearFOGTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/LinearFOGTests.cpp
@@ -95,7 +95,7 @@ protected:
 				{eAAMPConfig_EnableClientDai, false},
 				{eAAMPConfig_MatchBaseUrl, false},
 				{eAAMPConfig_UseAbsoluteTimeline, false},
-				{eAAMPConfig_DisableAC4, true},
+				{eAAMPConfig_DisableAC4, false},
 				{eAAMPConfig_AudioOnlyPlayback, false},
 				{eAAMPConfig_LimitResolution, false},
 				{eAAMPConfig_Disable4K, false},

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/MonitorLatencyTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/MonitorLatencyTests.cpp
@@ -191,7 +191,7 @@ protected:
 			{eAAMPConfig_EnableClientDai, true},
 			{eAAMPConfig_MatchBaseUrl, false},
 			{eAAMPConfig_UseAbsoluteTimeline, false},
-			{eAAMPConfig_DisableAC4, true},
+			{eAAMPConfig_DisableAC4, false},
 			{eAAMPConfig_AudioOnlyPlayback, false},
 			{eAAMPConfig_LimitResolution, false},
 			{eAAMPConfig_Disable4K, false},

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/StreamSelectionTest.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/StreamSelectionTest.cpp
@@ -339,7 +339,7 @@ protected:
 			{eAAMPConfig_EnableClientDai, true},
 			{eAAMPConfig_MatchBaseUrl, false},
 			{eAAMPConfig_UseAbsoluteTimeline, false},
-			{eAAMPConfig_DisableAC4, true},
+			{eAAMPConfig_DisableAC4, false},
 			{eAAMPConfig_AudioOnlyPlayback, false},
 			{eAAMPConfig_LimitResolution, false},
 			{eAAMPConfig_Disable4K, false},

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -161,7 +161,7 @@ public:
 			{eAAMPConfig_EnableClientDai, false},
 			{eAAMPConfig_MatchBaseUrl, false},
 			{eAAMPConfig_UseAbsoluteTimeline, false},
-			{eAAMPConfig_DisableAC4, true},
+			{eAAMPConfig_DisableAC4, false},
 			{eAAMPConfig_AudioOnlyPlayback, false},
 			{eAAMPConfig_LimitResolution, false},
 			{eAAMPConfig_Disable4K, false},


### PR DESCRIPTION
VPLAY-11527 [VIPA] SoC support for ac4 audio track selection

Reason for Change: correct misnamed APIs

Test Guidance: no l1/l2 failures

Risk: Low