### PR TITLE
VPLAY-10162 - Use threadID instead of flag in call isjoinable

### DIFF
--- a/AampDRMLicPreFetcher.cpp
+++ b/AampDRMLicPreFetcher.cpp
@@ -39,7 +39,6 @@ AampLicensePreFetcher::AampLicensePreFetcher(PrivateInstanceAAMP *aamp) : mPreFe
 		mFetchQueue(),
 		mQMutex(),
 		mQCond(),
-		mPreFetchThreadStarted(false),
 		mExitLoop(false),
 		mCommonKeyDuration(0),
 		mTrackStatus(),
@@ -50,7 +49,7 @@ AampLicensePreFetcher::AampLicensePreFetcher(PrivateInstanceAAMP *aamp) : mPreFe
 		mVssFetchQueue(),
 		mQVssMutex(),
 		mQVssCond(),
-		mVssPreFetchThreadStarted(false)
+		mIsSecClientError(false)
 {
 	mTrackStatus.fill(false);
 	mIsSecClientError = isSecFeatureEnabled();
@@ -67,19 +66,17 @@ AampLicensePreFetcher::~AampLicensePreFetcher()
 		std::lock_guard<std::mutex>lock(mQMutex);
 		mExitLoop = true;
 	}
-	if (mPreFetchThreadStarted)
+	if (mPreFetchThread.joinable())
 	{
 		mQCond.notify_one();
 		AAMPLOG_WARN("Joining mPreFetchThread");
 		mPreFetchThread.join();
-		mPreFetchThreadStarted = false;
 	}
-	if (mVssPreFetchThreadStarted)
+	if (mVssPreFetchThread.joinable())
 	{
 		mQVssCond.notify_one();
 		AAMPLOG_WARN("Joining mVssFetchThread");
 		mVssPreFetchThread.join();
-		mVssPreFetchThreadStarted = false;
 	}
 }
 
@@ -92,7 +89,7 @@ AampLicensePreFetcher::~AampLicensePreFetcher()
 bool AampLicensePreFetcher::Init()
 {
 	bool ret = true;
-	if (mPreFetchThreadStarted || mVssPreFetchThreadStarted)
+	if (mPreFetchThread.joinable() || mVssPreFetchThread.joinable())
 	{
 		AAMPLOG_WARN("PreFetch thread is already started when calling Init!!");
 	}
@@ -149,11 +146,10 @@ bool AampLicensePreFetcher::QueueContentProtection(DrmHelperPtr drmHelper, std::
 			{
 				std::lock_guard<std::mutex>lock(mQVssMutex);
 				mVssFetchQueue.push_back(std::move(fetchObject));
-				if (!mVssPreFetchThreadStarted)
+				if (!mVssPreFetchThread.joinable())
 				{
 					AAMPLOG_WARN("Starting mVssPreFetchThread");
 					mVssPreFetchThread = std::thread(&AampLicensePreFetcher::VssPreFetchThread, this);
-					mVssPreFetchThreadStarted = true;
 				}
 				else
 				{
@@ -174,11 +170,10 @@ bool AampLicensePreFetcher::QueueContentProtection(DrmHelperPtr drmHelper, std::
 				}
 
 				mFetchQueue.push_back(std::move(fetchObject));
-				if (!mPreFetchThreadStarted)
+				if (!mPreFetchThread.joinable())
 				{
 					AAMPLOG_WARN("Starting mPreFetchThread");
 					mPreFetchThread = std::thread(&AampLicensePreFetcher::PreFetchThread, this);
-					mPreFetchThreadStarted = true;
 				}
 				else
 				{

--- a/AampDRMLicPreFetcher.cpp
+++ b/AampDRMLicPreFetcher.cpp
@@ -148,7 +148,7 @@ bool AampLicensePreFetcher::QueueContentProtection(DrmHelperPtr drmHelper, std::
 				mVssFetchQueue.push_back(std::move(fetchObject));
 				if (!mVssPreFetchThread.joinable())
 				{
-					AAMPLOG_WARN("Starting mVssPreFetchThread");
+					AAMPLOG_MIL("Starting mVssPreFetchThread");
 					mVssPreFetchThread = std::thread(&AampLicensePreFetcher::VssPreFetchThread, this);
 				}
 				else

--- a/AampDRMLicPreFetcher.h
+++ b/AampDRMLicPreFetcher.h
@@ -229,7 +229,6 @@ private:
 	std::deque<LicensePreFetchObjectPtr> mFetchQueue;   /** Queue for storing content protection objects*/
 	std::mutex mQMutex;                                 /** Mutex for accessing the mFetchQueue*/
 	std::condition_variable mQCond;                     /** Conditional variable to notify addition of an obj to mFetchQueue*/
-	bool mPreFetchThreadStarted;                        /** Flag denotes if thread started*/
 	bool mExitLoop;                                     /** Flag denotes if pre-fetch thread has to be exited*/
 	int mCommonKeyDuration;                             /** Common key duration for deferred license acquisition*/
 	std::array<bool, AAMP_TRACK_COUNT> mTrackStatus;    /** To mark the status of license acquisition for tracks*/
@@ -241,7 +240,6 @@ private:
 	std::deque<LicensePreFetchObjectPtr> mVssFetchQueue;/** Queue for storing VSS content protection objects*/
 	std::mutex mQVssMutex;                              /** Mutex for accessing the mVssFetchQueue*/
 	std::condition_variable mQVssCond;                  /** Conditional variable to notify addition of an obj to mVssFetchQueue*/
-	bool mVssPreFetchThreadStarted;                     /** Flag denotes if Vss thread started*/
 	bool mIsSecClientError;
 };
 

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -486,7 +486,8 @@ public:
 	 */
 	bool IsDiscontinuityProcessed() { return discontinuityProcessed; }
 
-	bool isFragmentInjectorThreadStarted( ) {  return fragmentInjectorThreadID.joinable();}
+	bool isFragmentInjectorThreadStarted();
+	bool IsPlaylistDownloaderThreadActive() { return (playlistDownloaderThread != NULL) && playlistDownloaderThread->joinable(); }
 	void MonitorBufferHealth();
 	/**
 	 * @brief Signal the clock to subtitle module
@@ -877,7 +878,6 @@ private:
 	long long prevDownloadStartTime;		/**< Previous file download Start time*/
 
 	std::thread *playlistDownloaderThread;	/**< PlaylistDownloadThread of track*/
-	bool playlistDownloaderThreadStarted;	/**< Playlist downloader thread started or not*/
 	bool abortPlaylistDownloader;			/**< Flag used to abort playlist downloader*/
 	std::condition_variable plDownloadWait;	/**< Conditional variable for signaling timed wait*/
 	std::mutex dwnldMutex;					/**< Download mutex for conditional timed wait, used for playlist and fragment downloads*/

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -486,7 +486,7 @@ public:
 	 */
 	bool IsDiscontinuityProcessed() { return discontinuityProcessed; }
 
-	bool isFragmentInjectorThreadStarted( ) {  return fragmentInjectorThreadStarted;}
+	bool isFragmentInjectorThreadStarted( ) {  return fragmentInjectorThreadID.joinable();}
 	void MonitorBufferHealth();
 	/**
 	 * @brief Signal the clock to subtitle module
@@ -862,8 +862,6 @@ private:
 	std::thread subtitleClockThreadID;    	/**< subtitle clock synchronisation thread id */
 	int totalFragmentsDownloaded;       	/**< Total fragments downloaded since start by track*/
 	int totalFragmentChunksDownloaded;      /**< Total fragments downloaded since start by track*/
-	bool fragmentInjectorThreadStarted; 	/**< Fragment injector's thread started or not*/
-	bool bufferMonitorThreadStarted;    	/**< Buffer Monitor thread started or not */
 	bool UpdateSubtitleClockTaskStarted;    /**< Subtitle clock synchronization thread started, or not */
 	bool bufferMonitorThreadDisabled;    	/**< Buffer Monitor thread Disabled or not */
 	double totalInjectedDuration;       	/**< Total fragment injected duration*/

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -487,7 +487,7 @@ public:
 	bool IsDiscontinuityProcessed() { return discontinuityProcessed; }
 
 	bool isFragmentInjectorThreadStarted();
-	bool IsPlaylistDownloaderThreadActive() { return (playlistDownloaderThread != NULL) && playlistDownloaderThread->joinable(); }
+	bool isPlaylistDownloaderThreadStarted();
 	void MonitorBufferHealth();
 	/**
 	 * @brief Signal the clock to subtitle module

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -1546,6 +1546,7 @@ void PrivateCDAIObjectMPD::StopFulfillAdLoop()
 		mExitFulfillAdLoop = true;
 		NotifyAdLoopWait();
 		mAdObjThreadID.join();
+		AAMPLOG_INFO("mAdObjThreadID joined.");
 	}
 }
 

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -60,7 +60,7 @@ void CDAIObjectMPD::SetAlternateContents(const std::string &periodId, const std:
  * @brief PrivateCDAIObjectMPD constructor
  */
 PrivateCDAIObjectMPD::PrivateCDAIObjectMPD(PrivateInstanceAAMP* aamp) : mAamp(aamp),mDaiMtx(), mIsFogTSB(false), mAdBreaks(), mPeriodMap(), mCurPlayingBreakId(), mAdObjThreadID(), mCurAds(nullptr),
-					mCurAdIdx(-1), mContentSeekOffset(0), mAdState(AdState::OUTSIDE_ADBREAK),mPlacementObj(), mAdFulfillObj(),mAdObjThreadStarted(false),currentAdPeriodClosed(false),mAdtoInsertInNextBreakVec(),
+					mCurAdIdx(-1), mContentSeekOffset(0), mAdState(AdState::OUTSIDE_ADBREAK),mPlacementObj(), mAdFulfillObj(),currentAdPeriodClosed(false),mAdtoInsertInNextBreakVec(),
 					mAdBrkVecMtx(), mAdFulfillMtx(), mAdFulfillCV(), mAdFulfillQ(), mExitFulfillAdLoop(false), mAdPlacementMtx(), mAdPlacementCV()
 {
 	StartFulfillAdLoop();
@@ -1529,9 +1529,8 @@ void PrivateCDAIObjectMPD::FulfillAdLoop()
  */
 void PrivateCDAIObjectMPD::StartFulfillAdLoop()
 {
-	if(!mAdObjThreadStarted)
+	if(!mAdObjThreadID.joinable())
 	{
-		mAdObjThreadStarted = true;
 		mAdObjThreadID = std::thread(&PrivateCDAIObjectMPD::FulfillAdLoop, this);
 		AAMPLOG_INFO("Thread created mAdObjThreadID[%zx]", GetPrintableThreadID(mAdObjThreadID));
 	}
@@ -1542,15 +1541,11 @@ void PrivateCDAIObjectMPD::StartFulfillAdLoop()
  */
 void PrivateCDAIObjectMPD::StopFulfillAdLoop()
 {
-	if(mAdObjThreadStarted)
+	if(mAdObjThreadID.joinable())
 	{
 		mExitFulfillAdLoop = true;
 		NotifyAdLoopWait();
-		if (mAdObjThreadID.joinable())
-		{
-			mAdObjThreadID.join();
-		}
-		mAdObjThreadStarted = false;
+		mAdObjThreadID.join();
 	}
 }
 

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -352,7 +352,6 @@ public:
 	std::unordered_map<std::string, Period2AdData> mPeriodMap;          /**< periodId to Ad map */
 	std::string                                    mCurPlayingBreakId;  /**< Currently playing Ad */
 	std::thread                                    mAdObjThreadID;      /**< ThreadId of Ad fulfillment */
-	bool                                           mAdObjThreadStarted; /**< Flag denotes if ad object thread is started */
 	AdNodeVectorPtr                                mCurAds;             /**< Vector of ads from the current Adbreak */
 	int                                            mCurAdIdx;           /**< Currently playing Ad index */
 	AdFulfillObj                                   mAdFulfillObj;       /**< Temporary object for Ad fulfillment (to pass to the fulfillment thread) */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9567,7 +9567,7 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 			double lastPrdOffset = mBasePeriodOffset;
 			while (!exitFetchLoop)
 			{
-				if (mIsLiveStream && !mIsLiveManifest && playlistDownloaderContext->IsPlaylistDownloaderThreadActive())
+				if (mIsLiveStream && !mIsLiveManifest && playlistDownloaderContext->isPlaylistDownloaderThreadStarted())
 				{
 					// CDVR moved from "dynamic" to "static"
 					playlistDownloaderContext->StopPlaylistDownloaderThread();

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -134,7 +134,7 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 	,mMaxTracks(0)
 	,mDeltaTime(0)
 	,mHasServerUtcTime(false)
-	,latencyMonitorThreadStarted(false),prevLatencyStatus(LATENCY_STATUS_UNKNOWN),latencyStatus(LATENCY_STATUS_UNKNOWN),latencyMonitorThreadID()
+	,prevLatencyStatus(LATENCY_STATUS_UNKNOWN),latencyStatus(LATENCY_STATUS_UNKNOWN),latencyMonitorThreadID()
 	,mStreamLock()
 	,mProfileCount(0)
 	,mIterPeriodIndex(0), mNumberOfPeriods(0)
@@ -10354,7 +10354,7 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 		}
 	}
 
-	if(latencyMonitorThreadStarted)
+	if(latencyMonitorThreadID.joinable())
 	{
 		aamp->SetLLDashAdjustSpeed(false);
 		aamp->SetLLDashCurrentPlayBackRate(GETCONFIGVALUE(eAAMPConfig_NormalLatencyCorrectionPlaybackRate));
@@ -10365,7 +10365,6 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 		AAMPLOG_TRACE("Waiting to join StartLatencyMonitorThread");
 		latencyMonitorThreadID.join();
 		AAMPLOG_INFO("Joined StartLatencyMonitorThread");
-		latencyMonitorThreadStarted = false;
 	}
 	if (!aamp->DownloadsAreEnabled())
 	{
@@ -12661,11 +12660,10 @@ double StreamAbstractionAAMP_MPD::GetEncoderDisplayLatency()
  */
 void StreamAbstractionAAMP_MPD::StartLatencyMonitorThread()
 {
-	assert(!latencyMonitorThreadStarted);
+	assert(!latencyMonitorThreadID.joinable());
 	try
 	{
 		latencyMonitorThreadID = std::thread(&StreamAbstractionAAMP_MPD::MonitorLatency, this);
-		latencyMonitorThreadStarted = true;
 		AAMPLOG_INFO("Thread created Latency monitor [%zx]", GetPrintableThreadID(latencyMonitorThreadID));
 	}
 	catch(const std::exception& e)

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -138,7 +138,6 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 	,mStreamLock()
 	,mProfileCount(0)
 	,mIterPeriodIndex(0), mNumberOfPeriods(0)
-	,playlistDownloaderThreadStarted(false)
 	,mSubtitleParser()
 	,mMultiVideoAdaptationPresent(false)
 	,mLocalUtcTime(0)
@@ -9560,11 +9559,10 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 			double lastPrdOffset = mBasePeriodOffset;
 			while (!exitFetchLoop)
 			{
-				if (mIsLiveStream && !mIsLiveManifest && playlistDownloaderThreadStarted)
+				if (mIsLiveStream && !mIsLiveManifest && playlistDownloaderContext->IsPlaylistDownloaderThreadActive())
 				{
 					// CDVR moved from "dynamic" to "static"
 					playlistDownloaderContext->StopPlaylistDownloaderThread();
-					playlistDownloaderThreadStarted = false;
 				}
 				/* Calling the Refresh audio track, in order to switch to the newly selected Audio Track */
 				if(mPlayRate == AAMP_NORMAL_PLAY_RATE && mMediaStreamContext[eTRACK_AUDIO] && mMediaStreamContext[eTRACK_AUDIO]->refreshAudio )

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -1129,7 +1129,6 @@ protected:
 	AudioType mAudioType;
 	int mPrevAdaptationSetCount;
 	std::vector<BitsPerSecond> mBitrateIndexVector;
-	bool playlistDownloaderThreadStarted; // Playlist downloader thread start status
 	double mLivePeriodCulledSeconds;
 	bool mIsSegmentTimelineEnabled;   /**< Flag to indicate if segment timeline is enabled, to determine if PTS is available from manifest */
 	// In case of streams with multiple video Adaptation Sets, A profile

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -1235,7 +1235,6 @@ protected:
 
 	LatencyStatus latencyStatus; 		 /**< Latency status of the playback*/
 	LatencyStatus prevLatencyStatus;	 /**< Previous latency status of the playback*/
-	bool latencyMonitorThreadStarted;	 /**< Monitor latency thread  status*/
 	std::thread latencyMonitorThreadID;	 /**< Fragment injector thread id*/
 	int mProfileCount;			 /**< Total video profile count*/
 	std::unique_ptr<SubtitleParser> mSubtitleParser;	/**< Parser for subtitle data*/

--- a/middleware/drm/aes/Aes.cpp
+++ b/middleware/drm/aes/Aes.cpp
@@ -177,24 +177,24 @@ DrmReturn AesDec::SetDecryptInfo(const struct DrmInfo *drmInfo, int acquireKeyWa
 	mPrevDrmState = eDRM_INITIALIZED;
 	this->GetCurlInitCb(mCurlInstance);
 
-	if (licenseAcquisitionThreadStarted)
+	if (licenseAcquisitionThreadId.joinable())
 	{
 		licenseAcquisitionThreadId.join();
-		licenseAcquisitionThreadStarted = false;
 	}
 
-	try
+	if (!licenseAcquisitionThreadId.joinable())
 	{
-		licenseAcquisitionThreadId = std::thread(&AesDec::acquire_key, this);
-		err = eDRM_SUCCESS;
-		licenseAcquisitionThreadStarted = true;
+		try
+		{
+			licenseAcquisitionThreadId = std::thread(&AesDec::acquire_key, this);
+			err = eDRM_SUCCESS;
 //TODO		MW_LOG_INFO("Thread created for acquire_key [%zx]", GetPrintableThreadID(licenseAcquisitionThreadId));
-	}
-	catch(const std::exception& e)
-	{
-		MW_LOG_ERR("AesDec:: thread create failed for acquire_key : %s", e.what());
-		mDrmState = eDRM_KEY_FAILED;
-		licenseAcquisitionThreadStarted = false;
+		}
+		catch(const std::exception& e)
+		{
+			MW_LOG_ERR("AesDec:: thread create failed for acquire_key : %s", e.what());
+			mDrmState = eDRM_KEY_FAILED;
+		}
 	}
 	MW_LOG_INFO("AesDec: drmState:%d ", mDrmState);
 	return err;
@@ -292,10 +292,9 @@ void AesDec::Release()
 	{
 		WaitForKeyAcquireCompleteUnlocked(mAcquireKeyWaitTime, err, lock );
 	}
-	if (licenseAcquisitionThreadStarted)
+	if (licenseAcquisitionThreadId.joinable())
 	{
 		licenseAcquisitionThreadId.join();
-		licenseAcquisitionThreadStarted = false;
 	}
 	mCond.notify_all();
 	if (-1 != mCurlInstance)
@@ -361,7 +360,6 @@ AesDec::AesDec() :  mDrmState(eDRM_INITIALIZED),
 		mCond(), mMutex(), mOpensslCtx(),
          	mDrmInfo(), mCurlInstance(-1),
 		licenseAcquisitionThreadId(),
-		licenseAcquisitionThreadStarted(false),
 		mAcquireKeyWaitTime(MAX_LICENSE_ACQ_WAIT_TIME)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L

--- a/middleware/drm/aes/Aes.cpp
+++ b/middleware/drm/aes/Aes.cpp
@@ -33,7 +33,6 @@
 #include <errno.h>
 #include <mutex>
 #include "PlayerLogManager.h"
-#include "AampUtils.h"
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #define OPEN_SSL_CONTEXT mOpensslCtx
 #else
@@ -189,7 +188,7 @@ DrmReturn AesDec::SetDecryptInfo(const struct DrmInfo *drmInfo, int acquireKeyWa
 		{
 			licenseAcquisitionThreadId = std::thread(&AesDec::acquire_key, this);
 			err = eDRM_SUCCESS;
-			MW_LOG_INFO("Thread created for acquire_key [%zx]", GetPrintableThreadID(licenseAcquisitionThreadId));
+//TODO		MW_LOG_INFO("Thread created for acquire_key [%zx]", GetPrintableThreadID(licenseAcquisitionThreadId));
 		}
 		catch(const std::exception& e)
 		{

--- a/middleware/drm/aes/Aes.cpp
+++ b/middleware/drm/aes/Aes.cpp
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <mutex>
 #include "PlayerLogManager.h"
+#include "AampUtils.h"
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 #define OPEN_SSL_CONTEXT mOpensslCtx
 #else
@@ -188,7 +189,7 @@ DrmReturn AesDec::SetDecryptInfo(const struct DrmInfo *drmInfo, int acquireKeyWa
 		{
 			licenseAcquisitionThreadId = std::thread(&AesDec::acquire_key, this);
 			err = eDRM_SUCCESS;
-//TODO		MW_LOG_INFO("Thread created for acquire_key [%zx]", GetPrintableThreadID(licenseAcquisitionThreadId));
+			MW_LOG_INFO("Thread created for acquire_key [%zx]", GetPrintableThreadID(licenseAcquisitionThreadId));
 		}
 		catch(const std::exception& e)
 		{

--- a/middleware/drm/aes/Aes.cpp
+++ b/middleware/drm/aes/Aes.cpp
@@ -182,19 +182,16 @@ DrmReturn AesDec::SetDecryptInfo(const struct DrmInfo *drmInfo, int acquireKeyWa
 		licenseAcquisitionThreadId.join();
 	}
 
-	if (!licenseAcquisitionThreadId.joinable())
+	try
 	{
-		try
-		{
-			licenseAcquisitionThreadId = std::thread(&AesDec::acquire_key, this);
-			err = eDRM_SUCCESS;
+		licenseAcquisitionThreadId = std::thread(&AesDec::acquire_key, this);
+		err = eDRM_SUCCESS;
 //TODO		MW_LOG_INFO("Thread created for acquire_key [%zx]", GetPrintableThreadID(licenseAcquisitionThreadId));
-		}
-		catch(const std::exception& e)
-		{
-			MW_LOG_ERR("AesDec:: thread create failed for acquire_key : %s", e.what());
-			mDrmState = eDRM_KEY_FAILED;
-		}
+	}
+	catch(const std::exception& e)
+	{
+		MW_LOG_ERR("AesDec:: thread create failed for acquire_key : %s", e.what());
+		mDrmState = eDRM_KEY_FAILED;
 	}
 	MW_LOG_INFO("AesDec: drmState:%d ", mDrmState);
 	return err;

--- a/middleware/drm/aes/Aes.h
+++ b/middleware/drm/aes/Aes.h
@@ -218,7 +218,6 @@ private:
 	int mCurlInstance;
 	int mAcquireKeyWaitTime;
 	std::thread licenseAcquisitionThreadId;
-	bool licenseAcquisitionThreadStarted;
 };
 
 #endif // _AES_H_

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1118,7 +1118,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	//mTimeToTopProfile(0),
 	mTimeAtTopProfile(0),mPlaybackDuration(0),mTraceUUID(),
 	mIsFirstRequestToFOG(false),
-	mPausePositionMonitorMutex(), mPausePositionMonitorCV(), mPausePositionMonitoringThreadID(), mPausePositionMonitoringThreadStarted(false),
+	mPausePositionMonitorMutex(), mPausePositionMonitorCV(), mPausePositionMonitoringThreadID(),
 	mTuneType(eTUNETYPE_NEW_NORMAL)
 	,mCdaiObject(NULL), mAdEventsQ(),mAdEventQMtx(), mAdPrevProgressTime(0), mAdCurOffset(0), mAdDuration(0), mAdProgressId(""), mAdAbsoluteStartTime(0)
 	,mBufUnderFlowStatus(false), mVideoBasePTS(0)
@@ -1133,7 +1133,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	,mNetworkBandwidth(0)
 	,mTimeToTopProfile(0)
 	, fragmentCdmEncrypted(false) ,drmParserMutex(), aesCtrAttrDataList()
-	, drmSessionThreadStarted(false), createDRMSessionThreadID()
+	, createDRMSessionThreadID()
 	, mDRMLicenseManager(NULL)
 	,  mPreCachePlaylistThreadId(), mPreCacheDnldList()
 	, mPreCacheDnldTimeWindow(0), mParallelPlaylistFetchLock(), mAppName()
@@ -1668,15 +1668,17 @@ void PrivateInstanceAAMP::StartPausePositionMonitoring(long long pausePositionMi
 
 		AAMPLOG_INFO("Start PausePositionMonitoring at position %lld", pausePositionMilliseconds);
 
-		try
+		if (!mPausePositionMonitoringThreadID.joinable())
 		{
-			mPausePositionMonitoringThreadID = std::thread(&PrivateInstanceAAMP ::RunPausePositionMonitoring, this);
-			mPausePositionMonitoringThreadStarted = true;
-			AAMPLOG_INFO("Thread created for RunPausePositionMonitoring [%zx]", GetPrintableThreadID(mPausePositionMonitoringThreadID));
-		}
-		catch(const std::exception& e)
-		{
-			AAMPLOG_ERR("Failed to create PausePositionMonitor thread: %s", e.what());
+			try
+			{
+				mPausePositionMonitoringThreadID = std::thread(&PrivateInstanceAAMP ::RunPausePositionMonitoring, this);
+				AAMPLOG_INFO("Thread created for RunPausePositionMonitoring [%zx]", GetPrintableThreadID(mPausePositionMonitoringThreadID));
+			}
+			catch(const std::exception& e)
+			{
+				AAMPLOG_ERR("Failed to create PausePositionMonitor thread: %s", e.what());
+			}
 		}
 	}
 }
@@ -1686,7 +1688,7 @@ void PrivateInstanceAAMP::StartPausePositionMonitoring(long long pausePositionMi
  */
 void PrivateInstanceAAMP::StopPausePositionMonitoring(std::string reason)
 {
-	if (mPausePositionMonitoringThreadStarted)
+	if (mPausePositionMonitoringThreadID.joinable())
 	{
 		std::unique_lock<std::mutex> lock(mPausePositionMonitorMutex);
 
@@ -1701,7 +1703,6 @@ void PrivateInstanceAAMP::StopPausePositionMonitoring(std::string reason)
 		lock.unlock();
 		mPausePositionMonitoringThreadID.join();
 		AAMPLOG_TRACE("joined PositionMonitor");
-		mPausePositionMonitoringThreadStarted = false;
 	}
 }
 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1121,7 +1121,6 @@ public:
 	std::thread mPreCachePlaylistThreadId;
 	bool mbPlayEnabled;					/**< Send buffer to pipeline or just cache them */
 	std::thread createDRMSessionThreadID; 			/**< thread ID for DRM session creation */
-	bool drmSessionThreadStarted; 				/**< flag to indicate the thread is running on not */
 	AampDRMLicenseManager *mDRMLicenseManager;
 	int mPlaylistFetchFailError;				/**< To store HTTP error code when playlist download fails */
 	bool mAudioDecoderStreamSync; 				/**<  Flag to set or clear 'stream_sync_mode' property
@@ -4148,7 +4147,6 @@ protected:
 	std::mutex mPausePositionMonitorMutex;				// Mutex lock for PausePosition condition variable
 	std::condition_variable mPausePositionMonitorCV;	// Condition Variable to signal to stop PausePosition monitoring
     std::thread mPausePositionMonitoringThreadID;			// Thread Id of the PausePositionMonitoring thread
-	bool mPausePositionMonitoringThreadStarted;			// Flag to indicate PausePositionMonitoring thread started
 	TuneType mTuneType;
 	int m_fd;
 	bool mIsLive;				// Flag to indicate manifest type.

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1620,14 +1620,14 @@ bool MediaTrack::SignalIfEOSReached()
 void MediaTrack::StartInjectLoop()
 {
 
-	std::lock_guard<std::mutex> guard(injectorStartMutex);
-	if (fragmentInjectorThreadID.joinable())
+	try
 	{
-		AAMPLOG_WARN("Fragment injector thread already started");
-	}
-	else
-	{
-		try
+		std::lock_guard<std::mutex> guard(injectorStartMutex);
+		if (fragmentInjectorThreadID.joinable())
+		{
+			AAMPLOG_WARN("Fragment injector thread already started");
+		}
+		else
 		{
 			abort = false;
 			abortInject = false;
@@ -1636,10 +1636,10 @@ void MediaTrack::StartInjectLoop()
 			fragmentInjectorThreadID = std::thread(&MediaTrack::RunInjectLoop, this);
 			AAMPLOG_INFO("Thread created for RunInjectLoop [%zx]", GetPrintableThreadID(fragmentInjectorThreadID));
 		}
-		catch(const std::exception& e)
-		{
-			AAMPLOG_WARN("Failed to create FragmentInjector thread ; %s", e.what());
-		}
+	}
+	catch(const std::exception& e)
+	{
+		AAMPLOG_WARN("Failed to create FragmentInjector thread ; %s", e.what());
 	}
 }
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -83,13 +83,13 @@ void MediaTrack::StartPlaylistDownloaderThread()
 		playlistDownloaderThread = new std::thread(&MediaTrack::PlaylistDownloader, this);
 		AAMPLOG_INFO("Thread created for PlaylistDownloader [%zx]", GetPrintableThreadID(*playlistDownloaderThread));
 	}
-	else if(!playlistDownloaderThread->joinable())
+	else if(playlistDownloaderThread->joinable())
 	{
-		AAMPLOG_ERR("Failed to start thread, already initialized for %s", name);
+		AAMPLOG_INFO("Thread already running for %s", name);
 	}
 	else
 	{
-		AAMPLOG_INFO("Thread already running for %s", name);
+		AAMPLOG_WARN("Failed to start thread. thread is not joinable, but the thread pointer is non NULL for %s", name);
 	}
 }
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -74,20 +74,18 @@ AampMediaType TrackTypeToMediaType( TrackType trackType )
 void MediaTrack::StartPlaylistDownloaderThread()
 {
 	AAMPLOG_DEBUG("Starting playlist downloader for %s", name);
-	if(!playlistDownloaderThread || !playlistDownloaderThread->joinable())
+
+	if(!playlistDownloaderThread)
 	{
 		// Start a new thread for this track
-		if(!playlistDownloaderThread)
-		{
-			// Set thread abort flag to false and start the thread.
-			abortPlaylistDownloader = false;
-			playlistDownloaderThread = new std::thread(&MediaTrack::PlaylistDownloader, this);
-			AAMPLOG_INFO("Thread created for PlaylistDownloader [%zx]", GetPrintableThreadID(*playlistDownloaderThread));
-		}
-		else
-		{
-			AAMPLOG_ERR("Failed to start thread, already initialized for %s", name);
-		}
+		// Set thread abort flag to false and start the thread.
+		abortPlaylistDownloader = false;
+		playlistDownloaderThread = new std::thread(&MediaTrack::PlaylistDownloader, this);
+		AAMPLOG_INFO("Thread created for PlaylistDownloader [%zx]", GetPrintableThreadID(*playlistDownloaderThread));
+	}
+	else if(!playlistDownloaderThread->joinable())
+	{
+		AAMPLOG_ERR("Failed to start thread, already initialized for %s", name);
 	}
 	else
 	{
@@ -1622,14 +1620,14 @@ bool MediaTrack::SignalIfEOSReached()
 void MediaTrack::StartInjectLoop()
 {
 
-	try
+	std::lock_guard<std::mutex> guard(injectorStartMutex);
+	if (fragmentInjectorThreadID.joinable())
 	{
-		std::lock_guard<std::mutex> guard(injectorStartMutex);
-		if (fragmentInjectorThreadID.joinable())
-		{
-			AAMPLOG_WARN("Fragment injector thread already started");
-		}
-		else
+		AAMPLOG_WARN("Fragment injector thread already started");
+	}
+	else
+	{
+		try
 		{
 			abort = false;
 			abortInject = false;
@@ -1638,10 +1636,10 @@ void MediaTrack::StartInjectLoop()
 			fragmentInjectorThreadID = std::thread(&MediaTrack::RunInjectLoop, this);
 			AAMPLOG_INFO("Thread created for RunInjectLoop [%zx]", GetPrintableThreadID(fragmentInjectorThreadID));
 		}
-	}
-	catch(const std::exception& e)
-	{
-		AAMPLOG_WARN("Failed to create FragmentInjector thread ; %s", e.what());
+		catch(const std::exception& e)
+		{
+			AAMPLOG_WARN("Failed to create FragmentInjector thread ; %s", e.what());
+		}
 	}
 }
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -74,7 +74,7 @@ AampMediaType TrackTypeToMediaType( TrackType trackType )
 void MediaTrack::StartPlaylistDownloaderThread()
 {
 	AAMPLOG_DEBUG("Starting playlist downloader for %s", name);
-	if(!playlistDownloaderThreadStarted)
+	if((NULL == playlistDownloaderThread) || !playlistDownloaderThread->joinable())
 	{
 		// Start a new thread for this track
 		if(NULL == playlistDownloaderThread)
@@ -82,7 +82,6 @@ void MediaTrack::StartPlaylistDownloaderThread()
 			// Set thread abort flag to false and start the thread.
 			abortPlaylistDownloader = false;
 			playlistDownloaderThread = new std::thread(&MediaTrack::PlaylistDownloader, this);
-			playlistDownloaderThreadStarted = true;
 			AAMPLOG_INFO("Thread created for PlaylistDownloader [%zx]", GetPrintableThreadID(*playlistDownloaderThread));
 		}
 		else
@@ -101,14 +100,13 @@ void MediaTrack::StartPlaylistDownloaderThread()
  */
 void MediaTrack::StopPlaylistDownloaderThread()
 {
-	if ((playlistDownloaderThreadStarted) && (playlistDownloaderThread) && (playlistDownloaderThread->joinable()))
+	if ((playlistDownloaderThread) && (playlistDownloaderThread->joinable()))
 	{
 		abortPlaylistDownloader = true;
 		AbortWaitForPlaylistDownload();
 		AbortFragmentDownloaderWait();
 		playlistDownloaderThread->join();
 		SAFE_DELETE(playlistDownloaderThread);
-		playlistDownloaderThreadStarted = false;
 		AAMPLOG_WARN("[%s] Aborted", name);
 	}
 }
@@ -1819,6 +1817,16 @@ bool MediaTrack::Enabled()
 }
 
 /**
+ * @brief Check if fragment injector thread is started
+ * @return true if thread is joinable, false otherwise
+ */
+bool MediaTrack::isFragmentInjectorThreadStarted()
+{
+	std::lock_guard<std::mutex> guard(injectorStartMutex);
+	return fragmentInjectorThreadID.joinable();
+}
+
+/**
  *  @brief Get buffer to store the downloaded fragment content to cache next fragment
  */
 CachedFragment* MediaTrack::GetFetchBuffer(bool initialize)
@@ -2029,7 +2037,7 @@ MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* na
 		mSubtitleParser(), refreshSubtitles(false), refreshAudio(false), maxCachedFragmentsPerTrack(0),
 		mCachedFragmentChunks{}, unparsedBufferChunk{"unparsedBufferChunk"}, parsedBufferChunk{"parsedBufferChunk"}, fragmentChunkFetched(), fragmentChunkInjected(), maxCachedFragmentChunksPerTrack(0),
 		noMDATCount(0), loadNewAudio(false), audioFragmentCached(), audioMutex(), loadNewSubtitle(false), subtitleFragmentCached(), subtitleMutex(),
-		abortPlaylistDownloader(true), playlistDownloaderThreadStarted(false), plDownloadWait()
+		abortPlaylistDownloader(true), plDownloadWait()
 		,dwnldMutex(), playlistDownloaderThread(NULL), fragmentCollectorWaitingForPlaylistUpdate(false)
 		,frDownloadWait(),prevDownloadStartTime(-1)
 		,playContext(nullptr), seamlessAudioSwitchInProgress(false), lastInjectedPosition(0), lastInjectedDuration(0), seamlessSubtitleSwitchInProgress(false)
@@ -4175,7 +4183,7 @@ void StreamAbstractionAAMP::DisablePlaylistDownloads()
 void MediaTrack::AbortWaitForPlaylistDownload()
 {
 	std::unique_lock<std::mutex> lock(dwnldMutex);
-	if(playlistDownloaderThreadStarted)
+	if((playlistDownloaderThread) && (playlistDownloaderThread->joinable()))
 	{
 		plDownloadWait.notify_one();
 	}

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -74,10 +74,10 @@ AampMediaType TrackTypeToMediaType( TrackType trackType )
 void MediaTrack::StartPlaylistDownloaderThread()
 {
 	AAMPLOG_DEBUG("Starting playlist downloader for %s", name);
-	if((NULL == playlistDownloaderThread) || !playlistDownloaderThread->joinable())
+	if(!playlistDownloaderThread || !playlistDownloaderThread->joinable())
 	{
 		// Start a new thread for this track
-		if(NULL == playlistDownloaderThread)
+		if(!playlistDownloaderThread)
 		{
 			// Set thread abort flag to false and start the thread.
 			abortPlaylistDownloader = false;
@@ -1824,6 +1824,15 @@ bool MediaTrack::isFragmentInjectorThreadStarted()
 {
 	std::lock_guard<std::mutex> guard(injectorStartMutex);
 	return fragmentInjectorThreadID.joinable();
+}
+
+/**
+ * @brief Check if playlist downloader thread is started
+ * @return true if thread is joinable, false otherwise
+ */
+bool MediaTrack::isPlaylistDownloaderThreadStarted()
+{
+	return (playlistDownloaderThread && playlistDownloaderThread->joinable());
 }
 
 /**

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1627,7 +1627,7 @@ void MediaTrack::StartInjectLoop()
 	try
 	{
 		std::lock_guard<std::mutex> guard(injectorStartMutex);
-		if (fragmentInjectorThreadStarted)
+		if (fragmentInjectorThreadID.joinable())
 		{
 			AAMPLOG_WARN("Fragment injector thread already started");
 		}
@@ -1638,7 +1638,6 @@ void MediaTrack::StartInjectLoop()
 			discontinuityProcessed = false;
 
 			fragmentInjectorThreadID = std::thread(&MediaTrack::RunInjectLoop, this);
-			fragmentInjectorThreadStarted = true;
 			AAMPLOG_INFO("Thread created for RunInjectLoop [%zx]", GetPrintableThreadID(fragmentInjectorThreadID));
 		}
 	}
@@ -1698,12 +1697,11 @@ void MediaTrack::RunInjectLoop()
 	StreamAbstractionAAMP* pContext = GetContext();
 	if ((AAMP_NORMAL_PLAY_RATE == aamp->rate) )
 	{
-		if (!bufferMonitorThreadDisabled && !bufferMonitorThreadStarted)
+		if (!bufferMonitorThreadDisabled && !bufferMonitorThreadID.joinable())
 		{
 			try
 			{
 				bufferMonitorThreadID = std::thread(&MediaTrack::MonitorBufferHealth, this);
-				bufferMonitorThreadStarted = true;
 				AAMPLOG_INFO("Thread created for MonitorBufferHealth [%zx]", GetPrintableThreadID(bufferMonitorThreadID));
 			}
 			catch(const std::exception& e)
@@ -1805,12 +1803,11 @@ void MediaTrack::StopInjectLoop()
 	NotifyCachedAudioFragmentAvailable();
 	NotifyCachedSubtitleFragmentAvailable();
 	std::lock_guard<std::mutex> guard(injectorStartMutex);
-	if(fragmentInjectorThreadStarted && fragmentInjectorThreadID.joinable())
+	if(fragmentInjectorThreadID.joinable())
 	{
 		fragmentInjectorThreadID.join();
 		AAMPLOG_INFO("Fragment injector thread joined");
 	}
-	fragmentInjectorThreadStarted = false;
 }
 
 /**
@@ -2023,7 +2020,7 @@ void MediaTrack::OffsetTrackParams(double deltaFetchedDuration, double deltaInje
 MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* name) :
 		eosReached(false), enabled(false), numberOfFragmentsCached(0), numberOfFragmentChunksCached(0), fragmentIdxToInject(0), fragmentChunkIdxToInject(0),
 		fragmentIdxToFetch(0), fragmentChunkIdxToFetch(0), abort(false), fragmentInjectorThreadID(), bufferMonitorThreadID(), subtitleClockThreadID(), totalFragmentsDownloaded(0), totalFragmentChunksDownloaded(0),
-		fragmentInjectorThreadStarted(false), bufferMonitorThreadStarted(false), UpdateSubtitleClockTaskStarted(false), bufferMonitorThreadDisabled(false), totalInjectedDuration(0), totalInjectedChunksDuration(0), currentInitialCacheDurationSeconds(0),
+		UpdateSubtitleClockTaskStarted(false), bufferMonitorThreadDisabled(false), totalInjectedDuration(0), totalInjectedChunksDuration(0), currentInitialCacheDurationSeconds(0),
 		sinkBufferIsFull(false), cachingCompleted(false), fragmentDurationSeconds(0),  segDLFailCount(0),segDrmDecryptFailCount(0),mSegInjectFailCount(0),
 		bufferStatus(BUFFER_STATUS_GREEN), prevBufferStatus(BUFFER_STATUS_GREEN),
 		bandwidthBitsPerSecond(0), totalFetchedDuration(0),
@@ -2055,7 +2052,7 @@ MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* na
  */
 MediaTrack::~MediaTrack()
 {
-	if (bufferMonitorThreadStarted)
+	if (bufferMonitorThreadID.joinable())
 	{
 		bufferMonitorThreadID.join();
 		{

--- a/test/utests/fakes/FakeAdManager.cpp
+++ b/test/utests/fakes/FakeAdManager.cpp
@@ -40,7 +40,7 @@ void CDAIObjectMPD::SetAlternateContents(const std::string &adBreakId, const std
 }
 
 PrivateCDAIObjectMPD::PrivateCDAIObjectMPD(PrivateInstanceAAMP* aamp) : mAamp(aamp),mDaiMtx(), mIsFogTSB(false), mAdBreaks(), mPeriodMap(), mCurPlayingBreakId(), mAdObjThreadID(), mCurAds(nullptr),
-					mCurAdIdx(-1), mContentSeekOffset(0), mAdState(AdState::OUTSIDE_ADBREAK),mPlacementObj(), mAdFulfillObj(),mAdObjThreadStarted(false),mAdtoInsertInNextBreakVec(),mAdBrkVecMtx()
+					mCurAdIdx(-1), mContentSeekOffset(0), mAdState(AdState::OUTSIDE_ADBREAK),mPlacementObj(), mAdFulfillObj(),mAdtoInsertInNextBreakVec(),mAdBrkVecMtx()
 {
 }
 

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -224,6 +224,11 @@ void MediaTrack::StartPlaylistDownloaderThread()
 {
 }
 
+bool MediaTrack::isFragmentInjectorThreadStarted()
+{
+	return true;
+}
+
 MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* name) : parsedBufferChunk("parsedBufferChunk"), unparsedBufferChunk("unparsedBufferChunk"), name(name), aamp(aamp), type(type)
 {
 }

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -229,6 +229,11 @@ bool MediaTrack::isFragmentInjectorThreadStarted()
 	return true;
 }
 
+bool MediaTrack::isPlaylistDownloaderThreadStarted()
+{
+	return true;
+}
+
 MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* name) : parsedBufferChunk("parsedBufferChunk"), unparsedBufferChunk("unparsedBufferChunk"), name(name), aamp(aamp), type(type)
 {
 }

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -85,7 +85,7 @@ protected:
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
     mCdaiObj = new CDAIObjectMPD(mPrivateInstanceAAMP);
     mPrivateCDAIObjectMPD = mCdaiObj->GetPrivateCDAIObjectMPD();
-    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
 
     mManifest = nullptr;
     mMPD = nullptr;
@@ -447,7 +447,7 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 
   // Verify the result
   // mAdBreak updated and placementObj created
-  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.size(), 1);
   EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -524,7 +524,7 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 
   // Verify the result
   // mAdBreak updated and placementObj created
-  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.size(), 1);
   EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -576,7 +576,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_4)
 
   // Verify the result
   // mAdBreak updated and placementObj not created
-  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
   EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -652,7 +652,7 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 
   // Verify the result
   // mAdBreak updated and placementObj created
-  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.size(), 1);
   EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -730,7 +730,7 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 
   // Verify the result
   // mAdBreak updated and placementObj created
-  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.size(), 1);
   EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 2);
@@ -864,7 +864,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_10)
 
     // Verify the result
     // mAdBreak updated and placementObj not created
-    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
     EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
     EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -899,7 +899,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_11)
 
     // Verify the result
     // mAdBreak updated and placementObj not created
-    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
     EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
     EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -934,7 +934,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_12)
 
     // Verify the result
     // mAdBreak updated and placementObj not created
-    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
     EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
     EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -999,7 +999,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_13)
 
     // Verify the result
     // mAdBreak updated and placementObj not created
-    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
     EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
     EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);
@@ -1049,7 +1049,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_14)
 
     // Assert
     // mAdBreak updated and placementObj not created 
-    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadStarted);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
     EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
     EXPECT_EQ((mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads)->size(), 1);


### PR DESCRIPTION
Reason for change: Currently in aamp code, boolean flags are used
 at many instance where threads are created and deleted. Use isjoinable()
 check instead of flags and eliminate the redundant boolean flags.

Changes:
* isjoinable() check is used instead of boolean flags to decide whether a thread is already created.

Test Procedure: Refer JIRA ticket

Risks: low