### PR TITLE
VPLAY-12179 Race condition in AampTrackWorker highlighted by L1 test

### DIFF
--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -298,7 +298,7 @@ namespace aamp
 	void AampTrackWorker::Pause()
 	{
 		std::lock_guard<std::mutex> lock(mQueueMutex);
-		mPaused.store(true);
+		mPaused = true;
 		AAMPLOG_DEBUG("Pausing worker thread for media type %s", GetMediaTypeName(mMediaType));
 		mCondVar.notify_one(); // Wake up thread to pause
 	}
@@ -313,7 +313,7 @@ namespace aamp
 	void AampTrackWorker::Resume()
 	{
 		std::lock_guard<std::mutex> lock(mQueueMutex);
-		mPaused.store(false);
+		mPaused = false;
 		AAMPLOG_DEBUG("Resuming worker thread for media type %s", GetMediaTypeName(mMediaType));
 		mCondVar.notify_one();
 	}
@@ -387,7 +387,7 @@ namespace aamp
 
 				// Wait while (queue is empty or paused) and not stopped
 				self->mCondVar.wait(lock, [&] {
-					return self->mStop.load() || (!self->mPaused.load() && !self->mJobQueue.empty());
+					return self->mStop.load() || (!self->mPaused && !self->mJobQueue.empty());
 				});
 
 				if (self->mStop.load())
@@ -396,7 +396,7 @@ namespace aamp
 					break;
 				}
 
-				if (self->mPaused.load())
+				if (self->mPaused)
 				{
 					AAMPLOG_DEBUG("Worker thread paused for media type %s", GetMediaTypeName(self->mMediaType));
 					continue;

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -297,6 +297,7 @@ namespace aamp
 	 */
 	void AampTrackWorker::Pause()
 	{
+		std::lock_guard<std::mutex> lock(mQueueMutex);
 		mPaused.store(true);
 		AAMPLOG_DEBUG("Pausing worker thread for media type %s", GetMediaTypeName(mMediaType));
 		mCondVar.notify_one(); // Wake up thread to pause
@@ -311,6 +312,7 @@ namespace aamp
 	 */
 	void AampTrackWorker::Resume()
 	{
+		std::lock_guard<std::mutex> lock(mQueueMutex);
 		mPaused.store(false);
 		AAMPLOG_DEBUG("Resuming worker thread for media type %s", GetMediaTypeName(mMediaType));
 		mCondVar.notify_one();

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -163,7 +163,7 @@ namespace aamp
 		PrivateInstanceAAMP *aamp;
 		std::atomic<bool> mInitialized; // Flag to indicate if the worker is initialized
 		std::atomic<bool> mStop;
-		std::atomic<bool> mPaused; // Flag to pause the worker threads
+		bool mPaused; // Flag to pause the worker threads (protected by mQueueMutex)
 
 	private:
 		void ProcessJob(AampTrackWorkerWeakPtr weakSelf);

--- a/test/utests/tests/AampTrackWorkerTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampTrackWorkerTests/FunctionalTests.cpp
@@ -75,7 +75,8 @@ protected:
 
 		bool IsPaused()
 		{
-			return mPaused.load();
+			std::lock_guard<std::mutex> lock(mQueueMutex);
+			return mPaused;
 		}
 	};
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;


### PR DESCRIPTION
Fixed intermittent test failure where worker thread could miss wake-up notifications. Added mutex lock to Pause() and Resume()  to synchronize mPaused flag updates with the condition variable wait predicate in ProcessJob(), preventing lost notifications.

Risk: Low