### PR TITLE
VPLAY-11848: Cloud TSB No subtitles after rewinding (L3 Test 2014), regression from LLDASH optimizations

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -79,15 +79,6 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 		cachedFragment->absPosition = mActiveDownloadInfo->absolutePosition;
 		cachedFragment->timeScale = mActiveDownloadInfo->timeScale;
 		cachedFragment->PTSOffsetSec = mActiveDownloadInfo->ptsOffset.inSeconds();
-		/* The value of PTSOffsetSec in the context can get updated at the start of a period before
-		 * the last segment from the previous period has been injected, hence we copy it
-		 */
-		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp))
-		{
-			// apply pts offset to position which ends up getting put into gst_buffer in sendHelper
-			position += mActiveDownloadInfo->ptsOffset.inSeconds();
-			AAMPLOG_INFO("Type[%d] position after restamp = %fs", type, position);
-		}
 	}
 	else
 	{
@@ -545,6 +536,12 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 	};
 
 	cachedFragment->position = dlInfo->pts;
+	if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp))
+	{
+		// apply pts offset to position for restamped pts
+		cachedFragment->position += dlInfo->ptsOffset.inSeconds();
+		AAMPLOG_INFO("Type[%s] position after restamp = %fs", name, cachedFragment->position);
+	}
 	cachedFragment->duration = dlInfo->fragmentDurationSec;
 	cachedFragment->discontinuity = dlInfo->isDiscontinuity;
 	segDLFailCount = 0;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -626,8 +626,7 @@ bool StreamAbstractionAAMP_MPD::FetchFragment(MediaStreamContext *pMediaStreamCo
 		AAMPLOG_TRACE("[%" PRIu32 "] : %s,",url.first, url.second.url.c_str());
 	}
 
-	AampTicks ticks(pMediaStreamContext->fragmentDescriptor.Time, pMediaStreamContext->fragmentDescriptor.TimeScale);
-	double scaledPts = AampTime(ticks).inSeconds();
+	double scaledPts = static_cast<double>(pMediaStreamContext->fragmentDescriptor.Time) / static_cast<double>(pMediaStreamContext->fragmentDescriptor.TimeScale);
 	DownloadInfoPtr downloadInfo = std::make_shared<DownloadInfo>(
 		static_cast<AampMediaType>(pMediaStreamContext->type),
 		static_cast<AampCurlInstance>(curlInstance),

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -32,6 +32,11 @@
 #include "StreamAbstractionAAMP.h"
 
 using namespace testing;
+// Named constants for clarity
+static constexpr bool CHUNK_MODE_ENABLED{true};
+static constexpr bool CHUNK_MODE_DISABLED{false};
+static constexpr bool PTS_RESTAMP_ENABLED{true};
+static constexpr bool PTS_RESTAMP_DISABLED{false};
 
 /*
  * Test cases for FragmentDownloadTests
@@ -99,72 +104,90 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_NullActiveDownloadInfo)
 }
 
 /**
- * @brief Test case for OnFragmentDownloadSuccess with a valid download info
+ * @brief Struct to hold parameterized test data for download success scenarios
  */
-TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_ValidDownloadInfo)
+struct DownloadSuccessTestData
 {
+	bool chunkMode;
+	bool ptsRestampEnabled;
+};
+
+/**
+ * @brief Parameterized test cases for OnFragmentDownloadSuccess
+ */
+DownloadSuccessTestData validDownloadTestData[] = {
+	{CHUNK_MODE_DISABLED, PTS_RESTAMP_DISABLED},
+	{CHUNK_MODE_DISABLED, PTS_RESTAMP_ENABLED},
+	{CHUNK_MODE_ENABLED, PTS_RESTAMP_DISABLED},
+	{CHUNK_MODE_ENABLED, PTS_RESTAMP_ENABLED}};
+
+/**
+ * @brief Parameterized test fixture for OnFragmentDownloadSuccess
+ */
+class FragmentDownloadSuccessParamTest
+	: public FragmentDownloadTests,
+	  public ::testing::WithParamInterface<DownloadSuccessTestData>
+{
+};
+
+/**
+ * @brief Test case for OnFragmentDownloadSuccess with various configurations
+ */
+TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
+{
+	const auto &param = GetParam();
+	bool chunkMode = param.chunkMode;
+	bool ptsRestampEnabled = param.ptsRestampEnabled;
+
 	mMediaStreamContext->mActiveDownloadInfo = std::make_shared<DownloadInfo>();
 	DownloadInfoPtr dlInfo = std::make_shared<DownloadInfo>();
 	dlInfo->pts = 123.45;
 	dlInfo->fragmentDurationSec = 5.0;
 	dlInfo->isDiscontinuity = false;
+	dlInfo->ptsOffset = 1000;
 
+	// Mock necessary method calls and return values
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
 
-	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
-	// and append some data to it to simulate a buffer
+	// Mock buffer creation for the test
 	auto cachedFragment = std::make_shared<CachedFragment>();
 	cachedFragment->fragment.AppendBytes("test", 4);
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
+	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false)).WillOnce(Return(cachedFragment.get()));
 
-	// Mock the behavior of IsInjectionFromCachedFragmentChunks, return as non-chunk/non-TSB mode
-	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks())
-		.WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(chunkMode));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(chunkMode));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(ptsRestampEnabled));
 
-	// Test the behavior of OnFragmentDownloadSuccess in non-chunk mode	
 	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterFetch(_));
+	if (chunkMode)
+	{
+		EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterInject());
+	}
+
 	EXPECT_NO_THROW(mMediaStreamContext->OnFragmentDownloadSuccess(dlInfo));
-	// Free the cached fragment
+
+	// PTS restamp expectation
+	if (ptsRestampEnabled)
+	{
+		EXPECT_EQ(cachedFragment->position, dlInfo->pts + dlInfo->ptsOffset.inSeconds());
+	}
+	else
+	{
+		EXPECT_EQ(cachedFragment->position, dlInfo->pts);
+	}
+
 	cachedFragment->fragment.Free();
 }
 
 /**
- * @brief Test case for OnFragmentDownloadSuccess with a valid download info as chunk mode
+ * @brief Instantiate parameterized tests for OnFragmentDownloadSuccess
  */
-TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_ValidDownloadInfoChunk)
-{
-	mMediaStreamContext->mActiveDownloadInfo = std::make_shared<DownloadInfo>();
-	DownloadInfoPtr dlInfo = std::make_shared<DownloadInfo>();
-	dlInfo->pts = 123.45;
-	dlInfo->fragmentDurationSec = 5.0;
-	dlInfo->isDiscontinuity = false;
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
-
-	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
-	// and append some data to it to simulate a buffer
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	cachedFragment->fragment.AppendBytes("test", 4);
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
-	
-	// Mock the behavior of IsInjectionFromCachedFragmentChunks, return as chunk mode
-	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks())
-		.WillRepeatedly(Return(true));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(true));
-	
-	// Tes the behaviour of OnFragmentDownloadSuccess in chunk mode
-	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterFetch(_));
-	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterInject());
-	EXPECT_NO_THROW(mMediaStreamContext->OnFragmentDownloadSuccess(dlInfo));
-	cachedFragment->fragment.Free();
-}
+INSTANTIATE_TEST_SUITE_P(
+	AllDownloadVariants,
+	FragmentDownloadSuccessParamTest,
+	::testing::ValuesIn(validDownloadTestData));
 
 /**
  * @brief Test case for onFragmentDownloadFailed with null active download info


### PR DESCRIPTION
Reason for change: Correcting the position in FetchFragment and before UpdateTSAfterFetch
Risks: Low
Test Procedure: Test with 2014 test case
Priority: P1