### PR TITLE
VPLAY-11709 l2 test 2073 regression

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2532,7 +2532,7 @@ std::string StreamAbstractionAAMP_HLS::GetPlaylistURI(TrackType trackType, Strea
 {
 	std::string playlistURI;
 
-	format = FORMAT_UNKNOWN; /* default value*/
+	//format = FORMAT_UNKNOWN; /* default value*/ - breaks L2 2073
 
 	switch (trackType)
 	{


### PR DESCRIPTION
VPLAY-11709 l2 test 2073 regression

Reason for Change: workaround for regression from VPLAY-11588 impacting some HLS playback (audio-only hls playlist using aac in this case)

Test Guidance: l2 test 2073 passing again

Risk: High