### PR TITLE
VPLAY-11806 DrmLegacy L1 test broken - missing DrmSessionManager::getFailedKeyIdStatus fake

### DIFF
--- a/test/utests/fakes/FakeAampDRMSessionManager.cpp
+++ b/test/utests/fakes/FakeAampDRMSessionManager.cpp
@@ -113,3 +113,7 @@ void DrmSessionManager::setSessionMgrState(SessionMgrState state)
 {
 }
 
+bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
+{
+	return false;
+}


### PR DESCRIPTION
VPLAY-11806 DrmLegacy L1 test broken - missing DrmSessionManager::getFailedKeyIdStatus fake

Reason for Change: fix link error impacting DrmLegacy L1 test

Test Guidance: all l1 tests passing

Risk: None: fake-only change