### PR TITLE
Reapply "VPLAY-11062: Bringback with L2 & L3 fixes

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -622,6 +622,10 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 
 		if (aamp->mpStreamAbstractionAAMP && !(aamp->mbUsingExternalPlayer))
 		{
+			if (aamp->mbDetached)
+			{
+				aamp->enableEventProcessing();
+			}
 			if ( AAMP_SLOWMOTION_RATE != rate && !aamp->mIsIframeTrackPresent && rate != AAMP_NORMAL_PLAY_RATE && rate != 0 && aamp->mMediaFormat != eMEDIAFORMAT_PROGRESSIVE)
 			{
 				AAMPLOG_WARN("Ignoring trickplay. No iframe tracks in stream");
@@ -1092,6 +1096,11 @@ void PlayerInstanceAAMP::SeekInternal(double secondsRelativeToTuneTime, bool kee
 	{
 		AAMPPlayerState state = GetState();
 		aamp->StopPausePositionMonitoring("Seek() called");
+
+		if (aamp->mbDetached)
+		{
+			aamp->enableEventProcessing();
+		}
 
 		if ((aamp->mMediaFormat == eMEDIAFORMAT_HLS || aamp->mMediaFormat == eMEDIAFORMAT_HLS_MP4) && (eSTATE_INITIALIZING == state)  && aamp->mpStreamAbstractionAAMP)
 		{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6713,6 +6713,24 @@ bool PrivateInstanceAAMP::IsPlayEnabled()
 }
 
 /**
+ * @brief Enable event processing
+ */
+void PrivateInstanceAAMP::enableEventProcessing()
+{
+	// Reset Event Manager State to IDLE to resume event processing
+	mEventManager->SetPlayerState(eSTATE_IDLE);
+}
+
+/**
+ * @brief Disable event processing
+ */
+void PrivateInstanceAAMP::disableEventProcessing()
+{
+	// Set Event Manager State to RELEASED to avoid further event processing
+	mEventManager->SetPlayerState(eSTATE_RELEASED);
+}
+
+/**
  * @brief Soft stop the player instance.
  *
  */
@@ -6750,6 +6768,8 @@ void PrivateInstanceAAMP::detach()
 		mbDetached=true;
 		mPlayerPreBuffered  = false;
 		mTelemetryInterval = 0;
+		// disable event processing
+		disableEventProcessing();
 		//EnableDownloads();// enable downloads
 	}
 	else

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6770,7 +6770,6 @@ void PrivateInstanceAAMP::detach()
 		mbDetached=true;
 		mPlayerPreBuffered  = false;
 		mTelemetryInterval = 0;
-		// disable event processing
 		disableEventProcessing();
 		//EnableDownloads();// enable downloads
 	}

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3003,6 +3003,18 @@ public:
 	bool IsPlayEnabled();
 
 	/**
+	 *   @fn enableEventProcessing
+	 *
+	 *   @return void
+	 */
+	void enableEventProcessing();
+	/**
+	 *   @fn disableEventProcessing
+	 *
+	 *   @return void
+	 */
+	void disableEventProcessing();
+	/**
 	 * @fn detach
 	 *
 	 */

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -243,6 +243,14 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl, bool autoPlay, const
 	mFogTSBEnabled = strcasestr(mainManifestUrl, "tsb?");
 }
 
+void PrivateInstanceAAMP::enableEventProcessing()
+{
+}
+
+void PrivateInstanceAAMP::disableEventProcessing()
+{
+}
+
 void PrivateInstanceAAMP::detach()
 {
 }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -255,6 +255,14 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	mFogTSBEnabled = strcasestr(mainManifestUrl, "tsb?");
 }
 
+void PrivateInstanceAAMP::enableEventProcessing()
+{
+}
+
+void PrivateInstanceAAMP::disableEventProcessing()
+{
+}
+
 void PrivateInstanceAAMP::detach()
 {
 }


### PR DESCRIPTION
Reason for change: During detach(), set the EventManager state to
RELEASED to disable further event processing. When reusing a previously
detached player, reset the EventManager state to IDLE to re-enable
event handling.