### PR TITLE
VPLAY-12333 mp4demux hardening; fix crash when running without address sanitizer

### DIFF
--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -1004,7 +1004,7 @@ void Mp4Demux::ParseEsdsCodecConfigHelper(const uint8_t *next)
 				break;
 			case ESDS_TAG_DECODER_SPECIFIC_INFO:
 				// Leaf descriptor - contains actual codec configuration data
-				if( ptr+len > endPtr )
+				if( ptr + len > endPtr )
 				{
 					throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "esds: malformed config data");
 				}

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -1004,6 +1004,10 @@ void Mp4Demux::ParseEsdsCodecConfigHelper(const uint8_t *next)
 				break;
 			case ESDS_TAG_DECODER_SPECIFIC_INFO:
 				// Leaf descriptor - contains actual codec configuration data
+				if( ptr+len > endPtr )
+				{
+					throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "esds: malformed config data");
+				}
 				codecInfo.mCodecData = std::vector<uint8_t>(ptr, ptr + len);
 				ptr += len;
 				break;

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -1004,7 +1004,7 @@ void Mp4Demux::ParseEsdsCodecConfigHelper(const uint8_t *next)
 				break;
 			case ESDS_TAG_DECODER_SPECIFIC_INFO:
 				// Leaf descriptor - contains actual codec configuration data
-				if( ptr + len > endPtr )
+				if (ptr + len > next)
 				{
 					throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "esds: malformed config data");
 				}


### PR DESCRIPTION
VPLAY-12333 mp4demux hardening; fix crash when running without address sanitizer

Reason for Change: avoid crash in EsdsReadLenTests, SizeZeroEsdsValidTagButShortDataTriggersBoundaryMismatch, seen when address sanitizer is NOT used

Test Guidance: l1 tests complete without crash when run with address sanitizer disabled, or when run from command line

Risk: Low