### PR TITLE
VPLAY-11949 godspell cleanup - Nov 2025

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7583,7 +7583,7 @@ void StreamAbstractionAAMP_HLS::SelectSubtitleTrack()
  *
  * Scoring algorithm:
  * - Base: 1 point for any track
- * - Language: (list_size - position) * AAMP_LANGUAGE_SCORE (prioritizes order)
+ * - Language: (list_size - position) * AAMP_LANGUAGE_SCORE (prioritize order)
  * - Rendition: AAMP_ROLE_SCORE
  * - Name: AAMP_TYPE_SCORE
  *


### PR DESCRIPTION
Reason for Change: replace prioritizes with priority

Risk: None (change in comment)

Test Guidance: no godspell warnings