### PR TITLE
VPLAY-11554 WPEWebProcess crash due to lockup in GetManifestEndDelta

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1767,6 +1767,13 @@ public:
 	}
 
 	/**
+	 *   @fn UnblockVideoWaitForCachedFragmentChunk
+	 *
+	 *   @return void
+	 */
+	void UnblockWaitForCachedFragmentChunk();
+
+	/**
 	 *   @brief Get available thumbnail bitrates.
 	 *
 	 *   @return available thumbnail bitrates.

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1765,7 +1765,7 @@ public:
 	}
 
 	/**
-	 *   @fn UnblockVideoWaitForCachedFragmentChunk
+	 *   @fn UnblockWaitForCachedFragmentChunk
 	 *
 	 *   @return void
 	 */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7686,6 +7686,7 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		double bufferedDuration = 0.0;
 		if (mpStreamAbstractionAAMP)
 		{
+			mpStreamAbstractionAAMP->UnblockWaitForCachedFragmentChunk(); // avoid mutex lock if waiting for cached fragments
 			bufferedDuration = mpStreamAbstractionAAMP->GetBufferedVideoDurationSec();
 		}
 		double latency = GetCurrentLatency();

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3729,7 +3729,11 @@ bool StreamAbstractionAAMP::CheckForRampDownLimitReached()
 }
 
 /**
- *  @brief Unblock WaitForCachedFragment()
+ * @brief Unblocks all waiting tracks by calling AbortWaitForCachedFragmentChunk() on each track.
+ *
+ * Iterates over all track types and invokes AbortWaitForCachedFragmentChunk()
+ * on each MediaTrack, ensuring that any threads waiting for cached fragments
+ * are unblocked.
  */
 void StreamAbstractionAAMP::UnblockWaitForCachedFragmentChunk()
 {

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3719,6 +3719,21 @@ bool StreamAbstractionAAMP::CheckForRampDownLimitReached()
 }
 
 /**
+ *  @brief Unblock WaitForCachedFragment()
+ */
+void StreamAbstractionAAMP::UnblockWaitForCachedFragmentChunk()
+{
+	for ( int type = eTRACK_VIDEO; type <= eTRACK_AUX_AUDIO; type++)
+	{
+		MediaTrack *track = GetMediaTrack((TrackType)type);
+		if(track)
+		{
+			track->AbortWaitForCachedFragmentChunk();
+		}
+	}
+}
+
+/**
  *  @brief Get buffered video duration in seconds
  */
 double StreamAbstractionAAMP::GetBufferedVideoDurationSec()

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -73,6 +73,10 @@ void StreamAbstractionAAMP::RefreshSubtitles()
 {
 }
 
+void StreamAbstractionAAMP::UnblockWaitForCachedFragmentChunk()
+{
+}
+
 long StreamAbstractionAAMP::GetVideoBitrate(void)
 {
 	return 0;


### PR DESCRIPTION
Reason for change: Avoid deadlock in GetManifestEndDelta() on stop
Test Procedure: see ticket
Risks: Low