### PR TITLE
VPLAY-12382 [LLD] Network bandwidth capped at 1.85 Mbps on Ch 921 and 12.2 Mbps on Ch 922, preventing playback from reaching highest bitrate profile

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -726,7 +726,8 @@ BitsPerSecond ABRManager::CheckAbrThresholdSize(int bufferlen, int downloadTimeM
 	BitsPerSecond downloadbps = currentProfilebps;
 	if( downloadTimeMs )
 	{
-		downloadbps = (bufferlen*8000L)/downloadTimeMs;
+		// note: mathematically, would be less lossy to multiple first then divide, but this risks integer overflow
+		downloadbps = ((long)(bufferlen / downloadTimeMs)*8000);
 		
 		// extra coding to avoid picking lower profile
 		// Avoid this reset for Low bandwidth timeout cases

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -726,8 +726,10 @@ BitsPerSecond ABRManager::CheckAbrThresholdSize(int bufferlen, int downloadTimeM
 	BitsPerSecond downloadbps = currentProfilebps;
 	if( downloadTimeMs )
 	{
-		// note: mathematically, would be less lossy to multiple first then divide, but this risks integer overflow
-		downloadbps = ((long)(bufferlen / downloadTimeMs)*8000);
+		// Use 64-bit arithmetic and multiply first to avoid precision loss:
+		// bits per second = (bytes * 8 * 1000) / ms = (bytes * 8000) / ms
+		downloadbps = static_cast<BitsPerSecond>(
+			(static_cast<long long>(bufferlen) * 8000LL) / downloadTimeMs);
 		
 		// extra coding to avoid picking lower profile
 		// Avoid this reset for Low bandwidth timeout cases


### PR DESCRIPTION
VPLAY-12382 [LLD] Network bandwidth capped at 1.85 Mbps on Ch 921 and 12.2 Mbps on Ch 922, preventing playback from reaching highest bitrate profile

Reason for Change: revert an optimized calculation to avoid integer overflow and regression

Test Guidance: see ticket

Risk: Low