### PR TITLE
Revert "VPLAY-11886: Rate correction is enabled during RW on LLD"

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -3500,7 +3500,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 				liveAdjust = true;
 				notifyEnteringLive = true;
 			}
-			else if (((eTUNETYPE_SEEK == tuneType) || (eTUNETYPE_RETUNE == tuneType || eTUNETYPE_NEW_SEEK == tuneType)) && (currentRate != AAMP_RATE_PAUSE))
+			else if (((eTUNETYPE_SEEK == tuneType) || (eTUNETYPE_RETUNE == tuneType || eTUNETYPE_NEW_SEEK == tuneType)) && (currentRate > AAMP_RATE_PAUSE))
 			{
 				double seekWindowEnd = duration - aamp->mLiveOffset;
 				// check if seek beyond live point


### PR DESCRIPTION
Reverts rdkcentral/aamp#724

Reason for Change: patch is breaking L2 tests 8004 and 8015 
	test_8004[Trickplay_on_CDAI_back_to_back_source_period_CDAI_substitution_3
	test_8015[Trickplay_on_CDAI_Split_period_ad_with_short_ad_1

Risk: Low