### PR TITLE
VPLAY-12372 range based download failing when using local content

### DIFF
--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -212,7 +212,8 @@ void aamp_ResolveURL(std::string& dst, std::string base, const char *uri , bool 
  */
 bool aamp_IsAbsoluteURL( const std::string &url )
 {
-	return url.compare(0, 7, "http://")==0 || url.compare(0, 8, "https://")==0;
+	return url.compare(0, 7, "http://")==0 || url.compare(0, 8, "https://")==0
+	|| url.compare(0,7,"file://")==0;
 	// note: above slightly faster than equivalent url.rfind("http://",0)==0 || url.rfind("https://",0)==0;
 }
 

--- a/AampUtils.cpp
+++ b/AampUtils.cpp
@@ -208,13 +208,15 @@ void aamp_ResolveURL(std::string& dst, std::string base, const char *uri , bool 
 /**
  * @brief distinguish between absolute and relative urls
  *
- * @return true iff url starts with http:// or https://
- */
+ * @return true iff url starts with http:// or https:// or file://
+*/
 bool aamp_IsAbsoluteURL( const std::string &url )
 {
-	return url.compare(0, 7, "http://")==0 || url.compare(0, 8, "https://")==0
-	|| url.compare(0,7,"file://")==0;
-	// note: above slightly faster than equivalent url.rfind("http://",0)==0 || url.rfind("https://",0)==0;
+	return
+	url.compare(0, 7, "http://")==0 ||
+	url.compare(0, 8, "https://")==0 ||
+	url.compare(0, 7, "file://") == 0;
+	// note: above slightly faster than equivalent url.rfind("http://",0)==0 || url.rfind("https://",0)==0 || url.rfind("file://",0)==0
 }
 
 /**

--- a/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
+++ b/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
@@ -122,12 +122,19 @@ TEST(_AampUtils, aamp_IsAbsoluteURL)
 {
 	bool result;
 	std::string url;
+
 	url = "http://aaa.bbb.com";
 	result = aamp_IsAbsoluteURL(url);
 	EXPECT_TRUE(result);
+
 	url = "https://aaa.bbb.com";
 	result = aamp_IsAbsoluteURL(url);
 	EXPECT_TRUE(result);
+
+	url = "file://aaa.bbb.com";
+	result = aamp_IsAbsoluteURL(url);
+	EXPECT_TRUE(result);
+	
 	url = "";
 	result = aamp_IsAbsoluteURL(url);
 	EXPECT_FALSE(result);

--- a/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
+++ b/test/utests/tests/AampUtilsTests/AampUtilsTests.cpp
@@ -134,7 +134,7 @@ TEST(_AampUtils, aamp_IsAbsoluteURL)
 	url = "file://aaa.bbb.com";
 	result = aamp_IsAbsoluteURL(url);
 	EXPECT_TRUE(result);
-	
+
 	url = "";
 	result = aamp_IsAbsoluteURL(url);
 	EXPECT_FALSE(result);


### PR DESCRIPTION
VPLAY-12372 range based download failing when using local content

Reason for Change: test asset was failing to tune when played from local folder

This was caused by bad url construction.  locators starting with file:// were wrongly being considered relative paths, not absolute.

Test Guidance: new l1 test covers this

Risk: None