### PR TITLE
VPLAY-11880 :The manifest download keeps failing, eventually causing AAMP to crash

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -277,9 +277,8 @@ void AampMPDDownloader::Release()
 			mRefreshCondVar.notify_all();
 			mMPDDnldDataCondVar.notify_all();
 			mMPDNotifierCondVar.notify_all();
-
 		}
-		//Disable downloads before joining the threads,which will exit the download loops gracefully 
+		// Disable downloads before joining the threads,which will exit the download loops gracefully 
 		mDownloader1.Release();
 		mDownloader2.Release();
 

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -279,7 +279,7 @@ void AampMPDDownloader::Release()
 			mMPDNotifierCondVar.notify_all();
 
 		}
-
+		//Disable downloads before joining the threads,which will exit the download loops gracefully 
 		mDownloader1.Release();
 		mDownloader2.Release();
 
@@ -288,6 +288,9 @@ void AampMPDDownloader::Release()
 
 		if(mDownloaderThread_t2.joinable())
 			mDownloaderThread_t2.join();
+		// Clear the headers only after the graceful exit of download threads.
+		mDownloader1.CleanupCurlHeaderResources();
+		mDownloader2.CleanupCurlHeaderResources();
 
 		if(mManifestUpdateCb != NULL)
 		{

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -339,9 +339,9 @@ void AampCurlDownloader::Initialize(std::shared_ptr<DownloadConfig> dnldCfg)
 	
 	// Release and reset and previously called values
 	Release();
-	CleanupCurlHeaderResources();
 
 	std::lock_guard<std::mutex> lock(mCurlMutex);
+	CleanupCurlHeaderResources();
 	mDnldCfg = std::move(dnldCfg);
 	//mDnldCfg->show();
 	if (!mDnldCfg->pCurl)

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -341,32 +341,34 @@ void AampCurlDownloader::Initialize(std::shared_ptr<DownloadConfig> dnldCfg)
 	// Release and reset and previously called values
 	Release();
 
-	CleanupCurlHeaderResources();
-	std::lock_guard<std::mutex> lock(mCurlMutex);
-	mDnldCfg = std::move(dnldCfg);
-	//mDnldCfg->show();
-	if (!mDnldCfg->pCurl)
+	CleanupCurlHeaderResources(); // internally, this temporarily acquires mCurlMutex
+	
 	{
-		if(mCurl == NULL)
+		std::lock_guard<std::mutex> lock(mCurlMutex);
+		mDnldCfg = std::move(dnldCfg);
+		//mDnldCfg->show();
+		if (!mDnldCfg->pCurl)
 		{
-			mCurl = curl_easy_init();
-			mCreatedNewFd = true;
+			if(mCurl == NULL)
+			{
+				mCurl = curl_easy_init();
+				mCreatedNewFd = true;
+			}
+			
 		}
-
-	}
-	else
-	{
-		if(mCreatedNewFd && mCurl)
+		else
 		{
-			// Whatever created by this module should be freed by this module
-			// AampCurlDownloader is not responsible for the curl handles provided for download
-			curl_easy_cleanup(mCurl);
-			mCreatedNewFd = false;
+			if(mCreatedNewFd && mCurl)
+			{
+				// Whatever created by this module should be freed by this module
+				// AampCurlDownloader is not responsible for the curl handles provided for download
+				curl_easy_cleanup(mCurl);
+				mCreatedNewFd = false;
+			}
+			mCurl =	mDnldCfg->pCurl;
 		}
-		mCurl =	mDnldCfg->pCurl;
+		updateCurlParams();
 	}
-	updateCurlParams();
-
 }
 
 

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -152,6 +152,7 @@ AampCurlDownloader::~AampCurlDownloader()
 
 bool AampCurlDownloader::IsDownloadActive()
 {
+	std::lock_guard<std::mutex> lock(mCurlMutex);
 	return mDownloadActive;
 }
 
@@ -340,8 +341,8 @@ void AampCurlDownloader::Initialize(std::shared_ptr<DownloadConfig> dnldCfg)
 	// Release and reset and previously called values
 	Release();
 
-	std::lock_guard<std::mutex> lock(mCurlMutex);
 	CleanupCurlHeaderResources();
+	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDnldCfg = std::move(dnldCfg);
 	//mDnldCfg->show();
 	if (!mDnldCfg->pCurl)

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -339,6 +339,7 @@ void AampCurlDownloader::Initialize(std::shared_ptr<DownloadConfig> dnldCfg)
 	
 	// Release and reset and previously called values
 	Release();
+	CleanupCurlHeaderResources();
 
 	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDnldCfg = std::move(dnldCfg);

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -372,6 +372,11 @@ void AampCurlDownloader::Release()
 {
 	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadActive = false;
+}
+
+void AampCurlDownloader::CleanupCurlHeaderResources()
+{
+	std::lock_guard<std::mutex> lock(mCurlMutex);
 	mDownloadUpdatedTime = 0 ;
 	mDownloadStartTime =  0;
 	mWriteCallbackBufferSize = 0;

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -228,8 +228,21 @@ public:
 	*/	
 	void Release();
 	/**
-	* @brief CleanupCurlHeaderResources - function to cleanup headers after thread join
-	*/
+	 * @brief Cleanup curl header resources after downloads have stopped
+	 *
+	 * Frees the curl header list (mHeaders) using curl_slist_free_all and
+	 * resets any associated download timing or state required before the
+	 * next use of this downloader instance.
+	 *
+	 * This method must be called after Release() has been invoked and after
+	 * any worker or download threads using this instance have been joined to
+	 * ensure that no curl callbacks are still accessing the header list.
+	 *
+	 * @note This method is thread-safe; it acquires mCurlMutex internally.
+	 * @warning Do not call this method until all download activity associated
+	 *          with this instance has fully stopped, to avoid race conditions
+	 *          where headers are freed while curl callbacks are still running.
+	 */
 	void CleanupCurlHeaderResources();
 	void Clear();
 	/**

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -227,6 +227,10 @@ public:
 	* @param[in] dnldCfg - configuration for download
 	*/	
 	void Release();
+	/**
+	* @brief CleanupCurlHeaderResources - function to cleanup headers after thread join
+	*/
+	void CleanupCurlHeaderResources();
 	void Clear();
 	/**
 	* @brief Download - function to start  download 

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -161,8 +161,6 @@ void AampDRMLicenseManager::releaseLicenseRenewalThreads()
  */
 void AampDRMLicenseManager::setLicenseRequestAbort(bool isAbort)
 {
-	mAccessTokenConnector.Release();
-	mAccessTokenConnector.CleanupCurlHeaderResources();
 	licenseRequestAbort = isAbort;
 }
 void AampDRMLicenseManager::licenseRenewalThread(std::shared_ptr<DrmHelper> drmHelper, int sessionSlot, PrivateInstanceAAMP* aampInstance)

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -130,14 +130,13 @@ AampDRMLicenseManager::AampDRMLicenseManager(int maxDrmSessions, PrivateInstance
  */
 AampDRMLicenseManager::~AampDRMLicenseManager()
 {
-        SAFE_DELETE(mLicensePrefetcher);
+	SAFE_DELETE(mLicensePrefetcher);
 	SAFE_DELETE(mDrmSessionManager);
 	releaseLicenseRenewalThreads();
 	for(int i = 0 ; i < mMaxDRMSessions;i++)  
-        {
-
-             mLicenseDownloader[i].Release();
-             mLicenseDownloader[i].CleanupCurlHeaderResources();
+	{
+		mLicenseDownloader[i].Release();
+		mLicenseDownloader[i].CleanupCurlHeaderResources();
 	}
 	SAFE_DELETE_ARRAY( mLicenseDownloader );
 }

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -137,7 +137,7 @@ AampDRMLicenseManager::~AampDRMLicenseManager()
         {
 
              mLicenseDownloader[i].Release();
-			 mLicenseDownloader[i].CleanupCurlHeaderResources();
+             mLicenseDownloader[i].CleanupCurlHeaderResources();
 	}
 	SAFE_DELETE_ARRAY( mLicenseDownloader );
 }

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -137,6 +137,7 @@ AampDRMLicenseManager::~AampDRMLicenseManager()
         {
 
              mLicenseDownloader[i].Release();
+			 mLicenseDownloader[i].CleanupCurlHeaderResources();
 	}
 	SAFE_DELETE_ARRAY( mLicenseDownloader );
 }
@@ -162,6 +163,7 @@ void AampDRMLicenseManager::releaseLicenseRenewalThreads()
 void AampDRMLicenseManager::setLicenseRequestAbort(bool isAbort)
 {
 	mAccessTokenConnector.Release();
+	mAccessTokenConnector.CleanupCurlHeaderResources();
 	licenseRequestAbort = isAbort;
 }
 void AampDRMLicenseManager::licenseRenewalThread(std::shared_ptr<DrmHelper> drmHelper, int sessionSlot, PrivateInstanceAAMP* aampInstance)

--- a/drm/AampDRMLicManager.h
+++ b/drm/AampDRMLicManager.h
@@ -57,7 +57,6 @@ public:
 	bool licenseRequestAbort;
 	int mMaxDRMSessions;
 	std::vector<std::thread> mLicenseRenewalThreads;
-	AampCurlDownloader mAccessTokenConnector;
 	AampLicensePreFetcher* mLicensePrefetcher; /**< DRM license prefetcher instance */
 	PrivateInstanceAAMP *aampInstance; /** AAMP instance **/
 	/**

--- a/test/utests/fakes/FakeAampCurlDownloader.cpp
+++ b/test/utests/fakes/FakeAampCurlDownloader.cpp
@@ -98,6 +98,10 @@ void AampCurlDownloader::Release()
 {
 }
 
+void AampCurlDownloader::CleanupCurlHeaderResources()
+{
+}
+
 
 void AampCurlDownloader::Clear()
 {

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -469,15 +469,17 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 }
 
 /**
- * @brief Test case to verify calling order: Release() before CleanupCurlHeaderResources()
+ * @brief Test case to verify Release() stops download activity before header cleanup
  * 
- * This test demonstrates the recommended sequence where Release() is called first to stop
- * downloads (sets mDownloadActive=false), followed by CleanupCurlHeaderResources() to free
- * curl header resources. This ordering prevents potential race conditions where header
- * resources could be freed while curl callbacks are still executing.
+ * This test verifies that:
+ * 1. Release() sets mDownloadActive to false, which causes progress callbacks to abort
+ * 2. CleanupCurlHeaderResources() safely frees curl headers after download is stopped
+ * 3. The sequence prevents race conditions where headers could be accessed during cleanup
  */
 TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
+	DownloadResponsePtr respData = std::make_shared<DownloadResponse>();
 	DownloadConfigPtr config = std::make_shared<DownloadConfig>();
+	config->bIgnoreResponseHeader = false; // Enable header callback to use mHeaders
 	
 	EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
 	EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
@@ -489,40 +491,55 @@ TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCond
 		.WillOnce(Return(CURLE_OK));
 	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
 		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_HEADERDATA, mAampCurlDownloader))
+		.WillRepeatedly(Return(CURLE_OK));
+
 	
 	mAampCurlDownloader->Initialize(config);
 	
-	std::atomic<bool> releaseCompleted(false);
-	std::atomic<bool> headerCleanupStarted(false);
-	std::atomic<bool> raceConditionDetected(false);
+	ASSERT_NE(mCurlProgressCallback, nullptr);
 	
-	// Thread 1: Simulates download activity
+	std::atomic<bool> downloadAborted(false);
+	
+	// Simulate a download that will be interrupted by Release()
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_str(mCurlEasyHandle, CURLOPT_URL, mUrl.c_str()))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_perform(mCurlEasyHandle))
+		.WillOnce(DoAll(
+			InvokeWithoutArgs([&]() {
+				// Simulate ongoing download - progress callback should detect abort
+				std::this_thread::sleep_for(std::chrono::milliseconds(10));
+				int result = mCurlProgressCallback(mAampCurlDownloader, 0, 0, 0, 0);
+				if (result == -1) {
+					downloadAborted.store(true);
+				}
+			}),
+			Return(CURLE_ABORTED_BY_CALLBACK)));
+	EXPECT_CALL(*g_mockCurl, curl_easy_getinfo_int(mCurlEasyHandle, CURLINFO_RESPONSE_CODE, NotNull()))
+		.Times(0); // Should not be called when curl returns CURLE_ABORTED_BY_CALLBACK
+	
+	// Start download in separate thread
 	std::thread downloadThread([&]() {
-		for (int i = 0; i < 100 && !releaseCompleted.load(); ++i) {
-			if (headerCleanupStarted.load() && !releaseCompleted.load()) {
-				raceConditionDetected.store(true);
-			}
-			std::this_thread::sleep_for(std::chrono::milliseconds(1));
-		}
+		mAampCurlDownloader->Download(mUrl, respData);
 	});
 	
-	// Allow download thread to start
-	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	// Allow download to start
+	std::this_thread::sleep_for(std::chrono::milliseconds(5));
 	
-	// Step 1: Call Release() first to stop downloads
+	// Step 1: Call Release() to abort the download
 	mAampCurlDownloader->Release();
-	releaseCompleted.store(true);
 	
-	// Step 2: Call CleanupCurlHeaderResources() after downloads stopped
-	headerCleanupStarted.store(true);
-	mAampCurlDownloader->CleanupCurlHeaderResources();
-	
+	// Wait for download thread to complete
 	downloadThread.join();
 	
-	// Verify no race condition detected
-	EXPECT_FALSE(raceConditionDetected.load()) 
-		<< "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
+	// Verify download was aborted by Release()
+	EXPECT_TRUE(downloadAborted.load()) << "Progress callback should have detected abort from Release()";
+	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive()) << "Download should be inactive after Release()";
+	EXPECT_EQ(respData->iHttpRetValue, CURLE_ABORTED_BY_CALLBACK);
 	
-	// Verify download is stopped
+	// Step 2: Now it's safe to cleanup curl headers since download is stopped
+	mAampCurlDownloader->CleanupCurlHeaderResources();
+	
+	// Verify no crash occurred and state is clean
 	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
 }

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -475,7 +475,6 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
  * downloads (sets mDownloadActive=false), followed by CleanupCurlHeaderResources() to free
  * curl header resources. This ordering prevents potential race conditions where header
  * resources could be freed while curl callbacks are still executing.
- * 
  */
 TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
 	DownloadConfigPtr config = std::make_shared<DownloadConfig>();

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -478,52 +478,52 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
  * 
  */
 TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
-    DownloadConfigPtr config = std::make_shared<DownloadConfig>();
-    
-    EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
-    EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
-    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
-        .WillOnce(Return(CURLE_OK));
-    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
-        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
-    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
-        .WillOnce(Return(CURLE_OK));
-    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
-        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
-    
-    mAampCurlDownloader->Initialize(config);
-    
-    std::atomic<bool> releaseCompleted(false);
-    std::atomic<bool> headerCleanupStarted(false);
-    std::atomic<bool> raceConditionDetected(false);
-    
-    // Thread 1: Simulates download activity
-    std::thread downloadThread([&]() {
-        for (int i = 0; i < 100 && !releaseCompleted.load(); ++i) {
-            if (headerCleanupStarted.load() && !releaseCompleted.load()) {
-                raceConditionDetected.store(true);
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-    });
-    
-    // Allow download thread to start
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    
-    // Step 1: Call Release() first to stop downloads
+	DownloadConfigPtr config = std::make_shared<DownloadConfig>();
+	
+	EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+	
+	mAampCurlDownloader->Initialize(config);
+	
+	std::atomic<bool> releaseCompleted(false);
+	std::atomic<bool> headerCleanupStarted(false);
+	std::atomic<bool> raceConditionDetected(false);
+	
+	// Thread 1: Simulates download activity
+	std::thread downloadThread([&]() {
+		for (int i = 0; i < 100 && !releaseCompleted.load(); ++i) {
+			if (headerCleanupStarted.load() && !releaseCompleted.load()) {
+				raceConditionDetected.store(true);
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		}
+	});
+	
+	// Allow download thread to start
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	
+	// Step 1: Call Release() first to stop downloads
 	mAampCurlDownloader->Release();
 	releaseCompleted.store(true);
-    
-    // Step 2: Call CleanupCurlHeaderResources() after downloads stopped
+	
+	// Step 2: Call CleanupCurlHeaderResources() after downloads stopped
 	headerCleanupStarted.store(true);
 	mAampCurlDownloader->CleanupCurlHeaderResources();
-    
-    downloadThread.join();
-    
-    // Verify no race condition detected
-    EXPECT_FALSE(raceConditionDetected.load()) 
-        << "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
-		
+	
+	downloadThread.join();
+	
+	// Verify no race condition detected
+	EXPECT_FALSE(raceConditionDetected.load()) 
+		<< "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
+	
 	// Verify download is stopped
 	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
 }

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -467,3 +467,63 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 	respData->show();
 	respData->clear();
 }
+
+/**
+ * @brief Test case to verify calling order: Release() before CleanupCurlHeaderResources()
+ * 
+ * This test demonstrates the recommended sequence where Release() is called first to stop
+ * downloads (sets mDownloadActive=false), followed by CleanupCurlHeaderResources() to free
+ * curl header resources. This ordering prevents potential race conditions where header
+ * resources could be freed while curl callbacks are still executing.
+ * 
+ */
+TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCondition) {
+    DownloadConfigPtr config = std::make_shared<DownloadConfig>();
+    
+    EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+    EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+        .WillOnce(Return(CURLE_OK));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+        .WillOnce(Return(CURLE_OK));
+    EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+        .WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+    
+    mAampCurlDownloader->Initialize(config);
+    
+    std::atomic<bool> releaseCompleted(false);
+    std::atomic<bool> headerCleanupStarted(false);
+    std::atomic<bool> raceConditionDetected(false);
+    
+    // Thread 1: Simulates download activity
+    std::thread downloadThread([&]() {
+        for (int i = 0; i < 100 && !releaseCompleted.load(); ++i) {
+            if (headerCleanupStarted.load() && !releaseCompleted.load()) {
+                raceConditionDetected.store(true);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    });
+    
+    // Allow download thread to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    
+    // Step 1: Call Release() first to stop downloads
+	mAampCurlDownloader->Release();
+	releaseCompleted.store(true);
+    
+    // Step 2: Call CleanupCurlHeaderResources() after downloads stopped
+	headerCleanupStarted.store(true);
+	mAampCurlDownloader->CleanupCurlHeaderResources();
+    
+    downloadThread.join();
+    
+    // Verify no race condition detected
+    EXPECT_FALSE(raceConditionDetected.load()) 
+        << "Race condition detected: CleanupCurlHeaderResources() called before Release() completed";
+		
+	// Verify download is stopped
+	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
+}


### PR DESCRIPTION
Reason for change: Clearing curl headers in Initiatialize
Test Procedure: Refer ticket
Risks: Medium
Priority: P1

Signed-off-by: Abhi-jith-S <abhijithssa7@gmail.com>