### PR TITLE
VPLAY-11709: l2 test 2073 regression

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2532,8 +2532,6 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 {
 	std::string playlistURI;
 
-	format = FORMAT_UNKNOWN; /* default value*/
-
 	switch (trackType)
 	{
 	case eTRACK_VIDEO:

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -956,7 +956,7 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE1)
     mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = -1;
     StreamOutputFormat format = FORMAT_MPEGTS;
     auto playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
-    ASSERT_EQ(FORMAT_UNKNOWN, format);
+    ASSERT_EQ(FORMAT_MPEGTS, format); //value not changed
 }
 
 TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE2)
@@ -985,8 +985,9 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetPlaylistURISUBTITLE2)
 
     /* test vector index out of bounds */
     mStreamAbstractionAAMP_HLS->currentTextTrackProfileIndex = 2;
+    format = FORMAT_AUDIO_ES_ATMOS; //Some unlikely value
     playlistURI = mStreamAbstractionAAMP_HLS->GetPlaylistURI(eTRACK_SUBTITLE, format);
-    ASSERT_EQ(FORMAT_UNKNOWN, format);
+    ASSERT_EQ(FORMAT_AUDIO_ES_ATMOS, format); //not changed
 
 }
 


### PR DESCRIPTION
Reason For Change: Previous change VPLAY-11588 broke AAMP and L2 2073

A line of code was added to GetPlaylistURI() to initialize the stream format, but this was not present before. Remove this line

Risk: Low