### PR TITLE
VPLAY-8901 Add option to enable sanitizer on Ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ set(LIBAAMP_DEPENDS
 	-ldl
 )
 
-# TDB needs to bring back for UT. 
+# TDB needs to bring back for UT.
 #include(test/mocks/mocks.cmake NO_POLICY_SCOPE)
 
 # Adding subdirectories for internal libraries
@@ -364,11 +364,15 @@ endif()
 
 set(LIBAAMP_DEFINES "${LIBAAMP_DEFINES} -DAAMP_VANILLA_AES_SUPPORT -DAAMP_BUILD_INFO='${buildinfo}' -DSUPPORTS_MP4DEMUX")
 
+if (SANITIZER_ENABLED AND CMAKE_PLATFORM_UBUNTU)
+	set(LIBAAMP_DEFINES "${LIBAAMP_DEFINES} -fsanitize=address")
+	set(LIBAAMP_DEPENDS "${LIBAAMP_DEPENDS} -fsanitize=address -static-libasan")
+endif()
+
 if(CMAKE_USE_RDK_PLUGINS)
 	message("CMAKE_USE_RDK_PLUGINS set")
 	set(LIBAAMP_DEFINES "${LIBAAMP_DEFINES} -DCREATE_PIPE_SESSION_TO_XRE")
 endif()
-
 
 # AAMP Telemetry 2.0 support
 if (CMAKE_TELEMETRY_2_0_REQUIRED)
@@ -487,7 +491,7 @@ install(TARGETS gstTestHarness
 xcode_define_schema(gstTestHarness)
 
 #TODO: Decide which are the actual public headers
-install(FILES 
+install(FILES
 	Accessibility.hpp AampEvent.h AampConfig.h AampCMCDCollector.h AampEventManager.h
 	AampDefine.h AampEventListener.h AampMediaType.h AampLogManager.h
 	subtitle/vttCue.h AampUtils.h

--- a/scripts/install_aampcli.sh
+++ b/scripts/install_aampcli.sh
@@ -28,7 +28,7 @@ function aampcli_install_postbuild_fn()
             (open AAMP.xcodeproj) &
         else
             echo "To use Xcode, open aamp/build/AAMP.xcodeproj project file"
-        fi      
+        fi
     fi
 }
 
@@ -68,7 +68,7 @@ function aampcli_install_prebuild_fn()
     else
         echo "Creating default channel list file ${HOME}/aampcli.csv"
         cp ./OSX/aampcli.csv ${HOME}/aampcli.csv
-    fi 
+    fi
 }
 
 function aampcli_install_build_darwin_fn()
@@ -108,7 +108,7 @@ function aampcli_install_build_darwin_fn()
         echo "AAMP Environment FAILED to Install."
         arr_install_status+=("AAMP Environment FAILED to Install.")
     fi
-   
+
     echo "Starting Xcode, open aamp/build/AAMP.xcodeproj project file OR Execute ./aamp-cli or /playbintest <url> binaries"
     echo "Opening AAMP project in Xcode..."
     # Changed "\-bash" as that signifies login shell, running ./install-aamp.sh (as opposed to source install-aamp.sh) and that would not be the case
@@ -119,7 +119,7 @@ function aampcli_install_build_darwin_fn()
         chsh -s /bin/bash
     fi
 
-   
+
     echo "Now Building aamp-cli"
     xcodebuild -scheme aamp-cli  build
 
@@ -138,7 +138,7 @@ function aampcli_install_build_darwin_fn()
         arr_install_status+=("OSX AAMP Build FAILED")
         return 1
     fi
-    
+
 }
 
 function aampcli_install_build_linux_fn
@@ -150,7 +150,7 @@ function aampcli_install_build_linux_fn
     # Local built dependencies
     PKG_CONFIG="${LOCAL_DEPS_BUILD_DIR}/lib/pkgconfig"
 
-    PKG_CONFIG_PATH="${PKG_CONFIG}" cmake --no-warn-unused-cli -DCMAKE_INSTALL_PREFIX=${LOCAL_DEPS_BUILD_DIR} -DCMAKE_PLATFORM_UBUNTU=1 -DCMAKE_LIBRARY_PATH="${LOCAL_DEPS_BUILD_DIR}/lib" -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCOVERAGE_ENABLED=${OPTION_COVERAGE} -DUTEST_ENABLED=ON -DCMAKE_INBUILT_AAMP_DEPENDENCIES=1 -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_ENABLE_PTS_RESTAMP:BOOL=TRUE -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++ -S$PWD -B"${AAMP_DIR}/build" -G "Unix Makefiles"
+    PKG_CONFIG_PATH="${PKG_CONFIG}" cmake --no-warn-unused-cli -DSANITIZER_ENABLED=${OPTION_UBUNTU_SANITIZER} -DCMAKE_INSTALL_PREFIX=${LOCAL_DEPS_BUILD_DIR} -DCMAKE_PLATFORM_UBUNTU=1 -DCMAKE_LIBRARY_PATH="${LOCAL_DEPS_BUILD_DIR}/lib" -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -DCOVERAGE_ENABLED=${OPTION_COVERAGE} -DUTEST_ENABLED=ON -DCMAKE_INBUILT_AAMP_DEPENDENCIES=1 -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_ENABLE_PTS_RESTAMP:BOOL=TRUE -DCMAKE_C_COMPILER:FILEPATH=/usr/bin/gcc -DCMAKE_CXX_COMPILER:FILEPATH=/usr/bin/g++ -S$PWD -B"${AAMP_DIR}/build" -G "Unix Makefiles"
 
    echo "Making aamp-cli..."
    cd build

--- a/scripts/install_options.sh
+++ b/scripts/install_options.sh
@@ -106,7 +106,8 @@ function install_options_fn()
         [-s] Skip subtec build and installation]"
         echo "        Note:  Subtec is built by default but can be rebuilt separately with the subtec
         [-k] Skip aamp-cli Kotlin build and installation]
-        [-t] Remove .libs and build directories before build (full rebuild)"
+        [-t] Remove .libs and build directories before build (full rebuild)
+        [-u] Enable Ubuntu address sanitizer (Linux only)"
 
         echo "
         [-r] Specify rialto to be built

--- a/scripts/install_options.sh
+++ b/scripts/install_options.sh
@@ -34,13 +34,12 @@ OPTION_SUBTEC_BUILD=true
 OPTION_SUBTEC_CLEAN=false
 OPTION_CLEAN_BUILD=false
 OPTION_GOOGLETEST_REFERENCE="tags/release-1.11.0"
-
-
+OPTION_UBUNTU_SANITIZER=false
 
 function install_options_fn()
 {
   # Parse optional command line parameters
-  while getopts ":d:b:cf:np:r:g:qskt" OPT; do
+  while getopts ":d:b:cf:np:r:g:qsktu" OPT; do
     case ${OPT} in
       d ) # process option d install base directory name
         OPTION_BUILD_DIR=${OPTARG}
@@ -70,24 +69,28 @@ function install_options_fn()
         OPTION_QUICK=true
         echo "Skip AAMPCli : ${QUICK}"
         ;;
-      r ) 
+      r )
         OPTION_RIALTO_REFERENCE=${OPTARG}
         echo "rialto tag : ${RIALTO_REFERENCE}"
         ;;
-      s ) 
+      s )
         OPTION_SUBTEC_SKIP=true
         # overrides any subtec or subtec clean setting
         echo "Skip subtec: ${OPTION_SKIP_SUBTEC}"
         ;;
-      k ) 
+      u )
+        OPTION_UBUNTU_SANITIZER=true
+        echo "Enable Ubuntu sanitizer: ${OPTION_UBUNTU_SANITIZER}"
+        ;;
+      k )
         OPTION_AAMPCLIKOTLIN_SKIP=true
         echo "Skip aamp-cli on Kotlin: ${OPTION_AAMPCLIKOTLIN_SKIP}"
         ;;
-      p )     
+      p )
         OPTION_PROTOBUF_REFERENCE=${OPTARG}
         echo "protobuf branch : ${PROTOBUF_REFERENCE}"
-        ;; 
-      t )     
+        ;;
+      t )
         OPTION_CLEAN_BUILD=true
         echo "Will remove .libs and build directories before build"
         ;;
@@ -104,7 +107,7 @@ function install_options_fn()
         echo "        Note:  Subtec is built by default but can be rebuilt separately with the subtec
         [-k] Skip aamp-cli Kotlin build and installation]
         [-t] Remove .libs and build directories before build (full rebuild)"
-        
+
         echo "
         [-r] Specify rialto to be built
         [-p] Specify protobuf branch name] (Linux only)"
@@ -124,7 +127,7 @@ function install_options_fn()
 
   # Parse subtec options
   if  [[  ${@:$OPTIND:1} = "subtec" ]]; then
-    OPTION_SUBTEC_BUILD=true 
+    OPTION_SUBTEC_BUILD=true
     shift
     if  [[  ${@:$OPTIND:1} = "clean" ]]; then
         OPTION_SUBTEC_CLEAN=true


### PR DESCRIPTION
Reason for change: There is no easy way to enable the address sanitizer on Ubuntu builds. Add an option.

When enabled for aamp-cli:
- Occasionally aamp-cli core dumps straight away.
- Detects some leaks that could be investigated.

Risk: Low