### PR TITLE
VPLAY-11880:The manifest download keeps failing, eventually causing A…

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -279,7 +279,7 @@ void AampMPDDownloader::Release()
 			mMPDNotifierCondVar.notify_all();
 
 		}
-
+		//Disable downloads before joining the threads,which will exit the download loops gracefully 
 		mDownloader1.Release();
 		mDownloader2.Release();
 
@@ -288,6 +288,9 @@ void AampMPDDownloader::Release()
 
 		if(mDownloaderThread_t2.joinable())
 			mDownloaderThread_t2.join();
+		// Clear the headers only after the graceful exit of download threads.
+		mDownloader1.CleanupCurlHeaderResources();
+		mDownloader2.CleanupCurlHeaderResources();
 
 		if(mManifestUpdateCb != NULL)
 		{

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -383,6 +383,11 @@ void AampCurlDownloader::Release()
 {
 	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadActive = false;
+}
+
+void AampCurlDownloader::CleanupCurlHeaderResources()
+{
+	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadUpdatedTime = 0 ;
 	mDownloadStartTime =  0;
 	mWriteCallbackBufferSize = 0;

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -230,6 +230,10 @@ public:
 	* @param[in] dnldCfg - configuration for download
 	*/	
 	void Release();
+	/**
+	* @brief CleanupCurlHeaderResources - function to cleanup headers after thread join
+	*/
+	void CleanupCurlHeaderResources();
 	void Clear();
 	/**
 	* @brief Download - function to start  download 

--- a/test/utests/fakes/FakeAampCurlDownloader.cpp
+++ b/test/utests/fakes/FakeAampCurlDownloader.cpp
@@ -98,6 +98,10 @@ void AampCurlDownloader::Release()
 {
 }
 
+void AampCurlDownloader::CleanupCurlHeaderResources()
+{
+}
+
 
 void AampCurlDownloader::Clear()
 {

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -473,3 +473,63 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 	respData->show();
 	respData->clear();
 }
+
+/**
+ * @brief Test case to verify calling order: Release() before CleanupCurlHeaderResources()
+ * 
+ * This test demonstrates the recommended sequence where Release() is called first to stop
+ * downloads (sets mDownloadActive=false), followed by CleanupCurlHeaderResources() to free
+ * curl header resources. This ordering prevents potential race conditions where header
+ * resources could be freed while curl callbacks are still executing.
+ * 
+ */
+TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
+    DownloadConfigPtr config = std::make_shared<DownloadConfig>();
+    
+    EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+    EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+        .WillOnce(Return(CURLE_OK));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+        .WillOnce(Return(CURLE_OK));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+    
+    mAampCurlDownloader->Initialize(config);
+    
+    std::atomic<bool> releaseCompleted(false);
+    std::atomic<bool> headerCleanupStarted(false);
+    std::atomic<bool> raceConditionDetected(false);
+    
+    // Thread 1: Simulates download activity
+    std::thread downloadThread([&]() {
+        for (int i = 0; i < 100 && !releaseCompleted.load(); ++i) {
+            if (headerCleanupStarted.load() && !releaseCompleted.load()) {
+                raceConditionDetected.store(true);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+    
+    // Allow download thread to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    
+    // Step 1: Call Release() first to stop downloads
+	mAampCurlDownloader->Release();
+	releaseCompleted.store(true);
+    
+    // Step 2: Call CleanupCurlHeaderResources() after downloads stopped
+	headerCleanupStarted.store(true);
+	mAampCurlDownloader->CleanupCurlHeaderResources();
+    
+    downloadThread.join();
+    
+    // Verify no race condition detected
+    EXPECT_FALSE(raceConditionDetected.load()) 
+        << "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
+		
+	// Verify download is stopped
+	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
+}


### PR DESCRIPTION
…AMP to crash

VPLAY-11880:The manifest download keeps failing, eventually causing the AAMP to crash. (#718)

* Split AampCurlDownloader::Release() to fix thread-safe resource cleanup

Separated the Release() function into two parts to ensure thread-safe cleanup of curl headers:

1. Release() - Disables the downloader by setting mDownloadActive flag, allowing download threads to exit gracefully
2. ReleaseHeaders() - Cleans up curl headers and resets timing variables after threads have been joined

This prevents race conditions where headers could be freed while download threads are still active and potentially accessing them.

* Updated function name to better describe its purpose of initializing CURL header resources

* Added L1 test case

---------