### PR TITLE
VPLAY-12257: Add support for AAC_RAW format type

### DIFF
--- a/StreamOutputFormat.h
+++ b/StreamOutputFormat.h
@@ -31,6 +31,7 @@ enum StreamOutputFormat
     FORMAT_ISO_BMFF,        /**< ISO Base Media File format */
     FORMAT_AUDIO_ES_MP3,    /**< MP3 Audio Elementary Stream */
     FORMAT_AUDIO_ES_AAC,    /**< AAC Audio Elementary Stream */
+    FORMAT_AUDIO_ES_AAC_RAW, /**< AAC Raw Audio Elementary Stream */
     FORMAT_AUDIO_ES_AC3,    /**< AC3 Audio Elementary Stream */
     FORMAT_AUDIO_ES_EC3,    /**< Dolby Digital Plus Elementary Stream */
     FORMAT_AUDIO_ES_ATMOS,  /**< ATMOS Audio stream */

--- a/middleware/GstUtils.cpp
+++ b/middleware/GstUtils.cpp
@@ -52,6 +52,12 @@ GstCaps* GetCaps(GstStreamOutputFormat format)
 					"mpegversion", G_TYPE_INT, 2,
 					"stream-format", G_TYPE_STRING, "adts", NULL);
 			break;
+		case GST_FORMAT_AUDIO_ES_AAC_RAW:
+			caps = gst_caps_new_simple ("audio/mpeg",
+					"mpegversion", G_TYPE_INT, 4,
+					"framed", G_TYPE_BOOLEAN, TRUE,
+					"stream-format", G_TYPE_STRING, "raw", NULL);
+			break;
 		case GST_FORMAT_AUDIO_ES_AC3:
 			caps = gst_caps_new_simple ("audio/x-ac3", NULL, NULL);
 			break;

--- a/middleware/GstUtils.h
+++ b/middleware/GstUtils.h
@@ -66,6 +66,7 @@ enum GstStreamOutputFormat
         GST_FORMAT_ISO_BMFF,        /**< ISO Base Media File format */
         GST_FORMAT_AUDIO_ES_MP3,    /**< MP3 Audio Elementary Stream */
         GST_FORMAT_AUDIO_ES_AAC,    /**< AAC Audio Elementary Stream */
+        GST_FORMAT_AUDIO_ES_AAC_RAW, /**< AAC Raw Audio Elementary Stream */
         GST_FORMAT_AUDIO_ES_AC3,    /**< AC3 Audio Elementary Stream */
         GST_FORMAT_AUDIO_ES_EC3,    /**< Dolby Digital Plus Elementary Stream */
         GST_FORMAT_AUDIO_ES_ATMOS,  /**< ATMOS Audio stream */

--- a/middleware/test/utests/tests/GstUtilsTests/GstUtilsTests.cpp
+++ b/middleware/test/utests/tests/GstUtilsTests/GstUtilsTests.cpp
@@ -56,16 +56,25 @@ TEST_F(GstUtilsTests, esMP3test)
     EXPECT_TRUE(GetCaps(GST_FORMAT_AUDIO_ES_MP3)==caps);
 }
 
+TEST_F(GstUtilsTests, esAACRawtest)
+{
+    GstCaps dummycaps;
+    GstCaps *caps{&dummycaps};
+    EXPECT_CALL(*g_mockGStreamer,gst_caps_new_simple(StrEq("audio/mpeg"),StrEq("mpegversion"), G_TYPE_INT, 4, _)).WillOnce(Return(caps));
+    EXPECT_TRUE(GetCaps(GST_FORMAT_AUDIO_ES_AAC_RAW)==caps);
+}
+
 TEST_F(GstUtilsTests, GstCapsFormatsTest)
 {
     GstCaps dummycapslist;
     GstCaps *caps{&dummycapslist};
-    GstStreamOutputFormat GstCapsFormats[16] = {
+    GstStreamOutputFormat GstCapsFormats[17] = {
     GST_FORMAT_INVALID,         /**< Invalid format */
     GST_FORMAT_MPEGTS,          /**< MPEG Transport Stream */
     GST_FORMAT_ISO_BMFF,        /**< ISO Base Media File format */
     GST_FORMAT_AUDIO_ES_MP3,    /**< MP3 Audio Elementary Stream */
     GST_FORMAT_AUDIO_ES_AAC,    /**< AAC Audio Elementary Stream */
+    GST_FORMAT_AUDIO_ES_AAC_RAW, /**< AAC Raw Audio Elementary Stream */
     GST_FORMAT_AUDIO_ES_AC3,    /**< AC3 Audio Elementary Stream */
     GST_FORMAT_AUDIO_ES_EC3,    /**< Dolby Digital Plus Elementary Stream */
     GST_FORMAT_AUDIO_ES_ATMOS,  /**< ATMOS Audio stream */
@@ -79,8 +88,8 @@ TEST_F(GstUtilsTests, GstCapsFormatsTest)
     GST_FORMAT_UNKNOWN          /**< Unknown Format */
     };
 
-    for(int i=0;i<16;i++){
-    GetCaps(GstCapsFormats[i]);
-    ASSERT_FALSE(GetCaps(GstCapsFormats[i]));
+    for (int i = 0; i < 17; i++) {
+        GetCaps(GstCapsFormats[i]);
+        ASSERT_FALSE(GetCaps(GstCapsFormats[i]));
     }
 }


### PR DESCRIPTION
Reason for change: Added support for AAC_RAW format type in AAMP and middleware
Test Procedure: All L1/L2 should pass
Risks: None