### PR TITLE
VPLA-11918 aamp l2 test framework support to collect high watermark for concurrent threads

### DIFF
--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -21,7 +21,7 @@
  * @file Aampcli.cpp
  * @brief Stand alone AAMP player with command line interface.
  */
-
+#include <unistd.h>
 #include "Aampcli.h"
 #include "scte35/AampSCTE35.h"
 

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -371,7 +371,7 @@ static int main_func(int argc, char **argv)
 	AAMPCLI_PRINTF("**************************************************************************\n");
 	AAMPCLI_PRINTF("** ADVANCED ADAPTIVE MEDIA PLAYER (AAMP) - COMMAND LINE INTERFACE (CLI) **\n");
 	AAMPCLI_PRINTF("**************************************************************************\n");
-
+	AAMPCLI_PRINTF("process: %d\n", getpid()); //Used by L2 tests
 	mAampcli.initPlayerLoop(0,NULL);
 	mAampcli.newPlayerInstance();
 


### PR DESCRIPTION
Reason for change: L2 tests to check number of threads created by AAMP
Output PID when aamp-cli starts so L2 framework can read this information
Risk: Low