### PR TITLE
VPLAY-11879 LLD continue injection if there is underflow

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -687,10 +687,11 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 		{
 			bool ischunkMode = context->aamp->GetLLDashServiceData()->lowLatencyMode &&
 							   context->aamp->GetLLDashChunkMode() &&
-							   !mCtx->IsLocalTSBInjection() &&
-							   !(IsLocalAAMPTsb() && pipeline_paused);
+							   !mCtx->IsLocalTSBInjection();
+			// Prevent injection if the user paused the playback, but not if the playback was paused due to underflow
+			bool injectionPaused = (IsLocalAAMPTsb() && pipeline_paused && !context->aamp->GetBufUnderFlowStatus());
 
-			if (ischunkMode && ptr && (numBytesForBlock > 0) &&
+			if (ischunkMode && ptr && (numBytesForBlock > 0) && !injectionPaused &&
 				(context->mediaType == eMEDIATYPE_VIDEO ||
 				context->mediaType ==  eMEDIATYPE_AUDIO ||
 				context->mediaType ==  eMEDIATYPE_SUBTITLE))

--- a/test/utests/fakes/FakeMediaStreamContext.cpp
+++ b/test/utests/fakes/FakeMediaStreamContext.cpp
@@ -24,7 +24,11 @@ MockMediaStreamContext *g_mockMediaStreamContext = nullptr;
 
 bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl,long long dnldStartTime)
 {
-    return false;
+	if (g_mockMediaStreamContext != nullptr)
+	{
+		return g_mockMediaStreamContext->CacheFragmentChunk(actualType, ptr, size, remoteUrl, dnldStartTime);
+	}
+	return false;
 }
 
 bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int curlInstance, double position, double duration, const char *range, bool initSegment, bool discontinuity, bool playingAd, uint32_t scale)

--- a/test/utests/mocks/MockMediaStreamContext.h
+++ b/test/utests/mocks/MockMediaStreamContext.h
@@ -29,6 +29,8 @@ public:
 
 	MOCK_METHOD(bool, CacheFragment, (std::string fragmentUrl, unsigned int curlInstance, double position, double duration, const char *range, bool initSegment, bool discontinuity, bool playingAd, uint32_t scale));
 	MOCK_METHOD(bool, CacheTsbFragment, (std::shared_ptr<CachedFragment> fragment));
+	MOCK_METHOD(bool, CacheFragmentChunk, (AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, long long dnldStartTime));
+	MOCK_METHOD(bool, IsLocalTSBInjection, ());
 };
 
 extern MockMediaStreamContext *g_mockMediaStreamContext;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -49,6 +49,7 @@
 #include "fragmentcollector_mpd.h"
 #include "MockAdManager.h"
 #include "MockPlayerCCManager.h"
+#include "MockMediaStreamContext.h"
 
 using ::testing::An;
 using ::testing::DoAll;
@@ -97,6 +98,7 @@ protected:
 		g_mockAampCurlStore = new NiceMock<MockAampCurlStore>();
 		g_MockPrivateCDAIObjectMPD = new MockPrivateCDAIObjectMPD();
 		g_mockPlayerCCManager = std::make_shared<NiceMock<MockPlayerCCManager>>();
+		g_mockMediaStreamContext = new NiceMock<MockMediaStreamContext>();
 	}
 
 	void TearDown() override
@@ -111,6 +113,8 @@ protected:
 
 		delete g_mockCurl;
 		g_mockCurl = nullptr;
+		delete g_mockMediaStreamContext;
+		g_mockMediaStreamContext = nullptr;
 
 		delete g_mockStreamAbstractionAAMP;
 		g_mockStreamAbstractionAAMP = nullptr;
@@ -816,6 +820,128 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackTest)
 
 	size_t val1 = p_aamp->HandleSSLWriteCallback(NULL,1000,2000,NULL);
 	EXPECT_EQ(val,0);
+}
+
+TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedNoUnderflow)
+{
+	// Test HandleSSLWriteCallback when pipeline is paused and no underflow
+	// CacheFragmentChunk() should NOT be called
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedNoUnderflow - Setting up");
+
+	// Enable AAMP TSB for this test
+	p_aamp->SetLocalAAMPTsb(true);
+
+	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+
+	p_aamp->pipeline_paused = true;
+	p_aamp->mBufUnderFlowStatus = false;
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(1024);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 1024;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedNoUnderflow - Setup complete, pipeline_paused=%d, mBufUnderFlowStatus=%d",
+		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
+
+	// Simulate paused from live, not AAMP TSB
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+
+	// Check that AAMP is NOT injecting segments if playback is paused by the user
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+		.Times(0);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedNoUnderflow - Calling HandleSSLWriteCallback");
+
+	// Call with valid context - ptr is not NULL, so data processing happens
+	char testData[] = "test data";
+	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedNoUnderflow - Result: %zu", result);
+	// Result should be size*nmemb = strlen(testData)*1
+	EXPECT_EQ(result, strlen(testData));
+}
+
+TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
+{
+	// Test HandleSSLWriteCallback when pipeline is paused and there is underflow
+	// injection should not be paused and CacheFragmentChunk() should be called
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Setting up");
+
+	// Enable AAMP TSB for this test
+	p_aamp->SetLocalAAMPTsb(true);
+
+	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+
+	p_aamp->pipeline_paused = true;
+	p_aamp->mBufUnderFlowStatus = true;
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(1024);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 1024;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Setup complete, pipeline_paused=%d, mBufUnderFlowStatus=%d",
+		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
+
+	// Simulate paused from live, not AAMP TSB
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+
+	// Check that AAMP is injecting segments if playback is paused due to underflow
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+		.WillOnce(Return(true));
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Calling HandleSSLWriteCallback");
+
+	// Call with valid context - ptr is not NULL, so data processing happens
+	char testData[] = "test data with underflow";
+	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Result: %zu", result);
+	// Result should be size*nmemb = strlen(testData)*1
+	EXPECT_EQ(result, strlen(testData));
 }
 
 TEST_F(PrivAampTests, RunPausePositionMonitoringTest)

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -50,6 +50,7 @@
 #include "MockAdManager.h"
 #include "MockPlayerCCManager.h"
 #include "MockMediaStreamContext.h"
+#include "MockMediaTrack.h"
 
 using ::testing::An;
 using ::testing::DoAll;
@@ -99,10 +100,14 @@ protected:
 		g_MockPrivateCDAIObjectMPD = new MockPrivateCDAIObjectMPD();
 		g_mockPlayerCCManager = std::make_shared<NiceMock<MockPlayerCCManager>>();
 		g_mockMediaStreamContext = new NiceMock<MockMediaStreamContext>();
+		g_mockMediaTrack = new NiceMock<MockMediaTrack>();
 	}
 
 	void TearDown() override
 	{
+		delete g_mockMediaTrack;
+		g_mockMediaTrack = nullptr;
+
 		g_mockPlayerCCManager.reset();
 
 		delete g_MockPrivateCDAIObjectMPD;
@@ -843,7 +848,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedNoUnderflow)
 	// Set up stream abstraction to return our mock MediaStreamContext
 	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
-		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+		.WillRepeatedly(Return(g_mockMediaTrack));
 
 	p_aamp->pipeline_paused = true;
 	p_aamp->mBufUnderFlowStatus = false;
@@ -865,7 +870,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedNoUnderflow)
 		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
 
 	// Simulate paused from live, not AAMP TSB
-	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+	EXPECT_CALL(*g_mockMediaTrack, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 
 	// Check that AAMP is NOT injecting segments if playback is paused by the user
@@ -904,7 +909,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 	// Set up stream abstraction to return our mock MediaStreamContext
 	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
-		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+		.WillRepeatedly(Return(g_mockMediaTrack));
 
 	p_aamp->pipeline_paused = true;
 	p_aamp->mBufUnderFlowStatus = true;
@@ -926,7 +931,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
 
 	// Simulate paused from live, not AAMP TSB
-	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+	EXPECT_CALL(*g_mockMediaTrack, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 
 	// Check that AAMP is injecting segments if playback is paused due to underflow

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -50,7 +50,6 @@
 #include "MockAdManager.h"
 #include "MockPlayerCCManager.h"
 #include "MockMediaStreamContext.h"
-#include "MockMediaTrack.h"
 
 using ::testing::An;
 using ::testing::DoAll;
@@ -100,14 +99,10 @@ protected:
 		g_MockPrivateCDAIObjectMPD = new MockPrivateCDAIObjectMPD();
 		g_mockPlayerCCManager = std::make_shared<NiceMock<MockPlayerCCManager>>();
 		g_mockMediaStreamContext = new NiceMock<MockMediaStreamContext>();
-		g_mockMediaTrack = new NiceMock<MockMediaTrack>();
 	}
 
 	void TearDown() override
 	{
-		delete g_mockMediaTrack;
-		g_mockMediaTrack = nullptr;
-
 		g_mockPlayerCCManager.reset();
 
 		delete g_MockPrivateCDAIObjectMPD;
@@ -848,7 +843,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedNoUnderflow)
 	// Set up stream abstraction to return our mock MediaStreamContext
 	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
-		.WillRepeatedly(Return(g_mockMediaTrack));
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
 
 	p_aamp->pipeline_paused = true;
 	p_aamp->mBufUnderFlowStatus = false;
@@ -870,7 +865,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedNoUnderflow)
 		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
 
 	// Simulate paused from live, not AAMP TSB
-	EXPECT_CALL(*g_mockMediaTrack, IsLocalTSBInjection())
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 
 	// Check that AAMP is NOT injecting segments if playback is paused by the user
@@ -909,7 +904,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 	// Set up stream abstraction to return our mock MediaStreamContext
 	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
-		.WillRepeatedly(Return(g_mockMediaTrack));
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
 
 	p_aamp->pipeline_paused = true;
 	p_aamp->mBufUnderFlowStatus = true;
@@ -931,7 +926,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
 
 	// Simulate paused from live, not AAMP TSB
-	EXPECT_CALL(*g_mockMediaTrack, IsLocalTSBInjection())
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 
 	// Check that AAMP is injecting segments if playback is paused due to underflow


### PR DESCRIPTION
Reason for Change: Fix frozen AV after FF linear LLD service to live

Summary of Changes:
* Continue injecting segments if playback paused due to underflow
* HandleSSLWriteCallback L1 test with pipeline paused by the user
* HandleSSLWriteCallback L1 test with pipeline paused due to underflow

Test Procedure: With AAMP TSB FF to live and confirm playback continues

Risk: Low

Change-Id: I77e6e55dcbe3b1f53e602c0f0d301f87d15022d7