### PR TITLE
VPLAY-12451: Crash on manifest with no periods

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8896,6 +8896,12 @@ void StreamAbstractionAAMP_MPD::UpdatePtsOffset(bool isNewPeriod)
 	AampTime timelineStart;
 	AampTime duration;
 
+	if (!mCurrentPeriod)
+	{
+		AAMPLOG_ERR("No current period");
+		return;
+	}
+
 	IPeriod *period = mCurrentPeriod;
 	GetStartAndDurationForPtsRestamping(timelineStart, duration);
 


### PR DESCRIPTION
Reason for change: If a manifest has no periods a NULL mCurrentPeriod can be de-referenced causing a segfault Test Procedure:Refer Jira Ticket
Risks: Low