### PR TITLE
VPLAY-11948 : middleware leak found by address sanitizer

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -89,6 +89,7 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	{
 		delete[] mDrmSystem;
 	}
+	/* safe delete configuration parameter */
 	MW_SAFE_DELETE(m_gstConfigParam);
 	mScheduler.StopScheduler();
 	for (int i = 0; i < GST_TRACK_COUNT; i++)

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -89,6 +89,7 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	{
 		delete[] mDrmSystem;
 	}
+	MW_SAFE_DELETE(m_gstConfigParam);
 	mScheduler.StopScheduler();
 	for (int i = 0; i < GST_TRACK_COUNT; i++)
 	{


### PR DESCRIPTION
VPLAY-11948: middleware leak found by address sanitizer

Reason for change: Avoid memory leak in middleware component
Test Procedure: 
refer ticket
Risks: Low
Priority: P1
Signed-off-by: Rekha Kandhavelan [rekha_kandhavelan@comcast.com]