### PR TITLE
VPLAY-12360: [LLD] Add support to inject only MP4 chunks instead of network chunks

### DIFF
--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -265,8 +265,8 @@ struct CurlCallbackContext
 	size_t contentLength = 0;
 	long long downloadStartTime = -1;
 	long long processDelay = 0; /**< Indicate the external process delay in curl operation; especially for lld*/
-	size_t bufferOffset = 0; // Used for chunked download to keep track of current buffer offset
-	size_t chunkBoundary = 0; // Used for chunked download to store the current chunk boundary
+	size_t bufferOffset = 0; // Used for chunked injection to keep track of start offset of the last mp4 chunk in buffer
+	size_t chunkBoundary = 0; // Used for chunked injection to store the end offset of the last mp4 chunk in buffer
 
 	CurlCallbackContext(){}
 	CurlCallbackContext(PrivateInstanceAAMP *_aamp, AampGrowableBuffer *_buffer) : aamp(_aamp), buffer(_buffer){}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4618,7 +4618,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 					{
 						// This is not expected.
 						// Buffer is already cached through CURL write callback for low latency and there is no course correction.
-						// Let's log here for awareness, as it not clear if we should cache the extra data beyond chunk boundary.
+						// Let's log here for awareness, as it's not clear if we should cache the extra data beyond chunk boundary.
 						AAMPLOG_WARN("Discarding excess data for LL-DASH chunked download from chunk boundary %zu to %zu, skipped %zu bytes", context.chunkBoundary, buffer->GetLen(), buffer->GetLen() - context.chunkBoundary);
 					}
 				}

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -951,6 +951,63 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 	EXPECT_EQ(result, strlen(testData));
 }
 
+// Test HandleSSLWriteCallback when ParseBuffer API call fails in chunkInjection mode
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
+{
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithParseBufferFailure - Setting up");
+
+	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+	// In this test, parseBuffer() fails, so no mdat box is detected and CacheFragmentChunk() should not be called
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+		.Times(0);
+
+	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
+		.WillRepeatedly(Return(false)); // return no mdat for now
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(1024);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 1024;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+	context.bufferOffset = 0;
+	context.chunkBoundary = 0;
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithParseBufferFailure - Calling HandleSSLWriteCallback");
+
+	// Call with valid context - ptr is not NULL, so data processing happens
+	char testData[] = "test data with parse failure";
+	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithParseBufferFailure - Result: %zu", result);
+	// Result should be size*nmemb
+	EXPECT_EQ(result, strlen(testData));
+	// Verify that bufferOffset and chunkBoundary remain unchanged
+	EXPECT_EQ(context.bufferOffset, 0);
+	EXPECT_EQ(context.chunkBoundary, 0);
+}
+
 // Test HandleSSLWriteCallback when no mdat detected in chunkInjection mode
 TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 {
@@ -970,7 +1027,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
 	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
-	// In this test, chunkBoundary is not detected, so CacheFragmentChunk() should not be called
+	// In this test, complete mdat is not detected, so CacheFragmentChunk() should not be called
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
 		.Times(0);
 
@@ -1010,9 +1067,9 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 
 // Test HandleSSLWriteCallback when full mdat is received in chunkInjection mode
 // Done in 2 iterations to simulate data arriving in parts
-TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMp4ChunkBoundary)
 {
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Setting up");
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Setting up");
 
 	// RAII guard to ensure memory copying is disabled on test exit (success or failure)
 	struct MemoryCopyingGuard {
@@ -1055,7 +1112,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 	context.bufferOffset = startBufferOffset;
 	context.chunkBoundary = 0;
 
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Calling HandleSSLWriteCallback");
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Calling HandleSSLWriteCallback");
 
 	// Call HandleSSLWriteCallback twice with incremental data to simulate full mdat reception
 	char testDataPart1[] = "test data with mdat full chunk part 1";
@@ -1089,7 +1146,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 		.Times(1);
 
 	size_t result1 = p_aamp->HandleSSLWriteCallback(testDataPart1, strlen(testDataPart1), 1, &context);
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Intermediate Result: %zu", result1);
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Intermediate Result: %zu", result1);
 	EXPECT_EQ(result1, strlen(testDataPart1));
 	// bufferOffset should still be startBufferOffset
 	EXPECT_EQ(context.bufferOffset, startBufferOffset);
@@ -1098,7 +1155,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 	EXPECT_EQ(buffer.GetLen(), startBufferOffset + strlen(testDataPart1));
 
 	size_t result = p_aamp->HandleSSLWriteCallback(testDataPart2, strlen(testDataPart2), 1, &context);
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithChunkBoundary - Result: %zu", result);
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Result: %zu", result);
 	// Result should be size*nmemb
 	EXPECT_EQ(result, strlen(testDataPart2));
 	// Verify that bufferOffset is updated to total mdat size
@@ -1107,6 +1164,105 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkBoundary)
 	EXPECT_EQ(context.chunkBoundary, 0);
 	EXPECT_EQ(buffer.GetLen(), startBufferOffset + totalBufSize);
 	// guard destructor will call AampGrowableBuffer_EnableMemoryCopying(false)
+}
+
+// Test HandleSSLWriteCallback when multiple mdat boxes are received
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
+{
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMultipleMdatBoxes - Setting up");
+
+	// RAII guard to ensure memory copying is disabled on test exit
+	struct MemoryCopyingGuard {
+		MemoryCopyingGuard() { AampGrowableBuffer_EnableMemoryCopying(true); }
+		~MemoryCopyingGuard() { AampGrowableBuffer_EnableMemoryCopying(false); }
+	} guard;
+
+	// Enable LL DASH chunk mode
+	AampLLDashServiceData llData;
+	llData.lowLatencyMode = true;
+	p_aamp->SetLLDashServiceData(llData);
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableChunkInjection)).WillRepeatedly(Return(true));
+	p_aamp->SetLLDashChunkMode(true);
+
+	// Set up stream abstraction to return our mock MediaStreamContext
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetMediaTrack(eTRACK_VIDEO))
+		.WillRepeatedly(Return(reinterpret_cast<MediaTrack*>(g_mockMediaStreamContext)));
+	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
+		.WillRepeatedly(Return(false));
+
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
+
+	// Create a buffer for the context
+	AampGrowableBuffer buffer("test_buffer");
+	buffer.ReserveBytes(2048);
+
+	// Create a valid curl context
+	CurlCallbackContext context(p_aamp, &buffer);
+	context.mediaType = eMEDIATYPE_VIDEO;
+	context.contentLength = 2048;
+	context.remoteUrl = "http://example.com/video.m3u8";
+	context.downloadStartTime = 0;
+	context.bufferOffset = 0;
+	context.chunkBoundary = 0;
+
+	// Simulate receiving data with multiple mdat boxes
+	// First mdat: offset 10, size 100 (boundary at 110)
+	// Second mdat: offset 150, size 120 (boundary at 270)
+	// Third mdat: offset 300, size 150 (boundary at 450)
+	char testData[] = "test data with multiple mdat boxes in fragmented MP4 format";
+	size_t firstMdatStart = 10;
+	size_t firstMdatSize = 100;
+	size_t secondMdatStart = 150;
+	size_t secondMdatSize = 120;
+	size_t thirdMdatStart = 300;
+	size_t thirdMdatSize = 150;
+	size_t lastMdatBoundary = thirdMdatStart + thirdMdatSize; // Should use the last mdat
+
+	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
+		.WillRepeatedly(Return(true));
+
+	// Return mdat count as 3 (multiple fragments in buffer)
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
+		.WillOnce(DoAll(
+			SetArgReferee<0>(static_cast<size_t>(3)),
+			Return(true)
+		));
+
+	// getMdatBoxInfo will be called with index 2 (count - 1) to get the last mdat
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxInfo(2, _, _))
+		.WillOnce(DoAll(
+			SetArgReferee<1>(static_cast<size_t>(thirdMdatStart)),
+			SetArgReferee<2>(static_cast<size_t>(thirdMdatSize)),
+			Return(true)
+		));
+
+	// CacheFragmentChunk should be called once with data up to the last mdat boundary
+	EXPECT_CALL(*g_mockMediaStreamContext,
+		CacheFragmentChunk(eMEDIATYPE_VIDEO, buffer.GetPtr(), lastMdatBoundary, _, _))
+		.Times(1);
+
+	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
+
+	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMultipleMdatBoxes - Result: %zu", result);
+	EXPECT_EQ(result, strlen(testData));
+
+	// Verify that chunkBoundary was identified as the last mdat boundary
+	EXPECT_EQ(context.chunkBoundary, lastMdatBoundary);
+
+	// Now send more data to complete the chunk
+	std::vector<char> additionalData(500, 'X');
+
+	size_t result2 = p_aamp->HandleSSLWriteCallback(additionalData.data(), additionalData.size(), 1, &context);
+	EXPECT_EQ(result2, additionalData.size());
+
+	// After receiving enough data, bufferOffset should be updated to the boundary
+	EXPECT_EQ(context.bufferOffset, lastMdatBoundary);
+	// chunkBoundary should be reset
+	EXPECT_EQ(context.chunkBoundary, 0);
+	EXPECT_EQ(buffer.GetLen(), strlen(testData) + additionalData.size());
 }
 
 TEST_F(PrivAampTests, RunPausePositionMonitoringTest)


### PR DESCRIPTION
Reason for change: Minor comment cleanup and additional L1s No functional changes
Test Procedure: Refer ticket
Risks: None