### PR TITLE
VPLAY-11880:The manifest download keeps failing, eventually causing the AAMP to crash.

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -288,7 +288,7 @@ void AampMPDDownloader::Release()
 
 		if(mDownloaderThread_t2.joinable())
 			mDownloaderThread_t2.join();
-		// Clear the headers only after the gracefull exit of download threads.
+		// Clear the headers only after the graceful exit of download threads.
 		mDownloader1.InitializeCurlHeaderResources();
 		mDownloader2.InitializeCurlHeaderResources();
 

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -279,7 +279,7 @@ void AampMPDDownloader::Release()
 			mMPDNotifierCondVar.notify_all();
 
 		}
-
+		//Disabling the downloaders before joining the threads,which will exit the download loops gracefully 
 		mDownloader1.Release();
 		mDownloader2.Release();
 
@@ -288,6 +288,9 @@ void AampMPDDownloader::Release()
 
 		if(mDownloaderThread_t2.joinable())
 			mDownloaderThread_t2.join();
+		// Clear the headers only after the gracefull exit of download threads.
+		mDownloader1.ReleaseHeaders();
+		mDownloader2.ReleaseHeaders();
 
 		if(mManifestUpdateCb != NULL)
 		{

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -279,7 +279,7 @@ void AampMPDDownloader::Release()
 			mMPDNotifierCondVar.notify_all();
 
 		}
-		//Disabling the downloaders before joining the threads,which will exit the download loops gracefully 
+		//Disable downloads before joining the threads,which will exit the download loops gracefully 
 		mDownloader1.Release();
 		mDownloader2.Release();
 
@@ -289,8 +289,8 @@ void AampMPDDownloader::Release()
 		if(mDownloaderThread_t2.joinable())
 			mDownloaderThread_t2.join();
 		// Clear the headers only after the graceful exit of download threads.
-		mDownloader1.InitializeCurlHeaderResources();
-		mDownloader2.InitializeCurlHeaderResources();
+		mDownloader1.CleanupCurlHeaderResources();
+		mDownloader2.CleanupCurlHeaderResources();
 
 		if(mManifestUpdateCb != NULL)
 		{

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -289,8 +289,8 @@ void AampMPDDownloader::Release()
 		if(mDownloaderThread_t2.joinable())
 			mDownloaderThread_t2.join();
 		// Clear the headers only after the gracefull exit of download threads.
-		mDownloader1.ReleaseHeaders();
-		mDownloader2.ReleaseHeaders();
+		mDownloader1.InitializeCurlHeaderResources();
+		mDownloader2.InitializeCurlHeaderResources();
 
 		if(mManifestUpdateCb != NULL)
 		{

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -372,6 +372,11 @@ void AampCurlDownloader::Release()
 {
 	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadActive = false;
+}
+
+void AampCurlDownloader::ReleaseHeaders()
+{
+	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadUpdatedTime = 0 ;
 	mDownloadStartTime =  0;
 	mWriteCallbackBufferSize = 0;

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -374,7 +374,7 @@ void AampCurlDownloader::Release()
 	mDownloadActive = false;
 }
 
-void AampCurlDownloader::InitializeCurlHeaderResources()
+void AampCurlDownloader::CleanupCurlHeaderResources()
 {
 	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadUpdatedTime = 0 ;

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -374,7 +374,7 @@ void AampCurlDownloader::Release()
 	mDownloadActive = false;
 }
 
-void AampCurlDownloader::ReleaseHeaders()
+void AampCurlDownloader::InitializeCurlHeaderResources()
 {
 	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadUpdatedTime = 0 ;

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -229,9 +229,9 @@ public:
 	*/	
 	void Release();
 	/**
-	* @brief InitializeCurlHeaderResources - function to cleanup headers after thread join
+	* @brief CleanupCurlHeaderResources - function to cleanup headers after thread join
 	*/
-	void InitializeCurlHeaderResources();
+	void CleanupCurlHeaderResources();
 	void Clear();
 	/**
 	* @brief Download - function to start  download 

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -228,6 +228,10 @@ public:
 	* @param[in] dnldCfg - configuration for download
 	*/	
 	void Release();
+	/**
+	* @brief ReleaseHeaders - function to cleanup headers after thread join
+	*/
+	void ReleaseHeaders();
 	void Clear();
 	/**
 	* @brief Download - function to start  download 

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -229,9 +229,9 @@ public:
 	*/	
 	void Release();
 	/**
-	* @brief ReleaseHeaders - function to cleanup headers after thread join
+	* @brief InitializeCurlHeaderResources - function to cleanup headers after thread join
 	*/
-	void ReleaseHeaders();
+	void InitializeCurlHeaderResources();
 	void Clear();
 	/**
 	* @brief Download - function to start  download 

--- a/test/utests/fakes/FakeAampCurlDownloader.cpp
+++ b/test/utests/fakes/FakeAampCurlDownloader.cpp
@@ -98,7 +98,7 @@ void AampCurlDownloader::Release()
 {
 }
 
-void AampCurlDownloader::ReleaseHeaders()
+void AampCurlDownloader::InitializeCurlHeaderResources()
 {
 }
 

--- a/test/utests/fakes/FakeAampCurlDownloader.cpp
+++ b/test/utests/fakes/FakeAampCurlDownloader.cpp
@@ -98,6 +98,10 @@ void AampCurlDownloader::Release()
 {
 }
 
+void AampCurlDownloader::ReleaseHeaders()
+{
+}
+
 
 void AampCurlDownloader::Clear()
 {

--- a/test/utests/fakes/FakeAampCurlDownloader.cpp
+++ b/test/utests/fakes/FakeAampCurlDownloader.cpp
@@ -98,7 +98,7 @@ void AampCurlDownloader::Release()
 {
 }
 
-void AampCurlDownloader::InitializeCurlHeaderResources()
+void AampCurlDownloader::CleanupCurlHeaderResources()
 {
 }
 

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -26,6 +26,8 @@
 #include "AampLogManager.h"
 #include "MockCurl.h"
 #include <thread>
+#include <atomic>
+#include <vector>
 #include <unistd.h>
 
 using ::testing::DoAll;
@@ -48,6 +50,8 @@ protected:
 	curl_progress_callback_t mCurlProgressCallback = nullptr;
 	curl_write_func_t mCurlWriteFunc = nullptr;
 	std::string mUrl = "https://some.server/manifest.mpd";
+
+	
 
 	void SetUp() override
 	{
@@ -466,4 +470,61 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 	EXPECT_EQ(408, respData->iHttpRetValue);
 	respData->show();
 	respData->clear();
+}
+
+/**
+ * @brief Test case to verify correct order: Release() before InitializeCurlHeaderResources()
+ * 
+ * This test ensures that Release() is called before InitializeCurlHeaderResources()
+ * to prevent race conditions. Release() stops downloads, then cleanup can safely proceed.
+ */
+TEST_F(FunctionalTests, Release_BeforeInitializeCurlHeaderResources_PreventRaceCondition) {
+    DownloadConfigPtr config = std::make_shared<DownloadConfig>();
+    
+    EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+    EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+        .WillOnce(Return(CURLE_OK));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+        .WillOnce(Return(CURLE_OK));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+    
+    mAampCurlDownloader->Initialize(config);
+    
+    std::atomic<bool> releaseCompleted(false);
+    std::atomic<bool> headerCleanupStarted(false);
+    std::atomic<bool> raceConditionDetected(false);
+    
+    // Thread 1: Simulates download activity
+    std::thread downloadThread([&]() {
+        for (int i = 0; i < 100 && !releaseCompleted.load(); ++i) {
+            if (headerCleanupStarted.load() && !releaseCompleted.load()) {
+                raceConditionDetected.store(true);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+    
+    // Allow download thread to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    
+    // Step 1: Call Release() first to stop downloads
+  	mAampCurlDownloader->Release();
+  	releaseCompleted.store(true);
+    
+    // Step 2: Call InitializeCurlHeaderResources() after downloads stopped
+    headerCleanupStarted.store(true);
+    mAampCurlDownloader->InitializeCurlHeaderResources();
+    
+    downloadThread.join();
+    
+    // Verify no race condition detected
+    EXPECT_FALSE(raceConditionDetected.load()) 
+        << "Race condition detected: InitializeCurlHeaderResources() called before Release() completed";
+    
+    // Verify download is stopped
+    EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
 }

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -473,12 +473,12 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 }
 
 /**
- * @brief Test case to verify correct order: Release() before InitializeCurlHeaderResources()
+ * @brief Test case to verify correct order: Release() before CleanupCurlHeaderResources()
  * 
- * This test ensures that Release() is called before InitializeCurlHeaderResources()
+ * This test ensures that Release() is called before CleanupCurlHeaderResources()
  * to prevent race conditions. Release() stops downloads, then cleanup can safely proceed.
  */
-TEST_F(FunctionalTests, Release_BeforeInitializeCurlHeaderResources_PreventRaceCondition) {
+TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
     DownloadConfigPtr config = std::make_shared<DownloadConfig>();
     
     EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
@@ -515,15 +515,15 @@ TEST_F(FunctionalTests, Release_BeforeInitializeCurlHeaderResources_PreventRaceC
   	mAampCurlDownloader->Release();
   	releaseCompleted.store(true);
     
-    // Step 2: Call InitializeCurlHeaderResources() after downloads stopped
+    // Step 2: Call CleanupCurlHeaderResources() after downloads stopped
     headerCleanupStarted.store(true);
-    mAampCurlDownloader->InitializeCurlHeaderResources();
+    mAampCurlDownloader->CleanupCurlHeaderResources();
     
     downloadThread.join();
     
     // Verify no race condition detected
     EXPECT_FALSE(raceConditionDetected.load()) 
-        << "Race condition detected: InitializeCurlHeaderResources() called before Release() completed";
+        << "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
     
     // Verify download is stopped
     EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -26,8 +26,6 @@
 #include "AampLogManager.h"
 #include "MockCurl.h"
 #include <thread>
-#include <atomic>
-#include <vector>
 #include <unistd.h>
 
 using ::testing::DoAll;
@@ -50,8 +48,6 @@ protected:
 	curl_progress_callback_t mCurlProgressCallback = nullptr;
 	curl_write_func_t mCurlWriteFunc = nullptr;
 	std::string mUrl = "https://some.server/manifest.mpd";
-
-	
 
 	void SetUp() override
 	{
@@ -473,10 +469,13 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 }
 
 /**
- * @brief Test case to verify correct order: Release() before CleanupCurlHeaderResources()
+ * @brief Test case to verify calling order: Release() before CleanupCurlHeaderResources()
  * 
- * This test ensures that Release() is called before CleanupCurlHeaderResources()
- * to prevent race conditions. Release() stops downloads, then cleanup can safely proceed.
+ * This test demonstrates the recommended sequence where Release() is called first to stop
+ * downloads (sets mDownloadActive=false), followed by CleanupCurlHeaderResources() to free
+ * curl header resources. This ordering prevents potential race conditions where header
+ * resources could be freed while curl callbacks are still executing.
+ * 
  */
 TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
     DownloadConfigPtr config = std::make_shared<DownloadConfig>();
@@ -512,19 +511,19 @@ TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCond
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     
     // Step 1: Call Release() first to stop downloads
-  	mAampCurlDownloader->Release();
-  	releaseCompleted.store(true);
+	mAampCurlDownloader->Release();
+	releaseCompleted.store(true);
     
     // Step 2: Call CleanupCurlHeaderResources() after downloads stopped
-    headerCleanupStarted.store(true);
-    mAampCurlDownloader->CleanupCurlHeaderResources();
+	headerCleanupStarted.store(true);
+	mAampCurlDownloader->CleanupCurlHeaderResources();
     
     downloadThread.join();
     
     // Verify no race condition detected
     EXPECT_FALSE(raceConditionDetected.load()) 
         << "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
-    
-    // Verify download is stopped
-    EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
+		
+	// Verify download is stopped
+	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
 }


### PR DESCRIPTION
Reason for Change: Split AampCurlDownloader::Release() to fix thread-safe resource cleanup
Separated the Release() function into two parts to ensure thread-safe
cleanup of curl headers:

1. Release() - Disables the downloader by setting mDownloadActive flag,
   allowing download threads to exit gracefully
2. ReleaseHeaders() - Cleans up curl headers and resets timing variables
   after threads have been joined

This prevents race conditions where headers could be freed while download
threads are still active and potentially accessing them.

Test Procedure: Updated in the ticket.

Risk: Low