### PR TITLE
VPLAY-12165 compilation warnings seen while building l1 tests in GitH…

### DIFF
--- a/middleware/gst-plugins/CMakeLists.txt
+++ b/middleware/gst-plugins/CMakeLists.txt
@@ -17,7 +17,7 @@
 # Boston, MA 02110-1301, USA.
 #########################################################################
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.5)
 project (GST-PLUGINS)
 
 set(MW_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../")

--- a/middleware/test/utests/CMakeLists.txt
+++ b/middleware/test/utests/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.10.3)
+cmake_minimum_required(VERSION 3.15)
 
 project(UnitTests)
 

--- a/test/utests/CMakeLists.txt
+++ b/test/utests/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.10.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(UnitTests)
 
@@ -53,7 +53,8 @@ if (NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
 	find_path (JSC_INCDIR JavaScriptCore/JavaScript.h HINTS ${JSCORE_INCLUDE_DIRS} REQUIRED)
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+project (AAMP_L1_TESTS)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_GST1 -ggdb")
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")

--- a/test/utests/tests/CachedFragmentTests/CMakeLists.txt
+++ b/test/utests/tests/CachedFragmentTests/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.10.3)
+cmake_minimum_required(VERSION 3.5)
 
 # Project name
 project(CachedFragmentTests)


### PR DESCRIPTION
…ub actions

Reason for change: To update utest cmake version
Risks: Low
Priority: P1