### PR TITLE
VPLAY-12061:Closed captioning issues after introducing webvTT along …

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -370,6 +370,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{true, "enableChunkInjection", eAAMPConfig_EnableChunkInjection, true},
 	{false, "debugChunkTransfer", eAAMPConfig_DebugChunkTransfer, false},
 	{true, "utcSyncOnStartup", eAAMPConfig_UTCSyncOnStartup, true},
+	{false, "disableWebVTT", eAAMPConfig_DisableWebVTT, false},
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -215,7 +215,8 @@ typedef enum
 	eAAMPConfig_EnableChunkInjection,					/**< Config to enable chunk injection for low latency DASH */
 	eAAMPConfig_DebugChunkTransfer,					/**< app-managed chunked transfer protocol */
 	eAAMPConfig_UTCSyncOnStartup,					/**< Perform sync at startup */
-	eAAMPConfig_BoolMaxValue						/**< Max value of bool config always last element */
+	eAAMPConfig_DisableWebVTT,					/**< Config to disable/exclude WebVTT tracks (default: WebVTT enabled) */
+	eAAMPConfig_BoolMaxValue				/**< Max value of bool config always last element */	
 
 } AAMPConfigSettingBool;
 #define AAMPCONFIG_BOOL_COUNT (eAAMPConfig_BoolMaxValue)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6419,6 +6419,8 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 			SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnableLiveLatencyCorrection, true);
 		}
 		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnablePTSReStamp, SocUtils::EnablePTSRestamp());
+		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_DisableWebVTT, true);
+		AAMPLOG_INFO("app name:%s disableWebVTT(%d)", mAppName.c_str(), GETCONFIGVALUE_PRIV(eAAMPConfig_DisableWebVTT));
 	}
 
 	/* Reset counter in new tune */
@@ -10822,6 +10824,11 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 		std::vector<CCTrackInfo> updatedTextTracks;
 		UpdateCCTrackInfo(textTracksCopy,updatedTextTracks);
 		PlayerCCManager::GetInstance()->updateLastTextTracks(updatedTextTracks);
+		if( ISCONFIGSET_PRIV(eAAMPConfig_DisableWebVTT) )
+		{
+			trackInfo.swap(textTracksCopy);
+			AAMPLOG_DEBUG("Filtered track list to include only in-band CC tracks");
+		}
 		if (!trackInfo.empty())
 		{
 			//Convert to JSON format

--- a/test/utests/tests/PrivateInstanceAAMP/ClosedCaptionTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/ClosedCaptionTests.cpp
@@ -392,3 +392,72 @@ TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithLocalAAMPTsb_GetCurrentTex
 	// Basic sanity check since the mock Print returns minimal JSON
 	EXPECT_FALSE(result.empty()) << "Should return non-empty result even when GetCurrentTextTrack fails";
 }
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithDisableWebVTT_ReturnsOnlyCCTracks)
+{
+    // Enable DisableWebVTT so only Closed Caption (CC) tracks should be returned
+    gpGlobalConfig->SetConfigValue(AAMP_APPLICATION_SETTING, eAAMPConfig_DisableWebVTT, true);
+
+    // Copy only CC tracks from the mock list into a separate vector
+    std::vector<TextTrackInfo> textTracksCopy;
+    std::copy_if(begin(mockTextTracks), end(mockTextTracks), back_inserter(textTracksCopy),
+                 [](const TextTrackInfo& e){ return e.isCC; });
+
+    // Mock JSON array + item pointers (fake addresses used only for mocking)
+    cJSON* mockArray = reinterpret_cast<cJSON*>(0x3000);
+    cJSON* mockItem  = reinterpret_cast<cJSON*>(0x3003);
+
+    // Create a list of fake JSON object pointers, one per CC track
+    std::vector<cJSON*> mockObjects;
+    for (size_t i = 0; i < textTracksCopy.size(); i++) {
+        mockObjects.push_back(reinterpret_cast<cJSON*>(0x4000 + i));
+    }
+
+    // Expect CreateArray() to be called once and return our mock array pointer
+    EXPECT_CALL(*g_mockCJsonManager, CreateArray())
+        .WillOnce(Return(mockArray));
+
+    // Expect CreateObject() to be called once per CC track and return mock objects
+    EXPECT_CALL(*g_mockCJsonManager, CreateObject())
+        .WillOnce(Return(mockObjects[0]))
+        .WillOnce(Return(mockObjects[1]));
+
+    // For each CC track, set expectations for JSON field creation and availability flags
+    for (size_t i = 0; i < textTracksCopy.size(); i++) {
+        const auto& track = textTracksCopy[i];
+        cJSON* mockObj = mockObjects[i];
+
+        // Expect production code to add correct string fields (e.g., name, language)
+        setupTrackStringFieldExpectations(track, mockObj, mockItem);
+
+        // Expect production code to mark the track as available (non-TSB mode)
+        setupTrackAvailabilityExpectation(track, mockObj, mockItem, true);
+    }
+
+    // Expect AddItemToArray() to be called for each CC track
+    for (size_t i = 0; i < textTracksCopy.size(); i++) {
+        EXPECT_CALL(*g_mockCJsonManager, AddItemToArray(mockArray, mockObjects[i]))
+            .WillOnce(Return(cJSON_True));
+    }
+
+    // Allow Print() to be called and return minimal JSON (actual content not validated here)
+    EXPECT_CALL(*g_mockCJsonManager, Print(mockArray))
+        .WillOnce(Return("[]"));
+
+    // Expect Delete() to be called once to free the JSON array
+    EXPECT_CALL(*g_mockCJsonManager, Delete(mockArray))
+        .Times(1);
+
+    // Mock StreamAbstraction to return only CC tracks
+    EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(false))
+        .WillOnce(ReturnRef(textTracksCopy));
+
+    // Execute the function under test
+    std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+    // Validate that output is not empty (should contain CC-only JSON)
+    EXPECT_FALSE(result.empty()) << "Expected CC-only JSON output";
+
+    // Reset config to default
+    gpGlobalConfig->SetConfigValue(AAMP_APPLICATION_SETTING, eAAMPConfig_DisableWebVTT, false);
+}


### PR DESCRIPTION
VPLAY-12061:Closed captioning issues after introducing webvTT along with inBand CC tracks

Reason for change: filter out the webvtt tracks before sending the list of tracks to application
Test Procedure: see ticket
Risks: Low