### PR TITLE
VPLAY-11328 - Linear - Progress Bar jumping to the beginning while trickplay

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -146,6 +146,88 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 			}
 		}
 
+		if ((actualType == eMEDIATYPE_INIT_VIDEO || actualType == eMEDIATYPE_INIT_AUDIO || actualType == eMEDIATYPE_INIT_SUBTITLE) && ret) // Only if init fragment successful or available from cache
+		{
+			//To read track_id from the init fragments to check if there any mismatch.
+			//A mismatch in track_id is not handled in the gstreamer version 1.10.4
+			//But is handled in the latest version (1.18.5),
+			//so upon upgrade to it or introduced a patch in qtdemux,
+			//this portion can be reverted
+			IsoBmffBuffer buffer;
+			buffer.setBuffer((uint8_t *)cachedFragment->fragment.GetPtr(), cachedFragment->fragment.GetLen() );
+			buffer.parseBuffer();
+			uint32_t track_id = 0;
+			buffer.getTrack_id(track_id);
+			if(buffer.isInitSegment())
+			{
+				uint32_t timeScale = 0;
+				buffer.getTimeScale(timeScale);
+				if(actualType == eMEDIATYPE_INIT_VIDEO)
+				{
+					AAMPLOG_INFO("Video TimeScale [%d]", timeScale);
+					aamp->SetVidTimeScale(timeScale);
+				}
+				else if (actualType == eMEDIATYPE_INIT_AUDIO)
+				{
+					AAMPLOG_INFO("Audio TimeScale  [%d]", timeScale);
+					aamp->SetAudTimeScale(timeScale);
+				}
+				else if (actualType == eMEDIATYPE_INIT_SUBTITLE)
+				{
+					AAMPLOG_INFO("Subtitle TimeScale  [%d]", timeScale);
+					aamp->SetSubTimeScale(timeScale);
+				}
+			}
+			if(actualType == eMEDIATYPE_INIT_VIDEO)
+			{
+				AAMPLOG_INFO("Video track_id read from init fragment: %d ", track_id);
+				bool trackIdUpdated = false;
+				if(aamp->mCurrentVideoTrackId != -1 && track_id != aamp->mCurrentVideoTrackId)
+				{
+					if(overWriteTrackId)
+					{
+						//Overwrite the track id of the init fragment with the existing track id since overWriteTrackId is true only while pushing the encrypted init fragment while clear content is being played
+						buffer.parseBuffer(false, aamp->mCurrentVideoTrackId);
+						AAMPLOG_WARN("Video track_id of the current track is overwritten as init fragment is pushing only for DRM purpose, track id: %d ", track_id);
+						trackIdUpdated = true;
+					}
+					else
+					{
+						aamp->mIsTrackIdMismatch = true;
+						AAMPLOG_WARN("TrackId mismatch detected for video, current track_id: %d, next period track_id: %d", aamp->mCurrentVideoTrackId, track_id);
+					}
+				}
+				if(!trackIdUpdated)
+				{
+					aamp->mCurrentVideoTrackId = track_id;
+				}
+			}
+			else if(actualType == eMEDIATYPE_INIT_AUDIO)
+			{
+				bool trackIdUpdated = false;
+				AAMPLOG_INFO("Audio track_id read from init fragment: %d ", track_id);
+				if(aamp->mCurrentAudioTrackId != -1 && track_id != aamp->mCurrentAudioTrackId)
+				{
+					if(overWriteTrackId)
+					{
+						buffer.parseBuffer(false, aamp->mCurrentAudioTrackId);
+						AAMPLOG_WARN("Audio track_id of the current track is overwritten as init fragment is pushing only for DRM purpose, track id: %d ", track_id);
+						trackIdUpdated = true;
+					}
+					else
+					{
+						aamp->mIsTrackIdMismatch = true;
+						AAMPLOG_WARN("TrackId mismatch detected for audio, current track_id: %d, next period track_id: %d", aamp->mCurrentAudioTrackId, track_id);
+					}
+				}
+				if(!trackIdUpdated)
+				{
+					aamp->mCurrentAudioTrackId = track_id;
+				}
+			}
+			// Not overwriting for subtitles, as subtecmp4transform never read trackId from init fragments
+		}
+
 		if (iCurrentRate != AAMP_NORMAL_PLAY_RATE)
 		{
 			if(actualType == eMEDIATYPE_VIDEO)
@@ -155,90 +237,6 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 			else if(actualType == eMEDIATYPE_INIT_VIDEO)
 			{
 				actualType = eMEDIATYPE_INIT_IFRAME;
-			}
-		}
-		else
-		{
-			if ((actualType == eMEDIATYPE_INIT_VIDEO || actualType == eMEDIATYPE_INIT_AUDIO || actualType == eMEDIATYPE_INIT_SUBTITLE) && ret) // Only if init fragment successful or available from cache
-			{
-				//To read track_id from the init fragments to check if there any mismatch.
-				//A mismatch in track_id is not handled in the gstreamer version 1.10.4
-				//But is handled in the latest version (1.18.5),
-				//so upon upgrade to it or introduced a patch in qtdemux,
-				//this portion can be reverted
-				IsoBmffBuffer buffer;
-				buffer.setBuffer((uint8_t *)cachedFragment->fragment.GetPtr(), cachedFragment->fragment.GetLen() );
-				buffer.parseBuffer();
-				uint32_t track_id = 0;
-				buffer.getTrack_id(track_id);
-				if(buffer.isInitSegment())
-				{
-					uint32_t timeScale = 0;
-					buffer.getTimeScale(timeScale);
-					if(actualType == eMEDIATYPE_INIT_VIDEO)
-					{
-						AAMPLOG_INFO("Video TimeScale [%d]", timeScale);
-						aamp->SetVidTimeScale(timeScale);
-					}
-					else if (actualType == eMEDIATYPE_INIT_AUDIO)
-					{
-						AAMPLOG_INFO("Audio TimeScale  [%d]", timeScale);
-						aamp->SetAudTimeScale(timeScale);
-					}
-					else if (actualType == eMEDIATYPE_INIT_SUBTITLE)
-					{
-						AAMPLOG_INFO("Subtitle TimeScale  [%d]", timeScale);
-						aamp->SetSubTimeScale(timeScale);
-					}
-				}
-				if(actualType == eMEDIATYPE_INIT_VIDEO)
-				{
-					AAMPLOG_INFO("Video track_id read from init fragment: %d ", track_id);
-					bool trackIdUpdated = false;
-					if(aamp->mCurrentVideoTrackId != -1 && track_id != aamp->mCurrentVideoTrackId)
-					{
-						if(overWriteTrackId)
-						{
-							//Overwrite the track id of the init fragment with the existing track id since overWriteTrackId is true only while pushing the encrypted init fragment while clear content is being played
-							buffer.parseBuffer(false, aamp->mCurrentVideoTrackId);
-							AAMPLOG_WARN("Video track_id of the current track is overwritten as init fragment is pushing only for DRM purpose, track id: %d ", track_id);
-							trackIdUpdated = true;
-						}
-						else
-						{
-							aamp->mIsTrackIdMismatch = true;
-							AAMPLOG_WARN("TrackId mismatch detected for video, current track_id: %d, next period track_id: %d", aamp->mCurrentVideoTrackId, track_id);
-						}
-					}
-					if(!trackIdUpdated)
-					{
-						aamp->mCurrentVideoTrackId = track_id;
-					}
-				}
-				else if(actualType == eMEDIATYPE_INIT_AUDIO)
-				{
-					bool trackIdUpdated = false;
-					AAMPLOG_INFO("Audio track_id read from init fragment: %d ", track_id);
-					if(aamp->mCurrentAudioTrackId != -1 && track_id != aamp->mCurrentAudioTrackId)
-					{
-						if(overWriteTrackId)
-						{
-							buffer.parseBuffer(false, aamp->mCurrentAudioTrackId);
-							AAMPLOG_WARN("Audio track_id of the current track is overwritten as init fragment is pushing only for DRM purpose, track id: %d ", track_id);
-							trackIdUpdated = true;
-						}
-						else
-						{
-							aamp->mIsTrackIdMismatch = true;
-							AAMPLOG_WARN("TrackId mismatch detected for audio, current track_id: %d, next period track_id: %d", aamp->mCurrentAudioTrackId, track_id);
-						}
-					}
-					if(!trackIdUpdated)
-					{
-						aamp->mCurrentAudioTrackId = track_id;
-					}
-				}
-				// Not overwriting for subtitles, as subtecmp4transform never read trackId from init fragments
 			}
 		}
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1333,6 +1333,9 @@ void PrivateInstanceAAMP::ProcessID3Metadata(char *segment, size_t size, AampMed
 
 void PrivateInstanceAAMP::SetVidTimeScale(uint32_t vidTimeScale)
 {
+	if (g_mockPrivateInstanceAAMP != nullptr) {
+		g_mockPrivateInstanceAAMP->SetVidTimeScale(vidTimeScale);
+	}
 }
 
 void PrivateInstanceAAMP::SetAudTimeScale(uint32_t audTimeScale)

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -63,6 +63,7 @@ public:
 	MOCK_METHOD(void, SendAdResolvedEvent, (const std::string &adId, bool status, uint64_t startMS, uint64_t durationMs, AAMPCDAIError errorCode));
 	MOCK_METHOD(uint32_t, GetAudTimeScale, ());
 	MOCK_METHOD(uint32_t, GetVidTimeScale, ());
+	MOCK_METHOD(void, SetVidTimeScale, (uint32_t));
 	MOCK_METHOD(void, ProcessID3Metadata, (char *, size_t , AampMediaType , uint64_t ));
 	MOCK_METHOD(void, SetPauseOnStartPlayback, (bool enable));
 	MOCK_METHOD(bool, isDecryptClearSamplesRequired, ());

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -28,6 +28,7 @@
 #include "AampConfig.h"
 #include "AampTSBSessionManager.h"
 #include "MockAampConfig.h"
+#include "MockIsoBmffBuffer.h"
 #include "StreamAbstractionAAMP.h"
 #include "MockPrivateInstanceAAMP.h"
 #include "MockStreamAbstractionAAMP_MPD.h"
@@ -51,6 +52,7 @@ struct TestParams
 	bool paused;                       // true if pipeline is paused, false otherwise
 	bool underflow;                    // true if underflow occurred, false otherwise
 	bool init;                         // true if init fragment, false if media fragment
+	float rate;                        // play rate
 	int expectedFragmentChunksCached;  // expected number of fragments added to chunk cache
 	int expectedFragmentCached;        // expected number of fragments added to regular cache
 };
@@ -58,48 +60,51 @@ struct TestParams
 // Test cases
 TestParams testCases[] =
 {
-	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
 
 	// Test with AAMP TSB enabled, chunk cache is used for non-chunked fragments
-	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 
 	// Test EOS with AAMP TSB enabled
-	{.lowlatency = true, .chunk = true, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = true, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = false, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 
 	// Test with pipeline paused
-	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
 
 	// Test with AAMP TSB enabled and pipeline paused
-	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
 
 	// Test with pipeline paused and underflow
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = true, .init = false, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = true, .underflow = true, .init = false, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0}
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = true, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = true, .underflow = true, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+
+	// Test with rate != AAMP_NORMAL_PLAY_RATE
+	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .rate = (AAMP_NORMAL_PLAY_RATE*2), .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0}
 };
 
 
@@ -195,10 +200,14 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 			g_mockTSBSessionManager = new NiceMock<MockTSBSessionManager>(mPrivateInstanceAAMP);
 			mTsbReader = std::make_shared<AampTsbReader>(mPrivateInstanceAAMP, nullptr, eMEDIATYPE_VIDEO, "sessionId");
 			g_mockTSBReader = std::make_shared<MockTSBReader>();
+			g_mockIsoBmffBuffer = new NiceMock<MockIsoBmffBuffer>();
 		}
 
 		void TearDown() override
 		{
+			delete g_mockIsoBmffBuffer;
+			g_mockIsoBmffBuffer = nullptr;
+
 			g_mockTSBReader.reset();
 
 			delete g_mockTSBSessionManager;
@@ -273,13 +282,13 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 			mPeriod = new DummyPeriod();
 		}
 
-		void Initialize(bool lowlatency, bool chunk, bool tsb, bool eos, bool paused, bool underflow)
+		void Initialize(bool lowlatency, bool chunk, bool tsb, bool eos, bool paused, bool underflow, bool init, float rate)
 		{
 			unsigned char data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
 			AampLLDashServiceData llDashData;
 			llDashData.availabilityTimeOffset = 1.2;
 			llDashData.lowLatencyMode = lowlatency;
-			mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+			mPrivateInstanceAAMP->rate = rate;
 			mPrivateInstanceAAMP->SetLLDashServiceData(llDashData);
 			mPrivateInstanceAAMP->SetLocalAAMPTsb(tsb);
 			mPrivateInstanceAAMP->pipeline_paused = paused;
@@ -309,6 +318,11 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillOnce(Return(tsbSessionManager));
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(_, _, _, _, _, _, _, _, _, _, _, _, _, _)).WillOnce(Return(true));
 			EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(chunk));
+			if(init)
+			{
+				EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillRepeatedly(Return(true));
+				EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetVidTimeScale(_)).Times(AtLeast(1));
+			}
 		}
 };
 
@@ -320,7 +334,7 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 TEST_P(MediaStreamContextTest, CacheFragment)
 {
 	TestParams testParam = GetParam();
-	AAMPLOG_INFO("Test with lowlatency: %d, chunk: %d, AAMP TSB: %d, eos: %d, paused: %d, underflow: %d, init: %d, expectedFragmentChunksCached: %d, expectedFragmentCached: %d",
+	AAMPLOG_INFO("Test with lowlatency: %d, chunk: %d, AAMP TSB: %d, eos: %d, paused: %d, underflow: %d, init: %d, rate: %f, expectedFragmentChunksCached: %d, expectedFragmentCached: %d",
 		testParam.lowlatency,
 		testParam.chunk,
 		testParam.tsb,
@@ -328,10 +342,10 @@ TEST_P(MediaStreamContextTest, CacheFragment)
 		testParam.paused,
 		testParam.underflow,
 		testParam.init,
+		testParam.rate,
 		testParam.expectedFragmentChunksCached,
 		testParam.expectedFragmentCached);
-	Initialize(testParam.lowlatency, testParam.chunk, testParam.tsb, testParam.eos, testParam.paused, testParam.underflow);
-
+	Initialize(testParam.lowlatency, testParam.chunk, testParam.tsb, testParam.eos, testParam.paused, testParam.underflow, testParam.init, testParam.rate);
 	bool retResult = mMediaStreamContext->CacheFragment("remoteUrl", 0, 10, 0, NULL, testParam.init, false, false, 0, 0, false);
 
 	if (testParam.eos && !testParam.paused)


### PR DESCRIPTION
Issue observed is that the Progress Bar Point is jumping to the End/beginning
 while performing Trick Play/Seek in linear services. While analyzing
 the pts value of the segments, it is noticed that the restamped pts
 value of some of the segments in the main content is a very high value
 compared to the previous segment. This is happening because a wrong
 timescale is used for pts re calculation. RecalculatePTS function is
 using the timescale value saved in PrivateInstanceAAMP. When the downloads
 progresses from content to ad the timescale of the segment can change.
 When this happens, if the pay rate is not normal play rate, the new timescale
 is not set to PrivateInstanceAAMP and thus causing the issue.

Changes:
* CacheFragment function is modified to set the timescale to PrivateInstanceAAMP irrespective of the play rate.

Test Procedure: Refer JIRA ticket

Risks: low