### PR TITLE
RDK-60157 : unified support for SetAC4Tracks

### DIFF
--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -48,18 +48,6 @@ void DefaultSocInterface::SetAudioProperty(const char * &volume, const char * &m
 	isSinkBinVolume = true;
 #endif
 }
-/**
- * @brief Set AC4 tracks.
- * @param src Source element.
- * @param trackId Track ID.
- */
-void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
-{
-	if(src)
-	{
-		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
-	}
-}
 
 bool DefaultSocInterface::IsVideoSink(const char* name)
 {

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -21,6 +21,8 @@
 #include "vendor/amlogic/AmlogicSocInterface.h"
 #include "vendor/brcm/BrcmSocInterface.h"
 #include "vendor/realtek/RealtekSocInterface.h"
+#include "vendor/SocInterface.h"
+
 DefaultSocInterface::DefaultSocInterface()
 {
 }
@@ -53,7 +55,14 @@ void DefaultSocInterface::SetAudioProperty(const char * &volume, const char * &m
  */
 void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 {
-	g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
+if(src)
+	{
+		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
+	}
+}
+void SocInterface::SetAC4Tracks(GstElement *src, int trackId)
+{
+	//dummy implementation for the sake of tests
 }
 bool DefaultSocInterface::IsVideoSink(const char* name)
 {

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -21,7 +21,7 @@
 #include "vendor/amlogic/AmlogicSocInterface.h"
 #include "vendor/brcm/BrcmSocInterface.h"
 #include "vendor/realtek/RealtekSocInterface.h"
-#include "vendor/SocInterface.h"
+
 
 DefaultSocInterface::DefaultSocInterface()
 {
@@ -60,10 +60,7 @@ void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
 	}
 }
-void SocInterface::SetAC4Tracks(GstElement *src, int trackId)
-{
-	//dummy implementation for the sake of tests
-}
+
 bool DefaultSocInterface::IsVideoSink(const char* name)
 {
 	return name && (

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -55,7 +55,7 @@ void DefaultSocInterface::SetAudioProperty(const char * &volume, const char * &m
  */
 void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 {
-if(src)
+	if(src)
 	{
 		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
 	}

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -22,7 +22,6 @@
 #include "vendor/brcm/BrcmSocInterface.h"
 #include "vendor/realtek/RealtekSocInterface.h"
 
-
 DefaultSocInterface::DefaultSocInterface()
 {
 }

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -256,7 +256,13 @@ void SocInterface::ConfigureAcceptCaps(GstBaseTransformClass* base_transform_cla
  */
 void SocInterface::SetAC4Tracks(GstElement *src, int trackId)
 {
-	//redirect to Default implementation
-	DefaultSocInterface defaultSoc;
-	defaultSoc.SetAC4Tracks(src, trackId);
+	MW_LOG_INFO("Selecting AC4 Track Id : %d", trackId);
+	if(src)
+	{
+		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
+	}
+	else
+	{
+		MW_LOG_ERR("No valid src to set ac4-presentation-group-index");
+	}
 }

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -248,3 +248,15 @@ void SocInterface::ConfigureAcceptCaps(GstBaseTransformClass* base_transform_cla
         base_transform_class->accept_caps = GST_DEBUG_FUNCPTR(accept_caps_func);
     }
 }
+
+/**
+ * @brief Set AC4 tracks.
+ * @param src Source element.
+ * @param trackId Track ID.
+ */
+void SocInterface::SetAC4Tracks(GstElement *src, int trackId)
+{
+	//redirect to Default implementation
+	DefaultSocInterface defaultSoc;
+	defaultSoc.SetAC4Tracks(src, trackId);
+}

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -277,7 +277,7 @@ public:
 	 * @param src Source element.
 	 * @param trackId Track ID.
 	 */
-	virtual void SetAC4Tracks(GstElement *src, int trackId) = 0;
+	virtual void SetAC4Tracks(GstElement *src, int trackId);
 	
 	/**
 	 * @brief Set platform playback rate.

--- a/middleware/vendor/amlogic/AmlogicSocInterface.cpp
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.cpp
@@ -142,24 +142,6 @@ GstPad* AmlogicSocInterface::GetSourcePad(GstElement* source)
 }
 
 /**
- * @brief Set AC4 tracks.
- * @param src Source element.
- * @param trackId Track ID.
- */
-void AmlogicSocInterface::SetAC4Tracks(GstElement *src, int trackId)
-{
-	MW_LOG_INFO("Selecting AC4 Track Id : %d", trackId);
-	if(src)
-	{
-		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
-	}
-	else
-	{
-		MW_LOG_ERR("No valid src to set ac4-presentation-group-index");
-	}
-}
-
-/**
  * @brief Check if the given name is a video sink.
  * @param name Element name.
  * @return True if it's a video sink, false otherwise.

--- a/middleware/vendor/amlogic/AmlogicSocInterface.h
+++ b/middleware/vendor/amlogic/AmlogicSocInterface.h
@@ -84,13 +84,6 @@ class AmlogicSocInterface : public SocInterface
 		GstPad* GetSourcePad(GstElement* element) override;
 
 		/**
-		 * @brief Set AC4 tracks.
-		 * @param src Source element.
-		 * @param trackId Track ID.
-		 */
-		void SetAC4Tracks(GstElement *src, int trackId) override;
-
-		/**
 		 * @brief Get SVP Context
 		 */
 		void SvpGetContext(void **svpCtx, int flags)override;

--- a/middleware/vendor/brcm/BrcmSocInterface.h
+++ b/middleware/vendor/brcm/BrcmSocInterface.h
@@ -67,13 +67,6 @@ public:
 	GstElement* GetVideoSink(GstElement* sinkbin) override;
 	
 	/**
-	 * @brief Set AC4 tracks.
-	 * @param src Source element.
-	 * @param trackId Track ID.
-	 */
-	void SetAC4Tracks(GstElement *src, int trackId) override{MW_LOG_WARN("AC4 support has not done for this platform - track Id: %d", trackId);}
-	
-	/**
 	 * @brief Set platform playback rate.
 	 * @return True on success, false otherwise.
 	 */

--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -55,24 +55,6 @@ void DefaultSocInterface::SetAudioProperty(const char * &volume, const char * &m
 #endif
 }
 
-/**
- * @brief Set AC4 tracks.
- * @param src Source element.
- * @param trackId Track ID.
- */
-void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
-{
-	MW_LOG_INFO("Selecting AC4 Track Id : %d", trackId);
-	if(src)
-	{
-		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
-	}
-	else
-	{
-		MW_LOG_ERR("No valid src to set ac4-presentation-group-index");
-	}
-}
-
 bool DefaultSocInterface::IsVideoSink(const char* name)
 {
 	return name && (

--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -55,6 +55,28 @@ void DefaultSocInterface::SetAudioProperty(const char * &volume, const char * &m
 #endif
 }
 
+/**
+ * @brief Set AC4 tracks.
+ * @param src Source element.
+ * @param trackId Track ID.
+ */
+void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
+{
+	#if defined(__APPLE__) || defined(UBUNTU)
+		return false;
+    #else
+		MW_LOG_INFO("Selecting AC4 Track Id : %d", trackId);
+		if(src)
+		{
+			g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
+		}
+		else
+		{
+			MW_LOG_ERR("No valid src to set ac4-presentation-group-index");
+		}
+	#endif
+}
+
 bool DefaultSocInterface::IsVideoSink(const char* name)
 {
 	return name && (

--- a/middleware/vendor/default/DefaultSocInterface.cpp
+++ b/middleware/vendor/default/DefaultSocInterface.cpp
@@ -63,7 +63,14 @@ void DefaultSocInterface::SetAudioProperty(const char * &volume, const char * &m
 void DefaultSocInterface::SetAC4Tracks(GstElement *src, int trackId)
 {
 	MW_LOG_INFO("Selecting AC4 Track Id : %d", trackId);
-	g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
+	if(src)
+	{
+		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
+	}
+	else
+	{
+		MW_LOG_ERR("No valid src to set ac4-presentation-group-index");
+	}
 }
 
 bool DefaultSocInterface::IsVideoSink(const char* name)

--- a/middleware/vendor/default/DefaultSocInterface.h
+++ b/middleware/vendor/default/DefaultSocInterface.h
@@ -58,6 +58,13 @@ public:
 	void SetAudioProperty(const char * &volume, const char * &mute, bool& isSinkBinVolume)override;
 	
 	/**
+	 * @brief Set AC4 tracks.
+	 * @param src Source element.
+	 * @param trackId Track ID.
+	 */
+	void SetAC4Tracks(GstElement *src, int trackId);
+
+	/**
 	 * @brief Sets the playback rate for the given GStreamer elements.
 	 *
 	 * @param sources A vector of GStreamer source elements.

--- a/middleware/vendor/default/DefaultSocInterface.h
+++ b/middleware/vendor/default/DefaultSocInterface.h
@@ -68,14 +68,7 @@ public:
 	 * @return True if the playback rate was set successfully, false otherwise.
 	 */
 	bool SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec) override;
-	
-	/**
-	 * @brief Set AC4 tracks.
-	 * @param src Source element.
-	 * @param trackId Track ID.
-	 */
-	void SetAC4Tracks(GstElement *src, int trackId) override;
-	
+		
 	/**
 	 * @brief Set rate correction.
 	 * @return True on success, false otherwise.

--- a/middleware/vendor/realtek/RealtekSocInterface.cpp
+++ b/middleware/vendor/realtek/RealtekSocInterface.cpp
@@ -105,24 +105,6 @@ bool RealtekSocInterface::SetPlaybackRate(const std::vector<GstElement*>& source
 }
 
 /**
- * @brief Set AC4 tracks.
- * @param src Source element.
- * @param trackId Track ID.
- */
-void RealtekSocInterface::SetAC4Tracks(GstElement *src, int trackId)
-{
-	MW_LOG_INFO("Selecting AC4 Track Id : %d", trackId);
-	if(src)
-	{
-		g_object_set(src, "ac4-presentation-group-index", trackId, NULL);
-	}
-	else
-	{
-		MW_LOG_ERR("No valid src to set ac4-presentation-group-index");
-	}
-}
-
-/**
  * @brief Check if the given name is a video sink.
  * @param name Element name.
  * @return True if it's a video sink, false otherwise.

--- a/middleware/vendor/realtek/RealtekSocInterface.h
+++ b/middleware/vendor/realtek/RealtekSocInterface.h
@@ -115,13 +115,6 @@ class RealtekSocInterface : public SocInterface
 		bool SetPlaybackRate(const std::vector<GstElement*>& sources, GstElement *pipeline, double rate, GstElement *video_dec, GstElement *audio_dec) override;
 
 		/**
-		 * @brief Set AC4 tracks.
-		 * @param src Source element.
-		 * @param trackId Track ID.
-		 */
-		void SetAC4Tracks(GstElement *src, int trackId) override;
-
-		/**
 		 * @brief Set platform playback rate.
 		 * @return True on success, false otherwise.
 		 */


### PR DESCRIPTION
RDK-60157 : unified support for SetAC4Tracks
Reason for change : Redirect all SetAC4Tracks() calls to default implementation
Test Procedure : Detailed test steps mentioned in the ticket
Priority : P2
Risks : None
Signed-off-by : Nejuma T N <nejumatn28@gmail.com>