### PR TITLE
VPLAY-11545: OSX runtime failure running AampTSBSessionManager in Xcode

### DIFF
--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -1249,14 +1249,12 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 	merged.reserve(reservationList.size() + placementList.size());
 	merged.insert(merged.end(), reservationList.begin(), reservationList.end());
 	merged.insert(merged.end(), placementList.begin(), placementList.end());
-	
 	// Sort with strict weak ordering: first by position, then by order added
 	std::sort(merged.begin(), merged.end(), [](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
 	{
 		bool aLessThanB;
 		uint64_t aPos = a->GetPosition().milliseconds();
 		uint64_t bPos = b->GetPosition().milliseconds();
-		
 		if (aPos != bPos)
 		{
 			aLessThanB = aPos < bPos;
@@ -1266,7 +1264,6 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 			// Same position - sort by order added
 			aLessThanB = a->GetOrderAdded() < b->GetOrderAdded();
 		}
-		
 		return aLessThanB;
 	});
 	

--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -1242,7 +1242,7 @@ void AampTSBSessionManager::ShiftFutureAdEvents()
 }
 
 std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndSortAdMetaData(std::list<std::shared_ptr<AampTsbAdMetaData>> reservationList,
-                                                                                              std::list<std::shared_ptr<AampTsbAdMetaData>> placementList)
+																							  std::list<std::shared_ptr<AampTsbAdMetaData>> placementList)
 {
 	// Merge both lists
 	std::vector<std::shared_ptr<AampTsbAdMetaData>> merged;
@@ -1266,7 +1266,7 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 		}
 		return aLessThanB;
 	});
-	
+
 	return merged;
 }
 

--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -1260,6 +1260,7 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 		int priority;
 	};
 	
+	static constexpr int PRIORITY_LOWEST = 4; // For ERROR or other unexpected types
 	static const PriorityEntry priorityTable[] =
 	{
 		{ AampTsbAdMetaData::AdType::PLACEMENT,   AampTsbAdMetaData::EventType::END,   0 },
@@ -1267,16 +1268,17 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 		{ AampTsbAdMetaData::AdType::RESERVATION, AampTsbAdMetaData::EventType::START, 2 },
 		{ AampTsbAdMetaData::AdType::PLACEMENT,   AampTsbAdMetaData::EventType::START, 3 }
 	};
+	static constexpr size_t priorityTableSize = sizeof(priorityTable) / sizeof(priorityTable[0]);
 	
 	auto getPriority = [](AampTsbAdMetaData::AdType adType, AampTsbAdMetaData::EventType eventType) -> int
 	{
-		int priority = 4; // Default for ERROR or other types
+		int priority = PRIORITY_LOWEST;
 		
-		for (const auto& entry : priorityTable)
+		for (size_t i = 0; i < priorityTableSize; ++i)
 		{
-			if (entry.adType == adType && entry.eventType == eventType)
+			if (priorityTable[i].adType == adType && priorityTable[i].eventType == eventType)
 			{
-				priority = entry.priority;
+				priority = priorityTable[i].priority;
 				break;
 			}
 		}
@@ -1291,7 +1293,7 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 	merged.insert(merged.end(), placementList.begin(), placementList.end());
 	
 	// Sort with strict weak ordering: first by position, then by priority
-	std::sort(merged.begin(), merged.end(), [&getPriority](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
+	std::sort(merged.begin(), merged.end(), [getPriority](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
 	{
 		bool aLessThanB;
 		uint64_t aPos = a->GetPosition().milliseconds();

--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -1242,53 +1242,74 @@ void AampTSBSessionManager::ShiftFutureAdEvents()
 }
 
 std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndSortAdMetaData(std::list<std::shared_ptr<AampTsbAdMetaData>> reservationList,
-																							  std::list<std::shared_ptr<AampTsbAdMetaData>> placementList)
+                                                                                              std::list<std::shared_ptr<AampTsbAdMetaData>> placementList)
 {
-	// Merge both lists in chronological order
-	std::vector<std::shared_ptr<AampTsbAdMetaData>> merged;
-	for (const auto& meta : reservationList)
+	// Priority table for sorting ad metadata at the same position (lower value = higher priority)
+	// Assumptions:
+	// - A period/reservation cannot start and end at the same pos, i.e. have 0 duration, therefore
+	//   if both event types present it must be the previous ending, before the next starts.
+	// Rules:
+	// - PLACEMENT END before PLACEMENT START (previous placement ends before next starts)
+	// - PLACEMENT END before RESERVATION END (placement must be within reservation period)
+	// - RESERVATION END before RESERVATION START (previous reservation ends before next starts)
+	// - RESERVATION START before PLACEMENT START (placement must be within reservation period)
+	struct PriorityEntry
 	{
-		merged.push_back(meta);
-	}
-	for (const auto& meta : placementList)
+		AampTsbAdMetaData::AdType adType;
+		AampTsbAdMetaData::EventType eventType;
+		int priority;
+	};
+	
+	static const PriorityEntry priorityTable[] =
 	{
-		merged.push_back(meta);
-	}
-	// Sort merged list
-	std::sort(merged.begin(), merged.end(), [](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
+		{ AampTsbAdMetaData::AdType::PLACEMENT,   AampTsbAdMetaData::EventType::END,   0 },
+		{ AampTsbAdMetaData::AdType::RESERVATION, AampTsbAdMetaData::EventType::END,   1 },
+		{ AampTsbAdMetaData::AdType::RESERVATION, AampTsbAdMetaData::EventType::START, 2 },
+		{ AampTsbAdMetaData::AdType::PLACEMENT,   AampTsbAdMetaData::EventType::START, 3 }
+	};
+	
+	auto getPriority = [](AampTsbAdMetaData::AdType adType, AampTsbAdMetaData::EventType eventType) -> int
 	{
-		bool maintainOrder = true;
-		auto apos = a->GetPosition().milliseconds();
-		auto bpos = b->GetPosition().milliseconds();
-
-		// Different positions, sort by position
-		if (apos != bpos)
+		int priority = 4; // Default for ERROR or other types
+		
+		for (const auto& entry : priorityTable)
 		{
-			maintainOrder = apos < bpos;
+			if (entry.adType == adType && entry.eventType == eventType)
+			{
+				priority = entry.priority;
+				break;
+			}
+		}
+		
+		return priority;
+	};
+	
+	// Merge both lists
+	std::vector<std::shared_ptr<AampTsbAdMetaData>> merged;
+	merged.reserve(reservationList.size() + placementList.size());
+	merged.insert(merged.end(), reservationList.begin(), reservationList.end());
+	merged.insert(merged.end(), placementList.begin(), placementList.end());
+	
+	// Sort with strict weak ordering: first by position, then by priority
+	std::sort(merged.begin(), merged.end(), [&getPriority](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
+	{
+		bool aLessThanB;
+		uint64_t aPos = a->GetPosition().milliseconds();
+		uint64_t bPos = b->GetPosition().milliseconds();
+		
+		if (aPos != bPos)
+		{
+			aLessThanB = aPos < bPos;
 		}
 		else
 		{
-			// Same position, apply rules:
-			// Matching ad types, END should be before START
-			// Reservation events should be after Placement END
-			// Reservation events should be before Placement START
-			//
-			// This logic assumes that an advert exceeds a fragment duration, 
-			// i.e. an advert cannot start and end in the same fragment
-			auto aType = a->GetEventType();
-			auto bType = b->GetEventType();
-			auto aAdType = a->GetAdType();
-			auto bAdType = b->GetAdType();
-
-			if ( ((aAdType == bAdType) && (aType == AampTsbAdMetaData::EventType::START)) ||
-				 ((aAdType == AampTsbAdMetaData::AdType::RESERVATION) && bType == AampTsbAdMetaData::EventType::END) ||
-				 ((bAdType == AampTsbAdMetaData::AdType::RESERVATION) && aType == AampTsbAdMetaData::EventType::START) )
-			{
-				maintainOrder = false;
-			} 
+			// Same position - sort by priority
+			aLessThanB = getPriority(a->GetAdType(), a->GetEventType()) < getPriority(b->GetAdType(), b->GetEventType());
 		}
-		return maintainOrder;
+		
+		return aLessThanB;
 	});
+	
 	return merged;
 }
 

--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -1244,56 +1244,14 @@ void AampTSBSessionManager::ShiftFutureAdEvents()
 std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndSortAdMetaData(std::list<std::shared_ptr<AampTsbAdMetaData>> reservationList,
                                                                                               std::list<std::shared_ptr<AampTsbAdMetaData>> placementList)
 {
-	// Priority table for sorting ad metadata at the same position (lower value = higher priority)
-	// Assumptions:
-	// - A period/reservation cannot start and end at the same pos, i.e. have 0 duration, therefore
-	//   if both event types present it must be the previous ending, before the next starts.
-	// Rules:
-	// - PLACEMENT END before PLACEMENT START (previous placement ends before next starts)
-	// - PLACEMENT END before RESERVATION END (placement must be within reservation period)
-	// - RESERVATION END before RESERVATION START (previous reservation ends before next starts)
-	// - RESERVATION START before PLACEMENT START (placement must be within reservation period)
-	struct PriorityEntry
-	{
-		AampTsbAdMetaData::AdType adType;
-		AampTsbAdMetaData::EventType eventType;
-		int priority;
-	};
-	
-	static constexpr int PRIORITY_LOWEST = 4; // For ERROR or other unexpected types
-	static const PriorityEntry priorityTable[] =
-	{
-		{ AampTsbAdMetaData::AdType::PLACEMENT,   AampTsbAdMetaData::EventType::END,   0 },
-		{ AampTsbAdMetaData::AdType::RESERVATION, AampTsbAdMetaData::EventType::END,   1 },
-		{ AampTsbAdMetaData::AdType::RESERVATION, AampTsbAdMetaData::EventType::START, 2 },
-		{ AampTsbAdMetaData::AdType::PLACEMENT,   AampTsbAdMetaData::EventType::START, 3 }
-	};
-	static constexpr size_t priorityTableSize = sizeof(priorityTable) / sizeof(priorityTable[0]);
-	
-	auto getPriority = [](AampTsbAdMetaData::AdType adType, AampTsbAdMetaData::EventType eventType) -> int
-	{
-		int priority = PRIORITY_LOWEST;
-		
-		for (size_t i = 0; i < priorityTableSize; ++i)
-		{
-			if (priorityTable[i].adType == adType && priorityTable[i].eventType == eventType)
-			{
-				priority = priorityTable[i].priority;
-				break;
-			}
-		}
-		
-		return priority;
-	};
-	
 	// Merge both lists
 	std::vector<std::shared_ptr<AampTsbAdMetaData>> merged;
 	merged.reserve(reservationList.size() + placementList.size());
 	merged.insert(merged.end(), reservationList.begin(), reservationList.end());
 	merged.insert(merged.end(), placementList.begin(), placementList.end());
 	
-	// Sort with strict weak ordering: first by position, then by priority
-	std::sort(merged.begin(), merged.end(), [getPriority](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
+	// Sort with strict weak ordering: first by position, then by order added
+	std::sort(merged.begin(), merged.end(), [](const std::shared_ptr<AampTsbAdMetaData>& a, const std::shared_ptr<AampTsbAdMetaData>& b)
 	{
 		bool aLessThanB;
 		uint64_t aPos = a->GetPosition().milliseconds();
@@ -1305,8 +1263,8 @@ std::vector<std::shared_ptr<AampTsbAdMetaData>> AampTSBSessionManager::MergeAndS
 		}
 		else
 		{
-			// Same position - sort by priority
-			aLessThanB = getPriority(a->GetAdType(), a->GetEventType()) < getPriority(b->GetAdType(), b->GetEventType());
+			// Same position - sort by order added
+			aLessThanB = a->GetOrderAdded() < b->GetOrderAdded();
 		}
 		
 		return aLessThanB;

--- a/test/utests/tests/AampTSBSessionManager/FunctionalTests.cpp
+++ b/test/utests/tests/AampTSBSessionManager/FunctionalTests.cpp
@@ -404,43 +404,48 @@ TEST_F(FunctionalTests, TSBReadTests)
 
 	// Add two MockAampTsbAdMetaData objects to reservationMetadataList
 	std::list<std::shared_ptr<AampTsbMetaData>> reservationMetadataList;
+	std::list<std::shared_ptr<AampTsbMetaData>> placementMetadataList;
 	auto reservation1Start = std::make_shared<StrictMock<MockAampTsbAdReservationMetaData>>();
 	auto reservation1End = std::make_shared<StrictMock<MockAampTsbAdReservationMetaData>>();
 	auto reservation2Start = std::make_shared<StrictMock<MockAampTsbAdReservationMetaData>>();
-	EXPECT_CALL(*reservation1Start, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS));
-	EXPECT_CALL(*reservation1Start, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::RESERVATION));
-	EXPECT_CALL(*reservation1Start, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::START));
-
-	EXPECT_CALL(*reservation1End, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS + FRAG_DURATION));
-	EXPECT_CALL(*reservation1End, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::RESERVATION));
-	EXPECT_CALL(*reservation1End, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::END));
-
-	EXPECT_CALL(*reservation2Start, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS + FRAG_DURATION));
-	EXPECT_CALL(*reservation2Start, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::RESERVATION));
-	EXPECT_CALL(*reservation2Start, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::START));
-
-	reservationMetadataList.push_back(reservation1Start);
-	reservationMetadataList.push_back(reservation1End);
-	reservationMetadataList.push_back(reservation2Start);
-
-	std::list<std::shared_ptr<AampTsbMetaData>> placementMetadataList;
 	auto placement1Start = std::make_shared<StrictMock<MockAampTsbAdPlacementMetaData>>();
 	auto placement1End = std::make_shared<StrictMock<MockAampTsbAdPlacementMetaData>>();
 	auto placement2Start = std::make_shared<StrictMock<MockAampTsbAdPlacementMetaData>>();
+
+	EXPECT_CALL(*reservation1Start, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS));
+	EXPECT_CALL(*reservation1Start, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::RESERVATION));
+	EXPECT_CALL(*reservation1Start, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::START));
+	EXPECT_CALL(*reservation1Start, GetOrderAdded()).WillRepeatedly(Return(1));
+	reservationMetadataList.push_back(reservation1Start);
+
 	EXPECT_CALL(*placement1Start, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS));
 	EXPECT_CALL(*placement1Start, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::PLACEMENT));
 	EXPECT_CALL(*placement1Start, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::START));
+	EXPECT_CALL(*placement1Start, GetOrderAdded()).WillRepeatedly(Return(2));
+	placementMetadataList.push_back(placement1Start);
 
 	EXPECT_CALL(*placement1End, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS + FRAG_DURATION));
 	EXPECT_CALL(*placement1End, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::PLACEMENT));
 	EXPECT_CALL(*placement1End, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::END));
+	EXPECT_CALL(*placement1End, GetOrderAdded()).WillRepeatedly(Return(3));
+	placementMetadataList.push_back(placement1End);
+
+	EXPECT_CALL(*reservation1End, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS + FRAG_DURATION));
+	EXPECT_CALL(*reservation1End, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::RESERVATION));
+	EXPECT_CALL(*reservation1End, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::END));
+	EXPECT_CALL(*reservation1End, GetOrderAdded()).WillRepeatedly(Return(4));
+	reservationMetadataList.push_back(reservation1End);
+
+	EXPECT_CALL(*reservation2Start, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS + FRAG_DURATION));
+	EXPECT_CALL(*reservation2Start, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::RESERVATION));
+	EXPECT_CALL(*reservation2Start, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::START));
+	EXPECT_CALL(*reservation2Start, GetOrderAdded()).WillRepeatedly(Return(5));
+	reservationMetadataList.push_back(reservation2Start);
 
 	EXPECT_CALL(*placement2Start, GetPosition()).WillRepeatedly(Return(FRAG_FIRST_ABS_POS + FRAG_DURATION));
 	EXPECT_CALL(*placement2Start, GetAdType()).WillRepeatedly(Return(AampTsbAdMetaData::AdType::PLACEMENT));
 	EXPECT_CALL(*placement2Start, GetEventType()).WillRepeatedly(Return(AampTsbAdMetaData::EventType::START));
-
-	placementMetadataList.push_back(placement1Start);
-	placementMetadataList.push_back(placement1End);
+	EXPECT_CALL(*placement2Start, GetOrderAdded()).WillRepeatedly(Return(6));
 	placementMetadataList.push_back(placement2Start);
 
 	EXPECT_CALL(*g_mockAampTsbMetaDataManager,

--- a/test/utests/tests/AampTSBSessionManager/FunctionalTests.cpp
+++ b/test/utests/tests/AampTSBSessionManager/FunctionalTests.cpp
@@ -402,7 +402,7 @@ TEST_F(FunctionalTests, TSBReadTests)
 			return true;
 		}));
 
-	// Add two MockAampTsbAdMetaData objects to reservationMetadataList
+	// Create three reservation and three placement metadata objects for testing
 	std::list<std::shared_ptr<AampTsbMetaData>> reservationMetadataList;
 	std::list<std::shared_ptr<AampTsbMetaData>> placementMetadataList;
 	auto reservation1Start = std::make_shared<StrictMock<MockAampTsbAdReservationMetaData>>();


### PR DESCRIPTION
Reason for Change:
Restructured sort code, to improve structure and readability and remove strict-weak ordering exception.
Sorting is primarily done by position, secondary by order added.

Test Guidance:
l1 AampTsbSessionManager passing both with run.sh and when run in xcode 
l2 test 5003 passing

Risk: Low

Signed-off-by: anshephe <115161257+anshephe@users.noreply.github.com>