### PR TITLE
VPLAY-11407 godspell fix

### DIFF
--- a/AampEventManager.cpp
+++ b/AampEventManager.cpp
@@ -189,7 +189,7 @@ void AampEventManager::RemoveEventListener(AAMPEventType eventType, std::shared_
 			if (pListener->eventListener == eventListener)
 			{
 				*ppLast = pListener->pNext;
-				AAMPLOG_INFO("Eventtype:%d %p delete %p usecount = %d", eventType, eventListener.get(), pListener, (int)eventListener.use_count());
+				AAMPLOG_INFO("Eventtype:%d %p delete %p use_count = %d", eventType, eventListener.get(), pListener, (int)eventListener.use_count());
 				SAFE_DELETE(pListener);
 				return;
 			}


### PR DESCRIPTION
VPLAY-11407 godspell fix

Reason for Change: change logged text from usecount to use_count; this avoids godspell flagging it, but also aligns with use_count() method of shared_ptr API

Test Guidance: godspell passing

Risk: None