### PR TITLE
VPLAY-11267 : SLE thumbnails presented to the user is drifted by time…

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -88,35 +88,6 @@ struct StreamInfo
 	StreamInfo():enabled(false),isIframeTrack(false),validity(false),codecs(),bandwidthBitsPerSecond(0),resolution(),reason(),baseUrl(){};
 };
 
-
-struct TileLayout
-{
-	int numRows; 		/**< Number of Rows from Tile Inf */
-	int numCols; 		/**< Number of Cols from Tile Inf */
-	double posterDuration; 	/**< Duration of each Tile in Spritesheet */
-	double tileSetDuration; /**< Duration of whole tile set */
-};
-
-/**
-*	\struct	TileInfo
-* 	\brief	TileInfo structure for Thumbnail data
-*/
-class TileInfo
-{
-public:
-	TileInfo(): layout(), startTime(), url()
-	{
-	}
-
-	~TileInfo()
-	{
-	}
-
-	TileLayout layout;
-	double startTime;
-	std::string url;
-};
-
 /**
  * @brief Structure of cached fragment data
  *        Holds information about a cached fragment

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -4920,7 +4920,8 @@ StreamAbstractionAAMP_HLS::StreamAbstractionAAMP_HLS(class PrivateInstanceAAMP *
 	mFirstPTS(0),mDiscoCheckMutex(),
 	mPtsOffsetUpdate{ptsUpdate},
 	mDrmInterface(aamp),
-	mMetadataProcessor{nullptr}
+	mMetadataProcessor{nullptr},
+	indexedTileEndTime(0.0)
 {
 	if (aamp->mDRMLicenseManager)
 	{
@@ -5263,16 +5264,92 @@ std::vector<StreamInfo*> StreamAbstractionAAMP_HLS::GetAvailableThumbnailTracks(
 }
 
 /***************************************************************************
+* @fn IndexSleThumbnails
+* @brief Function to index SLE thumbnail manifest.
+*
+* @param iter Pointer to thumbnail manifest
+* @param tStartTime Start time of the requested thumbnails
+* @param lastProgramDateTime Program date time from which thumbnail to be requested
+* @return Updated vector of available thumbnail tracks.
+***************************************************************************/
+std::vector<TileInfo> IndexSleThumbnails( lstring iter, double tStartTime, long long lastProgramDateTime)
+{
+	std::vector<TileInfo> rc;
+	AampTime startTime = tStartTime;
+	TileLayout layout;
+	memset( &layout, 0, sizeof(layout) );
+	long long localProgramDateTime=0;
+	layout.numRows = DEFAULT_THUMBNAIL_TILE_ROWS;
+	layout.numCols = DEFAULT_THUMBNAIL_TILE_COLUMNS;
+
+	while(!iter.empty())
+	{
+		lstring ptr = iter.mystrpbrk();
+		if(!ptr.empty())
+		{
+			if (ptr.removePrefix("#EXT"))
+			{
+				if (ptr.removePrefix("-X-PROGRAM-DATE-TIME:"))
+				{
+					localProgramDateTime = (long long) ( ISO8601DateTimeToUTCSeconds(ptr.getPtr())*1000);
+					if(localProgramDateTime > lastProgramDateTime )
+						layout.progStartDateTime = localProgramDateTime;
+				}
+				if (ptr.removePrefix("INF:"))
+				{
+					if(localProgramDateTime > lastProgramDateTime )
+						layout.tileSetDuration = ptr.atof();
+				}
+				else if (ptr.removePrefix("-X-TILES:"))
+				{
+					if(localProgramDateTime > lastProgramDateTime )
+							ptr.ParseAttrList(ParseTileInfCallback, &layout);
+				}
+			}
+			else if( !ptr.startswith('#') )
+			{
+				TileInfo tileInfo;
+				if(localProgramDateTime > lastProgramDateTime && ptr.length()>4 )
+				{
+					if( 0.0f == layout.posterDuration )
+					{
+						if( layout.tileSetDuration )
+						{
+							layout.posterDuration = layout.tileSetDuration;
+						}
+						else
+						{
+							layout.posterDuration = DEFAULT_THUMBNAIL_TILE_DURATION;
+						}
+					}
+					tileInfo.layout = layout;
+					tileInfo.url = ptr.tostring();
+					tileInfo.startTime = startTime.inSeconds();
+					startTime += layout.tileSetDuration;
+					rc.push_back( tileInfo );
+				}
+			}
+		}
+	}
+	if(rc.empty() )
+	{
+		AAMPLOG_WARN("(not an error) IndexThumbnails failed. Last PDT in manifest(ms): %lld requested PDT from app(ms): %lld",
+							localProgramDateTime,lastProgramDateTime);
+	}
+	return rc;
+}
+
+/***************************************************************************
 * @fn IndexThumbnails
 * @brief Function to index thumbnail manifest.
 *
 * @param *ptr pointer to thumbnail manifest
 * @return Updated vector of available thumbnail tracks.
 ***************************************************************************/
-std::vector<TileInfo> IndexThumbnails( lstring iter , double stTime=0 )
+std::vector<TileInfo> IndexThumbnails( lstring iter )
 {
 	std::vector<TileInfo> rc;
-	AampTime startTime = stTime;
+	AampTime startTime = 0;
 	TileLayout layout;
 	memset( &layout, 0, sizeof(layout) );
 
@@ -5298,22 +5375,25 @@ std::vector<TileInfo> IndexThumbnails( lstring iter , double stTime=0 )
 			else if( !ptr.startswith('#') )
 			{
 				TileInfo tileInfo;
-				if( 0.0f == layout.posterDuration )
+				if( ptr.tostring().length() > 4 )
 				{
-					if( layout.tileSetDuration )
+					if( 0.0f == layout.posterDuration )
 					{
-						layout.posterDuration = layout.tileSetDuration;
+						if( layout.tileSetDuration )
+						{
+							layout.posterDuration = layout.tileSetDuration;
+						}
+						else
+						{
+							layout.posterDuration = DEFAULT_THUMBNAIL_TILE_DURATION;
+						}
 					}
-					else
-					{
-						layout.posterDuration = DEFAULT_THUMBNAIL_TILE_DURATION;
-					}
+					tileInfo.layout = layout;
+					tileInfo.url = ptr.tostring();
+					tileInfo.startTime = startTime.inSeconds();
+					startTime += layout.tileSetDuration;
+					rc.push_back( tileInfo );
 				}
-				tileInfo.layout = layout;
-				tileInfo.url = ptr.tostring();
-				tileInfo.startTime = startTime.inSeconds();
-				startTime += layout.tileSetDuration;
-				rc.push_back( tileInfo );
 			}
 		}
 	}
@@ -5391,7 +5471,70 @@ bool StreamAbstractionAAMP_HLS::SetThumbnailTrack( int thumbIndex )
 	return rc;
 }
 
+/**
+ * @brief handle the SLE thumbnail data
+ */
+void StreamAbstractionAAMP_HLS::HandleSleThumbnailData(double tStart, double tEnd)
+{
+	std::vector<TileInfo> newIndexedTileInfo;
+	lstring thumbNailIter = lstring(thumbnailManifest.GetPtr(),thumbnailManifest.GetLen());
+	if(!aamp->mThumbnailLastProgramDateTime )
+	{
+		//First Time;
+		indexedTileInfo.clear();
+		indexedTileInfo = IndexSleThumbnails( thumbNailIter, tStart,aamp->mThumbnailLastProgramDateTime);
+	}
+	else
+	{
+		if(!aamp->mLastSleThumbnailInfo.empty())
+		{
+			indexedTileInfo.clear();
+			indexedTileInfo.assign(aamp->mLastSleThumbnailInfo.begin(),aamp->mLastSleThumbnailInfo.end());
+			auto findIter = std::find_if(aamp->mLastSleThumbnailInfo.begin(), aamp->mLastSleThumbnailInfo.end(),
+							[tStart](const TileInfo& s)
+			{
+				/*
+				If prevStartTime is greater then input starttime OR
+				previous StartTime-tStart within the range OR
+				previous starttime is same as input start time
+				*/
+				return ( ( s.startTime == tStart)  ||
+						 ( fabs(s.startTime - tStart) < 1 ) ||
+						 ( s.startTime > tStart ) );
+   			});
 
+			if ( findIter != aamp->mLastSleThumbnailInfo.end())
+			{
+				if( ( findIter->startTime == tStart ) &&  ( tEnd <= indexedTileEndTime ))
+				{
+					//send saved data, no need to index again
+				}
+				else
+				{
+					double startTime = 0.0f;
+					if(!indexedTileInfo.empty())
+					{
+						aamp->mThumbnailLastProgramDateTime = indexedTileInfo.back().layout.progStartDateTime;
+						startTime  =  indexedTileInfo.back().startTime+indexedTileInfo.back().layout.tileSetDuration;
+					}
+
+					newIndexedTileInfo = IndexSleThumbnails( thumbNailIter, startTime, aamp->mThumbnailLastProgramDateTime );
+					if(!newIndexedTileInfo.empty() )
+					{
+						indexedTileInfo.insert(indexedTileInfo.end(), newIndexedTileInfo.begin(), newIndexedTileInfo.end());
+					}
+					newIndexedTileInfo.clear();
+				}
+			}
+			else
+			{
+				AAMPLOG_WARN("not found matching starttime:%lf",tStart);
+			}
+
+		}
+	}
+	indexedTileEndTime = tEnd; // Copy the end time. If the end time has changed, update indexedTileEndTime to the new value. 
+}
 /**
  * @brief Function to fetch the thumbnail data.
  */
@@ -5406,8 +5549,17 @@ std::vector<ThumbnailData> StreamAbstractionAAMP_HLS::GetThumbnailRangeData(doub
 		std::string tmpurl;
 		if(aamp->getAampCacheHandler()->RetrieveFromPlaylistCache(streamInfo.uri, &thumbnailManifest, tmpurl,eMEDIATYPE_PLAYLIST_IFRAME))
 		{
-			lstring iter = lstring(thumbnailManifest.GetPtr(),thumbnailManifest.GetLen());
-			indexedTileInfo = IndexThumbnails( iter, tStart );
+			HandleSleThumbnailData( tStart, tEnd );
+			aamp->mLastSleThumbnailInfo.clear();
+			if(!indexedTileInfo.empty())
+			{
+				aamp->mLastSleThumbnailInfo.assign(indexedTileInfo.begin(), indexedTileInfo.end());
+				aamp->mThumbnailLastProgramDateTime = indexedTileInfo.back().layout.progStartDateTime;
+			}
+			else
+			{
+				AAMPLOG_WARN("StreamAbstractionAAMP_HLS: indexedTileInfo is empty, cannot set mThumbnailLastProgramDateTime.");
+			}
 		}
 		else
 		{
@@ -5461,6 +5613,10 @@ std::vector<ThumbnailData> StreamAbstractionAAMP_HLS::GetThumbnailRangeData(doub
 	}
 	*width = streamInfo.resolution.width;
 	*height = streamInfo.resolution.height;
+	if( data.empty() )
+	{
+		AAMPLOG_WARN("thumbnail Data is empty");
+	}
 	return data;
 }
 

--- a/fragmentcollector_hls.h
+++ b/fragmentcollector_hls.h
@@ -856,8 +856,17 @@ class StreamAbstractionAAMP_HLS : public StreamAbstractionAAMP
 		 *
 		 *************************************************************************/
 		std::map<std::string,double> GetImageRangeString(double*, std::string, TileInfo*, double);
+		/***************************************************************************
+		 * @fn HandleImageData
+		 *
+		 * @param tStart start duration of thumbnail data.
+		 * @param tEnd end duration of thumbnail data.
+		 * @return void.
+		 ***************************************************************************/
+		void HandleSleThumbnailData(double tStart, double tEnd);
 		AampGrowableBuffer thumbnailManifest;	/**< Thumbnail manifest buffer holder */
 		std::vector<TileInfo> indexedTileInfo;	/**< Indexed Thumbnail information */
+		double indexedTileEndTime; /**< endTime received from player applications */
 		/***************************************************************************
 		 * @brief Function to get the total number of profiles
 		 *

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1245,6 +1245,8 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, mIsChunkMode(false)
 	, prevFirstPeriodStartTime(0)
 	, mIsFlushOperationInProgress(false)
+	, mThumbnailLastProgramDateTime(0)
+	, mLastSleThumbnailInfo()
 {
 	mAampCacheHandler = new AampCacheHandler(mPlayerId);
 	// Create the event manager for player instance

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -354,6 +354,37 @@ struct httpRespHeaderData {
 	std::string data;     /**< Header value */
 };
 
+struct TileLayout
+{
+	int numRows; 		/**< Number of Rows from Tile Inf */
+	int numCols; 		/**< Number of Cols from Tile Inf */
+	double posterDuration; 	/**< Duration of each Tile in Spritesheet */
+	double tileSetDuration; /**< Duration of whole tile set */
+	long long progStartDateTime; /**< Program start date time from manifest */
+	TileLayout(): numRows(0), numCols(0), posterDuration(0.0f), tileSetDuration(0.0f), progStartDateTime(0)
+	{
+	}
+};
+
+/**
+*	\struct	TileInfo
+* 	\brief	TileInfo structure for Thumbnail data
+*/
+class TileInfo
+{
+public:
+	TileInfo(): layout(), startTime(), url()
+	{
+	}
+
+	~TileInfo()
+	{
+	}
+
+	TileLayout layout;
+	double startTime;
+	std::string url;
+};
 /**
  * @struct ThumbnailData
  * @brief Holds the Thumbnail information
@@ -860,6 +891,8 @@ public:
 	std::string mTsbType;
 	int mTsbDepthMs;
 	int mDownloadDelay;
+	long long mThumbnailLastProgramDateTime;
+	std::vector<TileInfo> mLastSleThumbnailInfo;
 	/**
 	 * @brief A readonly, validatable position value.
 	 */

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -2752,7 +2752,7 @@ TEST_F(StreamAbstractionAAMP_HLSTest, RefreshAudioTest)
     EXPECT_EQ(1,mStreamAbstractionAAMP_HLS->currentAudioProfileIndex);
 }
 
-extern std::vector<TileInfo> IndexThumbnails( lstring iter, double stTime=0 );
+extern std::vector<TileInfo> IndexThumbnails( lstring iter );
 
 TEST_F(StreamAbstractionAAMP_HLSTest, ThumbnailIndexing)
 {
@@ -2794,6 +2794,54 @@ TEST_F(StreamAbstractionAAMP_HLSTest, ThumbnailIndexing)
 	EXPECT_EQ(x[2].layout.posterDuration,30);
 	EXPECT_EQ(x[2].layout.tileSetDuration,100.8367);
 }
+
+extern std::vector<TileInfo> IndexSleThumbnails( lstring iter, double tStartTime, long long lastProgramDateTime );
+
+TEST_F(StreamAbstractionAAMP_HLSTest, LiveThumbnailIndexing)
+{
+	const char *raw =
+	"#EXTM3U\r\n"
+	"#EXT-X-TARGETDURATION:10\r\n"
+	"#EXT-X-VERSION:7\r\n"
+	"#EXT-X-MEDIA-SEQUENCE:0\r\n"
+	"#EXT-X-IMAGES-ONLY\r\n"
+    "#EXT-X-PROGRAM-DATE-TIME:2023-05-12T04:10:34.412Z\n"
+	"#EXTINF:136.8367,\r\n"
+	"#EXT-X-TILES:RESOLUTION=336x189,LAYOUT=5x6,DURATION=10\r\n"
+	"pckimage-0.jpg\r\n"
+    "#EXT-X-PROGRAM-DATE-TIME:2023-05-12T04:10:37.412Z\n"
+	"#EXTINF:200,\r\n"
+	"#EXT-X-TILES:RESOLUTION=336x189,LAYOUT=9x17,DURATION=20\r\n"
+	"pckimage-1.jpg\r\n"
+    "#EXT-X-PROGRAM-DATE-TIME:2023-05-12T04:10:41.412Z\r\n"
+	"#EXTINF:100.8367,\r\n"
+	"#EXT-X-TILES:RESOLUTION=336x189,LAYOUT=4x3,DURATION=30\r\n"
+	"pckimage-2.jpg\r\n";
+
+    long long lpt=0;
+    double start=0.0f;
+    lstring ii = lstring( raw, strlen(raw) );
+	auto x = IndexSleThumbnails( ii, start, lpt );
+
+	EXPECT_EQ(x[0].url,"pckimage-0.jpg");
+	EXPECT_EQ(x[0].layout.numCols,5);
+	EXPECT_EQ(x[0].layout.numRows,6);
+	EXPECT_EQ(x[0].layout.posterDuration,10);
+	EXPECT_EQ(x[0].layout.tileSetDuration,136.8367);
+
+	EXPECT_EQ(x[1].url,"pckimage-1.jpg");
+	EXPECT_EQ(x[1].layout.numCols,9);
+	EXPECT_EQ(x[1].layout.numRows,17);
+	EXPECT_EQ(x[1].layout.posterDuration,20);
+	EXPECT_EQ(x[1].layout.tileSetDuration,200);
+
+	EXPECT_EQ(x[2].url,"pckimage-2.jpg");
+	EXPECT_EQ(x[2].layout.numCols,4);
+	EXPECT_EQ(x[2].layout.numRows,3);
+	EXPECT_EQ(x[2].layout.posterDuration,30);
+	EXPECT_EQ(x[2].layout.tileSetDuration,100.8367);
+}
+
 TEST_F(StreamAbstractionAAMP_HLSTest,SelectPreferredTextTrack)
 {
 	std::vector<TextTrackInfo> tracks;


### PR DESCRIPTION
…… (#662)

VPLAY-11267 : SLE thumbnails presented to the user is drifted by times ranging 10-15 seconds

Reason for change : added logic to correct sle live thumbnail timing
Risks: Low
Test Procedure: test SLE with thumbnails
Priority: P0