### PR TITLE
VPLAY-11786: Observed crash with fingerprint "88814015/82391305"

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8512,6 +8512,10 @@ void StreamAbstractionAAMP_MPD::CacheEncryptedHeader(int trackIdx, std::string h
 		{
 			AAMPLOG_ERR("regex exception in Calling CacheFragment: %s", e.what());
 		}
+		catch (...)
+		{
+			AAMPLOG_ERR("unknown exception calling CacheFragment");
+		}
 		if(!temp)
 		{
 			AAMPLOG_TRACE("StreamAbstractionAAMP_MPD: did not cache fragmentUrl %s fragmentTime %f", headerUrl.c_str(), mMediaStreamContext[trackIdx]->fragmentTime); //CID:84438 - checked return

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8499,7 +8499,14 @@ void StreamAbstractionAAMP_MPD::CacheEncryptedHeader(int trackIdx, std::string h
 		bool temp = false;
 		try
 		{
+			DownloadInfoPtr info = std::make_shared<DownloadInfo>();
+			info->absolutePosition = 0;
+			info->ptsOffset = 0;
+			info->isInitSegment = true;
+			info->mediaType = (AampMediaType)trackIdx;
+			mMediaStreamContext[trackIdx]->mActiveDownloadInfo = std::move(info);
 			temp =  mMediaStreamContext[trackIdx]->CacheFragment(headerUrl, (eCURLINSTANCE_VIDEO + mMediaStreamContext[trackIdx]->mediaType), mMediaStreamContext[trackIdx]->fragmentTime, 0.0, NULL, true, false, false, 0);
+			mMediaStreamContext[trackIdx]->mActiveDownloadInfo = nullptr;
 		}
 		catch(const std::regex_error& e)
 		{

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8506,7 +8506,6 @@ void StreamAbstractionAAMP_MPD::CacheEncryptedHeader(int trackIdx, std::string h
 			info->mediaType = (AampMediaType)trackIdx;
 			mMediaStreamContext[trackIdx]->mActiveDownloadInfo = std::move(info);
 			temp =  mMediaStreamContext[trackIdx]->CacheFragment(headerUrl, (eCURLINSTANCE_VIDEO + mMediaStreamContext[trackIdx]->mediaType), mMediaStreamContext[trackIdx]->fragmentTime, 0.0, NULL, true, false, false, 0);
-			mMediaStreamContext[trackIdx]->mActiveDownloadInfo = nullptr;
 		}
 		catch(const std::regex_error& e)
 		{
@@ -8516,6 +8515,7 @@ void StreamAbstractionAAMP_MPD::CacheEncryptedHeader(int trackIdx, std::string h
 		{
 			AAMPLOG_ERR("unknown exception calling CacheFragment");
 		}
+		mMediaStreamContext[trackIdx]->mActiveDownloadInfo = nullptr;
 		if(!temp)
 		{
 			AAMPLOG_TRACE("StreamAbstractionAAMP_MPD: did not cache fragmentUrl %s fragmentTime %f", headerUrl.c_str(), mMediaStreamContext[trackIdx]->fragmentTime); //CID:84438 - checked return


### PR DESCRIPTION
VPLAY-11786: Observed crash with fingerprint "88814015/82391305"

Reason for change:Fixing the CacheEncryptedHeader with downloadInfo before downloading Risks: Low
Test Procedure: Test with DRM contents
Priority: P1