### PR TITLE
VPLAY-12256 gst test harness not populating any user agent - results n http 403 from some servers

### DIFF
--- a/test/gstTestHarness/downloader.cpp
+++ b/test/gstTestHarness/downloader.cpp
@@ -130,7 +130,6 @@ gpointer LoadUrl( const std::string &url, gsize *pLen )
 		delim++;
 	}
 	
-	curl_easy_setopt(context.curl, CURLOPT_USERAGENT, "gstTestHarness/1.0");
 	if( starts_with(url,"http://") || starts_with(url,"https://" ) )
 	{
 		if( range.empty() )
@@ -149,7 +148,8 @@ gpointer LoadUrl( const std::string &url, gsize *pLen )
 		(void)curl_easy_setopt(context.curl, CURLOPT_WRITEFUNCTION, CurlContext::write_callback);
 		(void)curl_easy_setopt(context.curl, CURLOPT_WRITEDATA, &context);
 		(void)curl_easy_setopt(context.curl, CURLOPT_TCP_KEEPALIVE, 1L);
-		
+		(void)curl_easy_setopt(context.curl, CURLOPT_USERAGENT, "gstTestHarness/1.0");
+
 		context.clear();
 		CURLcode rc = curl_easy_perform(context.curl);
 		if (CURLE_OK == rc)

--- a/test/gstTestHarness/downloader.cpp
+++ b/test/gstTestHarness/downloader.cpp
@@ -130,6 +130,7 @@ gpointer LoadUrl( const std::string &url, gsize *pLen )
 		delim++;
 	}
 	
+	curl_easy_setopt(context.curl, CURLOPT_USERAGENT, "gstTestHarness/1.0");
 	if( starts_with(url,"http://") || starts_with(url,"https://" ) )
 	{
 		if( range.empty() )


### PR DESCRIPTION
VPLAY-12256 gst test harness not populating any user agent - results n http 403 from some servers

Reason for Change: add gstTestHarness/1.0 for user agent

Test Guidance: play test guidnce from aampcdn server

Risk: None