### PR TITLE
VPLAY-12072 : Middleware leak m_drmConfigParam = new configs()

### DIFF
--- a/middleware/drm/DrmSessionManager.cpp
+++ b/middleware/drm/DrmSessionManager.cpp
@@ -79,6 +79,7 @@ DrmSessionManager::~DrmSessionManager()
 	MW_SAFE_DELETE_ARRAY(drmSessionContexts);
 	MW_SAFE_DELETE_ARRAY(cachedKeyIDs);
 	MW_SAFE_DELETE(playerSecInstance);
+	MW_SAFE_DELETE(m_drmConfigParam);
 	ContentSecurityManager::setWatermarkSessionEvent_CB(nullptr);
 }
 void DrmSessionManager::UpdateDRMConfig(


### PR DESCRIPTION
VPLAY-12072 : Middleware leak m_drmConfigParam = new configs()

Reason for change: Avoid memory leak in middleware component
Test Procedure:
refer ticket
Risks: Low
Priority: P1
Signed-off-by: Rekha Kandhavelan [[rekha_kandhavelan@comcast.com]