### PR TITLE
VPLAY-12098: Fix L1 issues due to CPIX change revert

### DIFF
--- a/middleware/test/utests/fakes/Fakeopencdmsessionadapter.cpp
+++ b/middleware/test/utests/fakes/Fakeopencdmsessionadapter.cpp
@@ -24,7 +24,6 @@
 
 MockOpenCdmSessionAdapter *g_mockOpenCdmSessionAdapter = nullptr;
 std::vector<uint8_t> g_mockKeyId{1,2,3,4,5,6,7,8,9,0,1,2,3,4};
-const std::vector<std::vector<uint8_t>> g_emptyUsableKeys;
 
 OCDMSessionAdapter::OCDMSessionAdapter(std::shared_ptr<DrmHelper> drmHelper, DrmCallbacks *callbacks) :
     DrmSession("ocdmkeysystem"), m_keyId{g_mockKeyId}, m_drmHelper{drmHelper}
@@ -69,13 +68,7 @@ bool OCDMSessionAdapter::waitForState(KeyState state, const uint32_t timeout)
 {
     return true;
 }
-const std::vector<std::vector<uint8_t>>& OCDMSessionAdapter::getUsableKeys() const
-{
-    if (g_mockOpenCdmSessionAdapter) {
-        return g_mockOpenCdmSessionAdapter->getUsableKeys();
-    }
-    return g_emptyUsableKeys;
-}
+
 #if defined(USE_OPENCDM_ADAPTER)
 void OCDMSessionAdapter::setKeyId(const std::vector<uint8_t>& keyId)
 {

--- a/middleware/test/utests/mocks/MockOpenCdmSessionAdapter.h
+++ b/middleware/test/utests/mocks/MockOpenCdmSessionAdapter.h
@@ -28,7 +28,6 @@ class MockOpenCdmSessionAdapter
     public:
 
         MOCK_METHOD(bool, verifyOutputProtection, ());
-        MOCK_METHOD(const std::vector<std::vector<uint8_t>>&, getUsableKeys, (), (const));
         MOCK_METHOD(void, setKeyId, (const std::vector<uint8_t>&));
 };
 

--- a/middleware/test/utests/tests/OcdmBasicSessionAdapterTests/FunctionalTests.cpp
+++ b/middleware/test/utests/tests/OcdmBasicSessionAdapterTests/FunctionalTests.cpp
@@ -78,8 +78,6 @@ protected:
 		g_mockopencdm = new NiceMock<MockOpenCdm>();
 		m_ocdmbasicsessionadapter = new OCDMBasicSessionAdapter(drmHelper,nullptr);
 		g_mockOpenCdmSessionAdapter = new NiceMock<MockOpenCdmSessionAdapter>();
-		// Set default return value for getUsableKeys() to return an empty vector
-		ON_CALL(*g_mockOpenCdmSessionAdapter, getUsableKeys()).WillByDefault(testing::ReturnRef(g_emptyKeys));
 		g_mockMemorySystem = new NiceMock<MockDrmMemorySystem>();
 	}
 


### PR DESCRIPTION
Reason for change: Fix L1 middleware tests that are broken due to CPIX change revert
Test Procedure: Confirm L1 is working fine
Risks: None