### PR TITLE
VPLAY-11530: Increase in PLTV XSTPP-999 Failures on both Xi1/ES1

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1393,9 +1393,17 @@ void AampDRMLicenseManager::clearDrmSession(bool forceClearSession)
 {
 	mDrmSessionManager->clearDrmSession(forceClearSession);
 	for(int i = 0 ; i < mMaxDRMSessions;i++)
-    {
-        mLicenseDownloader[i].Clear();
-    }
+	{
+		bool isFailedKeyId = mDRMSessionManager->getFailedKeyIdStatus(i);
+		if(( mDRMSessionManager->drmSessionContexts != NULL && (isFailedKeyId || forceClearSession)  ))
+		{
+			if(mDRMSessionManager->drmSessionContexts[i].drmSession != NULL)
+			{
+				AAMPLOG_INFO("Clearing Session %d, isFailedKeyId=%d, forceClearSession=%d",i, isFailedKeyId, forceClearSession);
+				mLicenseDownloader[i].Clear();
+		    }
+		}
+	}
 }
 
 /**

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -168,6 +168,18 @@ void DrmSessionManager::clearAccessToken()
 }
 
 /**
+ * @brief Get the failed key ID status for a specific session
+ */
+bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
+{
+	if (sessionIndex >= 0 && sessionIndex < mMaxDrmSessions && cachedKeyIDs)
+	{
+		return cachedKeyIDs[sessionIndex].isFailedKeyId;
+	}
+	return false;
+}
+
+/**
  * @brief Clean up the Session Data if license key acquisition failed or if LicenseCaching is false.
  */
 void DrmSessionManager::clearDrmSession(bool forceClearSession)

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -301,6 +301,16 @@ public:
 	 * @return	void.
 	 */
 	void clearFailedKeyIds();
+
+
+	/**
+	 * @fn		getFailedKeyIdStatus
+	 *
+	 * @param	sessionIndex session index to check
+	 * @return	bool - true if the key ID is marked as failed, false otherwise
+	 */
+	bool getFailedKeyIdStatus(int sessionIndex);
+
 	/**
 	 * @fn		clearDrmSession
 	 *


### PR DESCRIPTION

Reintroduced the condition check before calling clear() in clearDrmSession(), which was missed during the DRM refactoring.

Reason for Change: Reintroduced the condition check before calling clear() in clearDrmSession. This was lost during DRM refactoring and was causing increase in PLTV XSTPP-999 failures.

Changes:
- Added getFailedKeyIdStatus() method to DrmSessionManager
- Modified clearDrmSession() in AampDRMLicenseManager to add condition checks
- Only clear license downloader when conditions are met

Cherry-picked from PR #619