### PR TITLE
VPLAY-12452: Disable lowBWTimeout when at the end of ABR ladder

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4375,6 +4375,8 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 	CURLcode res = CURLE_OK;
 	int fragmentDurationMs = (int)(fragmentDurationS*1000);
 	const char* failureReason = nullptr;
+	// Flag denotes if early abort logic was updated properly
+	bool earlyAbortUpdated = false;
 
 	int maxDownloadAttempt = 1;
 	switch( mediaType )
@@ -4447,6 +4449,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						// No need to perform early abort for lowest profile fragment downloads
 						context.earlyAbortEnabled = !mpStreamAbstractionAAMP->IsCurrentProfileLowest();
 						context.profileBps = mpStreamAbstractionAAMP->GetVideoBitrate();
+						earlyAbortUpdated = true;
 					}
 					else
 					{
@@ -4508,6 +4511,14 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				{
 					lowBWTimeout = GETCONFIGVALUE_PRIV(eAAMPConfig_NetworkTimeout) * LOW_BW_TIMEOUT_FACTOR;
 					lowBWTimeout = std::max(DEFAULT_LOW_BW_TIMEOUT, lowBWTimeout);
+				}
+				// For video fragments, disable low bandwidth timeout if already at the lowest profile
+				// This is already updated in context.earlyAbortEnabled above
+				if (lowBWTimeout > 0 && mediaType == eMEDIATYPE_VIDEO &&
+					earlyAbortUpdated && !context.earlyAbortEnabled)
+				{
+					lowBWTimeout = 0;
+					AAMPLOG_DEBUG("Disable low bandwidth timeout in aamp for lowest profile video fragment");
 				}
 				if (mFogTSBEnabled)
 				{

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -568,5 +568,12 @@ std::unique_ptr<SubtitleParser> StreamAbstractionAAMP::RegisterSubtitleParser_CB
 
 bool StreamAbstractionAAMP::IsCurrentProfileLowest()
 {
-	return false;
+	if (g_mockStreamAbstractionAAMP != nullptr)
+	{
+		return g_mockStreamAbstractionAAMP->IsCurrentProfileLowest();
+	}
+	else
+	{
+		return false;
+	}
 }

--- a/test/utests/mocks/MockStreamAbstractionAAMP.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP.h
@@ -102,6 +102,8 @@ public:
 	MOCK_METHOD(void, SetCurrentTextTrackIndex, (const std::string& index));
 
 	MOCK_METHOD(void, SetIsAtLivePoint, (bool isAtLivePoint));
+
+	MOCK_METHOD(bool, IsCurrentProfileLowest, ());
 };
 
 extern MockStreamAbstractionAAMP *g_mockStreamAbstractionAAMP;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -56,6 +56,7 @@
 using ::testing::An;
 using ::testing::DoAll;
 using ::testing::InvokeWithoutArgs;
+using ::testing::Invoke;
 using ::testing::Matcher;
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -5405,6 +5406,77 @@ TEST_F(PrivAampTests,VerifyPausedBehavior)
         p_aamp->mPausedBehavior = ePAUSED_BEHAVIOR_AUTOPLAY_IMMEDIATE;
         p_aamp->Tune("sampleUrl",false,NULL,true,false,NULL,true,NULL,0, session_id,NULL);
         EXPECT_FALSE(p_aamp->mSeekFromPausedState);
+}
+
+// Validates that low bandwidth timeout is enabled if the video is not at the lowest profile
+TEST_F(PrivAampTests, GetFileTest_EnableLowBWTimeoutOnNotLowestProfile)
+{
+	std::string effectiveUrl;
+	AampGrowableBuffer gBuff("GrowableBuffer");
+	AampMediaType mType = eMEDIATYPE_VIDEO;
+	const int lowBWTimeoutValue = 2; // 2 seconds
+
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	p_aamp->EnableDownloads();
+
+	p_aamp->curl[eCURLINSTANCE_VIDEO] = mCurlEasyHandle;
+	p_aamp->curlDLTimeout[eCURLINSTANCE_VIDEO] = 2000; // 2000ms timeout
+
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(Matcher<AAMPConfigSettingInt>(_))).WillRepeatedly(Return(0));
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(Matcher<AAMPConfigSettingFloat>(_))).WillRepeatedly(Return(0.0));
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(Matcher<AAMPConfigSettingString>(_))).WillRepeatedly(Return(""));
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr( mCurlEasyHandle, _, _)).WillRepeatedly(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_str( mCurlEasyHandle, _, _)).WillRepeatedly(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_long( mCurlEasyHandle, _, _)).WillRepeatedly(Return(CURLE_OK));
+
+	// By default lets, return 2s for lowBWTimeout
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_CurlDownloadLowBWTimeout)).WillRepeatedly(Return(lowBWTimeoutValue));
+	// Set IsCurrentProfileLowest to false
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, IsCurrentProfileLowest()).WillOnce(Return(false));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr( mCurlEasyHandle, CURLOPT_PROGRESSDATA, _))
+		.WillOnce(Invoke([lowBWTimeoutValue](void* handle, CURLoption option, const void* param) -> CURLcode {
+			const CurlProgressCbContext* ctx = static_cast<const CurlProgressCbContext*>(param);
+			EXPECT_EQ(ctx->lowBWTimeout, lowBWTimeoutValue);
+			return CURLE_OK;
+		}));
+
+	p_aamp->GetFile("remoteurl", mType, &gBuff, effectiveUrl);
+}
+
+// Validates that low bandwidth timeout is disabled if the video is at the lowest profile
+TEST_F(PrivAampTests, GetFileTest_DisableLowBWTimeoutOnLowestProfile)
+{
+	std::string effectiveUrl;
+	AampGrowableBuffer gBuff("GrowableBuffer");
+	AampMediaType mType = eMEDIATYPE_VIDEO;
+
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	p_aamp->EnableDownloads();
+
+	p_aamp->curl[eCURLINSTANCE_VIDEO] = mCurlEasyHandle;
+	p_aamp->curlDLTimeout[eCURLINSTANCE_VIDEO] = 2000; // 2000ms timeout
+
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(Matcher<AAMPConfigSettingInt>(_))).WillRepeatedly(Return(0));
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(Matcher<AAMPConfigSettingFloat>(_))).WillRepeatedly(Return(0.0));
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(Matcher<AAMPConfigSettingString>(_))).WillRepeatedly(Return(""));
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr( mCurlEasyHandle, _, _)).WillRepeatedly(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_str( mCurlEasyHandle, _, _)).WillRepeatedly(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_long( mCurlEasyHandle, _, _)).WillRepeatedly(Return(CURLE_OK));
+
+	// By default lets, return 2s for lowBWTimeout
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_CurlDownloadLowBWTimeout)).WillRepeatedly(Return(2));
+	// Set IsCurrentProfileLowest to true
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, IsCurrentProfileLowest()).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr( mCurlEasyHandle, CURLOPT_PROGRESSDATA, _))
+		.WillOnce(Invoke([](void* handle, CURLoption option, const void* param) -> CURLcode {
+			const CurlProgressCbContext* ctx = static_cast<const CurlProgressCbContext*>(param);
+			EXPECT_EQ(ctx->lowBWTimeout, 0);
+			return CURLE_OK;
+		}));
+
+	p_aamp->GetFile("remoteurl", mType, &gBuff, effectiveUrl);
 }
 
 // Pass null pointer as CurlCallbackContext and abort should be false


### PR DESCRIPTION
Reason for change: Disable lowBWTimeout when at the lowest profile as there is no scope for a rampdown and causes fragment skip
Test Procedure: Rampdown to lowest profile and confirm lowBWTimeout is not kicking in
Risks: Low