### PR TITLE
VPLAY-11588 [VIPA] inband captions not set correctly when playing HLS

### DIFF
--- a/StreamOutputFormat.h
+++ b/StreamOutputFormat.h
@@ -26,7 +26,7 @@
  */
 enum StreamOutputFormat
 {
-    FORMAT_INVALID,         /**< Invalid format */
+    FORMAT_INVALID,         /**< Invalid format. Used in rialto for subtitle track when there are inband captions. */
     FORMAT_MPEGTS,          /**< MPEG Transport Stream */
     FORMAT_ISO_BMFF,        /**< ISO Base Media File format */
     FORMAT_AUDIO_ES_MP3,    /**< MP3 Audio Elementary Stream */

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2577,7 +2577,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 
 				if (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE)
 				{
-					/* For closedCaption subtitles then we need a subtitle track setup in Riato for control. The actual subtitle
+					/* For closedCaption subtitles then we need a subtitle track setup in Rialto for control. The actual subtitle
 					* data is included in the video track. In this case we are using FORMAT_INVALID. Otherwise we use FORMAT_SUBTITLE_WEBVTT
 					*/
 					format = mediaInfoStore[currentTextTrackProfileIndex].isCC ? FORMAT_INVALID : FORMAT_SUBTITLE_WEBVTT;
@@ -7385,7 +7385,7 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
 			aamp->SetPreferredTextTrack(mTextTracks[0]);
 		}
 	}
-	AAMPLOG_INFO("using RialtoSink TextTrack Selected :%d isCC %d lang %s", currentTextTrackProfileIndex, aamp->mIsInbandCC, mTextTracks[0].language.c_str());
+	AAMPLOG_INFO("using RialtoSink TextTrack Selected %d", currentTextTrackProfileIndex);
 }
 
 bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo& selectedTextTrack)

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1311,7 +1311,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 			std::string tempEffectiveUrl;
 			AAMPLOG_TRACE(" Calling Getfile . buffer %p avail %d", &cachedFragment->fragment, (int)cachedFragment->fragment.GetAvail());
 			double downloadTime = 0;
-			
+
 			cachedFragment->discontinuityIndex = 0;
 			if( ISCONFIGSET(eAAMPConfig_HlsTsEnablePTSReStamp) )
 			{ // TODO: optimize me
@@ -1340,7 +1340,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 					}
 				}
 			}
-			
+
 			bool fetched = aamp->GetFile(fragmentUrl, (AampMediaType)(type), &cachedFragment->fragment,
 			 tempEffectiveUrl, &http_error, &downloadTime, range, type, false, NULL, NULL, fragmentDurationSeconds);
 			//Workaround for 404 of subtitle fragments
@@ -1757,7 +1757,7 @@ void TrackState::InjectFragmentInternal(CachedFragment* cachedFragment, bool &fr
 				aamp->SendStreamCopy(type, buf.data(), buf.size(), info.pts_s, info.dts_s, info.duration);
 			}
 		};
-		
+
 		if( demuxOp == eStreamOp_DEMUX_ALL && ISCONFIGSET(eAAMPConfig_HlsTsEnablePTSReStamp) )
 		{
 			if( context->mPtsOffsetMap.count(cachedFragment->discontinuityIndex)==0 )
@@ -1770,7 +1770,7 @@ void TrackState::InjectFragmentInternal(CachedFragment* cachedFragment, bool &fr
 			}
 			m_totalDurationForPtsRestamping += cachedFragment->duration;
 		}
-		
+
 		fragmentDiscarded = !playContext->sendSegment( &cachedFragment->fragment,
 			position.inSeconds(),
 			cachedFragment->duration,
@@ -2329,10 +2329,10 @@ void TrackState::ProcessPlaylist(AampGrowableBuffer& newPlaylist, int http_error
 		// Free previous playlist buffer and load with new one
 		playlist.Free();
 		playlist.Replace( &newPlaylist );
-		
+
 		AampTime culled{};
 		IndexPlaylist(true, culled);
-        
+
 		// Update culled seconds if playlist download was successful
 		// We need culledSeconds to find the timedMetadata position in playlist
 		// culledSeconds and FindTimedMetadata have been moved up here, because FindMediaForSequenceNumber
@@ -2567,7 +2567,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);
 				SETCONFIGVALUE(AAMP_STREAM_SETTING,eAAMPConfig_SubTitleLanguage,(std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
 				if (format) *format = (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE) ? FORMAT_SUBTITLE_WEBVTT : FORMAT_UNKNOWN;
-//				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language, playlistURI);
+				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language, playlistURI);
 			}
 			else
 			{
@@ -4561,7 +4561,7 @@ void StreamAbstractionAAMP_HLS::InitTracks()
 void StreamAbstractionAAMP_HLS::CachePlaylistThreadFunction(void)
 {
 	// required to work around Adobe SSAI session lifecycle problem
-	// Temporary workaround code 
+	// Temporary workaround code
 	aamp->PreCachePlaylistDownloadTask();
 	return;
 }
@@ -7108,7 +7108,7 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 			{
 				std::string index = std::to_string(i);
 				std::string language = (!media.language.empty()) ? GetLanguageCode(i) : std::string();
-//				AAMPLOG_WARN("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, group_id.c_str(), name.c_str(), instreamID.c_str(), characteristics.c_str());
+				AAMPLOG_WARN("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, group_id.c_str(), name.c_str(), instreamID.c_str(), characteristics.c_str());
 				mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
 			}
 			i++;

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2532,7 +2532,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 {
 	std::string playlistURI;
 
-	format = FORMAT_INVALID; /* default value*/
+	format = FORMAT_UNKNOWN; /* default value*/
 
 	switch (trackType)
 	{
@@ -2566,7 +2566,6 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);
 				SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_SubTitleLanguage, (std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
 
-				format = FORMAT_UNKNOWN;
 				if (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE)
 				{
 					/* For closedCaption subtitles then we need a subtitle track setup in Rialto for control. The actual subtitle

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2525,9 +2525,23 @@ int StreamAbstractionAAMP_HLS::GetBestAudioTrackByLanguage( void )
 /**
  *  @brief Function to get playlist URI based on media selection
  */
-std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, StreamOutputFormat* format)
+std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType )
+{
+	StreamOutputFormat unused_format;
+	return GetPlaylistURI(trackType, unused_format);
+}
+
+/**
+ * @brief Function to get playlist URI based on media selection
+ *
+ * TrackType is used to specify the type of stream track for which the playlist URI is requested.
+ * Typical values may include audio, video, subtitle, or other media types supported by the stream abstraction.
+ */
+std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, StreamOutputFormat &format)
 {
 	std::string playlistURI;
+
+	format = FORMAT_INVALID; /* default value*/
 
 	switch (trackType)
 	{
@@ -2538,10 +2552,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 			{
 				playlistURI = streamInfo->uri;
 			}
-			if (format)
-			{
-				*format = FORMAT_MPEGTS;
-			}
+			format = FORMAT_MPEGTS;
 		}
 		break;
 	case eTRACK_AUDIO:
@@ -2552,10 +2563,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				AAMPLOG_WARN("GetPlaylistURI : AudioTrack: language selected is %s", GetLanguageCode(currentAudioProfileIndex).c_str());
 				playlistURI = mediaInfoStore[currentAudioProfileIndex].uri;
 				mAudioTrackIndex = std::to_string(currentAudioProfileIndex);
-				if (format)
-				{
-					*format = GetStreamOutputFormatForTrack(trackType);
-				}
+				format = GetStreamOutputFormatForTrack(trackType);
 			}
 		}
 		break;
@@ -2565,28 +2573,25 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 			{
 				playlistURI = mediaInfoStore[currentTextTrackProfileIndex].uri;
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);
-				SETCONFIGVALUE(AAMP_STREAM_SETTING,eAAMPConfig_SubTitleLanguage,(std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
-				if (format)
-				{
-					if (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE)
-					{
+				SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_SubTitleLanguage, (std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
 
-						*format =mediaInfoStore[currentTextTrackProfileIndex].isCC ? FORMAT_INVALID:FORMAT_SUBTITLE_WEBVTT;
-					}
-					else
-					{
-						*format = FORMAT_UNKNOWN;
-					}
+				if (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE)
+				{
+					/* For closedCaption subtitles then we need a subtitle track setup in Riato for control. The actual subtitle
+					* data is included in the video track. In this case we are using FORMAT_INVALID. Otherwise we use FORMAT_SUBTITLE_WEBVTT
+					*/
+					format = mediaInfoStore[currentTextTrackProfileIndex].isCC ? FORMAT_INVALID : FORMAT_SUBTITLE_WEBVTT;
 				}
-				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language.c_str(), playlistURI.c_str());
+				else
+				{
+					format = FORMAT_UNKNOWN;
+				}
+
+				AAMPLOG_TRACE("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language.c_str(), playlistURI.c_str());
 			}
 			else
 			{
 				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: Couldn't find subtitle URI for preferred language: %s", aamp->mSubLanguage.c_str());
-				if (format != NULL)
-				{
-					*format = FORMAT_INVALID;
-				}
 			}
 		}
 		break;
@@ -2600,10 +2605,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				playlistURI = mediaInfoStore[index].uri;
 				AAMPLOG_WARN("GetPlaylistURI : Auxiliary Track: Audio selected name is %s", GetLanguageCode(index).c_str());
 				//No need to update back, matching track is either there or not
-				if (format)
-				{
-					*format = GetStreamOutputFormatForTrack(trackType);
-				}
+				format = GetStreamOutputFormatForTrack(trackType);
 			}
 		}
 		break;
@@ -3537,7 +3539,7 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 						lastSelectedProfileIndex = currentProfileIndex;
 						AAMPLOG_INFO("Trying BitRate: %ld, Max BitRate: %ld", bandwidthBitsPerSecond,
 						GetStreamInfo(GetMaxBWProfile())->bandwidthBitsPerSecond);
-						std::string uri = GetPlaylistURI(eTRACK_VIDEO, &video->streamOutputFormat);
+						std::string uri = GetPlaylistURI(eTRACK_VIDEO, video->streamOutputFormat);
 						if( !uri.empty() ){
 							aamp_ResolveURL(video->mPlaylistUrl, aamp->GetManifestUrl(), uri.c_str(), ISCONFIGSET(eAAMPConfig_PropagateURIParam));
 
@@ -4545,7 +4547,7 @@ void StreamAbstractionAAMP_HLS::InitTracks()
 				continue;
 			}
 		}
-		std::string uri = GetPlaylistURI((TrackType)iTrack, &ts->streamOutputFormat);
+		std::string uri = GetPlaylistURI((TrackType)iTrack, ts->streamOutputFormat);
 		if( !uri.empty() )
 		{
 			aamp_ResolveURL(ts->mPlaylistUrl, aamp->GetManifestUrl(), uri.c_str(), ISCONFIGSET(eAAMPConfig_PropagateURIParam));
@@ -7119,7 +7121,7 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 			{
 				std::string index = std::to_string(i);
 				std::string language = (!media.language.empty()) ? GetLanguageCode(i) : std::string();
-				AAMPLOG_WARN("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, media.group_id.c_str(), media.name.c_str(), media.instreamID.c_str(), media.characteristics.c_str());
+				AAMPLOG_TRACE("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, media.group_id.c_str(), media.name.c_str(), media.instreamID.c_str(), media.characteristics.c_str());
 				mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
 			}
 			i++;

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2523,15 +2523,6 @@ int StreamAbstractionAAMP_HLS::GetBestAudioTrackByLanguage( void )
 }
 
 /**
- *  @brief Function to get playlist URI based on media selection
- */
-std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType )
-{
-	StreamOutputFormat unused_format;
-	return GetPlaylistURI(trackType, unused_format);
-}
-
-/**
  * @brief Function to get playlist URI based on media selection
  *
  * TrackType is used to specify the type of stream track for which the playlist URI is requested.
@@ -2560,7 +2551,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 			if (currentAudioProfileIndex >= 0)
 			{
 				//aamp->UpdateAudioLanguageSelection( GetLanguageCode(currentAudioProfileIndex).c_str() );
-				AAMPLOG_WARN("GetPlaylistURI : AudioTrack: language selected is %s", GetLanguageCode(currentAudioProfileIndex).c_str());
+				AAMPLOG_INFO("GetPlaylistURI : AudioTrack: language selected is %s", GetLanguageCode(currentAudioProfileIndex).c_str());
 				playlistURI = mediaInfoStore[currentAudioProfileIndex].uri;
 				mAudioTrackIndex = std::to_string(currentAudioProfileIndex);
 				format = GetStreamOutputFormatForTrack(trackType);
@@ -2575,6 +2566,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);
 				SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_SubTitleLanguage, (std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
 
+				format = FORMAT_UNKNOWN;
 				if (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE)
 				{
 					/* For closedCaption subtitles then we need a subtitle track setup in Rialto for control. The actual subtitle
@@ -2582,12 +2574,8 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 					*/
 					format = mediaInfoStore[currentTextTrackProfileIndex].isCC ? FORMAT_INVALID : FORMAT_SUBTITLE_WEBVTT;
 				}
-				else
-				{
-					format = FORMAT_UNKNOWN;
-				}
 
-				AAMPLOG_TRACE("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language.c_str(), playlistURI.c_str());
+				AAMPLOG_INFO("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language.c_str(), playlistURI.c_str());
 			}
 			else
 			{
@@ -2603,7 +2591,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 			if (index != -1)
 			{
 				playlistURI = mediaInfoStore[index].uri;
-				AAMPLOG_WARN("GetPlaylistURI : Auxiliary Track: Audio selected name is %s", GetLanguageCode(index).c_str());
+				AAMPLOG_INFO("GetPlaylistURI : Auxiliary Track: Audio selected name is %s", GetLanguageCode(index).c_str());
 				//No need to update back, matching track is either there or not
 				format = GetStreamOutputFormatForTrack(trackType);
 			}
@@ -2611,6 +2599,15 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 		break;
 	}
 	return playlistURI;
+}
+
+/**
+ *  @brief Function to get playlist URI based on media selection. format parameter not needed
+ */
+std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType )
+{
+	StreamOutputFormat unused_format;
+	return GetPlaylistURI(trackType, unused_format);
 }
 
 /***************************************************************************
@@ -7121,7 +7118,7 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 			{
 				std::string index = std::to_string(i);
 				std::string language = (!media.language.empty()) ? GetLanguageCode(i) : std::string();
-				AAMPLOG_TRACE("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, media.group_id.c_str(), media.name.c_str(), media.instreamID.c_str(), media.characteristics.c_str());
+				AAMPLOG_INFO("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, media.group_id.c_str(), media.name.c_str(), media.instreamID.c_str(), media.characteristics.c_str());
 				mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
 			}
 			i++;

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2567,7 +2567,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);
 				SETCONFIGVALUE(AAMP_STREAM_SETTING,eAAMPConfig_SubTitleLanguage,(std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
 				if (format) *format = (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE) ? FORMAT_SUBTITLE_WEBVTT : FORMAT_UNKNOWN;
-				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language, playlistURI);
+				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language.c_str(), playlistURI.c_str());
 			}
 			else
 			{
@@ -7108,7 +7108,7 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 			{
 				std::string index = std::to_string(i);
 				std::string language = (!media.language.empty()) ? GetLanguageCode(i) : std::string();
-				AAMPLOG_WARN("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, group_id.c_str(), name.c_str(), instreamID.c_str(), characteristics.c_str());
+				AAMPLOG_WARN("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, media.group_id.c_str(), media.name.c_str(), media.instreamID.c_str(), media.characteristics.c_str());
 				mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
 			}
 			i++;

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2548,7 +2548,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 		break;
 	case eTRACK_AUDIO:
 		{
-			if (currentAudioProfileIndex >= 0 && currentTextTrackProfileIndex < (int)mediaInfoStore.size())
+			if (currentAudioProfileIndex >= 0 && currentAudioProfileIndex < (int)mediaInfoStore.size())
 			{
 				//aamp->UpdateAudioLanguageSelection( GetLanguageCode(currentAudioProfileIndex).c_str() );
 				AAMPLOG_INFO("GetPlaylistURI : AudioTrack: language selected is %s", GetLanguageCode(currentAudioProfileIndex).c_str());

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2566,7 +2566,18 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 				playlistURI = mediaInfoStore[currentTextTrackProfileIndex].uri;
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);
 				SETCONFIGVALUE(AAMP_STREAM_SETTING,eAAMPConfig_SubTitleLanguage,(std::string)mediaInfoStore[currentTextTrackProfileIndex].language);
-				if (format) *format = (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE) ? FORMAT_SUBTITLE_WEBVTT : FORMAT_UNKNOWN;
+				if (format)
+				{
+					if (mediaInfoStore[currentTextTrackProfileIndex].type == eMEDIATYPE_SUBTITLE)
+					{
+
+						*format =mediaInfoStore[currentTextTrackProfileIndex].isCC ? FORMAT_INVALID:FORMAT_SUBTITLE_WEBVTT;
+					}
+					else
+					{
+						*format = FORMAT_UNKNOWN;
+					}
+				}
 				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: subtitle found language %s, uri %s", mediaInfoStore[currentTextTrackProfileIndex].language.c_str(), playlistURI.c_str());
 			}
 			else
@@ -7362,21 +7373,12 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
 {
 	if( currentTextTrackProfileIndex  == -1)
 	{
-		TextTrackInfo *firstAvailTextTrack = nullptr;
-		for (int j = 0; j < mTextTracks.size(); j++)
+		if( mTextTracks.size())
 		{
-			if (!mTextTracks[j].isCC)
-			{
-		firstAvailTextTrack = &mTextTracks[j];
-				break;
-			}
-		}
-		if(firstAvailTextTrack != nullptr)
-		{
-			currentTextTrackProfileIndex = std::stoi(firstAvailTextTrack->index);
-			aamp->mIsInbandCC = false;
+			currentTextTrackProfileIndex = std::stoi(mTextTracks[0].index);
+			aamp->mIsInbandCC = mTextTracks[0].isCC;
 			aamp->SetCCStatus(false); //mute the subtitle track
-			aamp->SetPreferredTextTrack(*firstAvailTextTrack);
+			aamp->SetPreferredTextTrack(mTextTracks[0]);
 		}
 	}
 	AAMPLOG_INFO("using RialtoSink TextTrack Selected :%d", currentTextTrackProfileIndex);

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2602,7 +2602,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 }
 
 /**
- *  @brief Function to get playlist URI based on media selection. format parameter not needed
+ *  @brief Function to get playlist URI based on media selection. Format parameter not needed.
  */
 std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType )
 {

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7370,7 +7370,9 @@ bool TrackState::IsExtXByteRange( lstring ptr, size_t *byteRangeLength, size_t *
     return false;
 }
 
-//Enable default text track for Rialto
+/**
+ * @brief For rialto select any valid subtitle track
+ */
 void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
 {
 	if( currentTextTrackProfileIndex  == -1)
@@ -7383,7 +7385,7 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
 			aamp->SetPreferredTextTrack(mTextTracks[0]);
 		}
 	}
-	AAMPLOG_INFO("using RialtoSink TextTrack Selected :%d", currentTextTrackProfileIndex);
+	AAMPLOG_INFO("using RialtoSink TextTrack Selected :%d isCC %d lang %s", currentTextTrackProfileIndex, aamp->mIsInbandCC, mTextTracks[0].language.c_str());
 }
 
 bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo& selectedTextTrack)

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2548,7 +2548,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 		break;
 	case eTRACK_AUDIO:
 		{
-			if (currentAudioProfileIndex >= 0)
+			if (currentAudioProfileIndex >= 0 && currentTextTrackProfileIndex < (int)mediaInfoStore.size())
 			{
 				//aamp->UpdateAudioLanguageSelection( GetLanguageCode(currentAudioProfileIndex).c_str() );
 				AAMPLOG_INFO("GetPlaylistURI : AudioTrack: language selected is %s", GetLanguageCode(currentAudioProfileIndex).c_str());
@@ -2560,7 +2560,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 		break;
 	case eTRACK_SUBTITLE:
 		{
-			if (currentTextTrackProfileIndex != -1)
+			if (currentTextTrackProfileIndex != -1 && currentTextTrackProfileIndex < (int)mediaInfoStore.size()	)
 			{
 				playlistURI = mediaInfoStore[currentTextTrackProfileIndex].uri;
 				mTextTrackIndex = std::to_string(currentTextTrackProfileIndex);

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -924,7 +924,7 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 * @fn GetPlaylistURI
 		 *
 		 * @param[in] trackType Track type
-		 * @param[in] format stream output type
+		 * @param[in,out] format stream output type
 		 * @return string playlist URI
 		 ***************************************************************************/
 		std::string GetPlaylistURI(TrackType trackType, StreamOutputFormat &format);

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -927,7 +927,8 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 * @param[in] format stream output type
 		 * @return string playlist URI
 		 ***************************************************************************/
-		std::string GetPlaylistURI(TrackType trackType, StreamOutputFormat* format = NULL);
+		std::string GetPlaylistURI(TrackType trackType, StreamOutputFormat &format);
+		std::string GetPlaylistURI(TrackType trackType);
 		/***************************************************************************
 		 * @fn StopInjection
 		 *
@@ -1112,7 +1113,7 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 
 		std::mutex mMP_mutex;  // protects mMetadataProcessor
 		 std::unique_ptr<aamp::MetadataProcessorIntf> mMetadataProcessor;
-			 
+
 };
 
 StreamOutputFormat GetFormatFromFragmentExtension( const AampGrowableBuffer &playlist );

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -1111,9 +1111,8 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 
 		ptsoffset_update_t mPtsOffsetUpdate;	/**< Function to use to update the PTS offset */
 
-		std::mutex mMP_mutex;  // protects mMetadataProcessor
-		 std::unique_ptr<aamp::MetadataProcessorIntf> mMetadataProcessor;
-
+		std::mutex mMP_mutex; // protects mMetadataProcessor
+		std::unique_ptr<aamp::MetadataProcessorIntf> mMetadataProcessor;
 };
 
 StreamOutputFormat GetFormatFromFragmentExtension( const AampGrowableBuffer &playlist );

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -950,12 +950,34 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetAudioPlaylistURITest)
     ASSERT_NE(FORMAT_AUDIO_ES_AAC, format);
 }
 
-TEST_F(StreamAbstractionAAMP_HLSTest, GetVideoPlaylistURITest2)
+TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE1)
 {
-    // mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = 3;
+    /* test when no subtitle track selected*/
+    mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = -1;
     StreamOutputFormat format = FORMAT_MPEGTS;
-    TrackType type = eTRACK_SUBTITLE;
-    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(type, format);
+    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
+    ASSERT_EQ(FORMAT_UNKNOWN, format);
+}
+
+TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE2)
+{
+    MediaInfo MediaInfoObj0 = {.type = eMEDIATYPE_SUBTITLE, .uri= "idx0", .isCC = false};
+    MediaInfo MediaInfoObj1 = {.type = eMEDIATYPE_SUBTITLE, .uri= "idx1", .isCC = true};
+    StreamOutputFormat format = FORMAT_MPEGTS;
+    mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(MediaInfoObj0);
+    mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(MediaInfoObj1);
+
+    /* test when .isCC = false*/
+    mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = 0;
+    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
+    ASSERT_EQ(FORMAT_SUBTITLE_WEBVTT, format);
+    ASSERT_EQ("idx0", playlistURI);
+
+    /* test when .isCC = true*/
+    mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = 1;
+    playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
+    ASSERT_EQ(FORMAT_INVALID, format);
+    ASSERT_EQ("idx1", playlistURI);
 
 }
 

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -936,7 +936,7 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetVideoPlaylistURITest)
 {
     StreamOutputFormat format = FORMAT_MPEGTS;
     TrackType type = eTRACK_VIDEO;
-    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(type, &format);
+    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(type, format);
     ASSERT_EQ(format, FORMAT_MPEGTS);
     ASSERT_EQ(type, eTRACK_VIDEO);
 }
@@ -946,7 +946,7 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetAudioPlaylistURITest)
 {
     // mStreamAbstractionAAMP_HLS->currentAudioProfileIndex = 3;
     StreamOutputFormat format;
-    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_AUDIO, &format);
+    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_AUDIO, format);
     ASSERT_NE(FORMAT_AUDIO_ES_AAC, format);
 }
 
@@ -955,7 +955,7 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetVideoPlaylistURITest2)
     // mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = 3;
     StreamOutputFormat format = FORMAT_MPEGTS;
     TrackType type = eTRACK_SUBTITLE;
-    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(type, &format);
+    auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(type, format);
 
 }
 
@@ -2775,19 +2775,19 @@ TEST_F(StreamAbstractionAAMP_HLSTest, ThumbnailIndexing)
 	"#EXT-X-ENDLIST\r\n";
 	lstring ii = lstring( raw, strlen(raw) );
 	auto x = IndexThumbnails( ii );
-	
+
 	EXPECT_EQ(x[0].url,"pckimage-0.jpg");
 	EXPECT_EQ(x[0].layout.numCols,5);
 	EXPECT_EQ(x[0].layout.numRows,6);
 	EXPECT_EQ(x[0].layout.posterDuration,10);
 	EXPECT_EQ(x[0].layout.tileSetDuration,136.8367);
-	
+
 	EXPECT_EQ(x[1].url,"pckimage-1.jpg");
 	EXPECT_EQ(x[1].layout.numCols,9);
 	EXPECT_EQ(x[1].layout.numRows,17);
 	EXPECT_EQ(x[1].layout.posterDuration,20);
 	EXPECT_EQ(x[1].layout.tileSetDuration,200);
-	
+
 	EXPECT_EQ(x[2].url,"pckimage-2.jpg");
 	EXPECT_EQ(x[2].layout.numCols,4);
 	EXPECT_EQ(x[2].layout.numRows,3);

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -961,6 +961,10 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE1)
 
 TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE2)
 {
+    /*
+    * For test purposes we create 2 subtitle options inband and outband but
+    * in reality AAMP will not handle different subtitle formats in the same manifest
+    */
     MediaInfo MediaInfoObj0 = {.type = eMEDIATYPE_SUBTITLE, .uri= "idx0", .isCC = false};
     MediaInfo MediaInfoObj1 = {.type = eMEDIATYPE_SUBTITLE, .uri= "idx1", .isCC = true};
     StreamOutputFormat format = FORMAT_MPEGTS;
@@ -978,6 +982,11 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE2)
     playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
     ASSERT_EQ(FORMAT_INVALID, format);
     ASSERT_EQ("idx1", playlistURI);
+
+    /* test vector index out of bounds */
+    mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = 2;
+    playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
+    ASSERT_EQ(FORMAT_UNKNOWN, format);
 
 }
 


### PR DESCRIPTION
Reason for change:
For HLS stream with inband subtitles. The subtitle format passed to StreamSink::Configure() is defaulting to WEBVTT, it should be FORMAT_INVALID.

Summary of Changes:

- Replace passing of pointer to method with pass by reference
- Select correct subtitle format
- Add L1 tests

Risk: to HLS Medium, DASH zero