### PR TITLE
VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD…

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5690,15 +5690,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 	}
 
 	TeardownStream(newTune|| (eTUNETYPE_RETUNE == tuneType));
-	if (!newTune)
-	{
-		// Capture the current CC enabled state only for non-new tunes (e.g. retune/seek).
-		// For brand new tunes we intentionally do NOT restore any previous CC state;
-		// previousCCEnabled remains at its default (false) so RestoreCC() starts CC
-		// from a clean, disabled state for new content.
-		previousCCEnabled = PlayerCCManager::GetInstance()->GetStatus();
-		AAMPLOG_WARN("previousCCEnabled:%d isCCinBand:%d", previousCCEnabled, mIsInbandCC);
-	}
+
 	if(SocUtils::ResetNewSegmentEvent())
 	{
 		// Send new SEGMENT event only on all trickplay and trickplay -> play, not on pause -> play / seek while paused
@@ -6063,6 +6055,10 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 		{
 			IncreaseGSTBufferSize();
 		}
+
+		// Retrieve the current closed‑captioning state and log it along with the in‑band CC flag.
+		previousCCEnabled = PlayerCCManager::GetInstance()->GetStatus();
+		AAMPLOG_WARN("previousCCEnabled:%d isCCinBand:%d", previousCCEnabled, mIsInbandCC);
 
 		if (!mbUsingExternalPlayer)
 		{


### PR DESCRIPTION
VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD asset on perform FF till the ad break point

Reason for Change: fix inband CC resume from ad to content and content to ad

Test Guidance: Check the ticket

Risk: Low