### PR TITLE
Feature/vplay 11795 memset

### DIFF
--- a/AampLLDASHData.h
+++ b/AampLLDASHData.h
@@ -61,19 +61,7 @@ struct AampLLDashServiceData {
 	/**< API to reset the Data*/
 	void clear(void)
 	{
-		lowLatencyMode =false;
-		strictSpecConformance = false;
-		availabilityTimeOffset = 0.0;
-		availabilityTimeComplete = false;
-		targetLatency = 0;
-		minLatency = 0;
-		maxLatency = 0;
-		latencyThreshold = 0;
-		minPlaybackRate = 0.0;
-		maxPlaybackRate = 0.0;
-		isSegTimeLineBased = false;
-		fragmentDuration = 0.0; 
-		utcTiming = eUTC_HTTP_INVALID;
+		*this = AampLLDashServiceData();
 	}
 };
 

--- a/AampLLDASHData.h
+++ b/AampLLDASHData.h
@@ -29,39 +29,23 @@
  * @brief To store Low Latency Service configurations
  */
 struct AampLLDashServiceData {
-	bool lowLatencyMode;        	/**< LL Playback mode enabled */
-	bool strictSpecConformance; 	/**< Check for Strict LL Dash spec conformance*/
-	double availabilityTimeOffset;  	/**< LL Availability Time Offset */
-	bool availabilityTimeComplete;  	/**< LL Availability Time Complete */
-	int targetLatency;          	/**< Target Latency of playback */
-	int minLatency;             	/**< Minimum Latency of playback */
-	int maxLatency;             	/**< Maximum Latency of playback */
-	int latencyThreshold;       	/**< Latency when play rate correction kicks-in */
-	double minPlaybackRate;     	/**< Minimum playback rate for playback */
-	double maxPlaybackRate;     	/**< Maximum playback rate for playback */
-	bool isSegTimeLineBased;		/**< Indicates is stream is segmenttimeline based */
-	double fragmentDuration;		/**< Maximum Fragment Duration */
-	UtcTiming utcTiming;		/**< Server UTC timings */
+	bool lowLatencyMode = false;				/**< LL Playback mode enabled */
+	bool strictSpecConformance = false;			/**< Check for Strict LL Dash spec conformance*/
+	double availabilityTimeOffset = 0.0;		/**< LL Availability Time Offset */
+	bool availabilityTimeComplete = false;		/**< LL Availability Time Complete */
+	int targetLatency = 0;						/**< Target Latency of playback */
+	int minLatency = 0;							/**< Minimum Latency of playback */
+	int maxLatency = 0;							/**< Maximum Latency of playback */
+	int latencyThreshold = 0;					/**< Latency when play rate correction kicks-in */
+	double minPlaybackRate = 0.0;				/**< Minimum playback rate for playback */
+	double maxPlaybackRate = 0.0;				/**< Maximum playback rate for playback */
+	bool isSegTimeLineBased = false;			/**< Indicates is stream is segmenttimeline based */
+	double fragmentDuration = 0.0;				/**< Maximum Fragment Duration */
+	UtcTiming utcTiming = eUTC_HTTP_INVALID;	/**< Server UTC timings */
 
-	AampLLDashServiceData() : lowLatencyMode(false),
-			strictSpecConformance(false),
-			availabilityTimeOffset(0.0),
-			availabilityTimeComplete(false),
-			targetLatency(0),
-			minLatency(0),
-			maxLatency(0),
-			latencyThreshold(0),
-			minPlaybackRate(0.0),
-			maxPlaybackRate(0.0),
-			isSegTimeLineBased(false),
-			fragmentDuration(0.0),
-			utcTiming(eUTC_HTTP_INVALID)
-			{
-			}
-	/**< API to reset the Data*/
-	void clear(void)
+	void clear()
 	{
-		*this = AampLLDashServiceData();
+		*this = {};
 	}
 };
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -160,6 +160,7 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 	,mIsSegmentTimelineEnabled(false)
 	,mSeekedInPeriod(false)
 	,mIsFinalFirstPTS(false)
+	,mMediaStreamContext{}
 {
 	this->aamp = aamp;
 	if (aamp->mDRMLicenseManager)
@@ -167,7 +168,6 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 		AampDRMLicenseManager *licenseManager = aamp->mDRMLicenseManager;
 		licenseManager->SetLicenseFetcher(this);
 	}
-	memset(&mMediaStreamContext, 0, sizeof(mMediaStreamContext));
 	GetABRManager().clearProfiles();
 	mLastPlaylistDownloadTimeMs = aamp_GetCurrentTimeMS();
 
@@ -10200,7 +10200,7 @@ StreamAbstractionAAMP_MPD::~StreamAbstractionAAMP_MPD()
 	}
 
 	aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
-	memset(aamp->GetLLDashServiceData(),0x00,sizeof(AampLLDashServiceData));
+	aamp->GetLLDashServiceData()->clear();
 	aamp->SetLowLatencyServiceConfigured(false);
 	aamp->SyncEnd();
 	mManifestDnldRespPtr = nullptr;
@@ -10984,8 +10984,7 @@ static void indexThumbnails(dash::mpd::IMPD *mpd, int thumbIndexValue, std::vect
 												while( repeatCount-- >= 0 )
 												{
 													std::string tmedia = media;
-													TileInfo tileInfo;
-													memset( &tileInfo,0,sizeof(tileInfo) );
+													TileInfo tileInfo;  // Constructor already initializes all members
 													tileInfo.startTime = startTime + ( adDuration / timeScale) ;
 													AAMPLOG_TRACE("timeLineIndex[%d] size [%zu] updated durationMs[%" PRIu64 "] startTime:%f adDuration:%f repeatCount:%d",  timeLineIndex, timelines.size(), durationMs, startTime, adDuration, repeatCount);
 
@@ -11032,8 +11031,7 @@ static void indexThumbnails(dash::mpd::IMPD *mpd, int thumbIndexValue, std::vect
 											while(totalTiles-- > 0)
 											{
 												std::string tmedia = media;
-												TileInfo tileInfo;
-												memset( &tileInfo,0,sizeof(tileInfo));
+												TileInfo tileInfo;  // Constructor already initializes all members
 												tileInfo.startTime = tStartTime;
 												tStartTime += tDuration; //increment the nextStartTime by TileDuration
 												replace(tmedia,"RepresentationID",RepresentationID);
@@ -12597,10 +12595,9 @@ double StreamAbstractionAAMP_MPD::GetEncoderDisplayLatency()
 						{
 							AAMPLOG_TRACE("ProducerReferenceTime@wallClockTime [%s]", wallClockTime.c_str());
 
-							std::tm tmTime;
+							std::tm tmTime{};  // Zero-initialize all members
 							const char* format = "%Y-%m-%dT%H:%M:%S.%f%Z";
 							char out_buffer[ 80 ];
-							memset(&tmTime, 0, sizeof(tmTime));
 							strptime(wallClockTime.c_str(), format, &tmTime);
 							wTime = mktime(&tmTime);
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10984,7 +10984,7 @@ static void indexThumbnails(dash::mpd::IMPD *mpd, int thumbIndexValue, std::vect
 												while( repeatCount-- >= 0 )
 												{
 													std::string tmedia = media;
-													TileInfo tileInfo;  // Constructor already initializes all members
+													TileInfo tileInfo;
 													tileInfo.startTime = startTime + ( adDuration / timeScale) ;
 													AAMPLOG_TRACE("timeLineIndex[%d] size [%zu] updated durationMs[%" PRIu64 "] startTime:%f adDuration:%f repeatCount:%d",  timeLineIndex, timelines.size(), durationMs, startTime, adDuration, repeatCount);
 
@@ -11031,7 +11031,7 @@ static void indexThumbnails(dash::mpd::IMPD *mpd, int thumbIndexValue, std::vect
 											while(totalTiles-- > 0)
 											{
 												std::string tmedia = media;
-												TileInfo tileInfo;  // Constructor already initializes all members
+												TileInfo tileInfo;
 												tileInfo.startTime = tStartTime;
 												tStartTime += tDuration; //increment the nextStartTime by TileDuration
 												replace(tmedia,"RepresentationID",RepresentationID);
@@ -12595,7 +12595,7 @@ double StreamAbstractionAAMP_MPD::GetEncoderDisplayLatency()
 						{
 							AAMPLOG_TRACE("ProducerReferenceTime@wallClockTime [%s]", wallClockTime.c_str());
 
-							std::tm tmTime{};  // Zero-initialize all members
+							std::tm tmTime{};
 							const char* format = "%Y-%m-%dT%H:%M:%S.%f%Z";
 							char out_buffer[ 80 ];
 							strptime(wallClockTime.c_str(), format, &tmTime);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1374,7 +1374,6 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	mCustomHeaders["Connection:"] = std::vector<std::string> { "Keep-Alive" };
 	preferredLanguagesList.push_back("en");
 
-	memset(&aesCtrAttrDataList, 0, sizeof(aesCtrAttrDataList));
 	mHarvestCountLimit = GETCONFIGVALUE_PRIV(eAAMPConfig_HarvestCountLimit);
 	mHarvestConfig = GETCONFIGVALUE_PRIV(eAAMPConfig_HarvestConfig);
 	mAsyncTuneEnabled = ISCONFIGSET_PRIV(eAAMPConfig_AsyncTune);
@@ -6165,9 +6164,8 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	mIsFirstRequestToFOG = (mFogTSBEnabled == true);
 
 	{
-		char tuneStrPrefix[64];
+		char tuneStrPrefix[64] = {};
 		mTsbSessionRequestUrl.clear();
-		memset(tuneStrPrefix, '\0', sizeof(tuneStrPrefix));
 		if (!mAppName.empty())
 		{
 			snprintf(tuneStrPrefix, sizeof(tuneStrPrefix), "%s PLAYER[%d] APP: %s",(mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), mPlayerId, mAppName.c_str());
@@ -8983,8 +8981,7 @@ void PrivateInstanceAAMP::UpdateLiveOffset()
  */
 void PrivateInstanceAAMP::SendStalledErrorEvent()
 {
-	char description[MAX_ERROR_DESCRIPTION_LENGTH];
-	memset(description, '\0', MAX_ERROR_DESCRIPTION_LENGTH);
+	char description[MAX_ERROR_DESCRIPTION_LENGTH] = {};
 	int stalltimeout = GETCONFIGVALUE_PRIV(eAAMPConfig_StallTimeoutMS);
 	snprintf(description, (MAX_ERROR_DESCRIPTION_LENGTH - 1), "Playback has been stalled for more than %d ms due to lack of new fragments", stalltimeout);
 	SendErrorEvent(AAMP_TUNE_PLAYBACK_STALLED, description);
@@ -9121,8 +9118,7 @@ MediaFormat PrivateInstanceAAMP::GetMediaFormatTypeEnum() const
  */
 void PrivateInstanceAAMP::GetMoneyTraceString(std::string &customHeader) const
 {
-	char moneytracebuf[512];
-	memset(moneytracebuf, 0, sizeof(moneytracebuf));
+	char moneytracebuf[512] = {};
 
 	if (mCustomHeaders.size() > 0)
 	{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -978,7 +978,7 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 				//Reset speedcache when Fragment download Starts
 				struct SpeedCache* speedcache = NULL;
 				speedcache = aamp->GetLLDashSpeedCache();
-				memset(speedcache, 0x00, sizeof(struct SpeedCache));
+				*speedcache = SpeedCache();
 			}
 
 			downloadbps = getCurrentContentDownloadSpeed(aamp, context->mediaType, context->dlStarted, (long)context->downloadStartTime, dlnow);
@@ -13062,14 +13062,6 @@ void PrivateInstanceAAMP::SetSubTimeScale(uint32_t subTimeScale)
 uint32_t  PrivateInstanceAAMP::GetSubTimeScale(void)
 {
 	return subTimeScale;
-}
-
-/**
- * @brief Sets Speed Cache
- */
-void PrivateInstanceAAMP::SetLLDashSpeedCache(struct SpeedCache &speedCache)
-{
-	this->speedCache = speedCache;
 }
 
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12757,8 +12757,7 @@ struct curl_slist* PrivateInstanceAAMP::GetCustomHeaders(AampMediaType mediaType
 				{
 					continue;
 				}
-				char buf[512];
-				memset(buf, '\0', 512);
+				char buf[512] = {};
 				if (it->second.size() >= 2)
 				{
 					snprintf(buf, 512, "trace-id=%s;parent-id=%s;span-id=%lld",

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3527,14 +3527,6 @@ public:
 	uint32_t GetSubTimeScale(void);
 
 	/**
-	 *   @fn SetLLDashSpeedCache
-	 *
-	 *   @param[in] speedCache - Speed Cache
-	 *   @return void
-	 */
-	void SetLLDashSpeedCache(struct SpeedCache &speedCache);
-
-	/**
 	 *   @fn GetLLDashSpeedCache
 	 *
 	 *   @return struct SpeedCache speedCache*

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1982,8 +1982,7 @@ void MediaTrack::FlushFragments()
 	{
 		for (int i = 0; i < maxCachedFragmentsPerTrack; i++)
 		{
-			mCachedFragment[i].fragment.Free();
-			memset(&mCachedFragment[i], 0, sizeof(CachedFragment));
+			mCachedFragment[i].Clear();
 		}
 		fragmentIdxToInject = 0;
 		fragmentIdxToFetch = 0;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -3680,12 +3680,35 @@ TEST_F(PrivAampTests,SetAudTimeScaleTest)
  	EXPECT_EQ(val,val1);
 }
 
-TEST_F(PrivAampTests,SetLLDashSpeedCacheTest)
+TEST_F(PrivAampTests,GetLLDashSpeedCacheTest)
 {
-	struct SpeedCache spCache;
-	p_aamp->SetLLDashSpeedCache(spCache);
-
-	struct SpeedCache *pCache1 = p_aamp->GetLLDashSpeedCache();
+	// Test that GetLLDashSpeedCache returns a valid pointer and can be modified
+	struct SpeedCache *pCache = p_aamp->GetLLDashSpeedCache();
+	
+	ASSERT_NE(pCache, nullptr);
+	
+	pCache->last_sample_time_val = 12345;
+	pCache->speed_now = 5000000; // 5 Mbps
+	pCache->totalDownloaded = 1024000;
+	pCache->bStart = true;
+	pCache->mChunkSpeedData.push_back(std::make_pair(1.5, 4000000));
+	
+	struct SpeedCache *pCache2 = p_aamp->GetLLDashSpeedCache();
+	EXPECT_EQ(pCache2->last_sample_time_val, 12345);
+	EXPECT_EQ(pCache2->speed_now, 5000000);
+	EXPECT_EQ(pCache2->totalDownloaded, 1024000);
+	EXPECT_TRUE(pCache2->bStart);
+	EXPECT_EQ(pCache2->mChunkSpeedData.size(), 1);
+	
+	// Test resetting the cache 
+	*pCache = SpeedCache();
+	
+	// Verify reset worked
+	EXPECT_EQ(pCache->last_sample_time_val, 0);
+	EXPECT_EQ(pCache->speed_now, 0);
+	EXPECT_EQ(pCache->totalDownloaded, 0);
+	EXPECT_FALSE(pCache->bStart);
+	EXPECT_TRUE(pCache->mChunkSpeedData.empty());
 }
 
 TEST_F(PrivAampTests,SetLiveOffsetAppRequestTest)

--- a/tsFragmentProcessor.cpp
+++ b/tsFragmentProcessor.cpp
@@ -623,13 +623,11 @@ void TSFragmentProcessor::DemuxFragment(const uint8_t * base_packet_ptr, size_t 
 void TSFragmentProcessor::ProcessPMTSection(uint8_t * section, size_t sectionLength)
 {
 	unsigned char *programInfo, *programInfoEnd;
-	char work[32];
+	char work[32] = {};
 
 	int version = ((section[2] >> 1) & 0x1F);
 	int pcrPid = (((section[5] & 0x1F) << 8) + section[6]);
 	int infoLength = (((section[7] & 0x0F) << 8) + section[8]);
-
-	memset(work, 0, sizeof(work));
 
 	// Reset of old values
 	ResetAudioComponents();
@@ -817,15 +815,13 @@ void TSFragmentProcessor::ProcessPMTSection(uint8_t * section, size_t sectionLen
 
 void TSFragmentProcessor::ResetAudioComponents()
 {
-	// Reset of old values
 	for (auto & comp : m_audioComponents)
 	{
 		if (comp.associatedLanguage)
 		{
 			free(comp.associatedLanguage);
 		}
-		comp.associatedLanguage = nullptr;
-		memset(&comp, 0, sizeof(RecordingComponent));
+		comp = RecordingComponent();
 	}
 
 	m_audioComponentCount = 0;	
@@ -835,7 +831,7 @@ void TSFragmentProcessor::ResetVideoComponents()
 {
 	for (auto & comp : m_videoComponents)
 	{
-		memset(&comp, 0, sizeof(RecordingComponent));
+		comp = RecordingComponent();
 	}
 	m_videoComponentCount = 0;
 }

--- a/tsprocessor.cpp
+++ b/tsprocessor.cpp
@@ -237,16 +237,6 @@ TSProcessor::TSProcessor(class PrivateInstanceAAMP *aamp,StreamOperation streamO
 		}
 		m_demux = true;
 	}
-
-	for (auto & comp : videoComponents)
-	{
-		comp = RecordingComponent();
-	}
-
-	for (auto & comp : audioComponents)
-	{
-		comp = RecordingComponent();
-	}
 }
 
 /**
@@ -412,15 +402,6 @@ void TSProcessor::processPMTSection(unsigned char* section, int sectionLength)
 	int pcrPid = (((section[5] & 0x1F) << 8) + section[6]);
 	int infoLength = (((section[7] & 0x0F) << 8) + section[8]);
 
-	for (int i = 0; i < audioComponentCount; ++i)
-	{
-		if (audioComponents[i].associatedLanguage)
-		{
-			free(audioComponents[i].associatedLanguage);
-		}
-	}
-
-	// Use RAII: assignment operator invokes RecordingComponent constructor
 	for (auto & comp : videoComponents)
 	{
 		comp = RecordingComponent();
@@ -428,6 +409,10 @@ void TSProcessor::processPMTSection(unsigned char* section, int sectionLength)
 
 	for (auto & comp : audioComponents)
 	{
+		if (comp.associatedLanguage)
+		{
+			free(comp.associatedLanguage);
+		}
 		comp = RecordingComponent();
 	}
 

--- a/tsprocessor.cpp
+++ b/tsprocessor.cpp
@@ -238,9 +238,15 @@ TSProcessor::TSProcessor(class PrivateInstanceAAMP *aamp,StreamOperation streamO
 		m_demux = true;
 	}
 
-	int compBufLen = MAX_PIDS*sizeof(RecordingComponent);
-	memset(videoComponents, 0, compBufLen);
-	memset(audioComponents, 0, compBufLen);
+	for (auto & comp : videoComponents)
+	{
+		comp = RecordingComponent();
+	}
+
+	for (auto & comp : audioComponents)
+	{
+		comp = RecordingComponent();
+	}
 }
 
 /**

--- a/tsprocessor.cpp
+++ b/tsprocessor.cpp
@@ -395,9 +395,9 @@ void TSProcessor::insertPCR(unsigned char *packet, int pid)
 void TSProcessor::processPMTSection(unsigned char* section, int sectionLength)
 {
 	unsigned char *programInfo, *programInfoEnd;
-	unsigned int dataDescTags[MAX_PIDS];
+	unsigned int dataDescTags[MAX_PIDS] = {};
 	int streamType = 0, pid = 0, len = 0;
-	char work[32];
+	char work[32] = {};
 	StreamOutputFormat videoFormat = FORMAT_INVALID;
 	StreamOutputFormat audioFormat = FORMAT_INVALID;
 	bool cueiDescriptorFound = false;
@@ -414,12 +414,16 @@ void TSProcessor::processPMTSection(unsigned char* section, int sectionLength)
 		}
 	}
 
-	memset(videoComponents, 0, sizeof(videoComponents));
-	memset(audioComponents, 0, sizeof(audioComponents));
+	// Use RAII: assignment operator invokes RecordingComponent constructor
+	for (auto & comp : videoComponents)
+	{
+		comp = RecordingComponent();
+	}
 
-	memset(dataDescTags, 0, sizeof(dataDescTags));
-
-	memset(work, 0, sizeof(work));
+	for (auto & comp : audioComponents)
+	{
+		comp = RecordingComponent();
+	}
 
 	videoComponentCount = audioComponentCount = 0;
 	m_dsmccComponentFound = false;

--- a/tsprocessor.cpp
+++ b/tsprocessor.cpp
@@ -196,6 +196,8 @@ TSProcessor::TSProcessor(class PrivateInstanceAAMP *aamp,StreamOperation streamO
 	, m_auxiliaryAudio(false)
 	,m_audioGroupId()
 	,m_applyOffset(true)
+	,m_SPS{}
+	,m_PPS{}
 {
 	AAMPLOG_INFO(" constructor: %p", this);
 	bool optimizeMuxed = false;
@@ -205,8 +207,6 @@ TSProcessor::TSProcessor(class PrivateInstanceAAMP *aamp,StreamOperation streamO
 		optimizeMuxed = (m_streamOperation == eStreamOp_DEMUX_ALL);
 	}
 
-	memset(m_SPS, 0, 32 * sizeof(H264SPS));
-	memset(m_PPS, 0, 256 * sizeof(H264PPS));
 	m_versionPMT = 0;
 
 	if ((m_streamOperation == eStreamOp_DEMUX_ALL) || (m_streamOperation == eStreamOp_DEMUX_VIDEO) || (m_streamOperation == eStreamOp_DEMUX_VIDEO_AND_AUX))


### PR DESCRIPTION
VPLAY-11795: Replace unsafe memset with RAII patterns

Fixes undefined behaviour from memset on non-POD types and modernizes POD initialization.

Key changes:

Non-POD types: Use proper cleanup methods instead of memset
POD types: Use = {} initialization at declaration
Code cleanup: Remove dead code, simplify logic

Impact: 16 memset calls replaced across 6 files. No functional changes.

Risk: low