### PR TITLE
VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD…

### DIFF
--- a/middleware/closedcaptions/PlayerCCManager.cpp
+++ b/middleware/closedcaptions/PlayerCCManager.cpp
@@ -729,8 +729,12 @@ int PlayerCCManagerBase::SetTrack(const std::string &track, const CCFormat forma
 /**
  *  @brief To restore cc state after new tune
  */
-void PlayerCCManagerBase::RestoreCC()
+void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
+	if(!mEnabled && shouldRestoreCC)
+	{
+		mEnabled = shouldRestoreCC;
+	}
 	MW_LOG_WARN("PlayerCCManagerBase::mEnabled: %d, mTrickplayStarted: %d, mParentalCtrlLocked: %d, mCCHandle: %s",
 			mEnabled, mTrickplayStarted, mParentalCtrlLocked, (CheckCCHandle()) ? "set" : "not set");
 

--- a/middleware/closedcaptions/PlayerCCManager.cpp
+++ b/middleware/closedcaptions/PlayerCCManager.cpp
@@ -727,7 +727,10 @@ int PlayerCCManagerBase::SetTrack(const std::string &track, const CCFormat forma
 }
 
 /**
- *  @brief To restore cc state after new tune
+ * @brief Restores the closed captions state after a new tune operation.
+ *
+ * @param shouldRestoreCC Indicates whether the closed captions state
+ * should be restored.
  */
 void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {

--- a/middleware/closedcaptions/PlayerCCManager.h
+++ b/middleware/closedcaptions/PlayerCCManager.h
@@ -137,9 +137,10 @@ public:
 	/**
 	 * @fn RestoreCC 
 	 *
+	 * @param[in] shouldRestoreCC - previously captured CC enabled state to be restored after teardown
 	 * @return void
 	 */
-	void RestoreCC();
+	void RestoreCC(bool shouldRestoreCC = false);
 
 	virtual ~PlayerCCManagerBase(){ };
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5380,6 +5380,7 @@ static int aampApplyThreadPrioFromEnv(const char *env, int defaultPolicy, int de
 void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 {
 	bool newTune;
+	bool previousCCEnabled = false;
 
 	aampApplyThreadPrioFromEnv("AAMP_AV_PIPELINE_PRIORITY", SCHED_OTHER, 0);
 	for (int i = 0; i < AAMP_TRACK_COUNT; i++)
@@ -5453,6 +5454,11 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	}
 
 	TeardownStream(newTune|| (eTUNETYPE_RETUNE == tuneType));
+	if (!newTune)
+	{
+		previousCCEnabled = PlayerCCManager::GetInstance()->GetStatus();
+		AAMPLOG_WARN("previousCCEnabled:%d isCCinBand:%d", previousCCEnabled, mIsInbandCC);
+	}
 	if(SocUtils::ResetNewSegmentEvent())
 	{
 		// Send new SEGMENT event only on all trickplay and trickplay -> play, not on pause -> play / seek while paused
@@ -5935,7 +5941,9 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 		}
 		//restore CC if it was enabled for previous content.
 		if(mIsInbandCC)
-			PlayerCCManager::GetInstance()->RestoreCC();
+		{
+			PlayerCCManager::GetInstance()->RestoreCC(previousCCEnabled);
+		}
 	}
 
 	if (newTune && !mIsFakeTune)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5456,6 +5456,10 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	TeardownStream(newTune|| (eTUNETYPE_RETUNE == tuneType));
 	if (!newTune)
 	{
+		// Capture the current CC enabled state only for non-new tunes (e.g. retune/seek).
+		// For brand new tunes we intentionally do NOT restore any previous CC state;
+		// previousCCEnabled remains at its default (false) so RestoreCC() starts CC
+		// from a clean, disabled state for new content.
 		previousCCEnabled = PlayerCCManager::GetInstance()->GetStatus();
 		AAMPLOG_WARN("previousCCEnabled:%d isCCinBand:%d", previousCCEnabled, mIsInbandCC);
 	}

--- a/test/utests/fakes/FakeAampCCManager.cpp
+++ b/test/utests/fakes/FakeAampCCManager.cpp
@@ -61,7 +61,7 @@ int PlayerCCManagerBase::Init(void *handle)
 {
 	return 0;
 }
-void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
+void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC = false)
 {
 }
 void PlayerCCManagerBase::Release(int iID)

--- a/test/utests/fakes/FakeAampCCManager.cpp
+++ b/test/utests/fakes/FakeAampCCManager.cpp
@@ -61,7 +61,7 @@ int PlayerCCManagerBase::Init(void *handle)
 {
 	return 0;
 }
-void PlayerCCManagerBase::RestoreCC()
+void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
 }
 void PlayerCCManagerBase::Release(int iID)

--- a/test/utests/mocks/MockPlayerCCManager.h
+++ b/test/utests/mocks/MockPlayerCCManager.h
@@ -26,7 +26,7 @@ class MockPlayerCCManager
 {
 public:
 	MOCK_METHOD(int, Init, (void *handle));
-	MOCK_METHOD(void, RestoreCC, ());
+	MOCK_METHOD(void, RestoreCC, (bool shouldRestoreCC));
 	MOCK_METHOD(void, Release, (int iID));
 	MOCK_METHOD(bool, IsOOBCCRenderingSupported, ());
 	MOCK_METHOD(int, SetStatus, (bool enable));


### PR DESCRIPTION
… asset on perform FF till the ad break point

Reason for Change: fix inband CC resume after the seek based on enable/disable flag

Test Guidance: Check the ticket

Risk: Low