### PR TITLE
VPLAY-11304: [CPIX] Stay on HD profile if UHD profile fails with Decrypt Error

### DIFF
--- a/AampDRMLicPreFetcher.cpp
+++ b/AampDRMLicPreFetcher.cpp
@@ -249,6 +249,13 @@ void AampLicensePreFetcher::PreFetchThread()
 				if (!keyIdArray.empty() && mPrivAAMP->mDRMLicenseManager->mDrmSessionManager->IsKeyIdProcessed(keyIdArray, keyStatus))
 				{
 					AAMPLOG_WARN("Key already processed [status:%s] for type:%d adaptationSetIdx:%u !", keyStatus ? "SUCCESS" : "FAIL", obj->mType, obj->mAdaptationIdx);
+					if(!keyStatus)
+					{
+						AAMPLOG_INFO("Notifying DRM failure for type:%d adaptationSetIdx:%u", obj->mType, obj->mAdaptationIdx);
+						bool isSecClientError = isSecFeatureEnabled();
+						DrmMetaDataEventPtr e = std::make_shared<DrmMetaDataEvent>(AAMP_TUNE_FAILURE_UNKNOWN, "", 0, 0, isSecClientError, mPrivAAMP->GetSessionId());
+						NotifyDrmFailure(obj, std::move(e));
+					}
 					mPrivAAMP->setCurrentDrm(obj->mHelper);
 					skip = true;
 				}

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -52,8 +52,8 @@
 static void  registerCb(AampDRMLicenseManager* _this, DrmSessionManager* instance)
 {
 	/* Register the callback for acquire license data */
-	instance->RegisterLicenseDataCb([_this](int &responseCode, std::shared_ptr<DrmHelper> drmHelper, int sessionSlot, int &cdmError, int streamType,void *metaDataPtr, bool isLicenseRenewal = false ) -> KeyState {
-			return _this->acquireLicense(responseCode, std::move(drmHelper), sessionSlot, cdmError,
+	instance->RegisterLicenseDataCb([_this](int &responseCode, const std::shared_ptr<DrmHelper>& drmHelper, int sessionSlot, int &cdmError, int streamType,void *metaDataPtr, bool isLicenseRenewal = false ) -> KeyState {
+			return _this->acquireLicense(responseCode, drmHelper, sessionSlot, cdmError,
 					(AampMediaType)streamType,metaDataPtr, false);
 			});
 
@@ -63,7 +63,7 @@ static void  registerCb(AampDRMLicenseManager* _this, DrmSessionManager* instanc
 			});
 
 	/** Content Protection Callback */
-	instance->RegisterHandleContentProtectionCb([_this](std::shared_ptr<DrmHelper> drmHelper, int streamType, std::vector<uint8_t> keyId, int contentProtectionUpd)->std::string{
+	instance->RegisterHandleContentProtectionCb([_this](const std::shared_ptr<DrmHelper>& drmHelper, int streamType, const std::vector<uint8_t>& keyId, int contentProtectionUpd)->std::string{
 			return _this->HandleContentProtectionData(drmHelper, streamType, keyId, contentProtectionUpd);
 			});
 	/**  Register the profiler update callback for TriggerProfileBeginCb */
@@ -219,7 +219,7 @@ void AampDRMLicenseManager::renewLicense(std::shared_ptr<DrmHelper> drmHelper, v
 /**
  * @brief sent license challenge to the DRM server and provide the response to CDM
  */
-KeyState AampDRMLicenseManager::acquireLicense( int& responseCode, std::shared_ptr<DrmHelper> drmHelper, int sessionSlot, int &cdmError,
+KeyState AampDRMLicenseManager::acquireLicense( int& responseCode, const std::shared_ptr<DrmHelper>& drmHelper, int sessionSlot, int &cdmError,
 	 AampMediaType streamType, void *metaDataPtr,  bool isLicenseRenewal)
 {
 	DrmMetaDataEventPtr* eventHandlePtr = static_cast<DrmMetaDataEventPtr*>(metaDataPtr);
@@ -742,7 +742,7 @@ bool AampDRMLicenseManager::configureLicenseServerParameters(std::shared_ptr<Drm
 
 	return isContentMetadataAvailable;
 }
-void AampDRMLicenseManager::ContentProtectionDataUpdate(PrivateInstanceAAMP* aampInstance, std::vector<uint8_t> keyId, AampMediaType streamType)
+void AampDRMLicenseManager::ContentProtectionDataUpdate(PrivateInstanceAAMP* aampInstance, const std::vector<uint8_t>& keyId, AampMediaType streamType)
 {
 	std::string contentType = GetMediaTypeName(streamType);
 	int iter1 = 0;
@@ -1360,10 +1360,10 @@ std::shared_ptr<void> AampDRMLicenseManager::TriggerDrmMetaDataEvent()
 	auto drmEventPtrWrapper = std::make_shared<DrmMetaDataEventPtr>(drmEvent);
 	return drmEventPtrWrapper;
 }
-std::string  AampDRMLicenseManager::HandleContentProtectionData(std::shared_ptr<DrmHelper> drmHelper, int streamType, std::vector<uint8_t> keyId, int isContentProtectionSupported)
+std::string  AampDRMLicenseManager::HandleContentProtectionData(const std::shared_ptr<DrmHelper>& drmHelper, int streamType, const std::vector<uint8_t>& keyId, int isContentProtectionSupported)
 {
 	 /* To fetch correct codec type in tune time metrics when drm data is not given in manifest*/
-	 aampInstance->setCurrentDrm(std::move(drmHelper));
+	 aampInstance->setCurrentDrm(drmHelper);
 
 	bool RuntimeDRMConfigSupported = aampInstance->mConfig->IsConfigSet(eAAMPConfig_RuntimeDRMConfig);
 	if(isContentProtectionSupported)
@@ -1372,8 +1372,8 @@ std::string  AampDRMLicenseManager::HandleContentProtectionData(std::shared_ptr<
 	    {
 	    	aampInstance->mcurrent_keyIdArray = keyId;
 	    	AAMPLOG_INFO("App registered the ContentProtectionDataEvent to send new drm config");
-	    	ContentProtectionDataUpdate(aampInstance, std::move(keyId), (AampMediaType)streamType);
-	    	aampInstance->mcurrent_keyIdArray.clear();
+			ContentProtectionDataUpdate(aampInstance, keyId, (AampMediaType)streamType);
+			aampInstance->mcurrent_keyIdArray.clear();
 	    }
 	}
 	std::string customData = aampInstance->GetLicenseCustomData();
@@ -1446,17 +1446,22 @@ void AampDRMLicenseManager::UpdateMaxDRMSessions(int maxSessions)
         mLicenseRenewalThreads.resize(maxSessions);
 }
 
+/**
+ * @brief Clear DRM sessions
+ *
+ * @param[in] forceClearSession if true, clear all sessions including valid ones
+ */
 void AampDRMLicenseManager::clearDrmSession(bool forceClearSession)
 {
 	mDrmSessionManager->clearDrmSession(forceClearSession);
-	for(int i = 0 ; i < mMaxDRMSessions;i++)
+	for (int i = 0; i < mMaxDRMSessions; i++)
 	{
-		bool isFailedKeyId = mDrmSessionManager->getFailedKeyIdStatus(i);
-		if(( mDrmSessionManager->drmSessionContexts != NULL && (isFailedKeyId || forceClearSession)  ))
+		bool isFailedKeyEntries = mDrmSessionManager->getFailedKeyIdStatus(i);
+		if ((mDrmSessionManager->drmSessionContexts != NULL && (isFailedKeyEntries || forceClearSession)))
 		{
-			if(mDrmSessionManager->drmSessionContexts[i].drmSession != NULL)
+			if (mDrmSessionManager->drmSessionContexts[i].drmSession != NULL)
 			{
-				AAMPLOG_INFO("Clearing Session %d, isFailedKeyId=%d, forceClearSession=%d",i, isFailedKeyId, forceClearSession);
+				AAMPLOG_INFO("Clearing Session %d, isFailedKeyEntries=%d, forceClearSession=%d", i, isFailedKeyEntries, forceClearSession);
 				mLicenseDownloader[i].Clear();
 			}
 		}

--- a/drm/AampDRMLicManager.h
+++ b/drm/AampDRMLicManager.h
@@ -76,7 +76,7 @@ public:
 	/**
 	 * @fn acquireLicense
 	 */
-	KeyState acquireLicense(int& responseCode, std::shared_ptr<DrmHelper> drmHelper, int sessionSlot, int &cdmError,  
+	KeyState acquireLicense(int& responseCode, const std::shared_ptr<DrmHelper>& drmHelper, int sessionSlot, int &cdmError,
 					AampMediaType streamType, void *metaDataPtr,  bool isLicenseRenewal = false);
 
 
@@ -196,7 +196,7 @@ public:
 	/**
 	 * @fn ContentProtectionDataUpdate
 	 */
-	void ContentProtectionDataUpdate(PrivateInstanceAAMP* aampInstance, std::vector<uint8_t> keyId, AampMediaType streamType);
+	void ContentProtectionDataUpdate(PrivateInstanceAAMP* aampInstance, const std::vector<uint8_t>& keyId, AampMediaType streamType);
 	/**
 	 * @brief Set the Common Key Duration object
 	 * 
@@ -315,7 +315,7 @@ public:
 	 * @fn HandleContentProtectionData
 	 * @return string
 	 */
-	std::string HandleContentProtectionData(std::shared_ptr<DrmHelper> drmHelper, int streamType, std::vector<uint8_t> keyId, int contentProtectionUpd);
+	std::string HandleContentProtectionData(const std::shared_ptr<DrmHelper>& drmHelper, int streamType, const std::vector<uint8_t>& keyId, int contentProtectionUpd);
 
 	/** @fn 	Create the DRM session with DRM helper.
 	 * @param[in]   drmHelper shared ptr to drmhelper 

--- a/middleware/PlayerUtils.cpp
+++ b/middleware/PlayerUtils.cpp
@@ -265,3 +265,29 @@ void trim(std::string& src)
 		src = dst;
 	}
 }
+
+/**
+ * @brief Convert raw key bytes to key ID format (ASCII hex)
+ *
+ * @param[in] key Pointer to raw key bytes (may be nullptr if keySize == 0)
+ * @param[in] keySize Size of the raw key in bytes
+ * @return Vector containing the key ID in ASCII hex format (two ASCII chars per input byte)
+ */
+std::vector<uint8_t> RawKeyToKeyId(const uint8_t* key, std::size_t keySize)
+{
+    static constexpr char hexDigits[] = "0123456789abcdef";
+
+    if (!key || keySize == 0)
+        return {};
+
+    std::vector<uint8_t> out(keySize * 2);
+
+    for (std::size_t i = 0; i < keySize; ++i)
+    {
+        const uint8_t v = key[i];
+        out[(i << 1)]     = static_cast<uint8_t>(hexDigits[v >> 4]);
+        out[(i << 1) + 1] = static_cast<uint8_t>(hexDigits[v & 0x0F]);
+    }
+
+    return out;
+}

--- a/middleware/PlayerUtils.h
+++ b/middleware/PlayerUtils.h
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <iostream>
 #include <cstring>
+#include <vector>
 
 //Delete non-array object
 #define MW_SAFE_DELETE(ptr) { delete(ptr); ptr = NULL; }
@@ -98,6 +99,16 @@ long long GetCurrentTimeMS(void);
  * @param[in][out] src Buffer containing string
  */
 void trim(std::string& src);
+
+/**
+ * @fn RawKeyToKeyId
+ * @brief Convert raw key bytes to key ID format (ASCII hex)
+ *
+ * @param[in] key Pointer to raw key bytes
+ * @param[in] keySize Size of the raw key in bytes
+ * @return Vector containing the key ID in ASCII hex format
+ */
+std::vector<uint8_t> RawKeyToKeyId(const uint8_t* key, size_t keySize);
 
 #endif  /* __PLAYER_UTILS_H__ */
 

--- a/middleware/drm/DrmSession.cpp
+++ b/middleware/drm/DrmSession.cpp
@@ -65,3 +65,14 @@ int DrmSession::decrypt(const uint8_t *f_pbIV, uint32_t f_cbIV, const uint8_t *p
 	MW_LOG_ERR("Standard decrypt method not implemented");
 	return -1;
 }
+
+/**
+ * @brief Get the list of usable key IDs from the DRM session
+ * @retval Reference to vector of usable key IDs
+ * @note Default implementation returns the reference to an empty vector
+ */
+const std::vector<std::vector<uint8_t>>& DrmSession::getUsableKeys() const
+{
+	static const std::vector<std::vector<uint8_t>> emptyVector;
+	return emptyVector;;
+}

--- a/middleware/drm/DrmSession.h
+++ b/middleware/drm/DrmSession.h
@@ -136,6 +136,13 @@ public:
 	virtual void clearDecryptContext() = 0;
 
 	/**
+	 * @brief Get the list of usable key IDs from the DRM session
+	 * @retval Reference to vector of usable key IDs
+	 * @note Default implementation returns the reference to an empty vector
+	 */
+	virtual const std::vector<std::vector<uint8_t>>& getUsableKeys() const;
+
+	/**
 	 * @fn DrmSession
 	 * @param keySystem : DRM key system uuid
 	 */

--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -37,7 +37,10 @@
 #define INVALID_SESSION_SLOT -1
 #define DEFAULT_CDM_WAIT_TIMEOUT_MS 2000
 
-KeyID::KeyID() : creationTime(0), isFailedKeyId(false), isPrimaryKeyId(false), data()
+/**
+ * @brief KeyIdEntries constructor.
+ */
+KeyIdEntries::KeyIdEntries() : creationTime(0), isFailedKeyEntries(false), isPrimaryKeyId(false), data()
 {
 }
 
@@ -60,7 +63,7 @@ DrmSessionManager::DrmSessionManager(int maxDrmSessions, void *player, std::func
 		,mPlayerSendWatermarkSessionUpdateEventCB(watermarkSessionUpdateCallback)
 {
 	drmSessionContexts	= new DrmSessionContext[mMaxDRMSessions];
-	cachedKeyIDs		= new KeyID[mMaxDRMSessions];
+	cachedKeyIDs		= new KeyIdEntries[mMaxDRMSessions];
 	m_drmConfigParam = new configs();
 	playerSecInstance = new PlayerSecInterface();
 
@@ -114,7 +117,7 @@ void DrmSessionManager::clearSessionData()
 			std::lock_guard<std::mutex> guard(cachedKeyMutex);
 			if (cachedKeyIDs != NULL)
 			{
-				cachedKeyIDs[i] = KeyID();
+				cachedKeyIDs[i] = KeyIdEntries();
 			}
 		}
 	}
@@ -144,13 +147,13 @@ void DrmSessionManager::clearFailedKeyIds()
 	std::lock_guard<std::mutex> guard(cachedKeyMutex);
 	for(int i = 0 ; i < mMaxDRMSessions; i++)
 	{
-		if(cachedKeyIDs[i].isFailedKeyId)
+		if(cachedKeyIDs[i].isFailedKeyEntries)
 		{
 			if(!cachedKeyIDs[i].data.empty())
 			{
 				cachedKeyIDs[i].data.clear();
 			}
-			cachedKeyIDs[i].isFailedKeyId = false;
+			cachedKeyIDs[i].isFailedKeyEntries = false;
 			cachedKeyIDs[i].creationTime = 0;
 		}
 		cachedKeyIDs[i].isPrimaryKeyId = false;
@@ -179,7 +182,7 @@ bool DrmSessionManager::getFailedKeyIdStatus(int sessionIndex)
 	std::lock_guard<std::mutex> guard(cachedKeyMutex);
 	if (sessionIndex >= 0 && sessionIndex < mMaxDRMSessions && cachedKeyIDs)
 	{
-		rc = cachedKeyIDs[sessionIndex].isFailedKeyId;
+		rc = cachedKeyIDs[sessionIndex].isFailedKeyEntries;
 	}
 	return rc;
 }
@@ -192,7 +195,7 @@ void DrmSessionManager::clearDrmSession(bool forceClearSession)
 	for(int i = 0 ; i < mMaxDRMSessions; i++)
 	{
 		// Clear the session data if license key acquisition failed or if forceClearSession is true in the case of LicenseCaching is false.
-		if((cachedKeyIDs[i].isFailedKeyId || forceClearSession) && drmSessionContexts != NULL)
+		if((cachedKeyIDs[i].isFailedKeyEntries || forceClearSession) && drmSessionContexts != NULL)
 		{
 			std::lock_guard<std::mutex> guard(drmSessionContexts[i].sessionMutex);
 			if (drmSessionContexts[i].drmSession != NULL)
@@ -337,11 +340,17 @@ bool DrmSessionManager::IsKeyIdProcessed(std::vector<uint8_t> keyIdArray, bool &
 	for (int sessionSlot = 0; sessionSlot < mMaxDRMSessions; sessionSlot++)
 	{
 		auto keyIDSlot = cachedKeyIDs[sessionSlot].data;
-		if (!keyIDSlot.empty() && keyIDSlot.end() != std::find(keyIDSlot.begin(), keyIDSlot.end(), keyIdArray))
+		// Check if keyId is already cached or marked as failed
+		auto it = std::find_if(keyIDSlot.begin(), keyIDSlot.end(),
+			[&](const KeyIdEntry &entry)
+			{
+				return entry.keyId == keyIdArray;
+			});
+		if (it != keyIDSlot.end())
 		{
 			std::string debugStr = PlayerLogManager::getHexDebugStr(keyIdArray);
-			MW_LOG_INFO("Session created/in progress with same keyID %s at slot %d", debugStr.c_str(), sessionSlot);
-			status = !cachedKeyIDs[sessionSlot].isFailedKeyId;
+			status = !it->isFailedKeyId;
+			MW_LOG_INFO("Session created/in progress with same keyID %s at slot %d, status=%d", debugStr.c_str(), sessionSlot, status);
 			ret = true;
 			break;
 		}
@@ -470,7 +479,7 @@ DrmSession* DrmSessionManager::createDrmSession(int &responseCode, int &err, std
 	std::vector<uint8_t> keyId;
 	drmHelper->getKey(keyId);
 	/* callback to initiate content protection data update */
-	mCustomData = ContentUpdateCb(drmHelper, streamType, std::move(keyId), isContentProcess);
+	mCustomData = ContentUpdateCb(drmHelper, streamType, keyId, isContentProcess);
 	if (code == KEY_READY)
 	{
 		return drmSessionContexts[selectedSlot].drmSession;
@@ -488,7 +497,7 @@ DrmSession* DrmSessionManager::createDrmSession(int &responseCode, int &err, std
 		std::lock_guard<std::mutex> guard(cachedKeyMutex);
 		if (cachedKeyIDs)
 		{
-			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+			cachedKeyIDs[selectedSlot].isFailedKeyEntries = true;
 		}
 		return nullptr;
 	}
@@ -499,7 +508,7 @@ DrmSession* DrmSessionManager::createDrmSession(int &responseCode, int &err, std
 		std::lock_guard<std::mutex> guard(cachedKeyMutex);
 		if (cachedKeyIDs)
 		{
-			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+			cachedKeyIDs[selectedSlot].isFailedKeyEntries = true;
 		}
 		return nullptr;
 	}
@@ -510,9 +519,27 @@ DrmSession* DrmSessionManager::createDrmSession(int &responseCode, int &err, std
 		std::lock_guard<std::mutex> guard(cachedKeyMutex);
 		if (cachedKeyIDs)
 		{
-			cachedKeyIDs[selectedSlot].isFailedKeyId = true;
+			cachedKeyIDs[selectedSlot].isFailedKeyEntries = true;
 		}
 		return nullptr;
+	}
+
+	bool isMultiKeySession = false;
+	{
+		std::lock_guard<std::mutex> guard(cachedKeyMutex);
+		isMultiKeySession = (cachedKeyIDs[selectedSlot].data.size() > 1);
+	}
+	if (code == KEY_READY && isMultiKeySession)
+	{
+		// Multiple KeyIDs present for this session, validate them
+		if(!ValidateMultiKeySlot(keyId, selectedSlot))
+		{
+			// Validation failed as current keyId is marked as failed
+			std::lock_guard<std::mutex> guard(cachedKeyMutex);
+			cachedKeyIDs[selectedSlot].isFailedKeyEntries = true;
+			MW_LOG_WARN("ValidateMultiKeySlot failed for slot %d", selectedSlot);
+			return nullptr;
+		}
 	}
 
 	// License acquisition was done, so mContentSecurityManagerSession will be populated now
@@ -524,6 +551,94 @@ DrmSession* DrmSessionManager::createDrmSession(int &responseCode, int &err, std
 	}
 
 	return drmSessionContexts[selectedSlot].drmSession;
+}
+
+/**
+ * @fn Validate multiple key IDs for a given DRM session slot using the usable keys from the DrmSession
+ *
+ * @param[in] keyId The key ID to validate
+ * @param[in] selectedSlot The DRM session slot to validate
+ *
+ * @return true if validation is successful, false otherwise
+ */
+bool DrmSessionManager::ValidateMultiKeySlot(const std::vector<uint8_t>& keyId, int selectedSlot)
+{
+	if (selectedSlot < 0 || selectedSlot >= mMaxDRMSessions)
+	{
+		MW_LOG_ERR("invalid slot %d", selectedSlot);
+		return false;
+	}
+
+	MW_LOG_INFO("Multiple KeyIDs present for the session at slot %d, validating each", selectedSlot);
+
+	// Acquire usable keys from the DrmSession (under its mutex)
+	std::vector<std::vector<uint8_t>> usableKeyIds;
+	{
+		std::lock_guard<std::mutex> sessionGuard(drmSessionContexts[selectedSlot].sessionMutex);
+		if (drmSessionContexts[selectedSlot].drmSession)
+		{
+			usableKeyIds = drmSessionContexts[selectedSlot].drmSession->getUsableKeys();
+		}
+		else
+		{
+			MW_LOG_ERR("No drmSession present at slot %d", selectedSlot);
+			return false;
+		}
+	}
+
+	// Helper lambdas
+	auto normalizeHexString = [](const std::vector<uint8_t> &hexStringWithDashes) -> std::string
+	{
+		std::string out;
+		out.reserve(hexStringWithDashes.size());
+		for (auto c : hexStringWithDashes)
+		{
+			if (c != '-') // remove dashes
+				out.push_back(static_cast<char>(c));
+		}
+		return out;
+	};
+
+	auto vecToString = [](const std::vector<uint8_t> &hexString) -> std::string
+	{
+		return std::string(hexString.begin(), hexString.end());
+	};
+
+	auto keysMatch = [&](const std::vector<uint8_t> &cachedKey, const std::vector<uint8_t> &usableKey) -> bool
+	{
+		return normalizeHexString(cachedKey) == vecToString(usableKey);
+	};
+
+	// Update cachedKeyIDs under its mutex
+	std::lock_guard<std::mutex> cacheGuard(cachedKeyMutex);
+	for (auto &keyIdEntry : cachedKeyIDs[selectedSlot].data)
+	{
+		std::string debugStr = PlayerLogManager::getHexDebugStr(keyIdEntry.keyId);
+
+		auto it = std::find_if(
+			usableKeyIds.begin(),
+			usableKeyIds.end(),
+			[&](const std::vector<uint8_t> &usableKey)
+			{
+				return keysMatch(keyIdEntry.keyId, usableKey);
+			});
+
+		if (it == usableKeyIds.end())
+		{
+			MW_LOG_WARN("KeyID %s not found in usable keys, marking as failed for session at slot %d", debugStr.c_str(), selectedSlot);
+			keyIdEntry.isFailedKeyId = true;
+			if (keysMatch(keyId, keyIdEntry.keyId))
+			{
+				MW_LOG_ERR("KeyID %s matches primary key for session at slot %d, Exiting", debugStr.c_str(), selectedSlot);
+				return false;
+			}
+		}
+		else
+		{
+			MW_LOG_INFO("KeyID %s is usable for session at slot %d", debugStr.c_str(), selectedSlot);
+		}
+	}
+	return true;
 }
 
 /**
@@ -569,7 +684,13 @@ KeyState DrmSessionManager::getDrmSession(int &err, std::shared_ptr<DrmHelper> d
 		for (; sessionSlot < mMaxDRMSessions; sessionSlot++)
 		{
 			auto keyIDSlot = cachedKeyIDs[sessionSlot].data;
-			if (!keyIDSlot.empty() && keyIDSlot.end() != std::find(keyIDSlot.begin(), keyIDSlot.end(), keyIdArray))
+			// Check if keyId is already cached
+			auto it = std::find_if(keyIDSlot.begin(), keyIDSlot.end(),
+								   [&](const KeyIdEntry &entry)
+								   {
+									   return entry.keyId == keyIdArray;
+								   });
+			if (it != keyIDSlot.end())
 			{
 				MW_LOG_INFO("Session created/in progress with same keyID %s at slot %d", keyIdDebugStr.c_str(), sessionSlot);
 				keySlotFound = true;
@@ -614,7 +735,7 @@ KeyState DrmSessionManager::getDrmSession(int &err, std::shared_ptr<DrmHelper> d
 		else
 		{
 			// Already same session Slot is marked failed , not to proceed again .
-			if(cachedKeyIDs[sessionSlot].isFailedKeyId)
+			if(cachedKeyIDs[sessionSlot].isFailedKeyEntries)
 			{
 				MW_LOG_WARN(" Found FailedKeyId at sesssionSlot :%d, return key error",sessionSlot);
 				return KEY_ERROR;
@@ -629,14 +750,16 @@ KeyState DrmSessionManager::getDrmSession(int &err, std::shared_ptr<DrmHelper> d
 				cachedKeyIDs[sessionSlot].data.clear();
 			}
 
-			cachedKeyIDs[sessionSlot].isFailedKeyId = false;
+			cachedKeyIDs[sessionSlot].isFailedKeyEntries = false;
 
-			std::vector<std::vector<uint8_t>> data;
+			std::vector<KeyIdEntry> data;
 			for(auto& keyId : keyIdArrays)
 			{
+				KeyIdEntry keyIdEntry;
+				keyIdEntry.keyId = keyId.second;
 				std::string debugStr = PlayerLogManager::getHexDebugStr(keyId.second);
 				MW_LOG_INFO("Insert[%d] - slot:%d keyID %s", keyId.first, sessionSlot, debugStr.c_str());
-				data.push_back(keyId.second);
+				data.push_back(keyIdEntry);
 			}
 
 			cachedKeyIDs[sessionSlot].data = data;
@@ -654,53 +777,73 @@ KeyState DrmSessionManager::getDrmSession(int &err, std::shared_ptr<DrmHelper> d
 		{
 			MW_LOG_WARN("changing DRM session for %s to %s", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str(), drmHelper->ocdmSystemId().c_str());
 		}
-		else if (cachedKeyIDs[sessionSlot].data.end() != std::find(cachedKeyIDs[sessionSlot].data.begin(), cachedKeyIDs[sessionSlot].data.end() ,drmSessionContexts[sessionSlot].data))
+		else
 		{
-			KeyState existingState = drmSessionContexts[sessionSlot].drmSession->getState();
-			if (existingState == KEY_READY)
+			bool isKeyIdFound = false;
 			{
-				MW_LOG_INFO("Found drm session READY with same keyID %s - Reusing drm session", keyIdDebugStr.c_str());
-				auto slotSession = drmSessionContexts[sessionSlot].drmSession->getSecManagerSession();
-				if (slotSession.isSessionValid() && (!mContentSecurityManagerSession.isSessionValid()) )
-				{
-					// Set the drmSession's ID as mContentSecurityManagerSession so that this code will not be repeated for multiple calls for createDrmSession					
-					mContentSecurityManagerSession = slotSession;
-					bool videoMuteState = mIsVideoOnMute.load();
-					MW_LOG_WARN("Activating re-used DRM, sessionId[%" PRId64 "], with video mute = %d", slotSession.getSessionID(), videoMuteState);
-					ContentSecurityManager::GetInstance()->UpdateSessionState(slotSession.getSessionID(), true);
-				}
-				return KEY_READY;
+				// Protect access to cachedKeyIDs
+				std::lock_guard<std::mutex> guard(cachedKeyMutex);
+				auto &keyIDSlot = cachedKeyIDs[sessionSlot].data;
+				const auto &keyIdToFind = drmSessionContexts[sessionSlot].data;
+
+				auto it = std::find_if(
+					keyIDSlot.begin(),
+					keyIDSlot.end(),
+					[&](const KeyIdEntry &entry)
+					{
+						return entry.keyId == keyIdToFind;
+					});
+				isKeyIdFound = (it != keyIDSlot.end());
 			}
-			if (existingState == KEY_INIT)
+
+			if (isKeyIdFound)
 			{
-				MW_LOG_WARN("Found drm session in INIT state with same keyID %s - Reusing drm session", keyIdDebugStr.c_str());
-				return KEY_INIT;
-			}
-			else if (existingState <= KEY_READY)
-			{
-				if (drmSessionContexts[sessionSlot].drmSession->waitForState(KEY_READY, drmHelper->keyProcessTimeout()))
+				KeyState existingState = drmSessionContexts[sessionSlot].drmSession->getState();
+				if (existingState == KEY_READY)
 				{
-					MW_LOG_WARN("Waited for drm session READY with same keyID %s - Reusing drm session", keyIdDebugStr.c_str());
+					MW_LOG_INFO("Found drm session READY with same keyID %s - Reusing drm session", keyIdDebugStr.c_str());
+					auto slotSession = drmSessionContexts[sessionSlot].drmSession->getSecManagerSession();
+					if (slotSession.isSessionValid() && (!mContentSecurityManagerSession.isSessionValid()))
+					{
+						// Set the drmSession's ID as mContentSecurityManagerSession so that this code will not be repeated for multiple calls for createDrmSession
+						mContentSecurityManagerSession = slotSession;
+						bool videoMuteState = mIsVideoOnMute.load();
+						MW_LOG_WARN("Activating re-used DRM, sessionId[%" PRId64 "], with video mute = %d", slotSession.getSessionID(), videoMuteState);
+						ContentSecurityManager::GetInstance()->UpdateSessionState(slotSession.getSessionID(), true);
+					}
 					return KEY_READY;
 				}
-				MW_LOG_WARN("key was never ready for %s ", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str());
-				//CID-164094 : Added the mutex lock due to overriding the isFailedKeyId variable
-				std::lock_guard<std::mutex> guard(cachedKeyMutex);
-				cachedKeyIDs[selectedSlot].isFailedKeyId = true;
-				return KEY_ERROR;
+				if (existingState == KEY_INIT)
+				{
+					MW_LOG_WARN("Found drm session in INIT state with same keyID %s - Reusing drm session", keyIdDebugStr.c_str());
+					return KEY_INIT;
+				}
+				else if (existingState <= KEY_READY)
+				{
+					if (drmSessionContexts[sessionSlot].drmSession->waitForState(KEY_READY, drmHelper->keyProcessTimeout()))
+					{
+						MW_LOG_WARN("Waited for drm session READY with same keyID %s - Reusing drm session", keyIdDebugStr.c_str());
+						return KEY_READY;
+					}
+					MW_LOG_WARN("key was never ready for %s ", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str());
+					// CID-164094 : Added the mutex lock due to overriding the isFailedKeyEntries variable
+					std::lock_guard<std::mutex> guard(cachedKeyMutex);
+					cachedKeyIDs[selectedSlot].isFailedKeyEntries = true;
+					return KEY_ERROR;
+				}
+				else
+				{
+					MW_LOG_WARN("existing DRM session for %s has error state %d", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str(), existingState);
+					// CID-164094 : Added the mutex lock due to overriding the isFailedKeyEntries variable
+					std::lock_guard<std::mutex> guard(cachedKeyMutex);
+					cachedKeyIDs[selectedSlot].isFailedKeyEntries = true;
+					return KEY_ERROR;
+				}
 			}
 			else
 			{
-				MW_LOG_WARN("existing DRM session for %s has error state %d", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str(), existingState);
-				//CID-164094 : Added the mutex lock due to overriding the isFailedKeyId variable
-				std::lock_guard<std::mutex> guard(cachedKeyMutex);
-				cachedKeyIDs[selectedSlot].isFailedKeyId = true;
-				return KEY_ERROR;
+				MW_LOG_WARN("existing DRM session for %s has different key in slot %d", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str(), sessionSlot);
 			}
-		}
-		else
-		{
-			MW_LOG_WARN("existing DRM session for %s has different key in slot %d", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str(), sessionSlot);
 		}
 		MW_LOG_WARN("deleting existing DRM session for %s ", drmSessionContexts[sessionSlot].drmSession->getKeySystem().c_str());
 		MW_SAFE_DELETE(drmSessionContexts[sessionSlot].drmSession);
@@ -800,7 +943,7 @@ void DrmSessionManager::UpdateMaxDRMSessions(int maxSessions)
 		//Update to new session count
 		mMaxDRMSessions = maxSessions;
 		drmSessionContexts      = new DrmSessionContext[mMaxDRMSessions];
-		cachedKeyIDs            = new KeyID[mMaxDRMSessions];
+		cachedKeyIDs            = new KeyIdEntries[mMaxDRMSessions];
 		MW_LOG_INFO("Updated DrmSessionManager MaxSession to:%d", mMaxDRMSessions);
 	}
 }

--- a/middleware/drm/DrmSessionManager.h
+++ b/middleware/drm/DrmSessionManager.h
@@ -71,19 +71,37 @@ struct DrmSessionContext
 };
 
 /**
- *  @struct	KeyID
- *  @brief	Structure to hold, keyId and session creation time for
- *  		keyId
+ *  @struct	KeyIdEntry
+ *  @brief	Structure to hold, keyId and its failed status
  */
-struct KeyID
+struct KeyIdEntry
 {
-	std::vector<std::vector<uint8_t>> data;
-	long long creationTime;
-	bool isFailedKeyId;
-	bool isPrimaryKeyId;
+	std::vector<uint8_t> keyId; 	/**<  Key ID */
+	bool isFailedKeyId;				/**< Flag to mark the failed key ID status */
 
-	KeyID();
+	/**
+	 *  @fn KeyIdEntry - constructor
+	 */
+	KeyIdEntry() : keyId(), isFailedKeyId(false)
+	{
+	}
 };
+
+/**
+ *  @struct	KeyIdEntries
+ *  @brief	Structure to hold, keyIds and session creation time for Entries
+ */
+struct KeyIdEntries
+{
+	std::vector<KeyIdEntry> data;	// List of KeyIdEntry
+	long long creationTime;			// Session creation time
+	bool isPrimaryKeyId;			// Flag to mark the primary key ID status
+	bool isFailedKeyEntries;		// Flag to mark the complete entry invalid
+
+	KeyIdEntries();
+};
+
+
 
 /**
  *  @brief	Enum to represent session manager state.
@@ -133,7 +151,7 @@ public:
 	std::atomic<bool> mIsVideoOnMute;
 	std::atomic<int> mCurrentSpeed;
 private:
-	KeyID *cachedKeyIDs;
+	KeyIdEntries *cachedKeyIDs;
 	char* accessToken;
 	int accessTokenLen;
 	SessionMgrState sessionMgrState;
@@ -283,6 +301,15 @@ public:
 	 * 				false if key is not cached
 	 */
 	bool IsKeyIdProcessed(std::vector<uint8_t> keyIdArray, bool &status);
+	/**
+	 * @fn Validate multiple key IDs for a given DRM session slot using the provided DrmHelper
+	 *
+	 * @param[in] keyId The key ID to validate
+	 * @param[in] selectedSlot The DRM session slot to validate
+	 *
+	 * @return true if validation is successful, false otherwise
+	 */
+	bool ValidateMultiKeySlot(const std::vector<uint8_t>& keyId, int selectedSlot);
 	/**
 	 *  @fn         clearSessionData
 	 *
@@ -460,7 +487,7 @@ public:
 	/*
 	 * @brief Register Content Protection Update callback to application 
 	 */
-	using ContentUpdateCallback = std::function<std::string(DrmHelperPtr drmHelper, int streamType, std::vector<uint8_t> keyId, int contentProtectionUpd)>;
+	using ContentUpdateCallback = std::function<std::string(DrmHelperPtr drmHelper, int streamType, const std::vector<uint8_t>& keyId, int contentProtectionUpd)>;
 	ContentUpdateCallback ContentUpdateCb;
 	void RegisterHandleContentProtectionCb(const ContentUpdateCallback callback)
 	{

--- a/middleware/drm/ocdm/opencdmsessionadapter.cpp
+++ b/middleware/drm/ocdm/opencdmsessionadapter.cpp
@@ -69,7 +69,9 @@ OCDMSessionAdapter::OCDMSessionAdapter(DrmHelperPtr drmHelper, DrmCallbacks *cal
 		m_drmCallbacks(callbacks),
 		m_keyStatusWait(),
 		m_keyId(),
-		m_keyStored()
+		m_keyStored(),
+		m_usableKeys(),
+		m_usableKeysMutex()
 {
 	MW_LOG_WARN("OCDMSessionAdapter :: enter ");
 	MW_LOG_WARN("OCDMSessionAdapter :: key process timeout is %d", drmHelper->keyProcessTimeout());
@@ -216,11 +218,27 @@ void OCDMSessionAdapter::keyUpdateOCDM(const uint8_t key[], const uint8_t keySiz
 	if (m_pOpenCDMSession) {
 		m_keyStatus = opencdm_session_status(m_pOpenCDMSession, key, keySize);
 		m_keyStateIndeterminate = false;
+		std::vector<uint8_t> keyData = RawKeyToKeyId(key, keySize);
+		{
+			std::lock_guard<std::mutex> lock(m_usableKeysMutex);
+			// Check if this key already exists to avoid duplicates
+			if (std::find(m_usableKeys.begin(), m_usableKeys.end(), keyData) == m_usableKeys.end()) {
+				m_usableKeys.push_back(keyData);
+			}
+		}
 	} 
 	else {
 		m_keyStored.clear();
 		m_keyStored.assign(key, key+keySize);
 		m_keyStateIndeterminate = true;
+		std::vector<uint8_t> keyData = RawKeyToKeyId(key, keySize);
+		{
+			std::lock_guard<std::mutex> lock(m_usableKeysMutex);
+			// Check if this key already exists to avoid duplicates
+			if (std::find(m_usableKeys.begin(), m_usableKeys.end(), keyData) == m_usableKeys.end()) {
+				m_usableKeys.push_back(keyData);
+			}
+		}
 	}
   
 }
@@ -397,6 +415,13 @@ void OCDMSessionAdapter:: clearDecryptContext()
 		opencdm_destruct_session(m_pOpenCDMSession);
 		m_pOpenCDMSession = NULL;
 	}
+
+	// Clear usable keys when clearing the session
+	{
+		std::lock_guard<std::mutex> keyLock(m_usableKeysMutex);
+		m_usableKeys.clear();
+	}
+
 	m_eKeyState = KEY_INIT;
 }
 
@@ -419,4 +444,15 @@ bool OCDMSessionAdapter::verifyOutputProtection()
 	}
 
 	return true;
+}
+
+/**
+ * @fn getUsableKeys
+ * @brief Get the list of usable key IDs from the DRM session
+ * @retval Reference to vector of usable key IDs
+ */
+const std::vector<std::vector<uint8_t>>& OCDMSessionAdapter::getUsableKeys() const
+{
+	std::lock_guard<std::mutex> lock(m_usableKeysMutex);
+	return m_usableKeys;
 }

--- a/middleware/drm/ocdm/opencdmsessionadapter.h
+++ b/middleware/drm/ocdm/opencdmsessionadapter.h
@@ -105,6 +105,8 @@ protected:
 	KeyStatus m_keyStatus;
 	bool m_keyStateIndeterminate;
 	std::vector<uint8_t> m_keyStored;
+	std::vector<std::vector<uint8_t>> m_usableKeys; // Store usable key IDs from ocdm_update_callback
+	mutable std::mutex m_usableKeysMutex; // Protects m_usableKeys from concurrent access
 
 	Event m_challengeReady;
 	Event m_keyStatusReady;
@@ -121,6 +123,7 @@ public:
 	void processOCDMChallenge(const char destUrl[], const uint8_t challenge[], const uint16_t challengeSize);
 	void keysUpdatedOCDM();
 	void keyUpdateOCDM(const uint8_t key[], const uint8_t keySize);
+	const std::vector<std::vector<uint8_t>>& getUsableKeys() const;
 	long long timeBeforeCallback;
 
 private:

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -2577,12 +2577,12 @@ public:
 	std::string GetPreferredTextProperties();
 
 	/**
-	 *   @brief Set DRM type
+	 * @brief Set current DRM helper
 	 *
-	 *   @param[in] drm - New DRM type
-	 *   @return void
+	 * @param[in] drm - DRM helper instance
+	 * @return void
 	 */
-	void setCurrentDrm(DrmHelperPtr drm) { mCurrentDrm = std::move(drm); }
+	void setCurrentDrm(const DrmHelperPtr& drm) { mCurrentDrm = drm; }
 
 	/**
 	 * @fn GetMoneyTraceString


### PR DESCRIPTION
Reason for change: Save Usable KeyIds from key_update_callback. Filter the missed keyID for a multi key slot and mark it failed. Then remove the entry from ABR Risks: Low
Test Procedure: Test with Multi key UHD stream
Priority: P1