### PR TITLE
VPLAY-11530: Increase in PLTV XSTPP-999 Failures

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1450,10 +1450,17 @@ void AampDRMLicenseManager::clearDrmSession(bool forceClearSession)
 {
 	mDrmSessionManager->clearDrmSession(forceClearSession);
 	for(int i = 0 ; i < mMaxDRMSessions;i++)
-        {
-
-             mLicenseDownloader[i].Clear();
-        }
+	{
+		bool isFailedKeyId = mDrmSessionManager->getFailedKeyIdStatus(i);
+		if(( mDrmSessionManager->drmSessionContexts != NULL && (isFailedKeyId || forceClearSession)  ))
+		{
+			if(mDrmSessionManager->drmSessionContexts[i].drmSession != NULL)
+			{
+				AAMPLOG_INFO("Clearing Session %d, isFailedKeyId=%d, forceClearSession=%d",i, isFailedKeyId, forceClearSession);
+				mLicenseDownloader[i].Clear();
+		    }
+		}
+	}
 }
 
 /**

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -1458,7 +1458,7 @@ void AampDRMLicenseManager::clearDrmSession(bool forceClearSession)
 			{
 				AAMPLOG_INFO("Clearing Session %d, isFailedKeyId=%d, forceClearSession=%d",i, isFailedKeyId, forceClearSession);
 				mLicenseDownloader[i].Clear();
-		    }
+			}
 		}
 	}
 }

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -171,6 +171,18 @@ void DrmSessionManager::clearAccessToken()
 }
 
 /**
+ * @brief Get the failed key ID status for a specific session
+ */
+bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
+{
+	if (sessionIndex >= 0 && sessionIndex < mMaxDRMSessions && cachedKeyIDs)
+	{
+		return cachedKeyIDs[sessionIndex].isFailedKeyId;
+	}
+	return false;
+}
+
+/**
  * @brief Clean up the Session Data if license key acquisition failed or if LicenseCaching is false.
  */
 void DrmSessionManager::clearDrmSession(bool forceClearSession)

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -175,11 +175,13 @@ void DrmSessionManager::clearAccessToken()
  */
 bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
 {
+	bool rc = false;
+	std::lock_guard<std::mutex> guard(cachedKeyMutex);
 	if (sessionIndex >= 0 && sessionIndex < mMaxDRMSessions && cachedKeyIDs)
 	{
-		return cachedKeyIDs[sessionIndex].isFailedKeyId;
+		rc = cachedKeyIDs[sessionIndex].isFailedKeyId;
 	}
-	return false;
+	return rc;
 }
 
 /**

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -301,6 +301,16 @@ public:
 	 * @return	void.
 	 */
 	void clearFailedKeyIds();
+
+
+	/**
+	 * @fn		getFailedKeyIdStatus
+	 *
+	 * @param	sessionIndex- curl session index to check
+	 * @return	bool - true if the key ID is marked as failed, false otherwise
+	 */
+	bool getFailedKeyIdStatus(int sessionIndex);
+
 	/**
 	 * @fn		clearDrmSession
 	 *

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -306,7 +306,7 @@ public:
 	/**
 	 * @fn		getFailedKeyIdStatus
 	 *
-	 * @param	sessionIndex- curl session index to check
+	 * @param	sessionIndex - curl session index to check
 	 * @return	bool - true if the key ID is marked as failed, false otherwise
 	 */
 	bool getFailedKeyIdStatus(int sessionIndex);


### PR DESCRIPTION
Reason for Change : Reintroduced the condition check before calling clear() in clearDrmSession. This was lost during DRM refactoring.