### PR TITLE
VPLAY-11543 fix command line openssl path issues with utests

### DIFF
--- a/middleware/test/utests/CMakeLists.txt
+++ b/middleware/test/utests/CMakeLists.txt
@@ -27,6 +27,9 @@ set(PLAYER_ROOT "../../")
 
 find_package(PkgConfig REQUIRED)
 
+pkg_check_modules(OPENSSL REQUIRED openssl)
+include_directories(${OPENSSL_INCLUDE_DIRS})
+
 pkg_check_modules(GTEST REQUIRED gtest)
 pkg_check_modules(GMOCK REQUIRED gmock)
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
@@ -40,7 +43,7 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_path (JSC_INCDIR JavaScriptCore/JavaScript.h HINTS ${JSCORE_INCLUDE_DIRS} REQUIRED)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_GST1 -ggdb")
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/test/utests/CMakeLists.txt
+++ b/test/utests/CMakeLists.txt
@@ -34,7 +34,6 @@ include_directories(${AAMP_ROOT}/middleware/drm/ocdm)
 include_directories(${AAMP_ROOT}/middleware/playerJsonObject)
 include_directories(${AAMP_ROOT}/middleware/externals/contentsecuritymanager)
 
-
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(OPENSSL REQUIRED openssl)

--- a/test/utests/CMakeLists.txt
+++ b/test/utests/CMakeLists.txt
@@ -34,7 +34,11 @@ include_directories(${AAMP_ROOT}/middleware/drm/ocdm)
 include_directories(${AAMP_ROOT}/middleware/playerJsonObject)
 include_directories(${AAMP_ROOT}/middleware/externals/contentsecuritymanager)
 
+
 find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(OPENSSL REQUIRED openssl)
+include_directories(${OPENSSL_INCLUDE_DIRS})
 
 pkg_check_modules(GTEST REQUIRED gtest)
 pkg_check_modules(GMOCK REQUIRED gmock)


### PR DESCRIPTION
VPLAY-11543 fix command line openssl path issues with utests

Reason for Change: facing  "fatal error: 'openssl/sha.h' file not found" failures while attempting to build utests on OSX from command line; fix adds explicit package and include_directories(${OPENSSL_INCLUDE_DIRS}) in top level CMakeLists.txt, for both aamp and middleware utests

Test Guidance: able to build/run tests on new Macs from command line

Risk: Low