### PR TITLE
VPLAY-11530 : Increase in PLTV XSTPP-999 Failures on both Xi1/ES1

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1390,7 +1390,15 @@ void AampDRMLicenseManager::clearDrmSession(bool forceClearSession)
 	mDRMSessionManager->clearDrmSession(forceClearSession);
 	for(int i = 0 ; i < mMaxDRMSessions;i++)
 	{
-		mLicenseDownloader[i].Clear();
+		bool isFailedKeyId = mDRMSessionManager->getFailedKeyIdStatus(i);
+		if(( mDRMSessionManager->drmSessionContexts != NULL && (isFailedKeyId || forceClearSession)  ))
+		{
+			if(mDRMSessionManager->drmSessionContexts[i].drmSession != NULL)
+			{
+				AAMPLOG_INFO("Clearing Session %d, isFailedKeyId=%d, forceClearSession=%d",i, isFailedKeyId, forceClearSession);
+				mLicenseDownloader[i].Clear();
+		    }
+		}
 	}
 }
 

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -165,6 +165,18 @@ void DrmSessionManager::clearAccessToken()
 }
 
 /**
+ * @brief Get the failed key ID status for a specific session
+ */
+bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
+{
+	if (sessionIndex >= 0 && sessionIndex < mMaxDrmSessions && cachedKeyIDs)
+	{
+		return cachedKeyIDs[sessionIndex].isFailedKeyId;
+	}
+	return false;
+}
+
+/**
  * @brief Clean up the Session Data if license key acquisition failed or if LicenseCaching is false.
  */
 void DrmSessionManager::clearDrmSession(bool forceClearSession)

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -282,6 +282,16 @@ public:
 	 * @return	void.
 	 */
 	void clearFailedKeyIds();
+
+
+	/**
+	 * @fn		getFailedKeyIdStatus
+	 *
+	 * @param	sessionIndex session index to check
+	 * @return	bool - true if the key ID is marked as failed, false otherwise
+	 */
+	bool getFailedKeyIdStatus(int sessionIndex);
+
 	/**
 	 * @fn		clearDrmSession
 	 *


### PR DESCRIPTION
VPLAY-11530 [Charter XiOne | ES1][R38] Increase in PLTV XSTPP-999 Failures on both Xi1/ES1

Reason for Change : Reintroduced the condition check before calling clear() in clearDrmSession.