### PR TITLE
VPLAY-12267  single playbin - follow-up R&D

### DIFF
--- a/test/gstTestHarness/gst-port.cpp
+++ b/test/gstTestHarness/gst-port.cpp
@@ -304,7 +304,7 @@ public:
 				g_signal_connect(decodebin, "pad-added", G_CALLBACK(decodebin_pad_added_cb), this);
 				
 				// --- Configure appsrc flow control ---
-				g_object_set(appsrc, "max-bytes", maxBytes, nullptr);
+				g_object_set(appsrc, "max-bytes", (guint64)maxBytes, nullptr);
 				g_object_set(appsrc, "min-percent", 50, nullptr);
 				
 				need_data_handle_id   = g_signal_connect(appsrc, "need-data",    G_CALLBACK(need_data_cb),    this);


### PR DESCRIPTION
VPLAY-12267  single playbin - follow-up R&D

Reason for change: To fix gstTestHarness segfault on XiOne
Risks: Low
Priority: P1