### PR TITLE
VPLAY-11809 : Enhance UveAAMP stop() API with DRM handle cleanup parameter to prevent Deep Sleep playback failures

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -407,15 +407,34 @@ Note: starting in RDK 6.9, we support ability to start video paused on first fra
 
 ---
 
-### stop()
+### stop( forceCleanup )
+### stop( sendStateChangeEvent, forceCleanup )
 - Supported UVE version 0.7 and above.
 - Stop playback and free resources associated with playback.
-Usage example:
+
+**Single Parameter Form:**
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| forceCleanup | Boolean | Optional parameter. If true, forces DRM handle cleanup for Deep Sleep scenarios. Default is false. Prevents playback failures after device wake-up from Deep Sleep by clearing stale DRM sessions and failed key IDs. |
+
+**Two Parameter Form (Advanced Usage):**
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| sendStateChangeEvent | Boolean | If true, sends state change events during stop operation. Default is true. |
+| forceCleanup | Boolean | If true, forces DRM handle cleanup for Deep Sleep scenarios. Default is false. |
+
+Usage examples:
 ```js
     {
 	    .....
-	    // for immediate stop of playback
+	    // Standard stop - sends state change events
 	    player.stop();
+	    
+	    // Stop with DRM cleanup before Deep Sleep
+	    player.stop(true);
+	    
+	    // Advanced: Stop without state events, with DRM cleanup
+	    player.stop(false, true);
     }
 ```
 ---
@@ -2583,6 +2602,7 @@ A subset of UVE APIs and Events are available when using UVE JS APIs for ATSC pl
 
 ##### stop
 - Stop playback and free resources
+- Optional forceCleanup parameter for DRM cleanup in Deep Sleep scenarios
 
 ##### getAudioTrack
 - Get the index of the currently selected Audio track

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -4403,7 +4403,7 @@ static void AAMP_finalize(JSObjectRef thisObject)
 		{
 			//when finalizing JS object, don't generate state change events
 			LOG_WARN(pAAMP," aamp->Stop(false)");
-			_allocated_aamp->Stop(false);
+			_allocated_aamp->Stop(false, true);  // sendStateChangeEvent=false, forceCleanup=true
 			LOG_WARN(pAAMP,"delete aamp %p",_allocated_aamp);
 			SAFE_DELETE(_allocated_aamp);
 		}
@@ -4795,7 +4795,7 @@ void __attribute__ ((destructor(101))) _aamp_term()
 	{
 		LOG_WARN_EX("stopping aamp");
 		//when finalizing JS object, don't generate state change events
-		_allocated_aamp->Stop(false);
+		_allocated_aamp->Stop(false, true);  // sendStateChangeEvent=false, forceCleanup=true
 		LOG_WARN_EX("stopped aamp");
 		delete _allocated_aamp;
 		_allocated_aamp = NULL;

--- a/jsbindings/jsmediaplayer.cpp
+++ b/jsbindings/jsmediaplayer.cpp
@@ -310,7 +310,7 @@ static void releaseNativeResources(AAMPMediaPlayer_JS *privObj)
 		{
 			//when finalizing JS object, don't generate state change events
 			LOG_WARN(privObj," aamp->Stop(false)");
-			privObj->_aamp->Stop(false);
+			privObj->_aamp->Stop(false, true);  // sendStateChangeEvent=false, forceCleanup=true
 			privObj->clearCallbackForAllAdIds();
 			if (privObj->_listeners.size() > 0)
 			{
@@ -839,7 +839,7 @@ JSValueRef AAMPMediaPlayerJS_pause (JSContextRef ctx, JSObjectRef function, JSOb
  * @param[in] function JSObject that is the function being called
  * @param[in] thisObject JSObject that is the 'this' variable in the function's scope
  * @param[in] argumentCount number of args
- * @param[in] arguments[] JSValue array of args
+ * @param[in] arguments[] JSValue array of args - Optional forceCleanup boolean parameter
  * @param[out] exception pointer to a JSValueRef in which to return an exception, if any
  * @retval JSValue that is the function's return value
  */
@@ -853,8 +853,30 @@ JSValueRef AAMPMediaPlayerJS_stop (JSContextRef ctx, JSObjectRef function, JSObj
 		*exception = aamp_GetException(ctx, AAMPJS_MISSING_OBJECT, "Can only call stop() on instances of AAMPPlayer");
 		return JSValueMakeUndefined(ctx);
 	}
-	LOG_WARN(privObj," _aamp->Stop()");
-	privObj->_aamp->Stop();
+	
+	bool sendStateChangeEvent = true;   // Default: send state change events
+	bool forceCleanup = false;          // Default: no DRM cleanup
+	
+	if (argumentCount >= 1)
+	{
+		// For backward compatibility and UVE API design:
+		// - If 1 argument: treat as forceCleanup (boolean)
+		// - If 2 arguments: treat as (sendStateChangeEvent, forceCleanup)
+		if (argumentCount == 1)
+		{
+			// stop(forceCleanup) - send events by default, cleanup based on argument
+			forceCleanup = JSValueToBoolean(ctx, arguments[0]);
+		}
+		else if (argumentCount >= 2)
+		{
+			// stop(sendStateChangeEvent, forceCleanup) - both explicit
+			sendStateChangeEvent = JSValueToBoolean(ctx, arguments[0]);
+			forceCleanup = JSValueToBoolean(ctx, arguments[1]);
+		}
+	}
+	
+	LOG_WARN(privObj," _aamp->Stop() sendStateChangeEvent=%d forceCleanup=%d", sendStateChangeEvent, forceCleanup);
+	privObj->_aamp->Stop(sendStateChangeEvent, forceCleanup);
 	LOG_TRACE("Exit");
 	return JSValueMakeUndefined(ctx);
 }

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -258,9 +258,17 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent)
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
 		if (state != eSTATE_IDLE && state != eSTATE_RELEASED)
 		{
-			StopInternal(sendStateChangeEvent);
+			StopInternal(sendStateChangeEvent, forceCleanup);
 		}
-
+		// Enhanced DRM cleanup for Deep Sleep scenarios
+		// Must be done AFTER StopInternal() to ensure GStreamer pipeline is torn down
+		// and all encrypted buffers are flushed before destroying DRM sessions
+		if (forceCleanup && aamp->mDRMLicenseManager)
+		{
+			AAMPLOG_WARN("Force cleanup: Clearing DRM sessions and failed key IDs for Deep Sleep");
+			aamp->mDRMLicenseManager->clearDrmSession(true);
+			aamp->mDRMLicenseManager->clearFailedKeyIds();
+		}
 		//Release lock
 		mScheduler.ResumeScheduler();
 	}
@@ -3102,8 +3110,11 @@ void PlayerInstanceAAMP::StopInternal(bool sendStateChangeEvent)
 	{
 		aamp->TuneFail(true);
 	}
-	AAMPLOG_MIL("aamp_stop PlayerState=%d",state);
-	aamp->Stop();
+	AAMPLOG_MIL("aamp_stop PlayerState=%d forceCleanup=%d", state, forceCleanup);
+	
+	// Negate sendStateChangeEvent since no need to send state change event on destructor call
+	aamp->Stop(!sendStateChangeEvent);
+
 	// Revert all custom specific setting, tune specific setting and stream specific setting , back to App/default setting
 	mConfig.RestoreConfiguration(AAMP_CUSTOM_DEV_CFG_SETTING);
 	mConfig.RestoreConfiguration(AAMP_TUNE_SETTING);

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -35,6 +35,7 @@
 #include "PlayerLogManager.h"
 #include "PlayerMetadata.hpp"
 #include "PlayerLogManager.h"
+#include "AampDRMLicManager.h"
 
 #include <dlfcn.h>
 #include <termios.h>
@@ -189,7 +190,7 @@ PlayerInstanceAAMP::~PlayerInstanceAAMP()
 		mScheduler.RemoveAllTasks();
 		if (state != eSTATE_IDLE && state != eSTATE_RELEASED)
 		{
-			aamp->Stop( true );
+			aamp->Stop(false); // Don't send state change events during destruction
 		}
 		std::lock_guard<std::mutex> lock (mPrvAampMtx);
 		aamp = NULL;
@@ -241,7 +242,7 @@ void PlayerInstanceAAMP::ResetConfiguration()
 /**
  *  @brief Stop playback and release resources.
  */
-void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent)
+void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 {
 	if (aamp)
 	{
@@ -363,7 +364,7 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 		if ((state != eSTATE_IDLE) && (state != eSTATE_RELEASED) && (!IsOTAtoOTA))
 		{
 			//Calling tune without closing previous tune
-			StopInternal(false);
+			StopInternal(true, false);
 		}
 		aamp->getAampCacheHandler()->StartPlaylistCache();
 		aamp->Tune(mainManifestUrl, autoPlay, contentType, bFirstAttempt, bFinalAttempt, traceUUID, audioDecoderStreamSync, refreshManifestUrl, mpdStitchingMode, std::move(sid),manifestData);
@@ -3102,7 +3103,7 @@ void PlayerInstanceAAMP::PersistBitRateOverSeek(bool bValue)
 /**
  *  @brief Stop playback and release resources.
  */
-void PlayerInstanceAAMP::StopInternal(bool sendStateChangeEvent)
+void PlayerInstanceAAMP::StopInternal(bool sendStateChangeEvent, bool forceCleanup)
 {
 	aamp->StopPausePositionMonitoring("Stop() called");
 	AAMPPlayerState state = aamp->GetState();

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -150,9 +150,10 @@ public:
 	/**
 	 *   @brief Stop playback and release resources.
 	 *   @param[in]  sendStateChangeEvent - true if state change events need to be sent for Stop operation
+	 *   @param[in]  forceCleanup - true to force DRM handle cleanup for Deep Sleep scenarios (default false)
 	 *   @return void
 	 */
-	void Stop(bool sendStateChangeEvent = true);
+	void Stop(bool sendStateChangeEvent = true, bool forceCleanup = false);
 
 	/**
 	 *   @fn ResetConfiguration
@@ -1484,9 +1485,10 @@ private:
 	 *   @fn StopInternal
 	 *
 	 *   @param[in]  sendStateChangeEvent - true if state change events need to be sent for Stop operation
+	 *   @param[in]  forceCleanup - true to force DRM handle cleanup for Deep Sleep scenarios
 	 *   @return void
 	 */
-	void StopInternal(bool sendStateChangeEvent);
+	void StopInternal(bool sendStateChangeEvent, bool forceCleanup);
 
 	void* mJSBinding_DL;                /**< Handle to AAMP plugin dynamic lib.  */
 	static std::mutex mPrvAampMtx;      /**< Mutex to protect aamp instance in GetState() */

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -51,7 +51,7 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 									std::string session_id,
 									const char *preprocessedManifest
 									) { }
-    void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent) {  }
+    void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup) {  }
 	void PlayerInstanceAAMP::ResetConfiguration() {  }
 	void PlayerInstanceAAMP::SetRate(float rate, int overshootcorrection) {  }
 	void PlayerInstanceAAMP::PauseAt(double  position) {  }

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -28,7 +28,7 @@ class MockPrivateInstanceAAMP
 public:
     MOCK_METHOD(double, RecalculatePTS, (AampMediaType mediaType, const void *ptr, size_t len));
     
-	MOCK_METHOD(void, Stop, (bool sendStateChangeEvent));
+	MOCK_METHOD(void, Stop, (bool sendStateChangeEvent, bool forceCleanup));
 
 	MOCK_METHOD(void, StartPausePositionMonitoring, (long long pausePositionMilliseconds));
 


### PR DESCRIPTION
VPLAY-11809 : Enhance UveAAMP stop() API with DRM handle cleanup parameter to prevent Deep Sleep playback failures

Reason for change:
Linear and VOD playback fails after devices come out of Deep Sleep state due to stale DRM handles that are not properly released before entering Deep Sleep mode. The current stop() implementation does not provide a mechanism to force DRM handle cleanup, leading to tune failures with stale DRM sessions after device wake-up.

Test Procedure : Run L3 tests 

