### PR TITLE
VPLAY-11737 AAMP Test L3 2000, 2013, 2014, 2015 failing with Rialto+AmLogic since ~25 October 2025

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -1801,7 +1801,7 @@ void InterfacePlayerRDK::InitializeSourceForPlayer(void *PlayerInstance, void * 
 		g_object_set(source, "max-bytes", (guint64)MaxGstVideoBufBytes, NULL);			/* Sets the maximum video buffer bytes as per configuration*/
 		
 		if( privatePlayer->gstPrivateContext->usingRialtoSink &&
-		   privatePlayer->socInterface->IsVideoMaster(privatePlayer->gstPrivateContext->video_sink) )
+		   !privatePlayer->socInterface->IsVideoMaster(privatePlayer->gstPrivateContext->video_sink) )
 		{
 			// This property is required so that the segment event sent via gst_app_src_push_sample
 			MW_LOG_INFO("Setting handle-segment-change to 1");


### PR DESCRIPTION
VPLAY-11737 AAMP Test L3 2000, 2013, 2014, 2015 failing with Rialto+AmLogic since ~25 October 2025

Reason for Change: fix regression from VPLAY-11239, where use of IsVideoMaster was inadvertantly inverted to drive use of handle-segment-change

Test Guidance: named L3 tests again passing on AmLogic w/ Rialto