### PR TITLE
VPLAY-10806 AV playback stuck observed during profile reordering in multi-period streams.

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4074,7 +4074,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			}
 			// Update track with update in stream info
 			mUpdateStreamInfo = true;
-			ret = UpdateTrackInfo(!newTune, true);
+			ret = UpdateTrackInfo(!newTune, true, true);
 
 			if(eAAMPSTATUS_OK != ret)
 			{
@@ -4442,7 +4442,6 @@ AAMPStatusType StreamAbstractionAAMP_MPD::IndexNewMPDDocument(bool updateTrackIn
 				if(((AdState::IN_ADBREAK_AD_PLAYING != mCdaiObject->mAdState) && (AdState::IN_ADBREAK_WAIT2CATCHUP != mCdaiObject->mAdState))
 				   || (AdState::IN_ADBREAK_AD_PLAYING == mCdaiObject->mAdState && mUpdateStreamInfo))
 				{
-					AAMPLOG_TRACE("Indexing new mpd doc");
 					ret = UpdateTrackInfo(true, true);
 					if(ret != eAAMPSTATUS_OK)
 					{
@@ -7462,7 +7461,7 @@ static bool IsWebmVideoCodec(const std::string &codec )
 /**
  * @brief Updates track information based on current state
  */
-AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex)
+AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex, bool isUpdateDuringInit)
 {
 	AAMPStatusType ret = eAAMPSTATUS_OK;
 	long defaultBitrate = aamp->GetDefaultBitrate();
@@ -7610,8 +7609,10 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 				{
 					mUpdateStreamInfo = false;
 					int representationCount = 0;
+					bool repCountChanged = false;
 					std::set<uint32_t> blAdaptationIdxs;
 					bool bSeenNonWebmCodec = false;
+					std::map<int, long> iBandwidthMap;
 
 					const auto &blacklistedProfiles = aamp->GetBlacklistedProfiles();
 					// Filter the blacklisted profiles in the period
@@ -7648,10 +7649,22 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 							// chosenAdaptationIdxs.insert(0);
 						}
 					}
-					if ((representationCount != GetProfileCount()) && mStreamInfo)
+					bool shouldResetRepresentationIndex = (representationCount != GetProfileCount()) && (mStreamInfo != nullptr);
+					int currentRepIndex = pMediaStreamContext->representationIndex;
+					// On period change, check if current profile is present in new period
+					if( false == shouldResetRepresentationIndex && mStreamInfo != nullptr)
+					{
+						if (periodChanged && i == eMEDIATYPE_VIDEO && !ISCONFIGSET(eAAMPConfig_AudioOnlyPlayback))
+						{
+							shouldResetRepresentationIndex = ShoudResetRepresentationIndex(chosenAdaptationIdxs);
+							AAMPLOG_WARN("Period changed - representationIndex check: %s, currentProfileIndex to be maintained: %d",
+								shouldResetRepresentationIndex ? "true" : "false", currentProfileIndex);
+						}
+					}
+					if (shouldResetRepresentationIndex)
 					{
 						SAFE_DELETE_ARRAY(mStreamInfo);
-
+                        repCountChanged = (representationCount != GetProfileCount());
 						// reset representationIndex to -1 to allow updating the currentProfileIndex for period change.
 						pMediaStreamContext->representationIndex = -1;
 						AAMPLOG_WARN("representationIndex set to (-1) to find currentProfileIndex");
@@ -7823,6 +7836,14 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 							}
 						}
 					}
+					//To get the desired profile Index after period change
+					if( repCountChanged == true )
+					{
+						//Getting the desired profile to avoid crash while accessing invalid profile index
+						currentProfileIndex = GetProfileIndexForBandwidth(pMediaStreamContext->fragmentDescriptor.Bandwidth);
+						AAMPLOG_INFO("Current profile index after period change: %d Bandwidth %u", currentProfileIndex, pMediaStreamContext->fragmentDescriptor.Bandwidth);
+					}
+
 					if(adaptationSets.size() > 0)
 					{
 						// Skipping blacklist check for audio only track at the moment
@@ -7936,7 +7957,22 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 							}
 							UpdateIframeTracks();
 						}
-						currentProfileIndex = GetDesiredProfile(false);
+						/* During initialization its better to call the GetDesiredProfile(), which picks up the
+						* desired profile index corresponding to default bitrate.
+						* During subsequent 'period' change its better to call the  UpdateProfileBasedOnFragmentCache()
+						* which will Rampup and pick the highest profile index if the network bandwidth is high.
+						* and also RampsDown to the lowest profile if the network bandwidth is low.
+						*/
+						if(isUpdateDuringInit == true)
+						{
+							currentProfileIndex = GetDesiredProfile(false);
+							AAMPLOG_INFO("Profile updated based on Desired profile [%d]",currentProfileIndex);
+						}
+						else
+						{
+						    UpdateProfileBasedOnFragmentCache();
+							AAMPLOG_INFO("Profile updated based on fragment cache [%d]",currentProfileIndex);
+						}
 						// Adaptation Set Index corresponding to a particular profile
 						pMediaStreamContext->adaptationSetIdx = mProfileMaps[currentProfileIndex].adaptationSetIndex;
 						// Representation Index within a particular Adaptation Set
@@ -9431,6 +9467,8 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 {
 	bool ret = false;
 	waitForAdBreakCatchup = false; // reset this flag
+	AAMPLOG_INFO("SelectSourceOdAdPeriod: mIterPeriodIndex=%d, mNumberOfPeriods=%d, mCurrentPeriodIdx=%d, mBasePeriodId=%s, mPlayRate=%f",
+					mIterPeriodIndex, mNumberOfPeriods, mCurrentPeriodIdx, mBasePeriodId.c_str(), mPlayRate);
 	while ((mIterPeriodIndex < mNumberOfPeriods) && (mIterPeriodIndex >= 0) && !ret) // CID:95090 - No effect
 	{
 		periodChanged = (mIterPeriodIndex != mCurrentPeriodIdx) || (mBasePeriodId != mpd->GetPeriods().at(mCurrentPeriodIdx)->GetId());
@@ -9645,6 +9683,8 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 		}
 		ret = true;
 	}
+	AAMPLOG_INFO("SelectSourceOdAdPeriod: Exit mIterPeriodIndex=%d, mNumberOfPeriods=%d, mCurrentPeriodIdx=%d, mBasePeriodId=%s, periodChanged=%d, adStateChanged=%d, requireStreamSelection=%d, ret=%d",
+					mIterPeriodIndex, mNumberOfPeriods, mCurrentPeriodIdx, mBasePeriodId.c_str(), periodChanged, adStateChanged, requireStreamSelection, ret);
 	return ret;
 }
 
@@ -9675,7 +9715,7 @@ bool StreamAbstractionAAMP_MPD::IndexSelectedPeriod(bool periodChanged, bool adS
 		// Reset the video skip remainder to zero as this is a new period
 		mVideoPosRemainder = 0;
 		mIsFinalFirstPTS = false;
-		AAMPStatusType ret = UpdateTrackInfo(true, resetTimeLineIndex);
+		AAMPStatusType ret = UpdateTrackInfo(true, resetTimeLineIndex, false);
 		if (ret != eAAMPSTATUS_OK)
 		{
 			AAMPLOG_WARN("manifest : %d error", ret);
@@ -14399,4 +14439,48 @@ bool StreamAbstractionAAMP_MPD::DoStreamSinkFlushOnDiscontinuity()
 void StreamAbstractionAAMP_MPD::clearFirstPTS(void)
 {
 	mFirstPTS = 0.0;
+}
+/**
+ * @fn ShoudResetRepresentationIndex
+ * @brief Check whether the current representation is present in the new period or not
+ * @param chosenAdaptationIdxs - set of chosen adaptation indexes
+ * @param currentRepIndex - current representation index
+ * @return true if representation is not found in new period, false otherwise
+ */
+bool StreamAbstractionAAMP_MPD::ShoudResetRepresentationIndex( std::set<uint32_t> &chosenAdaptationIdxs )
+{
+	/* Added this for loop because, sometimes the while representations splits up 
+	* across multiple adaptation sets in the new period. So we need to check all the adaptation sets
+	* for finding the current profile in the new period.
+	* Example:
+	* Period 1: AdaptationSet 0 : Representations : 1000, 2000, 3000
+	* Period 2: AdaptationSet 0 : Representations : 1000, 3000
+	*           AdaptationSet 1 : Representations : 2000, 4000
+	* Here if current profile is 2000, we need to check both the adaptation sets to find the current profile
+	* in the new period.
+	*/	
+	bool representationChanged = false;
+	int repsize	= 0, reprIdx = 0;
+	for (const uint32_t &adaptIdx : chosenAdaptationIdxs)
+	{
+		IAdaptationSet* adaptationSet = mCurrentPeriod->GetAdaptationSets().at(adaptIdx);
+		const auto &representations = adaptationSet->GetRepresentation();
+		
+		for (reprIdx = 0; reprIdx < representations.size(); reprIdx++)
+		{
+			if( ( representations.at(reprIdx)->GetBandwidth() != mStreamInfo[repsize+reprIdx].bandwidthBitsPerSecond )  )	
+			{
+				representationChanged = true;
+				AAMPLOG_INFO("Representation order changed with bandwidth:%u in AdaptationSet index:%d", representations.at(reprIdx)->GetBandwidth(), adaptIdx);
+				break;
+			}	
+		}
+		if( reprIdx < representations.size())
+		{
+			AAMPLOG_INFO("Representation changed in AdaptationSet index:%d", adaptIdx);
+			break; //break the outer loop also if representation found
+		}
+		repsize += representations.size();
+	}
+	return representationChanged;
 }

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -573,6 +573,13 @@ public:
 	 * @brief Clears the mFirstPTS value to trigger update of first PTS
 	 */
 	void clearFirstPTS(void) override;
+	/**
+	 * @fn ShoudResetRepresentationIndex
+	 * @param chosenAdaptationIdxs set of adaptation indices
+	 * @param currentRepIndex current representation index
+	 * @retval true if representation index needs to be reset
+	 */
+	bool ShoudResetRepresentationIndex( std::set<uint32_t> &chosenAdaptationIdxs );
 
 protected:
 	/**
@@ -897,7 +904,7 @@ protected:
 	/**
 	 * @fn UpdateTrackInfo
 	 */
-	AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex = false);
+	AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex = false, bool isUpdateDuringInit = false);
 	/**
 	 * @fn SkipToEnd
 	 * @param pMediaStreamContext Track object pointer
@@ -1171,7 +1178,6 @@ protected:
 	bool isVidDiscInitFragFail;
 	double mLivePeriodCulledSeconds;
 	bool mIsSegmentTimelineEnabled;   /**< Flag to indicate if segment timeline is enabled, to determine if PTS is available from manifest */
-
 	// In case of streams with multiple video Adaptation Sets, A profile
 	// is a combination of an Adaptation Set and Representation within
 	// that Adaptation Set. Hence we need a mapping from a profile to

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2618,7 +2618,6 @@ int StreamAbstractionAAMP::GetDesiredProfileBasedOnCache(void)
 	return desiredProfileIndex;
 }
 
-
 /**
  *  @brief Rampdown profile
  */
@@ -2981,7 +2980,6 @@ bool StreamAbstractionAAMP::UpdateProfileBasedOnFragmentCache()
 
 	return retVal;
 }
-
 /**
  *  @brief Check if playback has stalled and update related flags.
  */

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -486,3 +486,7 @@ std::unique_ptr<SubtitleParser> StreamAbstractionAAMP::RegisterSubtitleParser_CB
 {
 	return nullptr;
 }
+bool StreamAbstractionAAMP::UpdateProfileBasedOnFragmentCache()
+{
+	return false;
+}

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -157,6 +157,11 @@ protected:
 		{
 			InitializeWorkers();
 		}
+		bool CallShoudResetRepresentationIndex(std::set<uint32_t>& chosenAdaptationIdxs)
+		{
+			return ShoudResetRepresentationIndex(chosenAdaptationIdxs);
+		}
+
 	};
 
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
@@ -260,7 +265,8 @@ protected:
 			{eAAMPConfig_ForceMultiPeriodDiscontinuity, false},
 			{eAAMPConfig_SuppressDecode, false},
 			{eAAMPConfig_useRialtoSink, false},
-			{eAAMPConfig_InterruptHandling, false}};
+			{eAAMPConfig_InterruptHandling, false},
+			{eAAMPConfig_DASHIgnoreBaseURLIfSlash, false}};
 
 	BoolConfigSettings mBoolConfigSettings;
 
@@ -1059,6 +1065,48 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 
 
 }
+/*TEST_F(FetcherLoopTests, SkipFetchAudioTests)
+{
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="dynamic" id="0000000000000018163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2.000S" maxSegmentDuration="PT0H0M1.92S" minimumUpdatePeriod="PT0H0M1.920S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2024-11-08T12:53:09.725Z">
+	<Period id="901591170" start="PT416006H37M27.854S">
+		<AdaptationSet id="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:ColourPrimaries" value="1"/>
+			<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:MatrixCoefficients" value="1"/>
+			<EssentialProperty schemeIdUri="urn:mpeg:mpegB:cicp:TransferCharacteristics" value="1"/>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+			<SegmentTemplate initialization="SKYNEHD_HD_SUD_SKYUKD_4050_18_0000000000000018163/track-video-repid-$RepresentationID$-tc--enc--header.mp4" media="SKYNEHD_HD_SUD_SKYUKD_4050_18_0000000000000018163/track-video-repid-$RepresentationID$-tc--enc--frag-$Number$.mp4" timescale="90000" startNumber="901599260" presentationTimeOffset="20213">
+				<SegmentTimeline>
+					<S t="1377581813" d="172800" r="14"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+			<Representation id="root_video3" bandwidth="1328400" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+			<Representation id="root_video2" bandwidth="1996000" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+			<Representation id="root_video1" bandwidth="4461200" codecs="hvc1.1.6.L120.90" width="1280" height="720" frameRate="50000/1000"/>
+			<Representation id="root_video0" bandwidth="6052400" codecs="hvc1.1.6.L123.90" width="1920" height="1080" frameRate="50000/1000"/>
+		</AdaptationSet>
+		<AdaptationSet id="3" contentType="audio" mimeType="audio/mp4" lang="en">
+			<AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+			<SegmentTemplate initialization="SKYNEHD_HD_SUD_SKYUKD_4050_18_0000000000000018163-eac3/track-audio-repid-$RepresentationID$-tc--enc--header.mp4" media="SKYNEHD_HD_SUD_SKYUKD_4050_18_0000000000000018163-eac3/track-audio-repid-$RepresentationID$-tc--enc--frag-$Number$.mp4" timescale="90000" startNumber="901599260" presentationTimeOffset="20213">
+				<SegmentTimeline>
+					<S t="1377583936" d="172800" r="14"/>
+				</SegmentTimeline>
+			</SegmentTemplate>
+			<Representation id="root_audio110" bandwidth="215200" codecs="ec-3" audioSamplingRate="48000"/>
+		</AdaptationSet>
+	</Period>
+	<SupplementalProperty schemeIdUri="urn:scte:dash:powered-by" value="example-mod_super8-4.4.0-1"/>
+</MPD>
+)";
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _, _, _))
+				.WillRepeatedly(Return(true));
+
+	AAMPStatusType status = InitializeMPD(manifest, eTUNETYPE_NEW_NORMAL, 10.0);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+}*/
 
 /**
  * @brief BasicFetcherLoop tests.
@@ -1424,4 +1472,272 @@ TEST_F(FetcherLoopTests, SelectSourceOrAdPeriodTests5)
 
 	EXPECT_TRUE(ret);
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING); // Validate expected state transition
+}
+/**
+ * @brief L1 Test - Same bandwidths same order
+ * 
+ * Tests the scenario where representations have the same bandwidths
+ * in the same order across periods. Should return false.
+ */
+TEST_F(FetcherLoopTests, ShoudResetRepresentationIndex_SameBandwidthsSameOrder)
+{
+	std::string fragmentUrl;
+	AAMPStatusType status;
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT0H2M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+	<BaseURL>http://host/asset/</BaseURL>
+	<Period id="period1" duration="PT30S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="2" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="3" mimeType="video/mp4" codecs="avc1.640028" bandwidth="5000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<Period id="period2" duration="PT30S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="4" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="5" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="6" mimeType="video/mp4" codecs="avc1.640028" bandwidth="5000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>)";
+
+	/* Initialize MPD. The video initialization segment is cached. */
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _, _, _))
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+	
+	bool periodChanged = true;
+	bool mpdChanged = false;
+	bool adStateChanged = false;
+	bool waitForAdBreakCatchup = false;
+	bool requireStreamSelection = false;
+	std::string currentPeriodId = "";
+
+	mTestableStreamAbstractionAAMP_MPD->IncrementCurrentPeriodIdx();
+	mTestableStreamAbstractionAAMP_MPD->SetCurrentPeriod(mTestableStreamAbstractionAAMP_MPD->GetMPD()->GetPeriods().at(1));
+
+	bool selectResult = mTestableStreamAbstractionAAMP_MPD->InvokeSelectSourceOrAdPeriod(
+		periodChanged, mpdChanged, adStateChanged, waitForAdBreakCatchup, 
+		requireStreamSelection, currentPeriodId);
+	
+	// Call the function under test - should return true for different bandwidths
+	std::set<uint32_t> chosenAdaptationIdxs = {0}; // Video adaptation set at index 0
+	
+	bool result = mTestableStreamAbstractionAAMP_MPD->CallShoudResetRepresentationIndex(chosenAdaptationIdxs);
+	EXPECT_FALSE(result);
+}
+/**
+ * @brief L1 Test - Same bandwidths in different order
+ * 
+ * Tests the scenario where representations have the same bandwidths but
+ * appear in different order across periods. Should return false.
+ */
+TEST_F(FetcherLoopTests, ShoudResetRepresentationIndex_SameBandwidthsDifferentOrder)
+{
+	std::string fragmentUrl;
+	AAMPStatusType status;
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT0H2M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+	<BaseURL>http://host/asset/</BaseURL>
+	<Period id="period1" duration="PT30S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="2" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="3" mimeType="video/mp4" codecs="avc1.640028" bandwidth="5000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<Period id="period2" duration="PT30S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="4" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="5" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="6" mimeType="video/mp4" codecs="avc1.640028" bandwidth="5000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>)";
+
+	/* Initialize MPD. The video initialization segment is cached. */
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _, _, _))
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+	
+	bool periodChanged = true;
+	bool mpdChanged = false;
+	bool adStateChanged = false;
+	bool waitForAdBreakCatchup = false;
+	bool requireStreamSelection = false;
+	std::string currentPeriodId = "";
+
+	mTestableStreamAbstractionAAMP_MPD->IncrementCurrentPeriodIdx();
+	mTestableStreamAbstractionAAMP_MPD->SetCurrentPeriod(mTestableStreamAbstractionAAMP_MPD->GetMPD()->GetPeriods().at(1));
+
+	bool selectResult = mTestableStreamAbstractionAAMP_MPD->InvokeSelectSourceOrAdPeriod(
+		periodChanged, mpdChanged, adStateChanged, waitForAdBreakCatchup, 
+		requireStreamSelection, currentPeriodId);
+	
+	// Call the function under test - should return true for different bandwidths
+	std::set<uint32_t> chosenAdaptationIdxs = {0}; // Video adaptation set at index 0
+	
+	bool result = mTestableStreamAbstractionAAMP_MPD->CallShoudResetRepresentationIndex(chosenAdaptationIdxs);
+	EXPECT_TRUE(result);
+}
+/**
+ * @brief L1 Test - Different bandwidths between periods
+ * 
+ * Tests the scenario where representations have different bandwidths
+ * across periods. Should return true.
+ */
+TEST_F(FetcherLoopTests, ShoudResetRepresentationIndex_DifferentBandwidths)
+{
+	std::string fragmentUrl;
+	AAMPStatusType status;
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT0H2M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+	<BaseURL>http://host/asset/</BaseURL>
+	<Period id="period1" duration="PT30S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="2" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="1" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<Period id="period2" duration="PT30S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="3" mimeType="video/mp4" codecs="avc1.640028" bandwidth="3000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="4" mimeType="video/mp4" codecs="avc1.640028" bandwidth="4000000">
+				<SegmentTemplate timescale="1000" media="video_$Number$.mp4" startNumber="8" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="4000" r="7" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>)";
+
+	/* Initialize MPD. The video initialization segment is cached. */
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _, _, _))
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+	
+	bool periodChanged = true;
+	bool mpdChanged = false;
+	bool adStateChanged = false;
+	bool waitForAdBreakCatchup = false;
+	bool requireStreamSelection = false;
+	std::string currentPeriodId = "";
+
+	mTestableStreamAbstractionAAMP_MPD->IncrementCurrentPeriodIdx();
+	mTestableStreamAbstractionAAMP_MPD->SetCurrentPeriod(mTestableStreamAbstractionAAMP_MPD->GetMPD()->GetPeriods().at(1));
+
+	bool selectResult = mTestableStreamAbstractionAAMP_MPD->InvokeSelectSourceOrAdPeriod(
+		periodChanged, mpdChanged, adStateChanged, waitForAdBreakCatchup, 
+		requireStreamSelection, currentPeriodId);
+	
+	// Call the function under test - should return true for different bandwidths
+	std::set<uint32_t> chosenAdaptationIdxs = {0}; // Video adaptation set at index 0
+	
+	bool result = mTestableStreamAbstractionAAMP_MPD->CallShoudResetRepresentationIndex(chosenAdaptationIdxs);
+	EXPECT_TRUE(result);
 }


### PR DESCRIPTION
Reason for change: If the Profile order changes across the periods, facing video stuck up issue as it retains the previous Representation index value during each period switch, so properly reset the Representation index during each period switch
Risks: Low
Test Procedure: Refer jira ticket
Priority: P1