### PR TITLE
VPLAY-12360: [LLD] Add support to inject only MP4 chunks instead of network chunks

### DIFF
--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -265,6 +265,8 @@ struct CurlCallbackContext
 	size_t contentLength = 0;
 	long long downloadStartTime = -1;
 	long long processDelay = 0; /**< Indicate the external process delay in curl operation; especially for lld*/
+	size_t bufferOffset = 0; // Used for chunked download to keep track of current buffer offset
+	size_t chunkBoundary = 0; // Used for chunked download to store the current chunk boundary
 
 	CurlCallbackContext(){}
 	CurlCallbackContext(PrivateInstanceAAMP *_aamp, AampGrowableBuffer *_buffer) : aamp(_aamp), buffer(_buffer){}

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -1230,41 +1230,46 @@ bool IsoBmffBuffer::setMediaHeaderDuration(uint64_t duration)
  */
 bool IsoBmffBuffer::getMdatBoxInfo(size_t index, size_t &start, size_t &size)
 {
-	return getBoxInfoInternal(&boxes, Box::MDAT, index, start, size);
+	return getBoxInfoInternal(Box::MDAT, index, start, size);
 }
 
 /**
  * @fn getBoxInfoInternal - Get box info
  *
- * @param[in] boxes - ISOBMFF boxes
  * @param[in] name - box name to get
  * @param[in] index - index of box in a parsed buffer
  * @param[out] start - start offset of box
  * @param[out] size - size of box
  * @return bool - true if box found, false otherwise
  */
-bool IsoBmffBuffer::getBoxInfoInternal(const std::vector<Box*> *boxes, const char *name, size_t index, size_t &start, size_t &size)
+bool IsoBmffBuffer::getBoxInfoInternal(const char *name, size_t index, size_t &start, size_t &size)
 {
 	bool ret = false;
 	size_t matchCount = 0;
-	for (size_t i = 0; i < boxes->size(); i++)
+	for (const auto& box : boxes)
 	{
-		Box *box = boxes->at(i);
 		if (IS_TYPE(box->getType(), name))
 		{
 			if (matchCount == index)
 			{
-				// Calculate the start offset of the box data within the buffer
-				start = static_cast<size_t>(box->getBase() - buffer);
-				// Get the size of the box
-				size = box->getSize();
-				ret = true;
+				if (box->getBase() >= buffer)
+				{
+					// Calculate the start offset of the box data within the buffer
+					start = static_cast<size_t>(box->getBase() - buffer);
+					// Get the size of the box
+					size = box->getSize();
+					ret = true;
+				}
+				else
+				{
+					AAMPLOG_ERR("Box of type %s has invalid base address:%p and buffer address:%p", name, box->getBase(), buffer);
+				}
 				break;
 			}
 			matchCount++;
 		}
 	}
-	if (matchCount == 0 || index >= matchCount)
+	if (!ret)
 	{
 		AAMPLOG_WARN("Box of type %s with index %zu not found, only %zu available", name, index, matchCount);
 	}

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -1170,6 +1170,11 @@ bool IsoBmffBuffer::setTrickmodeTimescale(uint32_t timescale)
 	return retval;
 }
 
+/**
+ * @brief Find the MDHD box and set the duration
+ * @param[in] duration - duration to set
+ * @return true if successful, false otherwise
+ */
 bool IsoBmffBuffer::setMediaHeaderDuration(uint64_t duration)
 {
 	bool retval{false};
@@ -1213,4 +1218,55 @@ bool IsoBmffBuffer::setMediaHeaderDuration(uint64_t duration)
 		AAMPLOG_WARN("No MOOV box within buffer");
 	}
 	return retval;
+}
+
+/**
+ * @fn getMdatBoxInfo - Get mdat box info
+ *
+ * @param[in] index - index of mdat box
+ * @param[out] start - start offset of mdat box
+ * @param[out] size - size of mdat box
+ * @return bool - true if box found, false otherwise
+ */
+bool IsoBmffBuffer::getMdatBoxInfo(size_t index, size_t &start, size_t &size)
+{
+	return getBoxInfoInternal(&boxes, Box::MDAT, index, start, size);
+}
+
+/**
+ * @fn getBoxInfoInternal - Get box info
+ *
+ * @param[in] boxes - ISOBMFF boxes
+ * @param[in] name - box name to get
+ * @param[in] index - index of box in a parsed buffer
+ * @param[out] start - start offset of box
+ * @param[out] size - size of box
+ * @return bool - true if box found, false otherwise
+ */
+bool IsoBmffBuffer::getBoxInfoInternal(const std::vector<Box*> *boxes, const char *name, size_t index, size_t &start, size_t &size)
+{
+	bool ret = false;
+	size_t matchCount = 0;
+	for (size_t i = 0; i < boxes->size(); i++)
+	{
+		Box *box = boxes->at(i);
+		if (IS_TYPE(box->getType(), name))
+		{
+			if (matchCount == index)
+			{
+				// Calculate the start offset of the box data within the buffer
+				start = static_cast<size_t>(box->getBase() - buffer);
+				// Get the size of the box
+				size = box->getSize();
+				ret = true;
+				break;
+			}
+			matchCount++;
+		}
+	}
+	if (matchCount == 0 || index >= matchCount)
+	{
+		AAMPLOG_WARN("Box of type %s with index %zu not found, only %zu available", name, index, matchCount);
+	}
+	return ret;
 }

--- a/isobmff/isobmffbuffer.h
+++ b/isobmff/isobmffbuffer.h
@@ -136,6 +136,18 @@ private:
 	 */
 	bool updateSampleDurationInternal(uint64_t duration, TrunBox& trun, TfhdBox& tfhd);
 
+	/**
+	 * @fn getBoxInfoInternal
+	 *
+	 * @param[in] boxes - ISOBMFF boxes
+	 * @param[in] name - box name to get
+	 * @param[in] index - index of box in a parsed buffer
+	 * @param[out] start - start offset of box
+	 * @param[out] size - size of box
+	 * @return bool true if box found at index, false otherwise
+	 */
+	bool getBoxInfoInternal(const std::vector<Box*> *boxes, const char *name, size_t index, size_t &start, size_t &size);
+
 public:
 	/**
 	 * @brief IsoBmffBuffer constructor
@@ -489,5 +501,15 @@ public:
 	 * @return true if sample duration set. false otherwise
 	 */
 	bool setMediaHeaderDuration(uint64_t duration);
+
+	/**
+	 * @fn getMdatBoxInfo
+	 *
+	 * @param[in] index - index of mdat box
+	 * @param[out] start - start offset of mdat box
+	 * @param[out] size - size of mdat box
+	 * @return bool if box found. false otherwise
+	 */
+	bool getMdatBoxInfo(size_t index, size_t &start, size_t &size);
 };
 #endif /* __ISOBMFFBUFFER_H__ */

--- a/isobmff/isobmffbuffer.h
+++ b/isobmff/isobmffbuffer.h
@@ -146,7 +146,7 @@ private:
 	 * @param[out] size - size of box
 	 * @return bool true if box found at index, false otherwise
 	 */
-	bool getBoxInfoInternal(const std::vector<Box*> *boxes, const char *name, size_t index, size_t &start, size_t &size);
+	bool getBoxInfoInternal(const char *name, size_t index, size_t &start, size_t &size);
 
 public:
 	/**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -664,6 +664,57 @@ static int ReadConfigNumericHelper(std::string buf, const char* prefixPtr, T& va
 	return ret;
 }
 
+/**
+ * @brief Identify mp4 chunk boundary in buffer
+ * @param[in] buffer - buffer to scan
+ * @param[in] bufferOffset - offset in buffer to start scanning from
+ * @param[out] chunkBoundaryOffset - offset of chunk boundary if found
+ * @retval true if chunk boundary found
+ */
+static bool IdentifyMp4ChunkBoundary(AampGrowableBuffer *buffer, size_t bufferOffset, size_t &chunkBoundaryOffset)
+{
+	bool found = false;
+	chunkBoundaryOffset = 0;
+
+	IsoBmffBuffer isobmffBuffer;
+	isobmffBuffer.setBuffer(reinterpret_cast<uint8_t*>(buffer->GetPtr()) + bufferOffset, buffer->GetLen() - bufferOffset);
+
+	try
+	{
+		// correctBoxSize argument set to false as we are parsing a fragment not a full mp4 file
+		if (isobmffBuffer.parseBuffer(false))
+		{
+			// Check for 'mdat' box which indicates the end of mp4 chunk
+			size_t count = 0;
+			// Get number of mdat boxes
+			if (isobmffBuffer.getMdatBoxCount(count))
+			{
+				if (count > 0)
+				{
+					size_t start = 0;
+					size_t size = 0;
+					// Get the last mdat box info
+					if (isobmffBuffer.getMdatBoxInfo(count - 1, start, size))
+					{
+						// Calculate chunk boundary offset
+						chunkBoundaryOffset = bufferOffset + start + size;
+						found = true;
+					}
+				}
+				AAMPLOG_DEBUG("IdentifyMp4ChunkBoundary: mdat box count=%zu and chunkBoundaryOffset=%zu", count, chunkBoundaryOffset);
+			}
+		}
+	}
+	catch (std::bad_alloc& ba)
+	{
+		AAMPLOG_ERR("Bad allocation: %s", ba.what());
+	}
+	catch (std::exception& e)
+	{
+		AAMPLOG_ERR("Unhandled exception: %s", e.what());
+	}
+	return found;
+}
 
 // End of helper functions for loading configuration
 
@@ -951,13 +1002,39 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 				context->mediaType ==  eMEDIATYPE_AUDIO ||
 				context->mediaType ==  eMEDIATYPE_SUBTITLE))
 			{
-				// Release PrivateInstanceAAMP mutex to unblock async APIs
-				lock.unlock();
-				AAMPLOG_TRACE("[%d] Caching chunk with size %zu nmemb:%zu size:%zu", context->mediaType, numBytesForBlock, nmemb, size);
-				long long startTime = aamp_GetCurrentTimeMS();
-				mCtx->CacheFragmentChunk(context->mediaType, ptr, numBytesForBlock, context->remoteUrl, context->downloadStartTime);
-				context->processDelay += aamp_GetCurrentTimeMS() - startTime;
-				lock.lock();
+				// We are trying to identify a mdat box boundary in the received buffer
+				if (context->chunkBoundary == 0)
+				{
+					size_t chunkBoundaryOffset = 0;
+					if (IdentifyMp4ChunkBoundary(context->buffer, context->bufferOffset, chunkBoundaryOffset))
+					{
+						context->chunkBoundary = chunkBoundaryOffset;
+						AAMPLOG_INFO("[%d] Identified chunk boundary at offset %zu", context->mediaType, context->chunkBoundary);
+					}
+				}
+				if (context->chunkBoundary > 0)
+				{
+					if (context->buffer->GetLen() >= context->chunkBoundary)
+					{
+						// Release PrivateInstanceAAMP mutex to unblock async APIs
+						lock.unlock();
+						AAMPLOG_DEBUG("[%d] Caching chunk with size %zu nmemb:%zu size:%zu", context->mediaType, numBytesForBlock, nmemb, size);
+						long long startTime = aamp_GetCurrentTimeMS();
+						mCtx->CacheFragmentChunk(context->mediaType, ptr, numBytesForBlock, context->remoteUrl, context->downloadStartTime);
+						context->processDelay += aamp_GetCurrentTimeMS() - startTime;
+						// Update buffer offset and reset nextChunkBoundary
+						// Note: bufferOffset = nextChunkBoundary (not +1) because CacheFragmentChunk
+						// processes bytes [bufferOffset, nextChunkBoundary), so nextChunkBoundary
+						// is the first byte of the next chunk (not yet processed)
+						context->bufferOffset = context->chunkBoundary;
+						context->chunkBoundary = 0;
+						lock.lock();
+					}
+					else
+					{
+						AAMPLOG_TRACE("[%d] Waiting for more data to reach chunk boundary at offset %zu (current buffer len %zu)", context->mediaType, context->chunkBoundary, context->buffer->GetLen());
+					}
+				}
 			}
 		}
 	}
@@ -4374,13 +4451,10 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				context.m_ChunkedTransferState = ChunkedTransferState::READING_CHUNK_SIZE; // reset
 				progressCtx.downloadStartTime = NOW_STEADY_TS_MS;
 
-				if(this->mAampLLDashServiceData.lowLatencyMode)
-				{
-					context.downloadStartTime = progressCtx.downloadStartTime;
-				}
 				progressCtx.downloadUpdatedTime = -1;
 				progressCtx.downloadSize = -1;
 				progressCtx.abortReason = eCURL_ABORT_REASON_NONE;
+				context.downloadStartTime = progressCtx.downloadStartTime;
 				CURL_EASY_SETOPT_POINTER(curl, CURLOPT_PROGRESSDATA, &progressCtx);
 				if(buffer->GetPtr() != NULL)
 				{
@@ -4514,6 +4588,16 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						// Use CURLE_PARTIAL_FILE to avoid bandwidth recalculation
 						res = CURLE_PARTIAL_FILE;
 						http_code = res;
+					}
+
+					if (mAampLLDashServiceData.lowLatencyMode &&
+						(http_code == 200 || http_code == 204 || http_code == 206) &&
+						context.chunkBoundary < buffer->GetLen())
+					{
+						// This is not expected.
+						// Buffer is already cached through CURL write callback for low latency and there is no course correction.
+						// Let's log here for awareness, as it not clear if we should cache the extra data beyond chunk boundary.
+						AAMPLOG_WARN("Truncating LL-DASH chunked download from %zu to chunk boundary %zu, skipped %zu bytes", buffer->GetLen(), context.chunkBoundary, buffer->GetLen() - context.chunkBoundary);
 					}
 				}
 				else

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -681,10 +681,11 @@ static bool IdentifyMp4ChunkBoundary(AampGrowableBuffer *buffer, size_t bufferOf
 
 	try
 	{
-		// correctBoxSize argument set to false as we are parsing a fragment not a full mp4 file
 		if (isobmffBuffer.parseBuffer(false))
 		{
 			// Check for 'mdat' box which indicates the end of mp4 chunk
+			// Specified in the ISO Base Media File Format (ISO/IEC 14496-12) specification that in fragmented MP4 files,
+			// a moof (Movie Fragment) box precedes the corresponding mdat (Media Data) box
 			size_t count = 0;
 			// Get number of mdat boxes
 			if (isobmffBuffer.getMdatBoxCount(count))
@@ -1016,19 +1017,37 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 				{
 					if (context->buffer->GetLen() >= context->chunkBoundary)
 					{
-						// Release PrivateInstanceAAMP mutex to unblock async APIs
-						lock.unlock();
-						AAMPLOG_DEBUG("[%d] Caching chunk with size %zu nmemb:%zu size:%zu", context->mediaType, numBytesForBlock, nmemb, size);
-						long long startTime = aamp_GetCurrentTimeMS();
-						mCtx->CacheFragmentChunk(context->mediaType, ptr, numBytesForBlock, context->remoteUrl, context->downloadStartTime);
-						context->processDelay += aamp_GetCurrentTimeMS() - startTime;
-						// Update buffer offset and reset nextChunkBoundary
-						// Note: bufferOffset = nextChunkBoundary (not +1) because CacheFragmentChunk
-						// processes bytes [bufferOffset, nextChunkBoundary), so nextChunkBoundary
-						// is the first byte of the next chunk (not yet processed)
-						context->bufferOffset = context->chunkBoundary;
-						context->chunkBoundary = 0;
-						lock.lock();
+						const char *bufferPtr = context->buffer->GetPtr() + context->bufferOffset;
+						size_t bufferLen = 0;
+						if (context->chunkBoundary > context->bufferOffset)
+						{
+							bufferLen = context->chunkBoundary - context->bufferOffset;
+						}
+						else
+						{
+							AAMPLOG_ERR("Invalid chunk boundary offset %zu buffer offset %zu", context->chunkBoundary, context->bufferOffset);
+							ret = 0; // abort download
+						}
+						if (bufferLen > 0)
+						{
+							// Release PrivateInstanceAAMP mutex to unblock async APIs
+							lock.unlock();
+							AAMPLOG_DEBUG("[%d] Caching chunk with size %zu", context->mediaType, bufferLen);
+							long long startTime = aamp_GetCurrentTimeMS();
+							mCtx->CacheFragmentChunk(context->mediaType,
+													bufferPtr,
+													bufferLen,
+													context->remoteUrl,
+													context->downloadStartTime);
+							context->processDelay += aamp_GetCurrentTimeMS() - startTime;
+							lock.lock();
+							// Update buffer offset and reset chunkBoundary
+							// Note: bufferOffset = chunkBoundary (not +1) because CacheFragmentChunk
+							// processes bytes [bufferOffset, chunkBoundary), so chunkBoundary
+							// is the first byte of the next chunk (not yet processed)
+							context->bufferOffset = context->chunkBoundary;
+							context->chunkBoundary = 0;
+						}
 					}
 					else
 					{
@@ -4454,6 +4473,8 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				progressCtx.downloadUpdatedTime = -1;
 				progressCtx.downloadSize = -1;
 				progressCtx.abortReason = eCURL_ABORT_REASON_NONE;
+				// Note: downloadStartTime is now set for all downloads (not just LL-DASH)
+				// so that timing/monitoring logic has a valid start timestamp in every case.
 				context.downloadStartTime = progressCtx.downloadStartTime;
 				CURL_EASY_SETOPT_POINTER(curl, CURLOPT_PROGRESSDATA, &progressCtx);
 				if(buffer->GetPtr() != NULL)
@@ -4592,12 +4613,13 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 
 					if (mAampLLDashServiceData.lowLatencyMode &&
 						(http_code == 200 || http_code == 204 || http_code == 206) &&
-						context.chunkBoundary < buffer->GetLen())
+						(context.chunkBoundary > 0) &&
+						(context.chunkBoundary < buffer->GetLen()))
 					{
 						// This is not expected.
 						// Buffer is already cached through CURL write callback for low latency and there is no course correction.
 						// Let's log here for awareness, as it not clear if we should cache the extra data beyond chunk boundary.
-						AAMPLOG_WARN("Truncating LL-DASH chunked download from %zu to chunk boundary %zu, skipped %zu bytes", buffer->GetLen(), context.chunkBoundary, buffer->GetLen() - context.chunkBoundary);
+						AAMPLOG_WARN("Discarding excess data for LL-DASH chunked download from chunk boundary %zu to %zu, skipped %zu bytes", context.chunkBoundary, buffer->GetLen(), buffer->GetLen() - context.chunkBoundary);
 					}
 				}
 				else

--- a/test/utests/fakes/FakeIsoBmffBuffer.cpp
+++ b/test/utests/fakes/FakeIsoBmffBuffer.cpp
@@ -268,3 +268,15 @@ bool IsoBmffBuffer::setMediaHeaderDuration(uint64_t duration)
         return false;
     }
 }
+
+bool IsoBmffBuffer::getMdatBoxInfo(size_t index, size_t &start, size_t &size)
+{
+    if (g_mockIsoBmffBuffer)
+    {
+        return g_mockIsoBmffBuffer->getMdatBoxInfo(index, start, size);
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/test/utests/mocks/MockIsoBmffBuffer.h
+++ b/test/utests/mocks/MockIsoBmffBuffer.h
@@ -45,6 +45,7 @@ public:
     MOCK_METHOD(bool, ParseChunkData, (const char* , char* &, uint32_t,	size_t & , size_t &, double& , double &));
 	MOCK_METHOD(bool, setTrickmodeTimescale, (uint32_t));
     MOCK_METHOD(bool, setMediaHeaderDuration, (uint64_t));
+    MOCK_METHOD(bool, getMdatBoxInfo, (size_t, size_t&, size_t&));
 };
 
 extern MockIsoBmffBuffer *g_mockIsoBmffBuffer;

--- a/test/utests/mocks/MockMediaStreamContext.h
+++ b/test/utests/mocks/MockMediaStreamContext.h
@@ -26,7 +26,6 @@
 class MockMediaStreamContext
 {
 public:
-
 	MOCK_METHOD(bool, CacheFragment, (std::string fragmentUrl, unsigned int curlInstance, double position, double duration, const char *range, bool initSegment, bool discontinuity, bool playingAd, uint32_t scale));
 	MOCK_METHOD(bool, CacheTsbFragment, (std::shared_ptr<CachedFragment> fragment));
 	MOCK_METHOD(bool, CacheFragmentChunk, (AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, long long dnldStartTime));

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -50,6 +50,7 @@
 #include "MockAdManager.h"
 #include "MockPlayerCCManager.h"
 #include "MockMediaStreamContext.h"
+#include "MockIsoBmffBuffer.h"
 
 using ::testing::An;
 using ::testing::DoAll;
@@ -70,6 +71,8 @@ const std::string session_id {"0259343c-cffc-4659-bcd8-97f9dd36f6b1"};
 const char SAMPLE_URL[] = "https://sampleUrl";
 const char SAMPLE_DEFOGGED_URL[] = "https://sampleDeFoggedUrl";
 const char SAMPLE_FOG_URL[] = "http://127.0.0.1:9080/tsb?clientId=\"FOG_AAMP\"&recordedUrl=https://sampleDeFoggedUrl";
+
+void AampGrowableBuffer_EnableMemoryCopying(bool enable); // forward declaration
 
 // Class to test class PrivateInstanceAAMP public interface
 class PrivAampTests : public ::testing::Test
@@ -99,6 +102,7 @@ protected:
 		g_MockPrivateCDAIObjectMPD = new MockPrivateCDAIObjectMPD();
 		g_mockPlayerCCManager = std::make_shared<NiceMock<MockPlayerCCManager>>();
 		g_mockMediaStreamContext = new NiceMock<MockMediaStreamContext>();
+		g_mockIsoBmffBuffer = new NiceMock<MockIsoBmffBuffer>();
 	}
 
 	void TearDown() override
@@ -139,6 +143,9 @@ protected:
 
 		delete g_mockAampGstPlayer;
 		g_mockAampGstPlayer = nullptr;
+
+		delete g_mockIsoBmffBuffer;
+		g_mockIsoBmffBuffer = nullptr;
 
 		delete (int*)mCurlEasyHandle;
 		mCurlEasyHandle = nullptr;
@@ -913,7 +920,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 
 	// Create a buffer for the context
 	AampGrowableBuffer buffer("test_buffer");
-	buffer.ReserveBytes(1024);
+	buffer.AppendBytes("dummy data", 12);
 
 	// Create a valid curl context
 	CurlCallbackContext context(p_aamp, &buffer);
@@ -921,6 +928,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 	context.contentLength = 1024;
 	context.remoteUrl = "http://example.com/video.m3u8";
 	context.downloadStartTime = 0;
+	context.chunkBoundary = buffer.GetLen(); // Simulate end of chunk
 
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Setup complete, pipeline_paused=%d, mBufUnderFlowStatus=%d",
 		p_aamp->pipeline_paused, p_aamp->mBufUnderFlowStatus);
@@ -942,6 +950,217 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Result: %zu", result);
 	// Result should be size*nmemb = strlen(testData)*1
 	EXPECT_EQ(result, strlen(testData));
+}
+
+// Test HandleSSLWriteCallback when no mdat detected in chunkInjection mode
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
+{
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithoutMdat - Setting up");
+
+	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+	// In this test, chunkBoundary is not detected, so CacheFragmentChunk() should not be called
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+		.Times(0);
+
+	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
+		.WillRepeatedly(Return(false)); // return no mdat for now
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(1024);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 1024;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+	context.bufferOffset = 0;
+	context.chunkBoundary = 0;
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithoutMdat - Calling HandleSSLWriteCallback");
+
+	// Call with valid context - ptr is not NULL, so data processing happens
+	char testData[] = "test data with zero mdat";
+	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithoutMdat - Result: %zu", result);
+	// Result should be size*nmemb
+	EXPECT_EQ(result, strlen(testData));
+	// Verify that bufferOffset and chunkBoundary remain unchanged
+	EXPECT_EQ(context.bufferOffset, 0);
+	EXPECT_EQ(context.chunkBoundary, 0);
+}
+
+// Test HandleSSLWriteCallback when mdat is detected, but not complete in chunkInjection mode
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithPartialChunk)
+{
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithPartialChunk - Setting up");
+
+	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+	// In this test, chunkBoundary is not filled, so CacheFragmentChunk() should not be called
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+		.Times(0);
+
+
+	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
+		.WillRepeatedly(Return(true));
+	// Return mdat count as 1, but buffer is less than chunkBoundary, so it's partial chunk
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
+		.WillOnce(DoAll(
+			SetArgReferee<0>(static_cast<size_t>(1)),
+			Return(true)
+		));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxInfo(0, _, _))
+		.WillOnce(DoAll(
+			SetArgReferee<1>(static_cast<size_t>(10)), // mdat start
+			SetArgReferee<2>(static_cast<size_t>(100)),// mdat size
+			Return(true)
+		));
+
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(1024);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 1024;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+	context.bufferOffset = 0;
+	context.chunkBoundary = 0;
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithPartialChunk - Calling HandleSSLWriteCallback");
+
+	// Call with valid context - ptr is not NULL, so data processing happens
+	char testData[] = "test data with mdat but partial chunk";
+	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithPartialChunk - Result: %zu", result);
+	// Result should be size*nmemb
+	EXPECT_EQ(result, strlen(testData));
+	// Verify that bufferOffset remain unchanged
+	EXPECT_EQ(context.bufferOffset, 0);
+	// chunkBoundary should be updated to mdat start + mdat size
+	EXPECT_EQ(context.chunkBoundary, 110);
+}
+
+// Test HandleSSLWriteCallback when full mdat is received in chunkInjection mode
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
+{
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Setting up");
+	AampGrowableBuffer_EnableMemoryCopying(true); // to cache data in GrowableBuffer
+
+	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+	// In this test, CacheFragmentChunk() should not be called only once and when full mdat is received
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+		.Times(1);
+
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(1024);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 1024;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+	context.bufferOffset = 0;
+	context.chunkBoundary = 0;
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Calling HandleSSLWriteCallback");
+
+	// Call HandleSSLWriteCallback twice with incremental data to simulate full mdat reception
+	char testData1[] = "test data with mdat full chunk part 1";
+	char testData2[] = "test data with mdat full chunk part 2";
+	size_t totalMdatSize = strlen(testData1) + strlen(testData2);
+
+	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
+		.WillRepeatedly(Return(true));
+	// Return mdat count as 1
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
+		.WillOnce(DoAll(
+			SetArgReferee<0>(static_cast<size_t>(1)),
+			Return(true)
+		));
+	// Return mdat info
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxInfo(0, _, _))
+		.WillOnce(DoAll(
+			SetArgReferee<1>(static_cast<size_t>(0)), // mdat start
+			SetArgReferee<2>(static_cast<size_t>(totalMdatSize)), // mdat size
+			Return(true)
+		));
+
+	size_t result1 = p_aamp->HandleSSLWriteCallback(testData1, strlen(testData1), 1, &context);
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Intermediate Result: %zu", result1);
+	EXPECT_EQ(result1, strlen(testData1));
+	// bufferOffset should still be 0
+	EXPECT_EQ(context.bufferOffset, 0);
+	// chunkBoundary should be updated to mdat start + mdat size
+	EXPECT_EQ(context.chunkBoundary, totalMdatSize);
+	EXPECT_EQ(buffer.GetLen(), strlen(testData1));
+
+	size_t result = p_aamp->HandleSSLWriteCallback(testData2, strlen(testData2), 1, &context);
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Result: %zu", result);
+	// Result should be size*nmemb
+	EXPECT_EQ(result, strlen(testData2));
+	// Verify that bufferOffset is updated to total mdat size
+	EXPECT_EQ(context.bufferOffset, totalMdatSize);
+	// chunkBoundary should be reset
+	EXPECT_EQ(context.chunkBoundary, 0);
+	EXPECT_EQ(buffer.GetLen(), totalMdatSize);
+	AampGrowableBuffer_EnableMemoryCopying(false);
 }
 
 TEST_F(PrivAampTests, RunPausePositionMonitoringTest)

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -51,6 +51,7 @@
 #include "MockPlayerCCManager.h"
 #include "MockMediaStreamContext.h"
 #include "MockIsoBmffBuffer.h"
+#include "MockAampGrowableBuffer.h"
 
 using ::testing::An;
 using ::testing::DoAll;
@@ -71,8 +72,6 @@ const std::string session_id {"0259343c-cffc-4659-bcd8-97f9dd36f6b1"};
 const char SAMPLE_URL[] = "https://sampleUrl";
 const char SAMPLE_DEFOGGED_URL[] = "https://sampleDeFoggedUrl";
 const char SAMPLE_FOG_URL[] = "http://127.0.0.1:9080/tsb?clientId=\"FOG_AAMP\"&recordedUrl=https://sampleDeFoggedUrl";
-
-void AampGrowableBuffer_EnableMemoryCopying(bool enable); // forward declaration
 
 // Class to test class PrivateInstanceAAMP public interface
 class PrivAampTests : public ::testing::Test
@@ -920,7 +919,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 
 	// Create a buffer for the context
 	AampGrowableBuffer buffer("test_buffer");
-	buffer.AppendBytes("dummy data", 12);
+	buffer.AppendBytes("dummy data", strlen("dummy data"));
 
 	// Create a valid curl context
 	CurlCallbackContext context(p_aamp, &buffer);
@@ -1009,81 +1008,17 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 	EXPECT_EQ(context.chunkBoundary, 0);
 }
 
-// Test HandleSSLWriteCallback when mdat is detected, but not complete in chunkInjection mode
-TEST_F(PrivAampTests, HandleSSLWriteCallbackWithPartialChunk)
-{
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithPartialChunk - Setting up");
-
-	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
-	AampLLDashServiceData llData;
-	llData.lowLatencyMode = true;
-	p_aamp->SetLLDashServiceData(llData);
-	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
-	p_aamp->SetLLDashChunkMode(true);
-
-	// Set up stream abstraction to return our mock MediaStreamContext
-	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
-		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
-	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
-		.WillRepeatedly(Return(false));
-	// In this test, chunkBoundary is not filled, so CacheFragmentChunk() should not be called
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
-		.Times(0);
-
-
-	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
-		.WillRepeatedly(Return(true));
-	// Return mdat count as 1, but buffer is less than chunkBoundary, so it's partial chunk
-	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
-		.WillOnce(DoAll(
-			SetArgReferee<0>(static_cast<size_t>(1)),
-			Return(true)
-		));
-	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxInfo(0, _, _))
-		.WillOnce(DoAll(
-			SetArgReferee<1>(static_cast<size_t>(10)), // mdat start
-			SetArgReferee<2>(static_cast<size_t>(100)),// mdat size
-			Return(true)
-		));
-
-	p_aamp->mDownloadsEnabled = true;
-	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
-
-	// Create a buffer for the context
-	AampGrowableBuffer buffer("test_buffer");
-	buffer.ReserveBytes(1024);
-
-	// Create a valid curl context
-	CurlCallbackContext context(p_aamp, &buffer);
-	context.mediaType = eMEDIATYPE_VIDEO;
-	context.contentLength = 1024;
-	context.remoteUrl = "http://example.com/video.m3u8";
-	context.downloadStartTime = 0;
-	context.bufferOffset = 0;
-	context.chunkBoundary = 0;
-
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithPartialChunk - Calling HandleSSLWriteCallback");
-
-	// Call with valid context - ptr is not NULL, so data processing happens
-	char testData[] = "test data with mdat but partial chunk";
-	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
-
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithPartialChunk - Result: %zu", result);
-	// Result should be size*nmemb
-	EXPECT_EQ(result, strlen(testData));
-	// Verify that bufferOffset remain unchanged
-	EXPECT_EQ(context.bufferOffset, 0);
-	// chunkBoundary should be updated to mdat start + mdat size
-	EXPECT_EQ(context.chunkBoundary, 110);
-}
-
 // Test HandleSSLWriteCallback when full mdat is received in chunkInjection mode
+// Done in 2 iterations to simulate data arriving in parts
 TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 {
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Setting up");
-	AampGrowableBuffer_EnableMemoryCopying(true); // to cache data in GrowableBuffer
+
+	// RAII guard to ensure memory copying is disabled on test exit (success or failure)
+	struct MemoryCopyingGuard {
+		MemoryCopyingGuard() { AampGrowableBuffer_EnableMemoryCopying(true); }
+		~MemoryCopyingGuard() { AampGrowableBuffer_EnableMemoryCopying(false); }
+	} guard;
 
 	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
 	AampLLDashServiceData llData;
@@ -1099,9 +1034,6 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
 	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
-	// In this test, CacheFragmentChunk() should not be called only once and when full mdat is received
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
-		.Times(1);
 
 	p_aamp->mDownloadsEnabled = true;
 	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
@@ -1109,22 +1041,30 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 	// Create a buffer for the context
 	AampGrowableBuffer buffer("test_buffer");
 	buffer.ReserveBytes(1024);
+	char initialData[] = "dummy data";
+	buffer.AppendBytes(initialData, strlen(initialData));
 
+	size_t startBufferOffset = buffer.GetLen();
 	// Create a valid curl context
 	CurlCallbackContext context(p_aamp, &buffer);
 	context.mediaType = eMEDIATYPE_VIDEO;
 	context.contentLength = 1024;
 	context.remoteUrl = "http://example.com/video.m3u8";
 	context.downloadStartTime = 0;
-	context.bufferOffset = 0;
+	// Lets also simulate existing buffer data scenario
+	context.bufferOffset = startBufferOffset;
 	context.chunkBoundary = 0;
 
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Calling HandleSSLWriteCallback");
 
 	// Call HandleSSLWriteCallback twice with incremental data to simulate full mdat reception
-	char testData1[] = "test data with mdat full chunk part 1";
-	char testData2[] = "test data with mdat full chunk part 2";
-	size_t totalMdatSize = strlen(testData1) + strlen(testData2);
+	char testDataPart1[] = "test data with mdat full chunk part 1";
+	char testDataPart2[] = "test data with mdat full chunk part 2";
+	size_t totalBufSize = strlen(testDataPart1) + strlen(testDataPart2);
+	// Lets assume mdat starts from offset 10 to end of buffer
+	size_t mdatStart = 10;
+	size_t mdatSize = totalBufSize - mdatStart;
+	size_t chunkBoundary = startBufferOffset + mdatStart + mdatSize;
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
 		.WillRepeatedly(Return(true));
@@ -1137,30 +1077,36 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 	// Return mdat info
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxInfo(0, _, _))
 		.WillOnce(DoAll(
-			SetArgReferee<1>(static_cast<size_t>(0)), // mdat start
-			SetArgReferee<2>(static_cast<size_t>(totalMdatSize)), // mdat size
+			SetArgReferee<1>(static_cast<size_t>(mdatStart)), // mdat start
+			SetArgReferee<2>(static_cast<size_t>(mdatSize)), // mdat size
 			Return(true)
 		));
 
-	size_t result1 = p_aamp->HandleSSLWriteCallback(testData1, strlen(testData1), 1, &context);
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Intermediate Result: %zu", result1);
-	EXPECT_EQ(result1, strlen(testData1));
-	// bufferOffset should still be 0
-	EXPECT_EQ(context.bufferOffset, 0);
-	// chunkBoundary should be updated to mdat start + mdat size
-	EXPECT_EQ(context.chunkBoundary, totalMdatSize);
-	EXPECT_EQ(buffer.GetLen(), strlen(testData1));
+	// In this test, CacheFragmentChunk() should be called exactly once when full mdat is received
+	// Lets make this a strict check using expected values
+	EXPECT_CALL(*g_mockMediaStreamContext,
+		CacheFragmentChunk(eMEDIATYPE_VIDEO, buffer.GetPtr() + startBufferOffset, chunkBoundary - startBufferOffset, _, _))
+		.Times(1);
 
-	size_t result = p_aamp->HandleSSLWriteCallback(testData2, strlen(testData2), 1, &context);
+	size_t result1 = p_aamp->HandleSSLWriteCallback(testDataPart1, strlen(testDataPart1), 1, &context);
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Intermediate Result: %zu", result1);
+	EXPECT_EQ(result1, strlen(testDataPart1));
+	// bufferOffset should still be startBufferOffset
+	EXPECT_EQ(context.bufferOffset, startBufferOffset);
+	// chunkBoundary should be updated to mdat start + mdat size
+	EXPECT_EQ(context.chunkBoundary, chunkBoundary);
+	EXPECT_EQ(buffer.GetLen(), startBufferOffset + strlen(testDataPart1));
+
+	size_t result = p_aamp->HandleSSLWriteCallback(testDataPart2, strlen(testDataPart2), 1, &context);
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Result: %zu", result);
 	// Result should be size*nmemb
-	EXPECT_EQ(result, strlen(testData2));
+	EXPECT_EQ(result, strlen(testDataPart2));
 	// Verify that bufferOffset is updated to total mdat size
-	EXPECT_EQ(context.bufferOffset, totalMdatSize);
+	EXPECT_EQ(context.bufferOffset, chunkBoundary);
 	// chunkBoundary should be reset
 	EXPECT_EQ(context.chunkBoundary, 0);
-	EXPECT_EQ(buffer.GetLen(), totalMdatSize);
-	AampGrowableBuffer_EnableMemoryCopying(false);
+	EXPECT_EQ(buffer.GetLen(), startBufferOffset + totalBufSize);
+	// guard destructor will call AampGrowableBuffer_EnableMemoryCopying(false)
 }
 
 TEST_F(PrivAampTests, RunPausePositionMonitoringTest)


### PR DESCRIPTION
Reason for change: Add support for mp4 chunk boundary detection in CURL write callback so that we can cache mp4 chunks instead of network chunks. Added L1 for validation
Test Procedure: No regression with LLD playback and the truncation log should not be observed during testing
Risks: Low