### PR TITLE
VPLAY-11854 Webprocess crash AampDRMLicenseManager::createDrmSession

### DIFF
--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
@@ -38,6 +38,7 @@
 #define RETRYSLEEP (300 * 1000) //Retry sleep
 
 #ifdef USE_PREINIT_DECODING
+static PowerController_PowerState_t prevState = POWER_STATE_ON;
 static void IARM_PowerChangeHandler (const PowerController_PowerState_t currentState,
                                       const PowerController_PowerState_t newState, void* userdata);
 #endif
@@ -100,6 +101,7 @@ void getPwrContInterface()
         }
         usleep(RETRYSLEEP); // 300ms
     }
+
     MW_LOG_INFO("Registering power mode change callback...");
     PowerController_RegisterPowerModeChangedCallback(IARM_PowerChangeHandler, nullptr);
 
@@ -143,12 +145,16 @@ static void IARM_PowerChangeHandler (const PowerController_PowerState_t currentS
 {
 	MW_LOG_INFO("Entering IARM_PowerChangeHandler:State Changed currentState: %d, newState: %d",
 			currentState, newState);
+    
+    bool isOnOrStandby = (newState == POWER_STATE_STANDBY || newState == POWER_STATE_ON);
 
-	if(currentState == POWER_STATE_STANDBY_DEEP_SLEEP && newState != POWER_STATE_STANDBY_DEEP_SLEEP )
+	if((currentState == POWER_STATE_STANDBY_DEEP_SLEEP && isOnOrStandby) || 
+        (prevState == POWER_STATE_STANDBY_DEEP_SLEEP && currentState == POWER_STATE_STANDBY_LIGHT_SLEEP && isOnOrStandby) )
 	{
 		MW_LOG_INFO(" DEEPSLEEP : calling triggerFakeTune  \n");
 		triggerFakeTune();
 	}
+    prevState = currentState;
 
 	MW_LOG_INFO("Exiting IARM_PowerChangeHandler..");
 }


### PR DESCRIPTION
    Reason for change: trigger the fake tune only when the device transitions from DEEPSLEEP to ON/STANDBY, we can make sure that HDMI is in the expected state and the playback should work as expected.
    Test Procedure: updated in ticket
    Risks: Low
