### PR TITLE
VPLAY-12497 gstreamer test harness - fix global state memory leaks

### DIFF
--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -1430,6 +1430,7 @@ public:
 			pipelineContext.track[eMEDIATYPE_AUDIO].Flush();
 			
 			// Reset pipeline state
+			pipelineContext.pipeline->Reset();
 			pipelineContext.pipeline->SetPipelineState(ePIPELINE_STATE_NULL);
 			delete pipelineContext.pipeline;
 			pipelineContext.pipeline = new Pipeline( &pipelineContext );

--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -1418,9 +1418,39 @@ public:
 		}
 		else if( strcmp(str,"stop")==0 )
 		{
+			// Clean up global Mp4Demux instances to prevent memory leaks
+			for (int i = 0; i < 2; i++)
+			{
+				delete gMp4Demux[i];
+				gMp4Demux[i] = nullptr;
+			}
+			
+			// Flush track queues to remove stale events
+			pipelineContext.track[eMEDIATYPE_VIDEO].Flush();
+			pipelineContext.track[eMEDIATYPE_AUDIO].Flush();
+			
+			// Reset pipeline state
 			pipelineContext.pipeline->SetPipelineState(ePIPELINE_STATE_NULL);
 			delete pipelineContext.pipeline;
-			pipelineContext.pipeline = new Pipeline( (class PipelineContext *)&pipelineContext );
+			pipelineContext.pipeline = new Pipeline( &pipelineContext );
+			
+			// Reset context state for clean restart (base class members)
+			pipelineContext.configured_stream_count = 0;
+			pipelineContext.initial_seek_performed = false;
+			
+			// Reset derived class members
+			pipelineContext.nextPTS = 0.0;
+			pipelineContext.nextTime = 0.0;
+			pipelineContext.seekPos = 0.0;
+			
+			// Reset track state
+			for (int i = 0; i < NUM_MEDIA_TYPES; i++)
+			{
+				pipelineContext.track[i].needsData = false;
+				pipelineContext.track[i].gstreamerReadyForInjection = false;
+			}
+			
+			printf("Pipeline stopped and reset\n");
 		}
 		else if( sscanf(str, "path %199s", base_path ) == 1 )
 		{

--- a/test/gstTestHarness/gst-test.h
+++ b/test/gstTestHarness/gst-test.h
@@ -54,7 +54,7 @@ public:
 	Track& operator=(const Track&)=delete;
 };
 
-class MyPipelineContext : PipelineContext
+class MyPipelineContext : public PipelineContext
 {
 public:
 	class Pipeline *pipeline;


### PR DESCRIPTION
VPLAY-12497 gstreamer test harness - fix global state memory leaks

Reason for Change:
Cleans up global Mp4Demux instances - Prevents memory leaks from accumulated demuxers Flushes track queues - Removes stale TrackEvent objects that could reference freed memory Resets pipeline state - Sets to NULL before deletion Recreates clean pipeline - Fresh instance without baggage Resets context state - All counters and flags back to initial values Resets track state - Clears needsData and injection flags This should significantly improve stability when stopping and playing different streams. The fix addresses the root cause of the crashes: incomplete cleanup leaving dangling pointers and stale state.

Test Guidance: use gst test harness to play different streams and tests and confirm no crashes