### PR TITLE
VPLAY-11360 IP_AAMP_TUNETIME logged multiple times

### DIFF
--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -305,7 +305,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 		snprintf(tuneTimeStrPrefix, sizeof(tuneTimeStrPrefix), "%s PLAYER[%d] IP_AAMP_TUNETIME", playerActiveMode.c_str(),playerId);
 	}
 
-	AAMPLOG_WARN("%s:%d,%s,%lld," // prefix, version, build, tuneStartBaseUTCMS
+	AAMPLOG_MIL("%s:%d,%s,%lld," // prefix, version, build, tuneStartBaseUTCMS
 		"%d,%d,%d,"		// main manifest (start,total,err)
 		"%d,%d,%d,"		// video playlist (start,total,err)
 		"%d,%d,%d,"		// audio playlist (start,total,err)

--- a/AampTelemetry2.cpp
+++ b/AampTelemetry2.cpp
@@ -131,7 +131,7 @@ bool AAMPTelemetry2::send( const std::string &markerName, const char *  data) {
 	bool bRet = false;
 	if(mInitializer.isInitialized()	&& NULL != data)
 	{
-		AAMPLOG_INFO("[S] Marker Name: %s value:%s", markerName.c_str(),data );
+		AAMPLOG_TRACE("[S] Marker Name: %s value:%s", markerName.c_str(),data );
 #ifndef AAMP_SIMULATOR_BUILD
 		T2ERROR t2Error =  t2_event_s( (char *)markerName.c_str(),(char*)data );
 		

--- a/AampTelemetry2.cpp
+++ b/AampTelemetry2.cpp
@@ -126,12 +126,10 @@ bool AAMPTelemetry2::send( const std::string &markerName, const std::map<std::st
 	return bRet;
 }
 
-
 bool AAMPTelemetry2::send( const std::string &markerName, const char *  data) {
 	bool bRet = false;
 	if(mInitializer.isInitialized()	&& NULL != data)
 	{
-		AAMPLOG_TRACE("[S] Marker Name: %s value:%s", markerName.c_str(),data );
 #ifndef AAMP_SIMULATOR_BUILD
 		T2ERROR t2Error =  t2_event_s( (char *)markerName.c_str(),(char*)data );
 		

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2755,7 +2755,7 @@ void PrivateInstanceAAMP::SendTuneMetricsEvent(std::string &timeMetricData)
 	// Providing the Tune Timemetric info as an event
 	TuneTimeMetricsEventPtr e = std::make_shared<TuneTimeMetricsEvent>(timeMetricData, GetSessionId());
 
-	AAMPLOG_INFO("PrivateInstanceAAMP: Sending TuneTimeMetric event: %s", e->getTuneMetricsData().c_str());
+	AAMPLOG_TRACE("PrivateInstanceAAMP: Sending TuneTimeMetric event: %s", e->getTuneMetricsData().c_str());
 	SendEvent(e,AAMP_EVENT_ASYNC_MODE);
 }
 

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -671,7 +671,8 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		case AAMP_EVENT_TUNE_TIME_METRICS:
 		{
 			TuneTimeMetricsEventPtr ev = std::dynamic_pointer_cast<TuneTimeMetricsEvent>(e);
-			AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_TUNE_TIME_METRICS\n\tData[%s]\n",ev->getTuneMetricsData().c_str());
+			// below is redundant with IP_AAMP_TUNETIME logging done in core aamp
+			//AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_TUNE_TIME_METRICS\n\tData[%s]\n",ev->getTuneMetricsData().c_str());
 			break;
 		}
 


### PR DESCRIPTION
VPLAY-11360 IP_AAMP_TUNETIME logged multiple times

Reason for Change: reduce some logs to trace level

Test Guidance: pair of verbose, redundant json IP_AAMP_TUNETIME logs no longer logged by default

Risk: None