### PR TITLE
VPLAY-12164 Http 404 for mpd while channel change

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -167,7 +167,7 @@ AampMPDDownloader::AampMPDDownloader() :  mMPDBufferQ(),mMPDBufferSize(1),mMPDBu
 	mManifestUpdateCb(NULL),mManifestUpdateCbArg(NULL),mDownloadNotifierThread(),mCachedMPDData(nullptr),
 	mCheckedLLDData(false),mMPDNotifierMtx(),mMPDNotifierCondVar(),mManifestRefreshCount(0),mIsLowLatency(false),
 	mMPDDnldDataMtx(),mMPDDnldDataCondVar()
-	,mLLDashData(),mCurrentposDeltaToManifestEnd(-1),mPublishTime(0),mMinimalRefreshRetryCount(0),mMPDNotifyPending(false)
+	,mLLDashData(),mCurrentposDeltaToManifestEnd(-1),mPublishTime(0),mMinimalRefreshRetryCount(0),mMPDNotifyPending(false),mFogTsbDeleted(false)
 {
 }
 
@@ -396,6 +396,12 @@ void AampMPDDownloader::downloadMPDThread1()
 			}
 			else
 			{
+				if(mFogTsbDeleted.load())
+				{
+					//TODO: Deprecate when Fog tsb is removed. Ignore the manifest request from AAMP after the TSB deleted in fog when the stop called.
+					AAMPLOG_INFO("Fog tsb deleted. Ignoring MPD request and exiting");
+					break;
+				}
 				mDownloader1.Download(tuneUrl, mMPDData->mMPDDownloadResponse);
 			}
 		}

--- a/AampMPDDownloader.h
+++ b/AampMPDDownloader.h
@@ -312,6 +312,12 @@ public:
 	 */
 	uint64_t GetPublishTime() { return mPublishTime;}
 
+	/**
+	*	@fn SetFogTsbDeleted
+	*	@brief Function to Set if Fog TSB is deleted
+	*/
+	void SetFogTsbDeleted(bool bDeleted) {mFogTsbDeleted.store(bDeleted);}
+
 private:
 
 	/**
@@ -439,6 +445,7 @@ private:
 	int mMinimalRefreshRetryCount;  /* A counter to checks if the publication time remains the same for 2 consecutive refresh*/
 	std::atomic_bool mMPDNotifyPending ; /*To allow wait for downloadNotifier based on NotifyPending Status */
 	std::function<std::string()> mMpdPreProcessFuncptr; /* function invoked to read the available preprocessed manifest data or to send event if manifest data is not available */
+	std::atomic<bool> mFogTsbDeleted{false};  /**< Flag indicating whether fog tsb is deleted or not.*/
 };
 
 #endif /* __AAMP_MPD_DOWNLOADER_H__ */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8359,6 +8359,10 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	//Moved the tsb delete request from XRE to AAMP to avoid the HTTP-404 erros
 	if(IsFogTSBSupported())
 	{
+		if(mMPDDownloaderInstance != nullptr)
+		{
+			mMPDDownloaderInstance->SetFogTsbDeleted(true);
+		}
 		std::string remoteUrl = "127.0.0.1:9080/tsb";
 		AampCurlDownloader T1;
 		DownloadResponsePtr respData = std::make_shared<DownloadResponse> ();

--- a/test/utests/fakes/FakeAampMPDDownloader.cpp
+++ b/test/utests/fakes/FakeAampMPDDownloader.cpp
@@ -67,7 +67,7 @@ AampMPDDownloader::AampMPDDownloader() :  mMPDBufferQ(),mMPDBufferSize(1),mMPDBu
 	mMPDDnldMutex(),mRefreshInterval(DEFAULT_INTERVAL_BETWEEN_PLAYLIST_UPDATES_MS),mLatencyValue(-1),mReleaseCalled(false),
 	mMPDDnldCfg(NULL),mDownloaderThread_t1(),mDownloaderThread_t2(),mDownloader1(),mDownloader2(),mMPDData(nullptr),mAppName(""),
 	mManifestUpdateCb(NULL),mManifestUpdateCbArg(NULL),mDownloadNotifierThread(),mCachedMPDData(nullptr),
-	mCheckedLLDData(false),mMPDNotifierMtx(),mMPDNotifierCondVar(),mManifestRefreshCount(0)
+	mCheckedLLDData(false),mMPDNotifierMtx(),mMPDNotifierCondVar(),mManifestRefreshCount(0),mFogTsbDeleted(false)
 {
 }
 


### PR DESCRIPTION
Reason for change: Moving the Teardown operation before the mpd update release cause some delay and results in more Http 404 errors.
Test Procedure: updated in ticket
Risks: Low