### PR TITLE
Feature/vplay 12203

### DIFF
--- a/middleware/closedcaptions/PlayerCCManager.cpp
+++ b/middleware/closedcaptions/PlayerCCManager.cpp
@@ -731,10 +731,7 @@ int PlayerCCManagerBase::SetTrack(const std::string &track, const CCFormat forma
  */
 void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
-	if (!mEnabled && shouldRestoreCC)
-	{
-		mEnabled = true;
-	}
+	mEnabled = shouldRestoreCC;
 	MW_LOG_WARN("PlayerCCManagerBase::mEnabled: %d, mTrickplayStarted: %d, mParentalCtrlLocked: %d, mCCHandle: %s",
 			mEnabled, mTrickplayStarted, mParentalCtrlLocked, (CheckCCHandle()) ? "set" : "not set");
 

--- a/middleware/closedcaptions/PlayerCCManager.cpp
+++ b/middleware/closedcaptions/PlayerCCManager.cpp
@@ -729,11 +729,18 @@ int PlayerCCManagerBase::SetTrack(const std::string &track, const CCFormat forma
 /**
  *  @brief To restore cc state after new tune
  */
-void PlayerCCManagerBase::RestoreCC()
+void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
+	
 	MW_LOG_WARN("PlayerCCManagerBase::mEnabled: %d, mTrickplayStarted: %d, mParentalCtrlLocked: %d, mCCHandle: %s",
 			mEnabled, mTrickplayStarted, mParentalCtrlLocked, (CheckCCHandle()) ? "set" : "not set");
-
+	if(!mEnabled && shouldRestoreCC)
+	{
+		mEnabled = true;
+		MW_LOG_WARN("PlayerCCManagerBase::mEnabled: %d, mTrickplayStarted: %d, mParentalCtrlLocked: %d, mCCHandle: %s",
+			mEnabled, mTrickplayStarted, mParentalCtrlLocked, (CheckCCHandle()) ? "set" : "not set");
+	}
+	
 	std::string trackId = GetTrack();
 
 	const auto& textTracks = getLastTextTracks();

--- a/middleware/closedcaptions/PlayerCCManager.h
+++ b/middleware/closedcaptions/PlayerCCManager.h
@@ -137,7 +137,7 @@ public:
 	/**
 	 * @fn RestoreCC 
 	 *
-	 * @param[in] shouldRestoreCC - flag indicating whether CC should be forcibly restored if currently disabled
+	 * @param[in] shouldRestoreCC - previously captured CC enabled state to be restored after teardown
 	 * @return void
 	 */
 	void RestoreCC(bool shouldRestoreCC = false);

--- a/middleware/closedcaptions/PlayerCCManager.h
+++ b/middleware/closedcaptions/PlayerCCManager.h
@@ -139,7 +139,7 @@ public:
 	 *
 	 * @return void
 	 */
-	void RestoreCC();
+	void RestoreCC(bool shouldRestoreCC=false);
 
 	virtual ~PlayerCCManagerBase(){ };
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5353,6 +5353,7 @@ static int aampApplyThreadPrioFromEnv(const char *env, int defaultPolicy, int de
 void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 {
 	bool newTune;
+	bool shouldRestoreCC=false;
 
 	aampApplyThreadPrioFromEnv("AAMP_AV_PIPELINE_PRIORITY", SCHED_OTHER, 0);
 	for (int i = 0; i < AAMP_TRACK_COUNT; i++)
@@ -5426,6 +5427,11 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	}
 
 	TeardownStream(newTune|| (eTUNETYPE_RETUNE == tuneType));
+	if( !newTune || eTUNETYPE_RETUNE == tuneType)
+	{
+		shouldRestoreCC = PlayerCCManager::GetInstance()->GetStatus();
+		AAMPLOG_WARN("shouldRestoreCC:%d isCCinBand:%d",shouldRestoreCC,mIsInbandCC);
+	}
 	if(SocUtils::ResetNewSegmentEvent())
 	{
 		// Send new SEGMENT event only on all trickplay and trickplay -> play, not on pause -> play / seek while paused
@@ -5901,14 +5907,16 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	if(!mIsFakeTune)
 	{
 		AAMPLOG_INFO("mCCId: %d",mCCId);
-		// if mCCId has non zero value means it is same instance and cc release was not callee then don't get id. if zero then call getid.
+		// if mCCId has non zero value means it is same instance and cc release was not called then don't get id. if zero then call getid.
 		if(mCCId == 0 )
 		{
 			mCCId = PlayerCCManager::GetInstance()->GetId();
 		}
 		//restore CC if it was enabled for previous content.
 		if(mIsInbandCC)
-			PlayerCCManager::GetInstance()->RestoreCC();
+		{
+			PlayerCCManager::GetInstance()->RestoreCC(shouldRestoreCC);
+		}
 	}
 
 	if (newTune && !mIsFakeTune)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5429,8 +5429,9 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	TeardownStream(newTune|| (eTUNETYPE_RETUNE == tuneType));
 	if (!newTune || eTUNETYPE_RETUNE == tuneType)
 	{
-		shouldRestoreCC = PlayerCCManager::GetInstance()->GetStatus();
-		AAMPLOG_WARN("shouldRestoreCC:%d isCCinBand:%d",shouldRestoreCC,mIsInbandCC);
+		bool wasCCEnabled = PlayerCCManager::GetInstance()->GetStatus();
+		AAMPLOG_WARN("wasCCEnabled:%d isCCinBand:%d", wasCCEnabled, mIsInbandCC);
+		shouldRestoreCC = wasCCEnabled;
 	}
 	if(SocUtils::ResetNewSegmentEvent())
 	{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5353,7 +5353,7 @@ static int aampApplyThreadPrioFromEnv(const char *env, int defaultPolicy, int de
 void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 {
 	bool newTune;
-	bool shouldRestoreCC = false;
+	bool previousCCEnabled = false;
 
 	aampApplyThreadPrioFromEnv("AAMP_AV_PIPELINE_PRIORITY", SCHED_OTHER, 0);
 	for (int i = 0; i < AAMP_TRACK_COUNT; i++)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5353,6 +5353,7 @@ static int aampApplyThreadPrioFromEnv(const char *env, int defaultPolicy, int de
 void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 {
 	bool newTune;
+	bool shouldRestoreCC=false;
 
 	aampApplyThreadPrioFromEnv("AAMP_AV_PIPELINE_PRIORITY", SCHED_OTHER, 0);
 	for (int i = 0; i < AAMP_TRACK_COUNT; i++)
@@ -5426,6 +5427,11 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	}
 
 	TeardownStream(newTune|| (eTUNETYPE_RETUNE == tuneType));
+	if( !newTune || eTUNETYPE_RETUNE == tuneType)
+	{
+		shouldRestoreCC = PlayerCCManager::GetInstance()->GetStatus();
+		AAMPLOG_WARN("shouldRestoreCC:%d",shouldRestoreCC);
+	}
 	if(SocUtils::ResetNewSegmentEvent())
 	{
 		// Send new SEGMENT event only on all trickplay and trickplay -> play, not on pause -> play / seek while paused
@@ -5901,14 +5907,19 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	if(!mIsFakeTune)
 	{
 		AAMPLOG_INFO("mCCId: %d",mCCId);
-		// if mCCId has non zero value means it is same instance and cc release was not callee then don't get id. if zero then call getid.
+		// if mCCId has non zero value means it is same instance and cc release was not called then don't get id. if zero then call getid.
 		if(mCCId == 0 )
 		{
 			mCCId = PlayerCCManager::GetInstance()->GetId();
 		}
 		//restore CC if it was enabled for previous content.
+		AAMPLOG_WARN("isCC:%d shouldRestoreCC:%d",mIsInbandCC, shouldRestoreCC);
 		if(mIsInbandCC)
-			PlayerCCManager::GetInstance()->RestoreCC();
+		{
+			AAMPLOG_WARN("isCC:%d shouldRestoreCC:%d",mIsInbandCC, shouldRestoreCC);
+			PlayerCCManager::GetInstance()->RestoreCC(shouldRestoreCC);
+			
+		}
 	}
 
 	if (newTune && !mIsFakeTune)


### PR DESCRIPTION
 VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD asset on perform FF till the ad break point
    
    Reason for Change: fix inband CC resume after the seek based on enable/disable flag
    
    Test Guidance: Check the ticket
    
    Risk: Low
