### PR TITLE
VPLAY-11618 Handle empty language in HLS manifest

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7582,23 +7582,24 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 
 	unsigned long long bestScore = 0;
 	bool bestTrackFound = false;
+	auto languageVectorToCheck = (aamp->preferredTextLanguagesList.empty()) ? aamp->preferredSubtitleLanguageVctr : aamp->preferredTextLanguagesList;
 
 	for (const auto &track : availableTracks)
 	{
 		unsigned long long score = 1; // Base score for any track
 
 		// Score language preference (higher priority = higher score)
-		if (!aamp->preferredTextLanguagesList.empty())
+		if (!languageVectorToCheck.empty())
 		{
 			std::string normalizedTrackLanguage =
 				(track.language.empty()) ? track.language : Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
-			auto iter = std::find(aamp->preferredTextLanguagesList.cbegin(),
-								  aamp->preferredTextLanguagesList.cend(),
+			auto iter = std::find(languageVectorToCheck.cbegin(),
+								  languageVectorToCheck.cend(),
 								  normalizedTrackLanguage);
-			if (iter != aamp->preferredTextLanguagesList.cend())
+			if (iter != languageVectorToCheck.cend())
 			{
-				size_t position = std::distance(aamp->preferredTextLanguagesList.cbegin(), iter);
-				size_t priorityMultiplier = aamp->preferredTextLanguagesList.size() - position;
+				size_t position = std::distance(languageVectorToCheck.cbegin(), iter);
+				size_t priorityMultiplier = languageVectorToCheck.size() - position;
 				score += priorityMultiplier * AAMP_LANGUAGE_SCORE;
 
 				AAMPLOG_TRACE("Track '%s' lang='%s' (normalized='%s') matches position %zu (bonus: %llu)",

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7590,7 +7590,8 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		// Score language preference (higher priority = higher score)
 		if (!aamp->preferredTextLanguagesList.empty())
 		{
-			std::string normalizedTrackLanguage = Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
+			std::string normalizedTrackLanguage =
+				(track.language.empty()) ? track.language : Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
 			auto iter = std::find(aamp->preferredTextLanguagesList.cbegin(),
 								  aamp->preferredTextLanguagesList.cend(),
 								  normalizedTrackLanguage);

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7605,7 +7605,7 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		if (!languageVectorToCheck.empty())
 		{
 			std::string normalizedTrackLanguage =
-				(track.language.empty()) ? track.language : Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
+				track.language.empty() ? "" : Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
 			AAMPLOG_TRACE("Track '%s' lang='%s' (normalized='%s')", track.name.c_str(), track.language.c_str(), normalizedTrackLanguage.c_str());
 
 			auto iter = std::find(languageVectorToCheck.cbegin(),

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -3467,6 +3467,10 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 
 				// Configure Subtitle track for the playback
 				ConfigureTextTrack();
+				
+				// Check for text track changes and notify
+				NotifyTextTrackChanges();
+				
 				if(ISCONFIGSET(eAAMPConfig_useRialtoSink) && (currentTextTrackProfileIndex == -1))
 				{
 					AAMPLOG_INFO("usingRialtoSink - No default text track is selected,configure default text track for rialto");
@@ -7307,21 +7311,12 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 		{
 			aamp->NotifyAudioTracksChanged();
 		}
-
-		tracksChanged = false;
-		if (-1 != aamp->mCurrentTextTrackIndex && aamp->mCurrentTextTrackIndex != currentTextTrackProfileIndex)
-		{
-			tracksChanged = true;
-		}
-		aamp->mCurrentTextTrackIndex = currentTextTrackProfileIndex;
-		if (tracksChanged)
-		{
-			aamp->NotifyTextTracksChanged();
-		}
+		
+		// Update closed caption track info
 		std::vector<TextTrackInfo> textTracksCopy;
 		std::copy_if(begin(mTextTracks), end(mTextTracks), back_inserter(textTracksCopy), [](const TextTrackInfo& e){return e.isCC;});
 		std::vector<CCTrackInfo> updatedTextTracks;
-		aamp->UpdateCCTrackInfo(textTracksCopy,updatedTextTracks);
+		aamp->UpdateCCTrackInfo(textTracksCopy, updatedTextTracks);
 		PlayerCCManager::GetInstance()->updateLastTextTracks(updatedTextTracks);
 	}
 	else
@@ -7330,6 +7325,25 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 		AAMPLOG_ERR("StreamAbstractionAAMP_HLS:: Fail to get available audio/text tracks, mMediaCount=%d and profileCount=%d!", mMediaCount, mProfileCount);
 	}
 
+}
+
+/**
+ * @brief Check for text track changes and send notification events
+ */
+void StreamAbstractionAAMP_HLS::NotifyTextTrackChanges()
+{
+	// Check if text track has changed from a valid previous selection
+	bool tracksChanged = (aamp->mCurrentTextTrackIndex != -1 && 
+	                      aamp->mCurrentTextTrackIndex != currentTextTrackProfileIndex);
+	
+	// Update current track index
+	aamp->mCurrentTextTrackIndex = currentTextTrackProfileIndex;
+	
+	// Send notification if track changed
+	if (tracksChanged)
+	{
+		aamp->NotifyTextTracksChanged();
+	}
 }
 
 /**
@@ -7593,6 +7607,8 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		{
 			std::string normalizedTrackLanguage =
 				(track.language.empty()) ? track.language : Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
+			AAMPLOG_TRACE("Track '%s' lang='%s' (normalized='%s')", track.name.c_str(), track.language.c_str(), normalizedTrackLanguage.c_str());
+
 			auto iter = std::find(languageVectorToCheck.cbegin(),
 								  languageVectorToCheck.cend(),
 								  normalizedTrackLanguage);

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7590,17 +7590,18 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		// Score language preference (higher priority = higher score)
 		if (!aamp->preferredTextLanguagesList.empty())
 		{
+			std::string normalizedTrackLanguage = Getiso639map_NormalizeLanguageCode(track.language);
 			auto iter = std::find(aamp->preferredTextLanguagesList.cbegin(),
 								  aamp->preferredTextLanguagesList.cend(),
-								  track.language);
+								  normalizedTrackLanguage);
 			if (iter != aamp->preferredTextLanguagesList.cend())
 			{
 				size_t position = std::distance(aamp->preferredTextLanguagesList.cbegin(), iter);
 				size_t priorityMultiplier = aamp->preferredTextLanguagesList.size() - position;
 				score += priorityMultiplier * AAMP_LANGUAGE_SCORE;
 
-				AAMPLOG_TRACE("Track '%s' lang='%s' matches position %zu (bonus: %llu)",
-							  track.name.c_str(), track.language.c_str(),
+				AAMPLOG_TRACE("Track '%s' lang='%s' (normalized='%s') matches position %zu (bonus: %llu)",
+							  track.name.c_str(), track.language.c_str(), normalizedTrackLanguage.c_str(),
 							  position, priorityMultiplier * AAMP_LANGUAGE_SCORE);
 			}
 		}

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7595,7 +7595,6 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 	}
 
 	unsigned long long bestScore = 0;
-	bool bestTrackFound = false;
 	const auto& languageVectorToCheck = (aamp->preferredTextLanguagesList.empty()) ? aamp->preferredSubtitleLanguageVctr : aamp->preferredTextLanguagesList;
 
 	for (const auto &track : availableTracks)
@@ -7642,7 +7641,6 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		if (score > bestScore)
 		{
 			bestScore = score;
-			bestTrackFound = true;
 			selectedTextTrack = track;
 
 			AAMPLOG_INFO("New best text track: lang=%s, rendition=%s, name=%s, score=%llu",
@@ -7651,12 +7649,12 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		}
 	}
 
-	if (!bestTrackFound)
+	if (bestScore == 0)
 	{
 		AAMPLOG_WARN("No suitable text track found");
 	}
 
-	return bestTrackFound;
+	return (bestScore > 0);
 }
 
 /*

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7590,7 +7590,7 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 		// Score language preference (higher priority = higher score)
 		if (!aamp->preferredTextLanguagesList.empty())
 		{
-			std::string normalizedTrackLanguage = Getiso639map_NormalizeLanguageCode(track.language);
+			std::string normalizedTrackLanguage = Getiso639map_NormalizeLanguageCode(track.language, aamp->GetLangCodePreference());
 			auto iter = std::find(aamp->preferredTextLanguagesList.cbegin(),
 								  aamp->preferredTextLanguagesList.cend(),
 								  normalizedTrackLanguage);

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -3469,7 +3469,7 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 				ConfigureTextTrack();
 				if(ISCONFIGSET(eAAMPConfig_useRialtoSink) && (currentTextTrackProfileIndex == -1))
 				{
-					AAMPLOG_INFO("No default text track is selected, configure default text track");
+					AAMPLOG_INFO("usingRialtoSink - No default text track is selected,configure default text track for rialto");
 					SelectSubtitleTrack();
 				}
 			}

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7585,7 +7585,7 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 
 	for (const auto &track : availableTracks)
 	{
-		unsigned long long score = 1; // Base score
+		unsigned long long score = 1; // Base score for any track
 
 		// Score language preference (higher priority = higher score)
 		if (!aamp->preferredTextLanguagesList.empty())

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7114,11 +7114,10 @@ void StreamAbstractionAAMP_HLS::ConfigureTextTrack()
 {
 	TextTrackInfo track = aamp->GetPreferredTextTrack();
 	currentTextTrackProfileIndex = -1;
-AAMPLOG_INFO("DJH TextTrack Language:%s Index:%s", track.language.c_str(), track.index.c_str());
+
 	if (!track.index.empty())
 	{
 		currentTextTrackProfileIndex = std::stoi(track.index);
-AAMPLOG_INFO("DJH TextTrack Selected by Index:%d", currentTextTrackProfileIndex);		
 	}
 	else
 	{
@@ -7311,7 +7310,6 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 		}
 
 		tracksChanged = false;
-		AAMPLOG_INFO("DJH aamp->mCurrentTextTrackIndex :%d currentTextTrackProfileIndex:%d", aamp->mCurrentTextTrackIndex, currentTextTrackProfileIndex);
 		if (-1 != aamp->mCurrentTextTrackIndex && aamp->mCurrentTextTrackIndex != currentTextTrackProfileIndex)
 		{
 			tracksChanged = true;

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7114,7 +7114,6 @@ void StreamAbstractionAAMP_HLS::ConfigureTextTrack()
 {
 	TextTrackInfo track = aamp->GetPreferredTextTrack();
 	currentTextTrackProfileIndex = -1;
-
 	if (!track.index.empty())
 	{
 		currentTextTrackProfileIndex = std::stoi(track.index);

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7564,7 +7564,7 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
  *
  * Scoring algorithm:
  * - Base: 1 point for any track
- * - Language: (list_size - position) * AAMP_LANGUAGE_SCORE (prioritises order)
+ * - Language: (list_size - position) * AAMP_LANGUAGE_SCORE (prioritizes order)
  * - Rendition: AAMP_ROLE_SCORE
  * - Name: AAMP_TYPE_SCORE
  *

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7554,9 +7554,9 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
 			aamp->mIsInbandCC = mTextTracks[0].isCC;
 			aamp->SetCCStatus(false); //mute the subtitle track
 			aamp->SetPreferredTextTrack(mTextTracks[0]);
-			AAMPLOG_INFO("Using TextTrack Selected %d", currentTextTrackProfileIndex);
 		}
 	}
+	AAMPLOG_INFO("using RialtoSink TextTrack Selected %d", currentTextTrackProfileIndex);
 }
 
 /**

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7596,7 +7596,7 @@ bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selected
 
 	unsigned long long bestScore = 0;
 	bool bestTrackFound = false;
-	auto languageVectorToCheck = (aamp->preferredTextLanguagesList.empty()) ? aamp->preferredSubtitleLanguageVctr : aamp->preferredTextLanguagesList;
+	const auto& languageVectorToCheck = (aamp->preferredTextLanguagesList.empty()) ? aamp->preferredSubtitleLanguageVctr : aamp->preferredTextLanguagesList;
 
 	for (const auto &track : availableTracks)
 	{

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -580,13 +580,19 @@ AAMPStatusType StreamAbstractionAAMP_HLS::ParseMainManifest()
 				{
 					mediaInfoStore.emplace_back(MediaInfo{});
 					ptr.ParseAttrList(ParseMediaAttributeCallback, this);
-					if( mediaInfoStore[mMediaCount].language.empty() )
-					{ // handle non-compliant manifest missing language attribute
-						mediaInfoStore[mMediaCount].language =  mediaInfoStore[mMediaCount].name;
-					}
-					if (mediaInfoStore[mMediaCount].type == eMEDIATYPE_AUDIO && !mediaInfoStore[mMediaCount].language.empty() )
+					if (mediaInfoStore[mMediaCount].type == eMEDIATYPE_AUDIO)
 					{
-						mLangList.insert(GetLanguageCode(mMediaCount));
+						auto& audioMedia = mediaInfoStore[mMediaCount];
+						if (audioMedia.language.empty())
+						{ // handle non-compliant manifest missing language attribute
+							AAMPLOG_WARN("Audio track %d missing language, using name '%s' as fallback",
+										 mMediaCount, audioMedia.name.c_str());
+							audioMedia.language = audioMedia.name;
+						}
+						if (!audioMedia.language.empty())
+						{
+							mLangList.insert(GetLanguageCode(mMediaCount));
+						}
 					}
 					mMediaCount++;
 				}
@@ -3431,27 +3437,42 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 
 			if(rate == AAMP_NORMAL_PLAY_RATE)
 			{
-				// Step 1: Configure the Audio for the playback .Get the audio index/group
+				// Configure the Audio for the playback .Get the audio index/group
 				ConfigureAudioTrack();
 			}
 
-			// Step 3: Based on the audio selection done , configure the profiles required
+			// Based on the audio selection done , configure the profiles required
 			ConfigureVideoProfiles();
 
 			if(rate == AAMP_NORMAL_PLAY_RATE)
 			{
-				// Step 2: Configure Subtitle track for the playback
-				ConfigureTextTrack();
+
 				// Generate audio and text track structures
 				PopulateAudioAndTextTracks();
+
+				// Select preferred text track based on user language preferences
+				TextTrackInfo selectedTextTrack;
+				if (SelectPreferredTextTrack(selectedTextTrack))
+				{
+					AAMPLOG_INFO("Selected text track - lang:%s, name:%s, rendition:%s",
+								 selectedTextTrack.language.c_str(),
+								 selectedTextTrack.name.c_str(),
+								 selectedTextTrack.rendition.c_str());
+					aamp->SetPreferredTextTrack(std::move(selectedTextTrack));
+				}
+				else
+				{
+					AAMPLOG_WARN("No text track matched user preferences, will use default selection");
+				}
+
+				// Configure Subtitle track for the playback
+				ConfigureTextTrack();
 				if(ISCONFIGSET(eAAMPConfig_useRialtoSink) && (currentTextTrackProfileIndex == -1))
 				{
-					AAMPLOG_INFO("usingRialtoSink - No default text track is selected,configure default text track for rialto");
+					AAMPLOG_INFO("No default text track is selected, configure default text track");
 					SelectSubtitleTrack();
 				}
 			}
-
-
 
 			currentProfileIndex = GetDesiredProfile(false);
 			HlsStreamInfo *streamInfo = (HlsStreamInfo*)GetStreamInfo(currentProfileIndex);
@@ -7093,9 +7114,11 @@ void StreamAbstractionAAMP_HLS::ConfigureTextTrack()
 {
 	TextTrackInfo track = aamp->GetPreferredTextTrack();
 	currentTextTrackProfileIndex = -1;
+AAMPLOG_INFO("DJH TextTrack Language:%s Index:%s", track.language.c_str(), track.index.c_str());
 	if (!track.index.empty())
 	{
 		currentTextTrackProfileIndex = std::stoi(track.index);
+AAMPLOG_INFO("DJH TextTrack Selected by Index:%d", currentTextTrackProfileIndex);		
 	}
 	else
 	{
@@ -7288,6 +7311,7 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 		}
 
 		tracksChanged = false;
+		AAMPLOG_INFO("DJH aamp->mCurrentTextTrackIndex :%d currentTextTrackProfileIndex:%d", aamp->mCurrentTextTrackIndex, currentTextTrackProfileIndex);
 		if (-1 != aamp->mCurrentTextTrackIndex && aamp->mCurrentTextTrackIndex != currentTextTrackProfileIndex)
 		{
 			tracksChanged = true;
@@ -7533,45 +7557,89 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
 			aamp->mIsInbandCC = mTextTracks[0].isCC;
 			aamp->SetCCStatus(false); //mute the subtitle track
 			aamp->SetPreferredTextTrack(mTextTracks[0]);
+			AAMPLOG_INFO("Using TextTrack Selected %d", currentTextTrackProfileIndex);
 		}
 	}
-	AAMPLOG_INFO("using RialtoSink TextTrack Selected %d", currentTextTrackProfileIndex);
 }
 
-bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo& selectedTextTrack)
+/**
+ * @brief Select best text track based on user preferences
+ *
+ * Scoring algorithm:
+ * - Base: 1 point for any track
+ * - Language: (list_size - position) * AAMP_LANGUAGE_SCORE (prioritises order)
+ * - Rendition: AAMP_ROLE_SCORE
+ * - Name: AAMP_TYPE_SCORE
+ *
+ * @param[out] selectedTextTrack The best matching track
+ * @return true if a track was selected, false otherwise
+ */
+bool StreamAbstractionAAMP_HLS::SelectPreferredTextTrack(TextTrackInfo &selectedTextTrack)
 {
-	bool bestTrackFound = false;
-	unsigned long long bestScore = 0;
-
 	std::vector<TextTrackInfo> availableTracks = GetAvailableTextTracks();
-
-	for (const auto& track : availableTracks)
+	if (availableTracks.empty())
 	{
-		unsigned long long score = 1; // Default score for each track
+		AAMPLOG_WARN("No text tracks available");
+		return false;
+	}
 
-		// Check for language match
-		if (!aamp->preferredTextLanguagesString.empty() && track.language == aamp->preferredTextLanguagesString)
+	unsigned long long bestScore = 0;
+	bool bestTrackFound = false;
+
+	for (const auto &track : availableTracks)
+	{
+		unsigned long long score = 1; // Base score
+
+		// Score language preference (higher priority = higher score)
+		if (!aamp->preferredTextLanguagesList.empty())
 		{
-			score += AAMP_LANGUAGE_SCORE; // Add score for language match
+			auto iter = std::find(aamp->preferredTextLanguagesList.cbegin(),
+								  aamp->preferredTextLanguagesList.cend(),
+								  track.language);
+			if (iter != aamp->preferredTextLanguagesList.cend())
+			{
+				size_t position = std::distance(aamp->preferredTextLanguagesList.cbegin(), iter);
+				size_t priorityMultiplier = aamp->preferredTextLanguagesList.size() - position;
+				score += priorityMultiplier * AAMP_LANGUAGE_SCORE;
+
+				AAMPLOG_TRACE("Track '%s' lang='%s' matches position %zu (bonus: %llu)",
+							  track.name.c_str(), track.language.c_str(),
+							  position, priorityMultiplier * AAMP_LANGUAGE_SCORE);
+			}
 		}
 
-		if( !aamp->preferredTextRenditionString.empty() && aamp->preferredTextRenditionString.compare(track.rendition) == 0)
+		// Score rendition preference
+		if (!aamp->preferredTextRenditionString.empty() &&
+			aamp->preferredTextRenditionString == track.rendition)
 		{
-			score += AAMP_ROLE_SCORE; // Add score for rendition match
+			score += AAMP_ROLE_SCORE;
 		}
 
-		// Check for name match
-		if( !aamp->preferredTextNameString.empty() && aamp->preferredTextNameString.compare(track.name) == 0)
+		// Score name preference
+		if (!aamp->preferredTextNameString.empty() &&
+			aamp->preferredTextNameString == track.name)
 		{
-			score += AAMP_TYPE_SCORE; // Add score for name match
+			score += AAMP_TYPE_SCORE;
 		}
-		if(score > bestScore)
+
+		// Update best if this score is higher
+		if (score > bestScore)
 		{
-			bestTrackFound = true;
 			bestScore = score;
+			bestTrackFound = true;
 			selectedTextTrack = track;
+
+			AAMPLOG_INFO("New best text track: lang=%s, rendition=%s, name=%s, score=%llu",
+						 track.language.c_str(), track.rendition.c_str(),
+						 track.name.c_str(), score);
 		}
 	}
+
+	if (!bestTrackFound)
+	{
+		AAMPLOG_WARN("No suitable text track found");
+	}
+
 	return bestTrackFound;
 }
 

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -1030,6 +1030,13 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 ***************************************************************************/
 		void PopulateAudioAndTextTracks();
 		/***************************************************************************
+		 * @fn NotifyTextTrackChanges
+		 * @brief Check for text track changes and send notification events
+		 *
+		 * @return void
+		 ***************************************************************************/
+		void NotifyTextTrackChanges();
+		/***************************************************************************
 		 * @fn ConfigureAudioTrack
 		 *
 		 * @return void

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -1029,6 +1029,7 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 * @return void
 		 ***************************************************************************/
 		void PopulateAudioAndTextTracks();
+
 		/***************************************************************************
 		 * @fn NotifyTextTrackChanges
 		 * @brief Check for text track changes and send notification events
@@ -1036,6 +1037,7 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 * @return void
 		 ***************************************************************************/
 		void NotifyTextTrackChanges();
+
 		/***************************************************************************
 		 * @fn ConfigureAudioTrack
 		 *

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2573,8 +2573,7 @@ void PlayerInstanceAAMP::SetPreferredLanguages(const char *languageList, const c
  */
 void PlayerInstanceAAMP::SetPreferredTextLanguages(const char *param)
 {
-	//DJH aamp->SetPreferredTextLanguages(param);
-	aamp->SetPreferredTextLanguages("{\"languages\":[\"eng\",\"\"]}");
+	aamp->SetPreferredTextLanguages(param);
 }
 
 /**

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2573,7 +2573,8 @@ void PlayerInstanceAAMP::SetPreferredLanguages(const char *languageList, const c
  */
 void PlayerInstanceAAMP::SetPreferredTextLanguages(const char *param)
 {
-	aamp->SetPreferredTextLanguages(param);
+	//DJH aamp->SetPreferredTextLanguages(param);
+	aamp->SetPreferredTextLanguages("{languages:[\"eng\",\"\"]}");
 }
 
 /**

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2574,7 +2574,7 @@ void PlayerInstanceAAMP::SetPreferredLanguages(const char *languageList, const c
 void PlayerInstanceAAMP::SetPreferredTextLanguages(const char *param)
 {
 	//DJH aamp->SetPreferredTextLanguages(param);
-	aamp->SetPreferredTextLanguages("{languages:[\"eng\",\"\"]}");
+	aamp->SetPreferredTextLanguages("{\"languages\":[\"eng\",\"\"]}");
 }
 
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12423,8 +12423,6 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 				std::string firstLanguage = preferredTextLanguagesList.at(0);
 				std::string trackLanguage = Getiso639map_NormalizeLanguageCode(
 					track.language, this->GetLangCodePreference());
-AAMPLOG_INFO("DJH trackLanguage %s firstLanguage %s currentPrefLanguage %s",
-				trackLanguage.c_str(), firstLanguage.c_str(), currentPrefLanguage.c_str());
 
 				if ((trackLanguage == firstLanguage) && (trackLanguage != currentPrefLanguage))
 				{
@@ -12554,16 +12552,9 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 							// Find the index of the selected track in the available tracks list
 							closedCaptionTrackId = FindTextTrackIndex(trackInfo, selectedTextTrack);
 
-							if (closedCaptionTrackId >= 0)
-							{
-								AAMPLOG_INFO("Selected text track at index %d (lang=%s)",
-											 closedCaptionTrackId, selectedTextTrack.language.c_str());
-								SetPreferredTextTrack(std::move(selectedTextTrack));
-							}
-							else
-							{
-								AAMPLOG_ERR("Selected text track not found in trackInfo vector");
-							}
+							AAMPLOG_INFO("Selected text track at index %d (lang=%s)",
+										 closedCaptionTrackId, selectedTextTrack.language.c_str());
+							SetPreferredTextTrack(std::move(selectedTextTrack));
 						}
 						else
 						{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12404,7 +12404,6 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	int currentTrackIndex = GetTextTrack();
 	int trackIdx = -1;
 
-	AAMPLOG_INFO("DJH currentTrackIndex %d", currentTrackIndex);
 	if (currentTrackIndex >= 0)
 	{
 		std::string currentPrefLanguage = Getiso639map_NormalizeLanguageCode(trackInfo[currentTrackIndex].language, this->GetLangCodePreference());

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12333,6 +12333,26 @@ void PrivateInstanceAAMP::SavePreferredTextLanguages(const char *param, bool &is
 }
 
 /**
+ * @brief Find the index of a text track in a vector
+ * @param tracks Vector of text tracks to search
+ * @param target Track to find
+ * @return Index of track (0-based), or -1 if not found
+ */
+int PrivateInstanceAAMP::FindTextTrackIndex(const std::vector<TextTrackInfo>& tracks, 
+                                            const TextTrackInfo& target) const
+{
+	int index = -1;
+	auto iter = std::find(tracks.cbegin(), tracks.cend(), target);
+	
+	if (iter != tracks.cend())
+	{
+		index = static_cast<int>(std::distance(tracks.cbegin(), iter));
+	}
+	
+	return index;
+}
+
+/**
  *  @brief Find closed caption track index if any
  */
 int PrivateInstanceAAMP::FindClosedCaptionTrackIndex(const std::vector<TextTrackInfo> &trackInfo) const
@@ -12377,6 +12397,7 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	int currentTrackIndex = GetTextTrack();
 	int trackIdx = -1;
 
+	AAMPLOG_INFO("DJH currentTrackIndex %d", currentTrackIndex);
 	if (currentTrackIndex >= 0)
 	{
 		std::string currentPrefLanguage = Getiso639map_NormalizeLanguageCode(trackInfo[currentTrackIndex].language, this->GetLangCodePreference());
@@ -12391,11 +12412,14 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 			// Logic to check whether the given language is present in the available tracks,
 			// if available, it should not match with current preferredLanguagesString, then call tune to reflect the language change.
 			// if not available, then avoid calling tune.
+			AAMPLOG_INFO("DJH preferredTextLanguagesList.size() %zu", preferredTextLanguagesList.size());
 			if (preferredTextLanguagesList.size() > 0)
 			{
 				std::string firstLanguage = preferredTextLanguagesList.at(0);
 				std::string trackLanguage = Getiso639map_NormalizeLanguageCode(
 					track.language, this->GetLangCodePreference());
+AAMPLOG_INFO("DJH trackLanguage %s firstLanguage %s currentPrefLanguage %s",
+				trackLanguage.c_str(), firstLanguage.c_str(), currentPrefLanguage.c_str());
 
 				if ((trackLanguage == firstLanguage) && (trackLanguage != currentPrefLanguage))
 				{
@@ -12522,7 +12546,23 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 						TextTrackInfo selectedTextTrack;
 						if (mpStreamAbstractionAAMP->SelectPreferredTextTrack(selectedTextTrack))
 						{
-							SetPreferredTextTrack(std::move(selectedTextTrack));
+							// Find the index of the selected track in the available tracks list
+							closedCaptionTrackId = FindTextTrackIndex(trackInfo, selectedTextTrack);
+							
+							if (closedCaptionTrackId >= 0)
+							{
+								SetPreferredTextTrack(std::move(selectedTextTrack));
+								AAMPLOG_INFO("Selected text track at index %d (lang=%s)", 
+								             closedCaptionTrackId, selectedTextTrack.language.c_str());
+							}
+							else
+							{
+								AAMPLOG_ERR("Selected text track not found in trackInfo vector");
+							}
+						}
+						else
+						{
+							AAMPLOG_WARN("SelectPreferredTextTrack failed to find a matching track");
 						}
 					}
 					seek_pos_seconds = GetPositionSeconds();
@@ -12564,6 +12604,7 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 				}
 				ReleaseStreamLock();
 
+				AAMPLOG_INFO("DJH Set closedCaptionTrackId %d", closedCaptionTrackId);
 				if (closedCaptionTrackId >= 0)
 				{
 					TextTrackInfo track = trackInfo[closedCaptionTrackId];

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -10403,9 +10403,14 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 					{
 						cJSON_AddStringToObject(item, "sub-type", "SUBTITLES");
 					}
-					//DJH if (!iter->language.empty())
+					if (!iter->language.empty())
 					{
 						cJSON_AddStringToObject(item, "language", iter->language.c_str());
+					}
+					//DJH
+					else
+					{
+						cJSON_AddStringToObject(item, "language", "clo");
 					}
 					if (!iter->rendition.empty())
 					{
@@ -12142,7 +12147,14 @@ void PrivateInstanceAAMP::SanitizeLanguageList(std::vector<std::string>& languag
 	std::transform( languages.begin(), languages.end(),
 					languages.begin(),
 					[this](std::string& lang)
-					{ return Getiso639map_NormalizeLanguageCode(lang, this->GetLangCodePreference()); } );
+					{
+						// Skip normalization for empty strings
+						if (lang.empty())
+						{
+							return lang;
+						}
+						return Getiso639map_NormalizeLanguageCode(lang, this->GetLangCodePreference());
+					} );
 
 	// To keep track of the languages that have already been encountered.
 	std::unordered_set<std::string> seen;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -10407,11 +10407,6 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 					{
 						cJSON_AddStringToObject(item, "language", iter->language.c_str());
 					}
-					//DJH
-					else
-					{
-						cJSON_AddStringToObject(item, "language", "clo");
-					}
 					if (!iter->rendition.empty())
 					{
 						cJSON_AddStringToObject(item, "rendition", iter->rendition.c_str());

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12418,7 +12418,6 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 			// Logic to check whether the given language is present in the available tracks,
 			// if available, it should not match with current preferredLanguagesString, then call tune to reflect the language change.
 			// if not available, then avoid calling tune.
-			AAMPLOG_INFO("DJH preferredTextLanguagesList.size() %zu", preferredTextLanguagesList.size());
 			if (preferredTextLanguagesList.size() > 0)
 			{
 				std::string firstLanguage = preferredTextLanguagesList.at(0);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12610,7 +12610,6 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 				}
 				ReleaseStreamLock();
 
-				AAMPLOG_INFO("DJH Set closedCaptionTrackId %d", closedCaptionTrackId);
 				if (closedCaptionTrackId >= 0)
 				{
 					TextTrackInfo track = trackInfo[closedCaptionTrackId];

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12548,12 +12548,12 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 						{
 							// Find the index of the selected track in the available tracks list
 							closedCaptionTrackId = FindTextTrackIndex(trackInfo, selectedTextTrack);
-							
+
 							if (closedCaptionTrackId >= 0)
 							{
+								AAMPLOG_INFO("Selected text track at index %d (lang=%s)",
+											 closedCaptionTrackId, selectedTextTrack.language.c_str());
 								SetPreferredTextTrack(std::move(selectedTextTrack));
-								AAMPLOG_INFO("Selected text track at index %d (lang=%s)", 
-								             closedCaptionTrackId, selectedTextTrack.language.c_str());
 							}
 							else
 							{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -10403,7 +10403,7 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 					{
 						cJSON_AddStringToObject(item, "sub-type", "SUBTITLES");
 					}
-					if (!iter->language.empty())
+					//DJH if (!iter->language.empty())
 					{
 						cJSON_AddStringToObject(item, "language", iter->language.c_str());
 					}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12341,8 +12341,8 @@ void PrivateInstanceAAMP::SavePreferredTextLanguages(const char *param, bool &is
 
 /**
  * @brief Find the index of a text track in a vector
- * @param tracks Vector of text tracks to search
- * @param target Track to find
+ * @param[in] tracks Vector of text tracks to search
+ * @param[in] target Track to find
  * @return Index of track (0-based), or -1 if not found
  */
 int PrivateInstanceAAMP::FindTextTrackIndex(const std::vector<TextTrackInfo>& tracks, 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -600,6 +600,15 @@ class PrivateInstanceAAMP : public DrmCallbacks, public std::enable_shared_from_
 	 */
 	int FindClosedCaptionTrackIndex(const std::vector<TextTrackInfo> &trackInfo) const;
 
+	/**
+	 * @brief Find the index of a text track in a vector
+	 * @param[in] tracks - Vector of text tracks to search
+	 * @param[in] target - Track to find
+	 * @return Index of track (0-based), or -1 if not found
+	 */
+	int FindTextTrackIndex(const std::vector<TextTrackInfo>& tracks, 
+	                       const TextTrackInfo& target) const;
+
 public:
 	/* @fn RecalculatePTS
 	 * @param[in] mediaType stream type


### PR DESCRIPTION
Reason for Change: When HLS CC track is missing the language the current behaviour is to create a language based on the track name which is wrong.

Summary of Changes:

Change the manifest parsing to not populate the language for the CC track if it is not present in the manifest.
Change the subtitle track selection to support a list of of languages provided via the config, or setPreferredTextLanguage()  i.e ["eng",""] allowing the matching of the empty string for non specified language

Risk: Low