### PR TITLE
VPLAY-11809 godspell

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -3105,7 +3105,7 @@ void PlayerInstanceAAMP::StopInternal(bool sendStateChangeEvent, bool forceClean
 	}
 	AAMPLOG_MIL("aamp_stop PlayerState=%d forceCleanup=%d", state, forceCleanup);
 	
-	// Negate sendStateChangeEvent since no need to send state change event on Destrcutor call
+	// Negate sendStateChangeEvent since no need to send state change event on destructor call
 	aamp->Stop(!sendStateChangeEvent);
 	
 	// Enhanced DRM cleanup for Deep Sleep scenarios


### PR DESCRIPTION
VPLAY-11809 godspell

Reason for Change: fix spelling of "destructor"

Test Guidance: no godspell warnings