### PR TITLE
VPLAY-11815: [VIPA] Fix video freeze during linear channel tuning

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -598,7 +598,7 @@ bool StreamAbstractionAAMP_MPD::FetchFragment(MediaStreamContext *pMediaStreamCo
 	bool retval = true;
 
 	URLBitrateMap uriList;
-	if(pMediaStreamContext->mediaType == eMEDIATYPE_VIDEO)
+	if(pMediaStreamContext->mediaType == eMEDIATYPE_VIDEO && !ISCONFIGSET(eAAMPConfig_AudioOnlyPlayback))
 	{
 		GenerateFragmentURLList(uriList, pMediaStreamContext, isInitializationSegment);
 	}
@@ -13895,11 +13895,22 @@ void StreamAbstractionAAMP_MPD::OnFragmentDownloadComplete(bool status, Download
 }
 
 /**
- * @fn GenerateFragmentURLList
- * @param[out] uriList fragment url list, bitrate as key and url as value
- * @param[in] pMediaStreamContext MediaStreamContext object
- * @param[in] isInit true if init fragment
- * @return fragment url list, bitrate as key and url as value
+ * @brief Generates fragment URL list for video representations across all adaptation sets
+ *
+ * This function iterates through all adaptation sets in the current period and generates
+ * fragment URLs for video representations, while filtering out blacklisted adaptation sets.
+ * It handles different segment types (SegmentTemplate, SegmentBase, SegmentList) and
+ * supports both initialization and media fragments.
+ *
+ * @param[out] uriList Map of bandwidth to URI information for generated fragments
+ * @param[in] pMediaStreamContext Media stream context containing fragment descriptor info
+ * @param[in] isInit Flag indicating whether to generate initialization fragments (true)
+ *                   or media fragments (false)
+ *
+ * @return void
+ *
+ * @note The function respects blacklisted adaptation set indexes and only processes
+ *       video content types that match the current trickplay configuration
  */
 void StreamAbstractionAAMP_MPD::GenerateFragmentURLList(URLBitrateMap &uriList, MediaStreamContext *pMediaStreamContext, bool isInit)
 {
@@ -13909,158 +13920,176 @@ void StreamAbstractionAAMP_MPD::GenerateFragmentURLList(URLBitrateMap &uriList, 
 		return;
 	}
 
-	auto adaptationSet = pMediaStreamContext->adaptationSet;
-	if (!adaptationSet || !mMPDParseHelper->IsContentType(adaptationSet, eMEDIATYPE_VIDEO))
+	// set of blacklisted adaptation indexes for the current period
+	std::set<uint32_t> blAdaptationIdxs;
+	const auto &blacklistedProfiles = aamp->GetBlacklistedProfiles();
+	// Filter the blacklisted profiles in the period
+	for (auto &blProfile : blacklistedProfiles)
 	{
-		return;
+		if (blProfile.mPeriodId == mCurrentPeriod->GetId())
+		{
+			blAdaptationIdxs.insert(blProfile.mAdaptationSetIdx);
+		}
 	}
-
-	auto appendBaseUrls = [&](FragmentDescriptor *desc, IRepresentation *repr)
+	const auto &adaptationSets = mCurrentPeriod->GetAdaptationSets();
+	for (uint32_t idx = 0; idx < adaptationSets.size(); idx++)
 	{
-		desc->ClearMatchingBaseUrl();
-		desc->AppendMatchingBaseUrl(&mpd->GetBaseUrls());
-		desc->AppendMatchingBaseUrl(&mCurrentPeriod->GetBaseURLs());
-		desc->AppendMatchingBaseUrl(&adaptationSet->GetBaseURLs());
-		desc->AppendMatchingBaseUrl(&repr->GetBaseURLs());
-	};
-
-	for (auto &representation : adaptationSet->GetRepresentation())
-	{
-		URIInfo uriInfo;
-		auto fragmentDescriptor = aamp_utils::make_unique<FragmentDescriptor>();
-		fragmentDescriptor->Bandwidth = representation->GetBandwidth();
-		fragmentDescriptor->RepresentationID = representation->GetId();
-		fragmentDescriptor->bUseMatchingBaseUrl = ISCONFIGSET(eAAMPConfig_MatchBaseUrl);
-		fragmentDescriptor->manifestUrl = (mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING)
-											  ? aamp->GetManifestUrl()
-											  : pMediaStreamContext->fragmentDescriptor.manifestUrl;
-		appendBaseUrls(fragmentDescriptor.get(), representation);
-
-		SegmentTemplates segmentTemplates(representation->GetSegmentTemplate(), adaptationSet->GetSegmentTemplate());
-		if (segmentTemplates.HasSegmentTemplate())
+		// If index is not present in blacklisted adaptation indexes, proceed further
+		if (blAdaptationIdxs.find(idx) == blAdaptationIdxs.end() && adaptationSets[idx] && mMPDParseHelper->IsContentType(adaptationSets[idx], eMEDIATYPE_VIDEO))
 		{
-			std::string urlTemplate = isInit ? segmentTemplates.Getinitialization() : segmentTemplates.Getmedia();
-			if (urlTemplate.empty())
+			// count iframe/video representations based on trickplay for allocating streamInfo.
+			bool selected = UseIframeTrack() ? IsIframeTrack(adaptationSets[idx]) : !IsIframeTrack(adaptationSets[idx]);
+			if (selected)
 			{
-				AAMPLOG_ERR("media is empty for representation %s", representation->GetId().c_str());
-				continue;
-			}
-
-			fragmentDescriptor->Number = pMediaStreamContext->fragmentDescriptor.Number;
-			fragmentDescriptor->Time = pMediaStreamContext->fragmentDescriptor.Time;
-			fragmentDescriptor->TimeScale = pMediaStreamContext->fragmentDescriptor.TimeScale;
-
-
-			if(mIsFogTSB && isInit)
-			{
-				// Seperate handling for fog TSB init fragments
-				// For fog TSB, we need to fetch init fragments from available bitrates
-				auto reprFromAvailableBitrates = mMPDParseHelper->GetBitrateInfoFromCustomMpd(adaptationSet);
-				for (auto rep : reprFromAvailableBitrates)
+				const auto &adaptationSet = adaptationSets[idx];
+				auto appendBaseUrls = [&](FragmentDescriptor *desc, IRepresentation *repr)
 				{
-					URIInfo fogUriInfo;
-					fragmentDescriptor->Bandwidth = rep->GetBandwidth();
-					// Note : Don't use std::move on urlTemplate as its used multiple times in the loop
-					ConstructFragmentURL(fogUriInfo.url, fragmentDescriptor.get(), urlTemplate, aamp->mConfig);
-					uriList[fragmentDescriptor->Bandwidth] = std::move(fogUriInfo);
-				}
-				break; // No need to process further representations for fog TSB init fragments
-			}
-			else
-			{
-				// For non-fog TSB, we can use the representation's bandwidth
-				// to construct the URL for init fragments
-				ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), std::move(urlTemplate), aamp->mConfig);
-				uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
-				continue;
-			}
-		}
+					desc->ClearMatchingBaseUrl();
+					desc->AppendMatchingBaseUrl(&mpd->GetBaseUrls());
+					desc->AppendMatchingBaseUrl(&mCurrentPeriod->GetBaseURLs());
+					desc->AppendMatchingBaseUrl(&adaptationSet->GetBaseURLs());
+					desc->AppendMatchingBaseUrl(&repr->GetBaseURLs());
+				};
 
-		if (auto segmentBase = representation->GetSegmentBase())
-		{
-			if (isInit)
-			{
-				const IURLType *urlType = segmentBase->GetInitialization();
-				uriInfo.range = urlType ? urlType->GetRange() : segmentBase->GetIndexRange();
-
-				if (!urlType)
+				for (auto &representation : adaptationSet->GetRepresentation())
 				{
-					uint64_t s1, s2;
-					sscanf(uriInfo.range.c_str(), "%" PRIu64 "-%" PRIu64 "", &s1, &s2);
-					char temp[MAX_RANGE_STRING_CHARS];
-					snprintf(temp, sizeof(temp), "0-%" PRIu64, s1 - 1);
-					uriInfo.range = temp;
-				}
-			}
-			// For segment base, we need to use the index range for the URL
-			// The range is identified by parsing sidx box and it is done at downloader level
-			ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), "", aamp->mConfig);
-			uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
-			continue;
-		}
+					URIInfo uriInfo;
+					auto fragmentDescriptor = aamp_utils::make_unique<FragmentDescriptor>();
+					fragmentDescriptor->Bandwidth = representation->GetBandwidth();
+					fragmentDescriptor->RepresentationID = representation->GetId();
+					fragmentDescriptor->bUseMatchingBaseUrl = ISCONFIGSET(eAAMPConfig_MatchBaseUrl);
+					fragmentDescriptor->manifestUrl = (mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING)
+														  ? aamp->GetManifestUrl()
+														  : pMediaStreamContext->fragmentDescriptor.manifestUrl;
+					appendBaseUrls(fragmentDescriptor.get(), representation);
 
-		if (auto segmentList = representation->GetSegmentList())
-		{
-			if (isInit)
-			{
-				const IURLType *urlType = segmentList->GetInitialization();
-				if (!urlType)
-				{
-					// Check if the segment list has an initialization URL at adaptation set level
-					segmentList = adaptationSet->GetSegmentList();
-					urlType = segmentList ? segmentList->GetInitialization() : nullptr;
-					if (!urlType)
+					SegmentTemplates segmentTemplates(representation->GetSegmentTemplate(), adaptationSet->GetSegmentTemplate());
+					if (segmentTemplates.HasSegmentTemplate())
 					{
-						AAMPLOG_ERR("initialization is null in segmentList");
-						return;
-					}
-				}
-
-				std::string initUrl = urlType->GetSourceURL();
-				if (!initUrl.empty())
-				{
-					ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), std::move(initUrl), aamp->mConfig);
-					uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
-				}
-				else
-				{
-					// Segment list uses range, so parse init from first segment URL
-					const auto &segmentURLs = segmentList->GetSegmentURLs();
-					if (!segmentURLs.empty() && segmentURLs[0])
-					{
-						const char *rangeStr = segmentURLs[0]->GetMediaRange().c_str();
-						int start, end;
-						if (sscanf(rangeStr, "%d-%d", &start, &end) == 2 && start > 1)
+						std::string urlTemplate = isInit ? segmentTemplates.Getinitialization() : segmentTemplates.Getmedia();
+						if (urlTemplate.empty())
 						{
-							char temp[MAX_RANGE_STRING_CHARS];
-							snprintf(temp, sizeof(temp), "0-%d", start - 1);
-							uriInfo.range = temp;
-							ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), "", aamp->mConfig);
-							uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
+							AAMPLOG_ERR("media is empty for representation %s", representation->GetId().c_str());
+							continue;
+						}
+
+						fragmentDescriptor->Number = pMediaStreamContext->fragmentDescriptor.Number;
+						fragmentDescriptor->Time = pMediaStreamContext->fragmentDescriptor.Time;
+						fragmentDescriptor->TimeScale = pMediaStreamContext->fragmentDescriptor.TimeScale;
+
+						if (mIsFogTSB && isInit)
+						{
+							// Separate handling for fog TSB init fragments
+							// For fog TSB, we need to fetch init fragments from available bitrates
+							auto reprFromAvailableBitrates = mMPDParseHelper->GetBitrateInfoFromCustomMpd(adaptationSet);
+							for (auto rep : reprFromAvailableBitrates)
+							{
+								URIInfo fogUriInfo;
+								fragmentDescriptor->Bandwidth = rep->GetBandwidth();
+								// Note : Don't use std::move on urlTemplate as its used multiple times in the loop
+								ConstructFragmentURL(fogUriInfo.url, fragmentDescriptor.get(), urlTemplate, aamp->mConfig);
+								uriList[fragmentDescriptor->Bandwidth] = std::move(fogUriInfo);
+							}
+							break; // No need to process further representations for fog TSB init fragments
 						}
 						else
 						{
-							AAMPLOG_ERR("Cannot determine init range from segmentList");
+							// For non-fog TSB, we can use the representation's bandwidth
+							// to construct the URL for init fragments
+							ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), std::move(urlTemplate), aamp->mConfig);
+							uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
+							continue;
 						}
 					}
-				}
-			}
-			else
-			{
-				const auto &segmentURLs = segmentList->GetSegmentURLs();
-				if (pMediaStreamContext->fragmentIndex < segmentURLs.size() && segmentURLs[pMediaStreamContext->fragmentIndex])
-				{
-					auto *segmentURL = segmentURLs[pMediaStreamContext->fragmentIndex];
-					auto rawAttrs = segmentList->GetRawAttributes();
-					if (rawAttrs.find("customlist") == rawAttrs.end())
+
+					if (auto segmentBase = representation->GetSegmentBase())
 					{
-						ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), segmentURL->GetMediaURI(), aamp->mConfig);
-						uriInfo.range = segmentURL->GetMediaRange();
+						if (isInit)
+						{
+							const IURLType *urlType = segmentBase->GetInitialization();
+							uriInfo.range = urlType ? urlType->GetRange() : segmentBase->GetIndexRange();
+
+							if (!urlType)
+							{
+								uint64_t s1, s2;
+								sscanf(uriInfo.range.c_str(), "%" PRIu64 "-%" PRIu64 "", &s1, &s2);
+								char temp[MAX_RANGE_STRING_CHARS];
+								snprintf(temp, sizeof(temp), "0-%" PRIu64, s1 - 1);
+								uriInfo.range = temp;
+							}
+						}
+						// For segment base, we need to use the index range for the URL
+						// The range is identified by parsing sidx box and it is done at downloader level
+						ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), "", aamp->mConfig);
 						uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
+						continue;
 					}
-					else
+
+					if (auto segmentList = representation->GetSegmentList())
 					{
-						AAMPLOG_ERR("segmentList is unsupported (customlist)");
+						if (isInit)
+						{
+							const IURLType *urlType = segmentList->GetInitialization();
+							if (!urlType)
+							{
+								// Check if the segment list has an initialization URL at adaptation set level
+								segmentList = adaptationSet->GetSegmentList();
+								urlType = segmentList ? segmentList->GetInitialization() : nullptr;
+								if (!urlType)
+								{
+									AAMPLOG_ERR("initialization is null in segmentList");
+									return;
+								}
+							}
+
+							std::string initUrl = urlType->GetSourceURL();
+							if (!initUrl.empty())
+							{
+								ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), std::move(initUrl), aamp->mConfig);
+								uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
+							}
+							else
+							{
+								// Segment list uses range, so parse init from first segment URL
+								const auto &segmentURLs = segmentList->GetSegmentURLs();
+								if (!segmentURLs.empty() && segmentURLs[0])
+								{
+									const char *rangeStr = segmentURLs[0]->GetMediaRange().c_str();
+									int start, end;
+									if (sscanf(rangeStr, "%d-%d", &start, &end) == 2 && start > 1)
+									{
+										char temp[MAX_RANGE_STRING_CHARS];
+										snprintf(temp, sizeof(temp), "0-%d", start - 1);
+										uriInfo.range = temp;
+										ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), "", aamp->mConfig);
+										uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
+									}
+									else
+									{
+										AAMPLOG_ERR("Cannot determine init range from segmentList");
+									}
+								}
+							}
+						}
+						else
+						{
+							const auto &segmentURLs = segmentList->GetSegmentURLs();
+							if (pMediaStreamContext->fragmentIndex < segmentURLs.size() && segmentURLs[pMediaStreamContext->fragmentIndex])
+							{
+								auto *segmentURL = segmentURLs[pMediaStreamContext->fragmentIndex];
+								auto rawAttrs = segmentList->GetRawAttributes();
+								if (rawAttrs.find("customlist") == rawAttrs.end())
+								{
+									ConstructFragmentURL(uriInfo.url, fragmentDescriptor.get(), segmentURL->GetMediaURI(), aamp->mConfig);
+									uriInfo.range = segmentURL->GetMediaRange();
+									uriList[fragmentDescriptor->Bandwidth] = std::move(uriInfo);
+								}
+								else
+								{
+									AAMPLOG_ERR("segmentList is unsupported (customlist)");
+								}
+							}
+						}
 					}
 				}
 			}

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -997,6 +997,617 @@ TEST_F(FetcherLoopTests, SelectSourceOrAdPeriodTests3)
 	EXPECT_EQ(mTestableStreamAbstractionAAMP_MPD->GetIteratorPeriodIdx(), 1);
 }
 
+/**
+ * @brief GenerateFragmentURLList tests.
+ *
+ * The tests verify the GenerateFragmentURLList method of StreamAbstractionAAMP_MPD for
+ * video-only manifest scenarios. The function should generate URLs for all representations
+ * in the adaptation set at a specific Number/Time specified in the MediaStreamContext.
+ */
+TEST_F(FetcherLoopTests, GenerateFragmentURLListVideoOnly)
+{
+	static const char *videoOnlyManifest = R"(<?xml version="1.0" encoding="utf-8"?>
+		<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="static">
+			<Period id="p0" start="PT0S">
+				<AdaptationSet id="0" contentType="video">
+					<Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_p0_init.mp4" media="video_p0_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="9" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+			</Period>
+		</MPD>
+		)";
+
+	std::string fragmentUrl;
+	AAMPStatusType status;
+
+	/* Initialize MPD. The video initialization segment is cached. */
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_p0_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(videoOnlyManifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	// Index the MPD document
+	status = mTestableStreamAbstractionAAMP_MPD->InvokeIndexNewMPDDocument(false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *videoTrack = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	EXPECT_NE(videoTrack, nullptr);
+
+	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
+	EXPECT_NE(pVideoContext, nullptr);
+
+	// Test GenerateFragmentURLList for video track
+	// Set fragment descriptor for segment 5 (Number=5, Time=20000 which is 5th segment at 5000 duration each)
+	pVideoContext->fragmentDescriptor.Number = 5;
+	pVideoContext->fragmentDescriptor.Time = 20000;  // 5th segment (4*5000 offset)
+	pVideoContext->fragmentDescriptor.TimeScale = 2500;
+	pVideoContext->fragmentDescriptor.Bandwidth = 800000;
+
+	URLBitrateMap uriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	// Should generate URL for the single representation at the specified Number/Time
+	EXPECT_EQ(uriList.size(), 1);
+	EXPECT_NE(uriList.find(800000), uriList.end());
+
+	// Verify URL format contains correct segment number
+	const auto& url = uriList[800000].url;
+	EXPECT_TRUE(url.find("video_p0_5.m4s") != std::string::npos);
+
+	// Test with initialization segment
+	URLBitrateMap initUriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(initUriList, pVideoContext, true);
+
+	EXPECT_EQ(initUriList.size(), 1);
+	EXPECT_NE(initUriList.find(800000), initUriList.end());
+	const auto& initUrl = initUriList[800000].url;
+	EXPECT_TRUE(initUrl.find("video_p0_init.mp4") != std::string::npos);
+}
+
+/**
+ * @brief GenerateFragmentURLList tests.
+ *
+ * The tests verify the GenerateFragmentURLList method of StreamAbstractionAAMP_MPD for
+ * intra-asset content with representations split in multiple adaptations. Tests that
+ * given a specific Number/Time in the MediaStreamContext, the function generates URLs
+ * for ALL representations in the current adaptation set at that same Number/Time.
+ */
+TEST_F(FetcherLoopTests, GenerateFragmentURLListIntraAssetMultipleAdaptations)
+{
+	static const char *multiAdaptationManifest = R"(<?xml version="1.0" encoding="utf-8"?>
+		<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="static">
+			<Period id="p0" start="PT0S">
+				<AdaptationSet id="0" contentType="video" intraAssetType="main">
+					<Representation id="video_main_low" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_main_low_init.mp4" media="video_main_low_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+					<Representation id="video_main_high" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000" width="1280" height="720" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_main_high_init.mp4" media="video_main_high_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="1" contentType="video" intraAssetType="commentary">
+					<Representation id="video_commentary" mimeType="video/mp4" codecs="avc1.640028" bandwidth="400000" width="320" height="240" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_commentary_init.mp4" media="video_commentary_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="2" contentType="video" intraAssetType="alternate">
+					<Representation id="video_alternate_1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1200000" width="960" height="540" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_alt1_init.mp4" media="video_alt1_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+					<Representation id="video_alternate_2" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1600000" width="1024" height="576" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_alt2_init.mp4" media="video_alt2_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="3" contentType="audio" lang="eng">
+					<Representation id="audio_eng" mimeType="audio/mp4" codecs="ec-3" bandwidth="128000">
+						<SegmentTemplate timescale="2500" initialization="audio_eng_init.mp4" media="audio_eng_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+			</Period>
+		</MPD>
+		)";
+
+	std::string fragmentUrl;
+	AAMPStatusType status;
+
+	/* Initialize MPD. The video and audio initialization segments are cached. */
+	//fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_main_low_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_eng_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(multiAdaptationManifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	// Index the MPD document
+	status = mTestableStreamAbstractionAAMP_MPD->InvokeIndexNewMPDDocument(false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *videoTrack = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	EXPECT_NE(videoTrack, nullptr);
+
+	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
+	EXPECT_NE(pVideoContext, nullptr);
+
+	// Test GenerateFragmentURLList for video adaptation with multiple representations
+	// Set fragment descriptor for segment 3 at time 10000
+	pVideoContext->fragmentDescriptor.Number = 3;
+	pVideoContext->fragmentDescriptor.Time = 10000;
+	pVideoContext->fragmentDescriptor.TimeScale = 2500;
+	pVideoContext->fragmentDescriptor.Bandwidth = 800000;  // Current bitrate
+
+	// Test media segments - should generate URLs for BOTH representations in the adaptation set
+	URLBitrateMap uriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	// Should generate URLs for all unique representations (5) in the adaptation set
+	EXPECT_EQ(uriList.size(), 5);
+
+	// Verify low bitrate representation
+	EXPECT_NE(uriList.find(800000), uriList.end());
+	const auto& lowUrl = uriList[800000].url;
+	EXPECT_TRUE(lowUrl.find("video_main_low_3.m4s") != std::string::npos);
+
+	// Verify high bitrate representation
+	EXPECT_NE(uriList.find(2000000), uriList.end());
+	const auto& highUrl = uriList[2000000].url;
+	EXPECT_TRUE(highUrl.find("video_main_high_3.m4s") != std::string::npos);
+
+	// Test initialization segments - should also generate for both representations
+	URLBitrateMap initUriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(initUriList, pVideoContext, true);
+
+	// Should generate init URLs for all unique representations (5) in the adaptation set
+	EXPECT_EQ(initUriList.size(), 5);
+
+	// Verify init segments
+	EXPECT_NE(initUriList.find(800000), initUriList.end());
+	EXPECT_TRUE(initUriList[800000].url.find("video_main_low_init.mp4") != std::string::npos);
+
+	EXPECT_NE(initUriList.find(2000000), initUriList.end());
+	EXPECT_TRUE(initUriList[2000000].url.find("video_main_high_init.mp4") != std::string::npos);
+}
+
+/**
+ * @brief GenerateFragmentURLList tests.
+ *
+ * The tests verify the GenerateFragmentURLList method behavior with edge cases
+ * such as null context. Tests that the function handles null input gracefully and
+ * generates proper URLs when given valid MediaStreamContext with Number/Time set.
+ */
+TEST_F(FetcherLoopTests, GenerateFragmentURLListEdgeCases)
+{
+	static const char *simpleManifest = R"(<?xml version="1.0" encoding="utf-8"?>
+		<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="static">
+			<Period id="p0" start="PT0S">
+				<AdaptationSet id="0" contentType="video">
+					<Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_init.mp4" media="video_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="4" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+			</Period>
+		</MPD>
+		)";
+
+	std::string fragmentUrl;
+	AAMPStatusType status;
+
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(simpleManifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	status = mTestableStreamAbstractionAAMP_MPD->InvokeIndexNewMPDDocument(false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *videoTrack = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	EXPECT_NE(videoTrack, nullptr);
+	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
+
+	URLBitrateMap uriList;
+
+	// Test with null context - should handle gracefully
+	uriList.clear();
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, nullptr, false);
+	EXPECT_TRUE(uriList.empty());
+
+	// Test with valid context and proper fragment descriptor
+	pVideoContext->fragmentDescriptor.Number = 2;
+	pVideoContext->fragmentDescriptor.Time = 5000;
+	pVideoContext->fragmentDescriptor.TimeScale = 2500;
+	pVideoContext->fragmentDescriptor.Bandwidth = 800000;
+
+	uriList.clear();
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	// Should generate URL for the representation
+	EXPECT_FALSE(uriList.empty());
+	EXPECT_NE(uriList.find(800000), uriList.end());
+	EXPECT_TRUE(uriList[800000].url.find("video_2.m4s") != std::string::npos);
+
+	// Test init segment
+	uriList.clear();
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, true);
+	EXPECT_FALSE(uriList.empty());
+	EXPECT_TRUE(uriList[800000].url.find("video_init.mp4") != std::string::npos);
+}
+
+/**
+ * @brief GenerateFragmentURLList tests.
+ *
+ * The tests verify the GenerateFragmentURLList method with SegmentList format
+ * instead of SegmentTemplate. Tests that given a fragment index in MediaStreamContext,
+ * the function generates URLs for all representations at that same fragment index.
+ */
+TEST_F(FetcherLoopTests, GenerateFragmentURLListSegmentList)
+{
+	static const char *segmentListManifest = R"(<?xml version="1.0" encoding="utf-8"?>
+		<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="static">
+			<Period id="p0" start="PT0S">
+				<AdaptationSet id="0" contentType="video">
+					<Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+						<SegmentList timescale="2500" duration="5000">
+							<Initialization sourceURL="video_init.mp4"/>
+							<SegmentURL media="video_seg1.m4s"/>
+							<SegmentURL media="video_seg2.m4s"/>
+							<SegmentURL media="video_seg3.m4s"/>
+							<SegmentURL media="video_seg4.m4s"/>
+							<SegmentURL media="video_seg5.m4s"/>
+						</SegmentList>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="1" contentType="video" intraAssetType="alternate">
+					<Representation id="1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1200000" width="960" height="540" frameRate="25">
+						<SegmentList timescale="2500" duration="5000">
+							<Initialization sourceURL="video_alt_init.mp4"/>
+							<SegmentURL media="video_alt_seg1.m4s"/>
+							<SegmentURL media="video_alt_seg2.m4s"/>
+							<SegmentURL media="video_alt_seg3.m4s"/>
+							<SegmentURL media="video_alt_seg4.m4s"/>
+							<SegmentURL media="video_alt_seg5.m4s"/>
+						</SegmentList>
+					</Representation>
+				</AdaptationSet>
+			</Period>
+		</MPD>
+		)";
+
+	std::string fragmentUrl;
+	AAMPStatusType status;
+
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(segmentListManifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	status = mTestableStreamAbstractionAAMP_MPD->InvokeIndexNewMPDDocument(false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *videoTrack = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	EXPECT_NE(videoTrack, nullptr);
+	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
+
+	URLBitrateMap uriList;
+
+	// Set fragment index to 2 (3rd segment - 0-indexed)
+	pVideoContext->fragmentIndex = 2;
+	pVideoContext->fragmentDescriptor.Bandwidth = 800000;
+
+	// Test media segment from SegmentList - should generate URLs for all representations
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	// Should generate URLs for both representations (main and alternate) at the same fragment index
+	EXPECT_EQ(uriList.size(), 2);
+
+	// Verify main representation (800kbps)
+	EXPECT_NE(uriList.find(800000), uriList.end());
+	const auto& mainUrl = uriList[800000].url;
+	EXPECT_TRUE(mainUrl.find("video_seg3.m4s") != std::string::npos);
+
+	// Verify alternate representation (1200kbps)
+	EXPECT_NE(uriList.find(1200000), uriList.end());
+	const auto& altUrl = uriList[1200000].url;
+	EXPECT_TRUE(altUrl.find("video_alt_seg3.m4s") != std::string::npos);
+
+	// Test initialization segments
+	uriList.clear();
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, true);
+
+	EXPECT_EQ(uriList.size(), 2);
+
+	// Verify init URLs for both representations
+	EXPECT_NE(uriList.find(800000), uriList.end());
+	EXPECT_TRUE(uriList[800000].url.find("video_init.mp4") != std::string::npos);
+
+	EXPECT_NE(uriList.find(1200000), uriList.end());
+	EXPECT_TRUE(uriList[1200000].url.find("video_alt_init.mp4") != std::string::npos);
+
+	// Test with different fragment index
+	pVideoContext->fragmentIndex = 0;
+	uriList.clear();
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	EXPECT_EQ(uriList.size(), 2);
+	EXPECT_TRUE(uriList[800000].url.find("video_seg1.m4s") != std::string::npos);
+	EXPECT_TRUE(uriList[1200000].url.find("video_alt_seg1.m4s") != std::string::npos);
+}
+
+/**
+ * @brief GenerateFragmentURLList tests with blacklisted adaptations.
+ *
+ * The tests verify that GenerateFragmentURLList correctly filters out blacklisted
+ * adaptation sets and only generates URLs for non-blacklisted adaptations.
+ */
+TEST_F(FetcherLoopTests, GenerateFragmentURLListWithBlacklistedAdaptations)
+{
+	static const char *multiAdaptationManifest = R"(<?xml version="1.0" encoding="utf-8"?>
+		<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="static">
+			<Period id="p0" start="PT0S">
+				<AdaptationSet id="0" contentType="video">
+					<Representation id="video_low" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_low_init.mp4" media="video_low_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+					<Representation id="video_high" mimeType="video/mp4" codecs="avc1.640028" bandwidth="2000000" width="1280" height="720" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_high_init.mp4" media="video_high_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="1" contentType="video" intraAssetType="alternate">
+					<Representation id="video_alt1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1200000" width="960" height="540" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_alt1_init.mp4" media="video_alt1_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+					<Representation id="video_alt2" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1600000" width="1024" height="576" frameRate="25">
+						<SegmentTemplate timescale="2500" initialization="video_alt2_init.mp4" media="video_alt2_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="2" contentType="video" intraAssetType="alternate2">
+					<Representation id="video_alt3" mimeType="video/mp4" codecs="avc1.640028" bandwidth="3000000" width="1920" height="1080" frameRate="30">
+						<SegmentTemplate timescale="2500" initialization="video_alt3_init.mp4" media="video_alt3_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="3" contentType="audio" lang="eng">
+					<Representation id="audio_eng" mimeType="audio/mp4" codecs="ec-3" bandwidth="128000">
+						<SegmentTemplate timescale="2500" initialization="audio_eng_init.mp4" media="audio_eng_$Number$.m4s" startNumber="1">
+							<SegmentTimeline>
+								<S t="0" d="5000" r="14" />
+							</SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+			</Period>
+		</MPD>
+		)";
+
+	std::string fragmentUrl;
+	AAMPStatusType status;
+
+	// Setup blacklist: Adaptation set 1 is blacklisted
+	StreamBlacklistProfileInfo blInfo;
+	blInfo.mPeriodId = "p0";
+	blInfo.mAdaptationSetIdx = 1; // Blacklist adaptation set 1
+	blInfo.mReason = PROFILE_BLACKLIST_DRM_FAILURE;
+	mPrivateInstanceAAMP->AddToBlacklistedProfiles(blInfo);
+
+	/* Initialize MPD */
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	fragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_eng_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(fragmentUrl, _, _, _, _, true, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	status = InitializeMPD(multiAdaptationManifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	// Index the MPD document
+	status = mTestableStreamAbstractionAAMP_MPD->InvokeIndexNewMPDDocument(false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *videoTrack = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	EXPECT_NE(videoTrack, nullptr);
+
+	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
+	EXPECT_NE(pVideoContext, nullptr);
+
+	// Set fragment descriptor
+	pVideoContext->fragmentDescriptor.Number = 5;
+	pVideoContext->fragmentDescriptor.Time = 20000;
+	pVideoContext->fragmentDescriptor.TimeScale = 2500;
+	pVideoContext->fragmentDescriptor.Bandwidth = 800000;
+
+	// Test GenerateFragmentURLList - should only include non-blacklisted adaptations
+	URLBitrateMap uriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	// Should generate URLs for 4 representations (2 from adaptation 0 + 1 from adaptation 2)
+	// Adaptation 1 is blacklisted, so its 2 representations should be excluded
+	EXPECT_EQ(uriList.size(), 3);
+
+	// Verify adaptation 0 representations are included
+	EXPECT_NE(uriList.find(800000), uriList.end());
+	EXPECT_TRUE(uriList[800000].url.find("video_low_5.m4s") != std::string::npos);
+
+	EXPECT_NE(uriList.find(2000000), uriList.end());
+	EXPECT_TRUE(uriList[2000000].url.find("video_high_5.m4s") != std::string::npos);
+
+	// Verify adaptation 1 representations are NOT included (blacklisted)
+	EXPECT_EQ(uriList.find(1200000), uriList.end());
+	EXPECT_EQ(uriList.find(1600000), uriList.end());
+
+	// Verify adaptation 2 representation is included
+	EXPECT_NE(uriList.find(3000000), uriList.end());
+	EXPECT_TRUE(uriList[3000000].url.find("video_alt3_5.m4s") != std::string::npos);
+
+	// Test with init segments
+	URLBitrateMap initUriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(initUriList, pVideoContext, true);
+
+	EXPECT_EQ(initUriList.size(), 3);
+	EXPECT_NE(initUriList.find(800000), initUriList.end());
+	EXPECT_NE(initUriList.find(2000000), initUriList.end());
+	EXPECT_NE(initUriList.find(3000000), initUriList.end());
+
+	// Blacklisted adaptations should not be in init list
+	EXPECT_EQ(initUriList.find(1200000), initUriList.end());
+	EXPECT_EQ(initUriList.find(1600000), initUriList.end());
+}
+
+/**
+ * @brief GenerateFragmentURLList tests with multiple blacklisted adaptations.
+ *
+ * Verifies that when multiple adaptation sets are blacklisted, only
+ * non-blacklisted adaptations generate URLs.
+ */
+TEST_F(FetcherLoopTests, GenerateFragmentURLListWithMultipleBlacklistedAdaptations)
+{
+	static const char *manifest = R"(<?xml version="1.0" encoding="utf-8"?>
+		<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" type="static">
+			<Period id="p0" start="PT0S">
+				<AdaptationSet id="0" contentType="video">
+					<Representation id="v0" bandwidth="500000">
+						<SegmentTemplate timescale="1000" initialization="v0_init.mp4" media="v0_$Number$.m4s" startNumber="1">
+							<SegmentTimeline><S t="0" d="2000" r="9" /></SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="1" contentType="video">
+					<Representation id="v1" bandwidth="1000000">
+						<SegmentTemplate timescale="1000" initialization="v1_init.mp4" media="v1_$Number$.m4s" startNumber="1">
+							<SegmentTimeline><S t="0" d="2000" r="9" /></SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="2" contentType="video">
+					<Representation id="v2" bandwidth="1500000">
+						<SegmentTemplate timescale="1000" initialization="v2_init.mp4" media="v2_$Number$.m4s" startNumber="1">
+							<SegmentTimeline><S t="0" d="2000" r="9" /></SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+				<AdaptationSet id="3" contentType="audio">
+					<Representation id="a0" bandwidth="128000">
+						<SegmentTemplate timescale="1000" initialization="a0_init.mp4" media="a0_$Number$.m4s" startNumber="1">
+							<SegmentTimeline><S t="0" d="2000" r="9" /></SegmentTimeline>
+						</SegmentTemplate>
+					</Representation>
+				</AdaptationSet>
+			</Period>
+		</MPD>
+		)";
+
+	// Blacklist adaptation sets 0 and 2
+	StreamBlacklistProfileInfo blInfo1;
+	blInfo1.mPeriodId = "p0";
+	blInfo1.mAdaptationSetIdx = 0;
+	blInfo1.mReason = PROFILE_BLACKLIST_DRM_FAILURE;
+	mPrivateInstanceAAMP->AddToBlacklistedProfiles(blInfo1);
+
+	StreamBlacklistProfileInfo blInfo2;
+	blInfo2.mPeriodId = "p0";
+	blInfo2.mAdaptationSetIdx = 2;
+	blInfo2.mReason = PROFILE_BLACKLIST_DRM_FAILURE;
+	mPrivateInstanceAAMP->AddToBlacklistedProfiles(blInfo2);
+
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _))
+		.Times(::testing::AtLeast(1))
+		.WillRepeatedly(Return(true));
+
+	AAMPStatusType status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	status = mTestableStreamAbstractionAAMP_MPD->InvokeIndexNewMPDDocument(false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *videoTrack = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	ASSERT_NE(videoTrack, nullptr);
+
+	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
+	pVideoContext->fragmentDescriptor.Number = 3;
+	pVideoContext->fragmentDescriptor.Time = 4000;
+	pVideoContext->fragmentDescriptor.TimeScale = 1000;
+	pVideoContext->fragmentDescriptor.Bandwidth = 1000000;
+
+	URLBitrateMap uriList;
+	mTestableStreamAbstractionAAMP_MPD->GenerateFragmentURLList(uriList, pVideoContext, false);
+
+	// Only adaptation 1 should be included (adaptations 0 and 2 are blacklisted)
+	EXPECT_EQ(uriList.size(), 1);
+	EXPECT_NE(uriList.find(1000000), uriList.end());
+	EXPECT_TRUE(uriList[1000000].url.find("v1_3.m4s") != std::string::npos);
+
+	// Blacklisted adaptations should not appear
+	EXPECT_EQ(uriList.find(500000), uriList.end());
+	EXPECT_EQ(uriList.find(1500000), uriList.end());
+}
+
 TEST_F(FetcherLoopTests, SkipFetchAudioTests)
 {
 	static const char *manifest =

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -391,7 +391,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 
 		MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
 		double fragmentDuration = ComputeFragmentDuration(12, 12); (void)fragmentDuration;
-		pMediaStreamContext->mediaType = eMEDIATYPE_VIDEO;
+		pMediaStreamContext->mediaType = static_cast<AampMediaType>(trackType);
 
 		SegmentTemplate *segmentTemplate = new SegmentTemplate();
 		const IFailoverContent *failoverContent = segmentTemplate->GetFailoverContent(); (void)failoverContent;


### PR DESCRIPTION
Reason for change: Fix GenerateFragmentURLList to consider intra assets and blacklisted profiles while selecting video URLs.
Risks: Low
Test Procedure: Test with intra asset channels

Signed-off-by: Nandakishor U M <nu641001@gmail.com>