### PR TITLE
VPLAY-11677 : Release 1.3.2 

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1387,9 +1387,17 @@ void AampDRMLicenseManager::clearDrmSession(bool forceClearSession)
 {
 	mDrmSessionManager->clearDrmSession(forceClearSession);
 	for(int i = 0 ; i < mMaxDRMSessions;i++)
-    {
-        mLicenseDownloader[i].Clear();
-    }
+	{
+		bool isFailedKeyId = mDRMSessionManager->getFailedKeyIdStatus(i);
+		if(( mDRMSessionManager->drmSessionContexts != NULL && (isFailedKeyId || forceClearSession)  ))
+		{
+			if(mDRMSessionManager->drmSessionContexts[i].drmSession != NULL)
+			{
+				AAMPLOG_INFO("Clearing Session %d, isFailedKeyId=%d, forceClearSession=%d",i, isFailedKeyId, forceClearSession);
+				mLicenseDownloader[i].Clear();
+		    }
+		}
+	}
 }
 
 /**

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -168,6 +168,18 @@ void DrmSessionManager::clearAccessToken()
 }
 
 /**
+ * @brief Get the failed key ID status for a specific session
+ */
+bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
+{
+	if (sessionIndex >= 0 && sessionIndex < mMaxDrmSessions && cachedKeyIDs)
+	{
+		return cachedKeyIDs[sessionIndex].isFailedKeyId;
+	}
+	return false;
+}
+
+/**
  * @brief Clean up the Session Data if license key acquisition failed or if LicenseCaching is false.
  */
 void DrmSessionManager::clearDrmSession(bool forceClearSession)

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -301,6 +301,16 @@ public:
 	 * @return	void.
 	 */
 	void clearFailedKeyIds();
+
+
+	/**
+	 * @fn		getFailedKeyIdStatus
+	 *
+	 * @param	sessionIndex session index to check
+	 * @return	bool - true if the key ID is marked as failed, false otherwise
+	 */
+	bool getFailedKeyIdStatus(int sessionIndex);
+
 	/**
 	 * @fn		clearDrmSession
 	 *


### PR DESCRIPTION
…ssion(), which was missed during the DRM refactoring (#619)

VPLAY-11530 Increase in tune failures

Reason for Change : Reintroduced the condition check before calling clear() in clearDrmSession. This was lost during DRM refactoring.