### PR TITLE
VPLAY-12061:Closed captioning issues after introducing webvTT along with inBand CC tracks

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -370,6 +370,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{true, "enableChunkInjection", eAAMPConfig_EnableChunkInjection, true},
 	{false, "debugChunkTransfer", eAAMPConfig_DebugChunkTransfer, false},
 	{true, "utcSyncOnStartup", eAAMPConfig_UTCSyncOnStartup, true},
+	{false, "disableWebVTT", eAAMPConfig_DisableWebVTT, false},
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -215,7 +215,8 @@ typedef enum
 	eAAMPConfig_EnableChunkInjection,					/**< Config to enable chunk injection for low latency DASH */
 	eAAMPConfig_DebugChunkTransfer,					/**< app-managed chunked transfer protocol */
 	eAAMPConfig_UTCSyncOnStartup,					/**< Perform sync at startup */
-	eAAMPConfig_BoolMaxValue						/**< Max value of bool config always last element */
+	eAAMPConfig_DisableWebVTT,					/**< Config to disable/exclude WebVTT tracks (default: WebVTT enabled) */
+	eAAMPConfig_BoolMaxValue				/**< Max value of bool config always last element */	
 
 } AAMPConfigSettingBool;
 #define AAMPCONFIG_BOOL_COUNT (eAAMPConfig_BoolMaxValue)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6419,6 +6419,8 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 			SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnableLiveLatencyCorrection, true);
 		}
 		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnablePTSReStamp, SocUtils::EnablePTSRestamp());
+		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_DisableWebVTT, true);
+		AAMPLOG_INFO("app name:%s disableWebVTT(%d)", mAppName.c_str(), GETCONFIGVALUE_PRIV(eAAMPConfig_DisableWebVTT));
 	}
 
 	/* Reset counter in new tune */
@@ -10822,6 +10824,11 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 		std::vector<CCTrackInfo> updatedTextTracks;
 		UpdateCCTrackInfo(textTracksCopy,updatedTextTracks);
 		PlayerCCManager::GetInstance()->updateLastTextTracks(updatedTextTracks);
+		if( ISCONFIGSET_PRIV(eAAMPConfig_DisableWebVTT) )
+		{
+			trackInfo.swap(textTracksCopy);
+			AAMPLOG_DEBUG("Filtered track list to include only in-band CC tracks");
+		}
 		if (!trackInfo.empty())
 		{
 			//Convert to JSON format

--- a/test/utests/tests/PrivateInstanceAAMP/ClosedCaptionTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/ClosedCaptionTests.cpp
@@ -392,3 +392,55 @@ TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithLocalAAMPTsb_GetCurrentTex
 	// Basic sanity check since the mock Print returns minimal JSON
 	EXPECT_FALSE(result.empty()) << "Should return non-empty result even when GetCurrentTextTrack fails";
 }
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithDisableWebVTT_ReturnsOnlyCCTracks)
+{
+    // Enable DisableWebVTT so only Closed Caption (CC) tracks should be returned
+    gpGlobalConfig->SetConfigValue(AAMP_APPLICATION_SETTING, eAAMPConfig_DisableWebVTT, true);
+
+    cJSON *mockArray = reinterpret_cast<cJSON*>(0x1001);
+    cJSON *mockItem  = reinterpret_cast<cJSON*>(0x1003);
+
+    std::vector<cJSON*> mockObjects = setupBasicCJsonExpectations(mockArray, mockItem);
+
+    // Set up expectations for each track
+    for (size_t i = 0; i < mockTextTracks.size(); i++)
+    {
+        const auto& track = mockTextTracks[i];
+        cJSON* mockObj = mockObjects[i];
+
+        // Verify production code adds correct fields with correct values
+        setupTrackStringFieldExpectations(track, mockObj, mockItem);
+
+        // In normal mode (non-TSB), all tracks are available
+        setupTrackAvailabilityExpectation(track, mockObj, mockItem, true);
+    }
+
+    // Verify objects are added to array correctly
+    setupArrayFinalizationExpectations(mockArray, mockObjects);
+
+    // Mock StreamAbstraction to return our test tracks
+    EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(false))
+        .WillOnce(ReturnRef(mockTextTracks));
+
+    // Execute the function under test — should return CC-only tracks
+    std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+    // Validate that output is not empty (should contain CC-only JSON)
+    EXPECT_FALSE(result.empty()) << "Expected CC-only JSON output";
+
+    // Ensure non-CC tracks do NOT appear
+    for (auto &t : mockTextTracks)
+    {
+        if (!t.isCC)
+        {
+            EXPECT_EQ(result.find(t.language), std::string::npos)
+                << "Non-CC track '" << t.language << "' should NOT appear";
+        }
+    }
+
+    // Reset config to default
+    gpGlobalConfig->SetConfigValue(AAMP_APPLICATION_SETTING, eAAMPConfig_DisableWebVTT, false);
+}
+
+


### PR DESCRIPTION
VPLAY-12061:Closed captioning issues after introducing webvTT along with inBand CC tracks

Reason for change: filter out the webvtt tracks before sending the list of tracks to application
Test Procedure: see ticket
Risks: Low