### PR TITLE
VPLAY-12305: Fix AampTrackWorkerTests Intermittent Failures

### DIFF
--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -163,7 +163,7 @@ namespace aamp
 	 *
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
-		: aamp(_aamp), mMediaType(_mediaType), mStop(false), mPaused(false), mActiveJob(nullptr), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mInitialized(false)
+		: aamp(_aamp), mMediaType(_mediaType), mStop(true), mPaused(false), mActiveJob(nullptr), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar()
 	{
 		if (_aamp == nullptr)
 		{
@@ -194,7 +194,8 @@ namespace aamp
 	 */
 	void AampTrackWorker::StartWorker()
 	{
-		if (mWorkerThread.joinable() || mInitialized)
+		std::lock_guard<std::mutex> lock(mQueueMutex);
+		if (mWorkerThread.joinable() || !mStop.load())
 		{
 			AAMPLOG_WARN("Worker thread for media type %s is already running", GetMediaTypeName(mMediaType));
 			throw std::runtime_error("Worker thread is already running");
@@ -202,12 +203,8 @@ namespace aamp
 
 		try
 		{
-			if(!mInitialized)
-			{
-				mStop.store(false);
-				mWorkerThread = std::thread(&AampTrackWorker::ProcessJob, shared_from_this(), std::weak_ptr<AampTrackWorker>(shared_from_this()));
-				mInitialized = true;
-			}
+			mStop.store(false);
+			mWorkerThread = std::thread(&AampTrackWorker::ProcessJob, shared_from_this(), std::weak_ptr<AampTrackWorker>(shared_from_this()));
 		}
 		catch (const std::exception &e)
 		{
@@ -230,20 +227,20 @@ namespace aamp
 	 */
 	void AampTrackWorker::StopWorker()
 	{
-		mStop.store(true);
 		AAMPLOG_DEBUG("Stopping worker thread for media type %s", GetMediaTypeName(mMediaType));
-		if(mInitialized)
 		{
+			std::lock_guard<std::mutex> lock(mQueueMutex);
+			mStop.store(true);
 			mCondVar.notify_all();
-			if (mWorkerThread.joinable())
-			{
-				mWorkerThread.join();
-			}
-			ClearJobs();
-			std::lock_guard<std::mutex> queueLock(mQueueMutex);
-			mActiveJob = nullptr; // Clear active job
-			mInitialized = false;
 		}
+		
+		if (mWorkerThread.joinable())
+		{
+			mWorkerThread.join();
+		}
+		ClearJobs();
+		std::lock_guard<std::mutex> queueLock(mQueueMutex);
+		mActiveJob = nullptr; // Clear active job
 	}
 
 	/**

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -163,7 +163,8 @@ namespace aamp
 	 *
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
-		: aamp(_aamp), mMediaType(_mediaType), mStopped(true), mPaused(false), mActiveJob(nullptr), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar()
+		: mMediaType(_mediaType), mWorkerThread(), mQueueMutex(), mCondVar(), mJobQueue(),
+		  aamp(_aamp), mStopped(true), mPaused(false), mActiveJob(nullptr)
 	{
 		if (_aamp == nullptr)
 		{

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -194,27 +194,27 @@ namespace aamp
 	 */
 	void AampTrackWorker::StartWorker()
 	{
-		std::lock_guard<std::mutex> lock(mQueueMutex);
-		if (mWorkerThread.joinable() || !mStop.load())
+		if (mWorkerThread.joinable() || !mStop)
 		{
 			AAMPLOG_WARN("Worker thread for media type %s is already running", GetMediaTypeName(mMediaType));
 			throw std::runtime_error("Worker thread is already running");
 		}
 
+		mStop = false;
+
 		try
 		{
-			mStop.store(false);
 			mWorkerThread = std::thread(&AampTrackWorker::ProcessJob, shared_from_this(), std::weak_ptr<AampTrackWorker>(shared_from_this()));
 		}
 		catch (const std::exception &e)
 		{
 			AAMPLOG_ERR("Exception caught in AampTrackWorker %s", e.what());
-			mStop.store(true);
+			mStop = true;
 		}
 		catch (...)
 		{
 			AAMPLOG_ERR("Unknown exception caught in AampTrackWorker for media type %s", GetMediaTypeName(mMediaType));
-			mStop.store(true);
+			mStop = true;
 		}
 	}
 
@@ -230,7 +230,7 @@ namespace aamp
 		AAMPLOG_DEBUG("Stopping worker thread for media type %s", GetMediaTypeName(mMediaType));
 		{
 			std::lock_guard<std::mutex> lock(mQueueMutex);
-			mStop.store(true);
+			mStop = true;
 			mCondVar.notify_all();
 		}
 		
@@ -241,6 +241,17 @@ namespace aamp
 		ClearJobs();
 		std::lock_guard<std::mutex> queueLock(mQueueMutex);
 		mActiveJob = nullptr; // Clear active job
+	}
+
+	/**
+	 * @brief Checks if the worker is stopped.
+	 *
+	 * @return true if the worker is stopped, false otherwise.
+	 */
+	bool AampTrackWorker::IsStopped() const
+	{
+		std::lock_guard<std::mutex> lock(mQueueMutex);
+		return mStop;
 	}
 
 	/**
@@ -263,7 +274,7 @@ namespace aamp
 		auto future = job->GetFuture();
 		{
 			std::lock_guard<std::mutex> lock(mQueueMutex);
-			if (!mStop.load())
+			if (!mStop)
 			{
 				if (highPriority)
 				{
@@ -384,10 +395,10 @@ namespace aamp
 
 				// Wait while (queue is empty or paused) and not stopped
 				self->mCondVar.wait(lock, [&] {
-					return self->mStop.load() || (!self->mPaused && !self->mJobQueue.empty());
+					return self->mStop || (!self->mPaused && !self->mJobQueue.empty());
 				});
 
-				if (self->mStop.load())
+				if (self->mStop)
 				{
 					AAMPLOG_DEBUG("Worker thread stopped for media type %s", GetMediaTypeName(self->mMediaType));
 					break;
@@ -433,7 +444,7 @@ namespace aamp
 
 				lock.lock();
 				self->mActiveJob = nullptr;
-				if (self->mStop.load())
+				if (self->mStop)
 				{
 					break;
 				}

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -164,7 +164,7 @@ namespace aamp
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
 		: mMediaType(_mediaType), mWorkerThread(), mQueueMutex(), mCondVar(), mJobQueue(),
-		  aamp(_aamp), mStopped(true), mPaused(false), mActiveJob(nullptr)
+		  aamp(_aamp), mStopped(true), mActiveJob(nullptr), mPaused(false)
 	{
 		if (_aamp == nullptr)
 		{

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -222,25 +222,41 @@ namespace aamp
 	 * @brief Stops the worker thread.
 	 *
 	 * Signals the worker thread to stop and waits for it to finish.
+	 * This method is noexcept because it's called from the destructor.
+	 * Any errors are logged but do not propagate.
 	 *
 	 * @return void
 	 */
-	void AampTrackWorker::StopWorker()
+	void AampTrackWorker::StopWorker() noexcept
 	{
 		AAMPLOG_DEBUG("Stopping worker thread for media type %s", GetMediaTypeName(mMediaType));
-		{
-			std::lock_guard<std::mutex> lock(mQueueMutex);
-			mStopped = true;
-			mCondVar.notify_all();
-		}
 		
-		if (mWorkerThread.joinable())
+		try
 		{
-			mWorkerThread.join();
+			{
+				std::lock_guard<std::mutex> lock(mQueueMutex);
+				mStopped = true;
+				mCondVar.notify_all();
+			}
+			
+			if (mWorkerThread.joinable())
+			{
+				mWorkerThread.join();
+			}
+			
+			ClearJobs();
+			
+			std::lock_guard<std::mutex> queueLock(mQueueMutex);
+			mActiveJob = nullptr;
 		}
-		ClearJobs();
-		std::lock_guard<std::mutex> queueLock(mQueueMutex);
-		mActiveJob = nullptr; // Clear active job
+		catch (const std::exception &e)
+		{
+			AAMPLOG_ERR("Exception in StopWorker for media type %s: %s", GetMediaTypeName(mMediaType), e.what());
+		}
+		catch (...)
+		{
+			AAMPLOG_ERR("Unknown exception in StopWorker for media type %s", GetMediaTypeName(mMediaType));
+		}
 	}
 
 	/**
@@ -386,7 +402,7 @@ namespace aamp
 					std::unique_lock<std::mutex> lock(self->mQueueMutex);
 
 					// Wait while (queue is empty or paused) and not stopped
-					self->mCondVar.wait(lock, [&]
+					self->mCondVar.wait(lock, [self]() -> bool
 										{ return self->mStopped || (!self->mPaused && !self->mJobQueue.empty()); });
 
 					if (self->mStopped)
@@ -433,7 +449,7 @@ namespace aamp
 				}
 
 				{
-					std::unique_lock<std::mutex> lock(self->mQueueMutex);
+					std::lock_guard<std::mutex> lock(self->mQueueMutex);
 
 					self->mActiveJob = nullptr;
 					if (self->mStopped)

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -163,7 +163,7 @@ namespace aamp
 	 *
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
-		: aamp(_aamp), mMediaType(_mediaType), mStop(true), mPaused(false), mActiveJob(nullptr), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar()
+		: aamp(_aamp), mMediaType(_mediaType), mStopped(true), mPaused(false), mActiveJob(nullptr), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar()
 	{
 		if (_aamp == nullptr)
 		{
@@ -194,13 +194,13 @@ namespace aamp
 	 */
 	void AampTrackWorker::StartWorker()
 	{
-		if (mWorkerThread.joinable() || !mStop)
+		if (mWorkerThread.joinable() || !mStopped)
 		{
 			AAMPLOG_WARN("Worker thread for media type %s is already running", GetMediaTypeName(mMediaType));
 			throw std::runtime_error("Worker thread is already running");
 		}
 
-		mStop = false;
+		mStopped = false;
 
 		try
 		{
@@ -209,12 +209,12 @@ namespace aamp
 		catch (const std::exception &e)
 		{
 			AAMPLOG_ERR("Exception caught in AampTrackWorker %s", e.what());
-			mStop = true;
+			mStopped = true;
 		}
 		catch (...)
 		{
 			AAMPLOG_ERR("Unknown exception caught in AampTrackWorker for media type %s", GetMediaTypeName(mMediaType));
-			mStop = true;
+			mStopped = true;
 		}
 	}
 
@@ -230,7 +230,7 @@ namespace aamp
 		AAMPLOG_DEBUG("Stopping worker thread for media type %s", GetMediaTypeName(mMediaType));
 		{
 			std::lock_guard<std::mutex> lock(mQueueMutex);
-			mStop = true;
+			mStopped = true;
 			mCondVar.notify_all();
 		}
 		
@@ -263,7 +263,7 @@ namespace aamp
 		auto future = job->GetFuture();
 		{
 			std::lock_guard<std::mutex> lock(mQueueMutex);
-			if (!mStop)
+			if (!mStopped)
 			{
 				if (highPriority)
 				{
@@ -384,10 +384,10 @@ namespace aamp
 
 				// Wait while (queue is empty or paused) and not stopped
 				self->mCondVar.wait(lock, [&] {
-					return self->mStop || (!self->mPaused && !self->mJobQueue.empty());
+					return self->mStopped || (!self->mPaused && !self->mJobQueue.empty());
 				});
 
-				if (self->mStop)
+				if (self->mStopped)
 				{
 					AAMPLOG_DEBUG("Worker thread stopped for media type %s", GetMediaTypeName(self->mMediaType));
 					break;
@@ -433,7 +433,7 @@ namespace aamp
 
 				lock.lock();
 				self->mActiveJob = nullptr;
-				if (self->mStop)
+				if (self->mStopped)
 				{
 					break;
 				}

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -200,6 +200,7 @@ namespace aamp
 			throw std::runtime_error("Worker thread is already running");
 		}
 
+		// No lock needed here as this is called before the thread starts
 		mStopped = false;
 
 		try

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -248,7 +248,7 @@ namespace aamp
 	 *
 	 * @return true if the worker is stopped, false otherwise.
 	 */
-	bool AampTrackWorker::IsStopped() const
+	bool AampTrackWorker::IsStopped() 
 	{
 		std::lock_guard<std::mutex> lock(mQueueMutex);
 		return mStop;

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -204,7 +204,7 @@ namespace aamp
 
 		try
 		{
-			mWorkerThread = std::thread(&AampTrackWorker::ProcessJob, shared_from_this(), std::weak_ptr<AampTrackWorker>(shared_from_this()));
+			mWorkerThread = std::thread(&AampTrackWorker::ProcessJob, std::weak_ptr<AampTrackWorker>(shared_from_this()));
 		}
 		catch (const std::exception &e)
 		{
@@ -380,36 +380,37 @@ namespace aamp
 
 			while (true)
 			{
-				std::unique_lock<std::mutex> lock(self->mQueueMutex);
-
-				// Wait while (queue is empty or paused) and not stopped
-				self->mCondVar.wait(lock, [&] {
-					return self->mStopped || (!self->mPaused && !self->mJobQueue.empty());
-				});
-
-				if (self->mStopped)
-				{
-					AAMPLOG_DEBUG("Worker thread stopped for media type %s", GetMediaTypeName(self->mMediaType));
-					break;
-				}
-
-				if (self->mPaused)
-				{
-					AAMPLOG_DEBUG("Worker thread paused for media type %s", GetMediaTypeName(self->mMediaType));
-					continue;
-				}
-
-				// Extract the job safely
 				AampTrackWorkerJobSharedPtr currentJob;
-				if (!self->mJobQueue.empty())
+
 				{
-					self->mActiveJob = std::move(self->mJobQueue.front());
-					self->mJobQueue.pop_front();
-					currentJob = self->mActiveJob;
+					std::unique_lock<std::mutex> lock(self->mQueueMutex);
+
+					// Wait while (queue is empty or paused) and not stopped
+					self->mCondVar.wait(lock, [&]
+										{ return self->mStopped || (!self->mPaused && !self->mJobQueue.empty()); });
+
+					if (self->mStopped)
+					{
+						AAMPLOG_DEBUG("Worker thread stopped for media type %s", GetMediaTypeName(self->mMediaType));
+						break;
+					}
+
+					if (self->mPaused)
+					{
+						AAMPLOG_DEBUG("Worker thread paused for media type %s", GetMediaTypeName(self->mMediaType));
+						continue;
+					}
+
+					// Extract the job safely
+					if (!self->mJobQueue.empty())
+					{
+						self->mActiveJob = std::move(self->mJobQueue.front());
+						self->mJobQueue.pop_front();
+						currentJob = self->mActiveJob;
+					}
 				}
 
-				lock.unlock(); // Release lock before executing the job
-
+				// Execute job without holding lock
 				if (currentJob)
 				{
 					try
@@ -431,11 +432,14 @@ namespace aamp
 					}
 				}
 
-				lock.lock();
-				self->mActiveJob = nullptr;
-				if (self->mStopped)
 				{
-					break;
+					std::unique_lock<std::mutex> lock(self->mQueueMutex);
+
+					self->mActiveJob = nullptr;
+					if (self->mStopped)
+					{
+						break;
+					}
 				}
 			}
 			AAMPLOG_INFO("Exiting for media type %s", GetMediaTypeName(self->mMediaType));

--- a/AampTrackWorker.cpp
+++ b/AampTrackWorker.cpp
@@ -244,17 +244,6 @@ namespace aamp
 	}
 
 	/**
-	 * @brief Checks if the worker is stopped.
-	 *
-	 * @return true if the worker is stopped, false otherwise.
-	 */
-	bool AampTrackWorker::IsStopped() 
-	{
-		std::lock_guard<std::mutex> lock(mQueueMutex);
-		return mStop;
-	}
-
-	/**
 	 * @brief Submits a job to the worker thread.
 	 *
 	 * The job is a function that will be executed by the worker thread.

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -150,9 +150,9 @@ namespace aamp
 		void ClearJobs();
 		void RescheduleActiveJob();
 		void StartWorker();
-		void StopWorker();
-		bool IsStopped() const { return mStopped; }
-		AampMediaType GetMediaType() const { return mMediaType; }
+		void StopWorker() noexcept;
+		bool IsStopped() const noexcept { return mStopped; }
+		AampMediaType GetMediaType() const noexcept { return mMediaType; }
 
 	protected:
 		AampMediaType mMediaType;

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -151,7 +151,7 @@ namespace aamp
 		void RescheduleActiveJob();
 		void StartWorker();
 		void StopWorker();
-		bool IsStopped() const;
+		bool IsStopped();
 		AampMediaType GetMediaType() const { return mMediaType; }
 
 	protected:

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -151,17 +151,17 @@ namespace aamp
 		void RescheduleActiveJob();
 		void StartWorker();
 		void StopWorker();
-		bool IsStopped() const { return mStop.load(); }
+		bool IsStopped() const;
 		AampMediaType GetMediaType() const { return mMediaType; }
 
 	protected:
 		AampMediaType mMediaType;
 		std::thread mWorkerThread;
-		std::mutex mQueueMutex; // Mutex to protect job queue and mStop
+		std::mutex mQueueMutex; // Mutex to protect job queue and worker state
 		std::condition_variable mCondVar; // Condition variable to notify worker thread
 		std::deque<AampTrackWorkerJobSharedPtr> mJobQueue; // Job queue
 		PrivateInstanceAAMP *aamp;
-		std::atomic<bool> mStop; // Flag to indicate if the worker should stop (protected by mQueueMutex)
+		bool mStop; // Flag to indicate if the worker should stop (protected by mQueueMutex)
 		bool mPaused; // Flag to pause the worker threads (protected by mQueueMutex)
 
 	private:

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -165,7 +165,7 @@ namespace aamp
 		bool mPaused; // Flag to pause the worker threads (protected by mQueueMutex)
 
 	private:
-		void ProcessJob(AampTrackWorkerWeakPtr weakSelf);
+		static void ProcessJob(AampTrackWorkerWeakPtr weakSelf);
 		AampTrackWorkerJobSharedPtr mActiveJob; // Active job being processed
 	};
 } // namespace aamp

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -151,7 +151,7 @@ namespace aamp
 		void RescheduleActiveJob();
 		void StartWorker();
 		void StopWorker();
-		bool IsStopped() const { return mStop; }
+		bool IsStopped() const { return mStopped; }
 		AampMediaType GetMediaType() const { return mMediaType; }
 
 	protected:
@@ -161,7 +161,7 @@ namespace aamp
 		std::condition_variable mCondVar; // Condition variable to notify worker thread
 		std::deque<AampTrackWorkerJobSharedPtr> mJobQueue; // Job queue
 		PrivateInstanceAAMP *aamp;
-		bool mStop; // Flag to indicate if the worker should stop (protected by mQueueMutex)
+		bool mStopped; // Flag to indicate if the worker is stopped (protected by mQueueMutex)
 		bool mPaused; // Flag to pause the worker threads (protected by mQueueMutex)
 
 	private:

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -157,12 +157,11 @@ namespace aamp
 	protected:
 		AampMediaType mMediaType;
 		std::thread mWorkerThread;
-		std::mutex mQueueMutex; // Mutex to protect job queue
+		std::mutex mQueueMutex; // Mutex to protect job queue and mStop
 		std::condition_variable mCondVar; // Condition variable to notify worker thread
 		std::deque<AampTrackWorkerJobSharedPtr> mJobQueue; // Job queue
 		PrivateInstanceAAMP *aamp;
-		std::atomic<bool> mInitialized; // Flag to indicate if the worker is initialized
-		std::atomic<bool> mStop;
+		std::atomic<bool> mStop; // Flag to indicate if the worker should stop (protected by mQueueMutex)
 		bool mPaused; // Flag to pause the worker threads (protected by mQueueMutex)
 
 	private:

--- a/AampTrackWorker.hpp
+++ b/AampTrackWorker.hpp
@@ -151,7 +151,7 @@ namespace aamp
 		void RescheduleActiveJob();
 		void StartWorker();
 		void StopWorker();
-		bool IsStopped();
+		bool IsStopped() const { return mStop; }
 		AampMediaType GetMediaType() const { return mMediaType; }
 
 	protected:

--- a/AampTrackWorkerManager.cpp
+++ b/AampTrackWorkerManager.cpp
@@ -104,13 +104,6 @@ namespace aamp
 	 */
 	std::shared_future<void> AampTrackWorkerManager::SubmitJob(AampMediaType mediaType, aamp::AampTrackWorkerJobSharedPtr job, bool highPriority)
 	{
-		// If stopping, reject new submissions immediately (fast path, no lock)
-		if (mStopInProgress.load())
-		{
-			AAMPLOG_WARN("SubmitJob rejected: stop in progress for media type %s", GetMediaTypeName(mediaType));
-			return std::shared_future<void>(); // default future indicates failure
-		}
-
 		std::lock_guard<std::mutex> lock(mMutex);
 		// check again under lock to avoid race where stop started after first check
 		if (mStopInProgress.load())

--- a/test/utests/fakes/FakeAampTrackWorker.cpp
+++ b/test/utests/fakes/FakeAampTrackWorker.cpp
@@ -264,7 +264,7 @@ namespace aamp
 	 *
 	 * @return void
 	 */
-	void AampTrackWorker::StopWorker()
+	void AampTrackWorker::StopWorker() noexcept
 	{
 	}
 

--- a/test/utests/fakes/FakeAampTrackWorker.cpp
+++ b/test/utests/fakes/FakeAampTrackWorker.cpp
@@ -149,7 +149,7 @@ namespace aamp
 	 *
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
-		: aamp(_aamp), mMediaType(_mediaType), mStop(false), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mPaused(false), mActiveJob(nullptr), mInitialized(false)
+		: aamp(_aamp), mMediaType(_mediaType), mStop(false), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mPaused(false), mActiveJob(nullptr)
 	{
 	}
 

--- a/test/utests/fakes/FakeAampTrackWorker.cpp
+++ b/test/utests/fakes/FakeAampTrackWorker.cpp
@@ -149,7 +149,7 @@ namespace aamp
 	 *
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
-		: aamp(_aamp), mMediaType(_mediaType), mStop(false), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mPaused(false), mActiveJob(nullptr)
+		: aamp(_aamp), mMediaType(_mediaType), mStopped(false), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mPaused(false), mActiveJob(nullptr)
 	{
 	}
 

--- a/test/utests/fakes/FakeAampTrackWorker.cpp
+++ b/test/utests/fakes/FakeAampTrackWorker.cpp
@@ -149,7 +149,7 @@ namespace aamp
 	 *
 	 */
 	AampTrackWorker::AampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
-		: aamp(_aamp), mMediaType(_mediaType), mStopped(false), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mPaused(false), mActiveJob(nullptr)
+		: aamp(_aamp), mMediaType(_mediaType), mStopped(true), mWorkerThread(), mJobQueue(), mQueueMutex(), mCondVar(), mPaused(false), mActiveJob(nullptr)
 	{
 	}
 

--- a/test/utests/tests/AampTrackWorkerTests/AampTrackWorkerManagerTests.cpp
+++ b/test/utests/tests/AampTrackWorkerTests/AampTrackWorkerManagerTests.cpp
@@ -119,13 +119,11 @@ TEST_F(AampTrackWorkerManagerTest, WaitForCompletionWorks)
 		std::this_thread::sleep_for(std::chrono::milliseconds(200)); // Simulate a long-running job
 	});
 
-	// Submit the job to the worker
-	auto future = worker->SubmitJob(job, false);
-	EXPECT_TRUE(future.valid());
-
 	bool timeoutOccurred = false;
-	// Wait for completion with a timeout
 	mTrackWorkerManager->StartWorkers();
+	auto future = worker->SubmitJob(job, false); 
+	EXPECT_TRUE(future.valid());
+	// Wait for completion with a timeout of 50ms, which should trigger the timeout as job takes 200ms
 	mTrackWorkerManager->WaitForCompletionWithTimeout(50, [&]() { timeoutOccurred = true; mTrackWorkerManager->StopWorkers(); });
 	EXPECT_TRUE(timeoutOccurred);
 	EXPECT_TRUE(worker->IsStopped());
@@ -147,14 +145,15 @@ TEST_F(AampTrackWorkerManagerTest, WaitForCompletionSkipsNonCriticalWorkers)
 	auto textJob = std::make_shared<MediaSegmentDownloadJob>(nullptr, []() {
 		std::this_thread::sleep_for(std::chrono::milliseconds(100)); // Simulate
 	});
-	// Submit the job to the worker
+
+	bool timeoutOccurred = false;
+	mTrackWorkerManager->StartWorkers();
 	auto videoFuture = videoWorker->SubmitJob(videoJob, false);
 	auto textFuture = textWorker->SubmitJob(textJob, false);
 	EXPECT_TRUE(videoFuture.valid());
 	EXPECT_TRUE(textFuture.valid());
-	bool timeoutOccurred = false;
-	// Wait for completion with a timeout
-	mTrackWorkerManager->StartWorkers();
+
+	// Wait for completion with a timeout of 50ms, which should trigger the timeout as jobs take 100ms
 	mTrackWorkerManager->WaitForCompletionWithTimeout(50, [&]() { timeoutOccurred = true; mTrackWorkerManager->StopWorkers(); });
 	EXPECT_TRUE(timeoutOccurred);
 	EXPECT_TRUE(videoWorker->IsStopped());

--- a/test/utests/tests/AampTrackWorkerTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampTrackWorkerTests/FunctionalTests.cpp
@@ -58,6 +58,7 @@ protected:
 
 		size_t GetJobQueueSize()
 		{
+			std::lock_guard<std::mutex> lock(mQueueMutex);
 			return mJobQueue.size();
 		}
 

--- a/test/utests/tests/AampTrackWorkerTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampTrackWorkerTests/FunctionalTests.cpp
@@ -41,16 +41,9 @@ protected:
 	class TestableAampTrackWorker : public aamp::AampTrackWorker
 	{
 	public:
-		using AampTrackWorker::mQueueMutex; // Expose protected member for testing
-
 		TestableAampTrackWorker(PrivateInstanceAAMP *_aamp, AampMediaType _mediaType)
 			: aamp::AampTrackWorker(_aamp, _mediaType)
 		{
-		}
-
-		void SetStopFlag(bool stop)
-		{
-			mStop.store(stop);
 		}
 
 		PrivateInstanceAAMP *GetAampInstance()
@@ -61,11 +54,6 @@ protected:
 		AampMediaType GetMediaType()
 		{
 			return mMediaType;
-		}
-
-		void NotifyConditionVariable()
-		{
-			mCondVar.notify_one();
 		}
 
 		size_t GetJobQueueSize()


### PR DESCRIPTION
**Summary**
Resolves race conditions causing intermittent test failures through improved thread synchronization.

**Root Cause**
ampTrackWorker::StopWorker() didn't hold the mutex whilst setting the stopped flag and notifying, resulting in process job being stuck on the wait occasionally

**Main Changes**
Added mutex lock to StopWorker()
Replaced manual lock/unlock with RAII scoped locking in ProcessJob()
Made ProcessJob() static, improved lambda captures
Renamed mStop → mStopped for clarity
Removed double-check pattern in SubmitJob()

**Risk**: Low 
**Testing**: All L1 & L2 tests 