### PR TITLE
VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD

### DIFF
--- a/test/utests/fakes/FakeAampCCManager.cpp
+++ b/test/utests/fakes/FakeAampCCManager.cpp
@@ -36,6 +36,11 @@ public:
 		{
 			result = g_mockPlayerCCManager->SetStatus(enable);
 		}
+		// Track mEnabled state to support GetStatus()
+		if (result == 0)
+		{
+			mEnabled = enable;
+		}
 		return result;
 	}
 
@@ -63,6 +68,15 @@ int PlayerCCManagerBase::Init(void *handle)
 }
 void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
+	if (g_mockPlayerCCManager)
+	{
+		g_mockPlayerCCManager->RestoreCC(shouldRestoreCC);
+	}
+	// Update mEnabled state as the real implementation does
+	if (!mEnabled && shouldRestoreCC)
+	{
+		mEnabled = shouldRestoreCC;
+	}
 }
 void PlayerCCManagerBase::Release(int iID)
 {

--- a/test/utests/fakes/FakeAampCCManager.cpp
+++ b/test/utests/fakes/FakeAampCCManager.cpp
@@ -29,6 +29,12 @@ std::shared_ptr<MockPlayerCCManager> g_mockPlayerCCManager{};
 class TestPlayerCCManager : public PlayerCCManagerBase
 {
 public:
+	TestPlayerCCManager() : PlayerCCManagerBase()
+	{
+		// Initialize mEnabled to false
+		mEnabled = false;
+	}
+
 	int SetStatus(bool enable) override
 	{
 		int result = 0;
@@ -126,6 +132,7 @@ int PlayerCCManagerBase::SetAnalogChannel(unsigned int id)
 void PlayerCCManager::DestroyInstance()
 {
 	delete mInstance;
+	mInstance = nullptr;
 }
 
 void PlayerCCManager::SetRialto(bool state)

--- a/test/utests/mocks/MockPlayerCCManager.h
+++ b/test/utests/mocks/MockPlayerCCManager.h
@@ -30,6 +30,7 @@ public:
 	MOCK_METHOD(void, Release, (int iID));
 	MOCK_METHOD(bool, IsOOBCCRenderingSupported, ());
 	MOCK_METHOD(int, SetStatus, (bool enable));
+	MOCK_METHOD(bool, GetStatus, ());
 	MOCK_METHOD(int, SetStyle, (const std::string &options));
 	MOCK_METHOD(int, SetTrack, (const std::string &track, const CCFormat format));
 	MOCK_METHOD(void, SetTrickplayStatus, (bool enable));

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -85,6 +85,10 @@ public:
 protected:
 	void SetUp() override
 	{
+		// Ensure PlayerCCManager starts in a clean state for each test
+		// This prevents order-dependent failures where mEnabled state persists
+		PlayerCCManager::DestroyInstance();
+
 		config=new AampConfig();
 		p_aamp = new PrivateInstanceAAMP(config);
 		mCurlEasyHandle = new int(1); // Valid ptr, though not used.
@@ -4052,7 +4056,7 @@ TEST_F(PrivAampTests,RestoreCCWhenCCWasDisabledBeforeTune)
 
 TEST_F(PrivAampTests,RestoreCCDuringAdContentTransitionsWithNewTune)
 {
-	// Test that CC state is preserved across ad↔content transitions with newTune=true
+	// Test that CC state is preserved across ad<->content transitions with newTune=true
 	p_aamp->mIsInbandCC = true;
 
 	// Initial tune (content) - SetStatus(false) is called

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -106,8 +106,6 @@ protected:
 
 	void TearDown() override
 	{
-		g_mockPlayerCCManager.reset();
-
 		delete g_MockPrivateCDAIObjectMPD;
 		g_MockPrivateCDAIObjectMPD = nullptr;
 		
@@ -151,6 +149,9 @@ protected:
 
 		delete p_aamp;
 		p_aamp = nullptr;
+
+		PlayerCCManager::DestroyInstance();
+		g_mockPlayerCCManager.reset();
 
 		delete config;
 		config = nullptr;
@@ -4025,8 +4026,9 @@ TEST_F(PrivAampTests,RestoreCCWhenCCWasEnabledBeforeTune)
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
 	// Now tune again (simulating a new content tune)
-	// The GetStatus() call should return true, and RestoreCC(true) should be called
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	// RestoreCC(true) should be called based on the tracked state
+	// SetCCStatusInternal is called during tune setup which calls SetStatus(true)
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
 	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
 	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
 }
@@ -4063,16 +4065,16 @@ TEST_F(PrivAampTests,RestoreCCDuringAdContentTransitionsWithNewTune)
 	p_aamp->SetCCStatus(true);
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Transition to ad - SetStatus(false) and RestoreCC(true) should be called
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	// Transition to ad - SetStatus(true) and RestoreCC(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).Times(1);
 	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
 	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
 	
 	// CC should still be enabled after ad tune
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Transition back to content - SetStatus(false) and RestoreCC(true) should be called again
-	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	// Transition back to content - SetStatus(true) and RestoreCC(true) should be called again
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).Times(1);
 	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
 	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
 	

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -4054,12 +4054,12 @@ TEST_F(PrivAampTests,RestoreCCWhenCCWasDisabledBeforeTune)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
 }
 
-TEST_F(PrivAampTests,RestoreCCDuringAdContentTransitionsWithNewTune)
+TEST_F(PrivAampTests,RestoreCCPreservesStateAcrossMultipleTunes)
 {
-	// Test that CC state is preserved across ad<->content transitions with newTune=true
+	// Test that CC state is preserved and RestoreCC is called on consecutive tunes
 	p_aamp->mIsInbandCC = true;
 
-	// Initial tune (content) - SetStatus(false) is called
+	// Initial tune - SetStatus(false) is called
 	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
 	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
 	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
@@ -4069,20 +4069,20 @@ TEST_F(PrivAampTests,RestoreCCDuringAdContentTransitionsWithNewTune)
 	p_aamp->SetCCStatus(true);
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Transition to ad - SetStatus(true) and RestoreCC(true) should be called
+	// Second tune - SetStatus(true) and RestoreCC(true) should be called
 	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).Times(1);
 	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
 	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
 	
-	// CC should still be enabled after ad tune
+	// CC should still be enabled after second tune
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
-	// Transition back to content - SetStatus(true) and RestoreCC(true) should be called again
+	// Third tune - SetStatus(true) and RestoreCC(true) should be called again
 	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).Times(1);
 	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
 	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
 	
-	// CC should still be enabled after returning to content
+	// CC should still be enabled after third tune
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 }
 

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -4009,6 +4009,77 @@ TEST_F(PrivAampTests,SetCCStatusPostTuneWithVideoMute)
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 }
 
+TEST_F(PrivAampTests,RestoreCCWhenCCWasEnabledBeforeTune)
+{
+	// Test that RestoreCC(true) is called when CC was enabled before tune
+	p_aamp->mIsInbandCC = true;
+
+	// Initial tune - SetStatus(false) is called in SetCCStatusInternal during TuneHelper
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// Enable CC after tune - SetStatus(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Now tune again (simulating a new content tune)
+	// The GetStatus() call should return true, and RestoreCC(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+}
+
+TEST_F(PrivAampTests,RestoreCCWhenCCWasDisabledBeforeTune)
+{
+	// Test that RestoreCC(false) is called when CC was disabled before tune
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC is disabled by default
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Call TuneHelper - SetStatus(false) is called first, then RestoreCC(false) should be called since CC is disabled
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(false)).Times(1);
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+}
+
+TEST_F(PrivAampTests,RestoreCCDuringAdContentTransitionsWithNewTune)
+{
+	// Test that CC state is preserved across ad↔content transitions with newTune=true
+	p_aamp->mIsInbandCC = true;
+
+	// Initial tune (content) - SetStatus(false) is called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	// Enable CC - SetStatus(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Transition to ad - SetStatus(false) and RestoreCC(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	// CC should still be enabled after ad tune
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Transition back to content - SetStatus(false) and RestoreCC(true) should be called again
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	// CC should still be enabled after returning to content
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+}
+
 TEST_F(PrivAampTests,NotifyAudioTracksChangedTest)
 {
 	p_aamp->NotifyAudioTracksChanged();


### PR DESCRIPTION
VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD

Reason for Change: l1 tests added for VPLAY-12203

Test Guidance: all (and new) l1 tests passing

Risk: None