### PR TITLE
VPLAY-11707 Subtitles displayed for channels when subtitles are disab…

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -7109,6 +7109,11 @@ void StreamAbstractionAAMP_HLS::ConfigureTextTrack()
 			}
 		}
 	}
+
+	if(currentTextTrackProfileIndex > -1 )
+	{
+		aamp->mIsInbandCC = mediaInfoStore[currentTextTrackProfileIndex].isCC;
+	}
 	AAMPLOG_WARN("TextTrack Selected :%d", currentTextTrackProfileIndex);
 }
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2986,7 +2986,7 @@ void PrivateInstanceAAMP::NotifySpeedChanged(float rate, bool changeState)
 				if (HasSidecarData())
 				{ // has sidecar data
 					if (mpStreamAbstractionAAMP)
-						mpStreamAbstractionAAMP->ResumeSubtitleOnPlay(subtitles_muted, mData.get());
+						mpStreamAbstractionAAMP->ResumeSubtitleOnPlay(subtitles_muted.load(), mData.get());
 				}
 			}
 			SetState(eSTATE_PLAYING);
@@ -5599,13 +5599,17 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			if (sink)
 			{
 				sink->SetVideoZoom(zoom_mode);
-				AAMPLOG_INFO("SetVideoMute video_muted %d mApplyCachedVideoMute %d", video_muted, mApplyCachedVideoMute);
-				sink->SetVideoMute(video_muted);
+				AAMPLOG_INFO("SetVideoMute video_muted %d mApplyCachedVideoMute %d", video_muted.load(), mApplyCachedVideoMute);
 				if (mApplyCachedVideoMute)
 				{
+					SetVideoMuteInternal(video_muted.load());
 					mApplyCachedVideoMute = false;
-					SetCCStatusInternal();
 				}
+				else
+				{
+					sink->SetVideoMute(video_muted.load());
+				}
+				SetCCStatusInternal();
 				sink->SetAudioVolume(volume);
 				if (mbPlayEnabled)
 				{
@@ -5661,7 +5665,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			if (HasSidecarData())
 			{
 				// has sidecar data
-				mpStreamAbstractionAAMP->ResumeSubtitleAfterSeek(subtitles_muted, mData.get());
+				mpStreamAbstractionAAMP->ResumeSubtitleAfterSeek(subtitles_muted.load(), mData.get());
 			}
 
 			if (!mTextStyle.empty())
@@ -6202,11 +6206,11 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	if(mApplyCachedVideoMute)
 	{
 		mApplyCachedVideoMute = false;
-		AAMPLOG_INFO("Cached videoMute is being executed, mute value: %d", video_muted);
+		AAMPLOG_INFO("Cached videoMute is being executed, mute value: %d", video_muted.load());
 		if (mpStreamAbstractionAAMP)
 		{
 			//These two fns are being called in PlayerInstanceAAMP::SetVideoMute
-			SetVideoMuteInternal(video_muted);
+			SetVideoMuteInternal(video_muted.load());
 			SetCCStatusInternal();
 		}
 		else
@@ -7175,7 +7179,7 @@ void PrivateInstanceAAMP::SetVideoZoom(VideoZoomMode zoom)
  */
 void PrivateInstanceAAMP::SetVideoMute(bool muted)
 {
-	AAMPLOG_INFO("mute %s subtitles_muted %s", muted?"true":"false", subtitles_muted?"true":"false");
+	AAMPLOG_INFO("mute %s subtitles_muted %s", muted?"true":"false", subtitles_muted.load()?"true":"false");
 	video_muted = muted;
 
 	//If lock could not be acquired, then cache it
@@ -7231,7 +7235,7 @@ void PrivateInstanceAAMP::SetSubtitleMute(bool muted)
 	AcquireStreamLock();
 	if (mpStreamAbstractionAAMP)
 	{
-		SetSubtitleMuteInternal(video_muted || muted);
+		SetSubtitleMuteInternal(video_muted.load() || muted);
 	}
 	else
 	{
@@ -9027,7 +9031,7 @@ void PrivateInstanceAAMP::NotifyFirstBufferProcessed(const std::string& videoRec
 	if(ISCONFIGSET_PRIV(eAAMPConfig_UseSecManager) || ISCONFIGSET_PRIV(eAAMPConfig_UseFireboltSDK))
 	{
 		double streamPositionMs = GetStreamPositionMs();
-		mDRMLicenseManager->setVideoMute(IsLive(), GetCurrentLatency(), IsAtLivePoint(), GetLiveOffsetMs(), video_muted, streamPositionMs);
+		mDRMLicenseManager->setVideoMute(IsLive(), GetCurrentLatency(), IsAtLivePoint(), GetLiveOffsetMs(), video_muted.load(), streamPositionMs);
 		mDRMLicenseManager->setPlaybackSpeedState(IsLive(), GetCurrentLatency(), IsAtLivePoint(), GetLiveOffsetMs(),rate, streamPositionMs, true);
 		int x = 0,y = 0,w = 0,h = 0;
 		if (!videoRectangle.empty())
@@ -11076,7 +11080,7 @@ int PrivateInstanceAAMP::GetTextTrack()
 			}
 		}
 	}
-	if (mpStreamAbstractionAAMP && idx == -1 && !subtitles_muted)
+	if (mpStreamAbstractionAAMP && idx == -1 && !subtitles_muted.load())
 	{
 		idx = mpStreamAbstractionAAMP->GetTextTrack();
 	}
@@ -11098,25 +11102,27 @@ void PrivateInstanceAAMP::SetCCStatusInternal(void)
 {
 	// StreamLock is recursive, so it is fine to call this method with it locked.
 	AcquireStreamLock();
-	// Mute subtitles if either video is muted or subtitles are muted
-	bool mute_subtitles_applied = video_muted || subtitles_muted;
-	AAMPLOG_TRACE("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
-		mIsInbandCC, ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled), mute_subtitles_applied, video_muted, subtitles_muted);
-	if (mIsInbandCC || !ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled))
+	if (mpStreamAbstractionAAMP)
 	{
-		PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
-	}
-	else
-	{
-		if (mpStreamAbstractionAAMP)
+		// Mute subtitles if either video is muted or subtitles are muted
+		bool mute_subtitles_applied = video_muted.load() || subtitles_muted.load();
+		bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
+		AAMPLOG_TRACE("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
+					  mIsInbandCC, isGstSubtecEnabled, mute_subtitles_applied, video_muted.load(), subtitles_muted.load());
+
+		if (mIsInbandCC || !isGstSubtecEnabled)
+		{
+			PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
+		}
+		else
 		{
 			mpStreamAbstractionAAMP->MuteSubtitles(mute_subtitles_applied);
 			if (HasSidecarData())
 			{ // has sidecar data
 				mpStreamAbstractionAAMP->MuteSidecarSubtitles(mute_subtitles_applied);
 			}
+			SetSubtitleMuteInternal(mute_subtitles_applied);
 		}
-		SetSubtitleMuteInternal(mute_subtitles_applied);
 	}
 	ReleaseStreamLock();
 }
@@ -11126,7 +11132,7 @@ void PrivateInstanceAAMP::SetCCStatusInternal(void)
  */
 bool PrivateInstanceAAMP::GetCCStatus(void)
 {
-	return !(subtitles_muted);
+	return !(subtitles_muted.load());
 }
 
 /**

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1054,8 +1054,8 @@ public:
 	Accessibility  preferredAudioAccessibilityNode; 	/**< Preferred Accessibility Node for Audio  */
 	AudioTrackTuple mAudioTuple;				/**< Deprecated **/
 	VideoZoomMode zoom_mode;
-	bool video_muted; /**< true iff video plane is logically muted */
-	bool subtitles_muted; /**< true iff subtitle plane is logically muted */
+	std::atomic<bool> video_muted; /**< true if video plane is logically muted */
+	std::atomic<bool> subtitles_muted; /**< true if subtitle plane is logically muted */
 	int audio_volume;
 	std::vector<std::string> subscribedTags;
 	std::vector<TimedMetadata> timedMetadata;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -3342,177 +3342,162 @@ TEST_F(PrivAampTests,SetTextTrackTest_1)
 	EXPECT_EQ(-1,val);
 }
 
-TEST_F(PrivAampTests,SetCCStatusTest)
+TEST_F(PrivAampTests,SetCCStatusPreTune)
 {
 	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
 
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
 
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true))
-		.WillOnce(Return(0));
+	// Enable CC and check that status is stored, 
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
 	p_aamp->SetCCStatus(true);
-	EXPECT_TRUE(p_aamp->GetCCStatus()); // Preference is stored
+	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
+	// Now call TuneHelper to create the StreamAbstraction object
+	// SetStatus(true) should be called to apply the stored CC status
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// Disable CC and check that status is stored,
+	// and SetStatus(false) is called since we are now tuned
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
 	p_aamp->SetCCStatus(false);
 	EXPECT_FALSE(p_aamp->GetCCStatus()); // Preference is stored
 }
 
-TEST_F(PrivAampTests,SetCCStatusWithOOBTest)
+TEST_F(PrivAampTests,SetCCStatusPreTuneOOB)
 {
-	// Out-of-band subtitles case
-	p_aamp->mIsInbandCC = false;
-	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_GstSubtecEnabled))
-		.WillByDefault(Return(true));
+	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_GstSubtecEnabled)).WillByDefault(Return(true));
 
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
 
+	// Enable CCStatus and check that status is stored, 
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
 	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
-	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
-	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(false)).Times(1);
-
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
 	p_aamp->SetCCStatus(true);
-	EXPECT_TRUE(p_aamp->GetCCStatus()); // Preference is stored
+	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	// Now call TuneHelper to create the StreamAbstraction object
+	// SetSubtitleMute(false) should be called to apply the stored CC status
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(false)).Times(1);
 	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+
+	// Set mIsInbandCC to false to simulate it being done during Tune for OOB subtitles
+	p_aamp->mIsInbandCC = false;
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// Disable CCStatus and check that status is stored,
+	// and SetSubtitleMute(true) is called since we are now tuned
 	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(true)).Times(1);
 	p_aamp->SetCCStatus(false);
 	EXPECT_FALSE(p_aamp->GetCCStatus()); // Preference is stored
 }
 
-TEST_F(PrivAampTests,SetCCStatusWithVideoMutedTest)
+TEST_F(PrivAampTests,SetCCStatusPreTuneWithVideoMute01)
 {
-	// Test behaviour when video is muted BEFORE CC is enabled
-	// This tests the interaction when SetVideoMute(true) is called before SetCCStatus()
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
 
 	// Initial state - CC should be disabled by default (subtitles_muted=true)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
 
-	// Mute video first - in idle state, this will set video_muted=true but be cached
-	p_aamp->SetVideoMute(true);
-
-	// Now try to enable CC while video is muted
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
-	p_aamp->SetCCStatus(true);
-	EXPECT_TRUE(p_aamp->GetCCStatus()); // CC preference is true
-
-	// Unmute video - in idle state, this will set video_muted=false but be cached
-	p_aamp->SetVideoMute(false);
-	EXPECT_TRUE(p_aamp->GetCCStatus()); // CC preference is still true
-
-	// Enable CC preference again after unmuting video
-	// This should now enable CC since video is unmuted
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true))
-		.WillOnce(Return(0));
-	p_aamp->SetCCStatus(true);
-	EXPECT_TRUE(p_aamp->GetCCStatus()); // CC preference is still true
-
-	// Disable CC preference
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
-	p_aamp->SetCCStatus(false);
-	EXPECT_FALSE(p_aamp->GetCCStatus()); // CC preference is now false
-}
-
-TEST_F(PrivAampTests,SetCCStatusWithStreamAbstractionCreationTest)
-{
-	// Test that when SetCCStatus(true) is called before creating the StreamAbstraction object,
-	// CC has the expected value once the StreamAbstraction object is created
-
-	// Initially CC is disabled by default (subtitles_muted=true)
-	EXPECT_FALSE(p_aamp->GetCCStatus());
-
-	// Step 1: Enable CC first
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true))
-		.WillOnce(Return(0));
-	p_aamp->SetCCStatus(true);
-	EXPECT_TRUE(p_aamp->GetCCStatus());
-
-	// Step 2: SetStatus(true) will not be called when stream abstraction is created
-	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_))
-		.WillRepeatedly(Return(g_mockAampGstPlayer));
+	// Enable CC and check that status is stored, 
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
 	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
-
-	// Step 3: Call TuneHelper which will create the stream abstraction
-	TuneType tuneType = eTUNETYPE_NEW_NORMAL;
-	p_aamp->TuneHelper(tuneType, false);
-
-	// Verify that CC status preference is still true
-	EXPECT_TRUE(p_aamp->GetCCStatus());
-
-	// Cleanup: delete the StreamAbstraction object created by TuneHelper()
-	p_aamp->TeardownStream(false);
-}
-
-TEST_F(PrivAampTests,SetCCStatusAndSetVideoMuteWithStreamAbstractionCreationTest)
-{
-	// Test that PlayerCCManager::SetStatus() is called only when stream abstraction exists
-
-	// Initially CC is disabled by default (subtitles_muted=true)
-	EXPECT_FALSE(p_aamp->GetCCStatus());
-
-	// Enable CC first
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true))
-		.WillOnce(Return(0));
 	p_aamp->SetCCStatus(true);
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Set video to muted state - this will be cached since player is in idle state
+	// Set video mute - should not call SetStatus() since we are not yet tuned
 	p_aamp->SetVideoMute(true);
-
-	// Now call TuneHelper which will create the stream abstraction
-	// After stream abstraction is created, SetStatus(false) will be called because video is muted
-	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_))
-		.WillRepeatedly(Return(g_mockAampGstPlayer));
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
-	TuneType tuneType = eTUNETYPE_NEW_NORMAL;
-	p_aamp->TuneHelper(tuneType, false);
-
-	// Verify that CC status preference is still true
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Now that stream abstraction exists, SetCCStatus should trigger SetStatus() calls
-	// Since video is muted and CC is enabled, SetStatus(false) will be called
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
-	p_aamp->SetCCStatus(true);
+	// Now call TuneHelper to create the StreamAbstraction object
+	// SetStatus(false) should be called due to video being muted, overriding the stored CC status
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Cleanup: delete the StreamAbstraction object created by TuneHelper()
-	p_aamp->TeardownStream(false);
-}
-
-TEST_F(PrivAampTests,SetCCStatusWithStreamAbstractionTest)
-{
-	// Test CC status behavior with a mocked stream abstraction to verify SetStatus() calls
-	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP_MPD;
-
-	// Test enabling CC with stream abstraction available
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true))
-		.WillOnce(Return(0));
-	p_aamp->SetCCStatus(true);
-	EXPECT_TRUE(p_aamp->GetCCStatus());
-
-	// Test video mute affecting CC - SetVideoMute will trigger SetCCStatusInternal
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
-	p_aamp->SetVideoMute(true);
-
-	// Test unmuting video - SetVideoMute will trigger SetCCStatusInternal again
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true))
-		.WillOnce(Return(0));
+	// Disable video mute - SetVideoMute will trigger SetCCStatusInternal
+	// and SetStatus(true) is called since we are now tuned and stored CC status is true
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
 	p_aamp->SetVideoMute(false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+}
 
-	// Test disabling CC
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false))
-		.WillOnce(Return(0));
+// Same as previous test but video mute is set before CC enable
+TEST_F(PrivAampTests,SetCCStatusPreTuneWithVideoMute02)
+{
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
 
-	p_aamp->SetCCStatus(false);
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Set video mute - should not call SetStatus() since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	p_aamp->SetVideoMute(true);
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Enable CC and check that status is stored, 
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Now call TuneHelper to create the StreamAbstraction object
+	// SetStatus(false) should be called due to video being muted, overriding the stored CC status
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Disable video mute - SetVideoMute will trigger SetCCStatusInternal
+	// and SetStatus(true) is called since we are now tuned and stored CC status is true
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetVideoMute(false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+}
+
+TEST_F(PrivAampTests,SetCCStatusPostTuneWithVideoMute)
+{
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Set video mute - should not call SetStatus() since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	p_aamp->SetVideoMute(true);
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Now call TuneHelper to create the StreamAbstraction object
+	// SetStatus(false) should be called due to video being muted
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Enable CC and check that status is stored, however SetStatus(false) is called since video is still muted
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Disable video mute - SetVideoMute will trigger SetCCStatusInternal
+	// and SetStatus(true) is called since we are now tuned and stored CC status is true
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetVideoMute(false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
 }
 
 TEST_F(PrivAampTests,NotifyAudioTracksChangedTest)


### PR DESCRIPTION
…led (#691)

VPLAY-11707 Subtitles displayed for channels when subtitles are disabled

Reason for change:
Subtiles not initially muted when SetCCStatus called prior to load

Risks: Low

Test Procedure:
Test subtitles/closed captions are muted correctly, e.g. on tune

Priority: P1