### PR TITLE
VPLAY-12462: [LLD] Add support to detect chunked mdat boxes for bounary detection

### DIFF
--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -287,6 +287,20 @@ struct CurlCallbackContext
 	// Disabled copy constructor and copy assignment
 	CurlCallbackContext(const CurlCallbackContext &other) = delete;
 	CurlCallbackContext& operator=(const CurlCallbackContext& other) = delete;
+
+	/**
+	 * @brief Reset the context variables specific to each download attempt
+	 */
+	void ResetForNewDownload()
+	{
+		chunkedDownload = false;
+		m_ChunkedBytesRemaining = 0;
+		m_ChunkedTransferState = ChunkedTransferState::READING_CHUNK_SIZE;
+		bufferOffset = 0;
+		chunkBoundary = 0;
+		abortReason = eCURL_ABORT_REASON_NONE;
+		dataTransferStartTime = -1;
+	}
 };
 
 /**

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -597,7 +597,6 @@ bool IsoBmffBuffer::getBoxesInternal(const std::vector<Box*> *boxes, const char 
 	for (size_t i = 0; i < size; i++)
 	{
 		Box *box = boxes->at(i);
-
 		if (IS_TYPE(box->getType(), name))
 		{
 			pBoxes->push_back(box);
@@ -1246,24 +1245,22 @@ bool IsoBmffBuffer::getBoxInfoInternal(const char *name, size_t index, size_t &s
 {
 	bool ret = false;
 	size_t matchCount = 0;
-	for (const auto& box : boxes)
+	size_t numBoxes = boxes.size();
+	//Adjust size when chunked box is available
+	if(chunkedBox)
 	{
+		numBoxes -= 1;
+	}
+	for (size_t i = 0; i < numBoxes; i++)
+	{
+		Box *box = boxes.at(i);
 		if (IS_TYPE(box->getType(), name))
 		{
 			if (matchCount == index)
 			{
-				if (box->getBase() >= buffer)
-				{
-					// Calculate the start offset of the box data within the buffer
-					start = static_cast<size_t>(box->getBase() - buffer);
-					// Get the size of the box
-					size = box->getSize();
-					ret = true;
-				}
-				else
-				{
-					AAMPLOG_ERR("Box of type %s has invalid base address:%p and buffer address:%p", name, box->getBase(), buffer);
-				}
+				start = box->getOffset();
+				size = box->getSize();
+				ret = true;
 				break;
 			}
 			matchCount++;
@@ -1272,6 +1269,25 @@ bool IsoBmffBuffer::getBoxInfoInternal(const char *name, size_t index, size_t &s
 	if (!ret)
 	{
 		AAMPLOG_WARN("Box of type %s with index %zu not found, only %zu available", name, index, matchCount);
+	}
+	return ret;
+}
+
+/**
+ * @fn getChunkedMdatBoxInfo - Get chunked mdat box info
+ *
+ * @param[out] start - start offset of chunked mdat box
+ * @param[out] size - size of chunked mdat box
+ * @return bool - true if chunked mdat box found, false otherwise
+ */
+bool IsoBmffBuffer::getChunkedMdatBoxInfo(size_t &start, size_t &size) const
+{
+	bool ret = false;
+	if ((chunkedBox != nullptr) && IS_TYPE(chunkedBox->getType(), Box::MDAT))
+	{
+		start = chunkedBox->getOffset();
+		size = chunkedBox->getSize();
+		ret = true;
 	}
 	return ret;
 }

--- a/isobmff/isobmffbuffer.h
+++ b/isobmff/isobmffbuffer.h
@@ -511,5 +511,14 @@ public:
 	 * @return bool if box found. false otherwise
 	 */
 	bool getMdatBoxInfo(size_t index, size_t &start, size_t &size);
+
+	/**
+	 * @fn getChunkedMdatBoxInfo
+	 *
+	 * @param[out] start - start offset of chunked mdat box
+	 * @param[out] size - size of chunked mdat box
+	 * @return true if chunked mdat box is present. false otherwise
+	 */
+	bool getChunkedMdatBoxInfo(size_t &start, size_t &size) const;
 };
 #endif /* __ISOBMFFBUFFER_H__ */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -668,12 +668,13 @@ static int ReadConfigNumericHelper(std::string buf, const char* prefixPtr, T& va
 
 /**
  * @brief Identify mp4 chunk boundary in buffer
+ * @param[in] type - media type
  * @param[in] buffer - buffer to scan
  * @param[in] bufferOffset - offset in buffer to start scanning from
  * @param[out] chunkBoundaryOffset - offset of chunk boundary if found
  * @retval true if chunk boundary found
  */
-static bool IdentifyMp4ChunkBoundary(AampGrowableBuffer *buffer, size_t bufferOffset, size_t &chunkBoundaryOffset)
+static bool IdentifyMp4ChunkBoundary(AampMediaType type, AampGrowableBuffer *buffer, size_t bufferOffset, size_t &chunkBoundaryOffset)
 {
 	bool found = false;
 	chunkBoundaryOffset = 0;
@@ -688,23 +689,33 @@ static bool IdentifyMp4ChunkBoundary(AampGrowableBuffer *buffer, size_t bufferOf
 			// Check for 'mdat' box which indicates the end of mp4 chunk
 			// Specified in the ISO Base Media File Format (ISO/IEC 14496-12) specification that in fragmented MP4 files,
 			// a moof (Movie Fragment) box precedes the corresponding mdat (Media Data) box
-			size_t count = 0;
+			size_t mdatCount = 0;
+			size_t mdatStart = 0;
+			size_t mdatSize = 0;
 			// Get number of mdat boxes
-			if (isobmffBuffer.getMdatBoxCount(count))
+			if (isobmffBuffer.getMdatBoxCount(mdatCount) && mdatCount > 0)
 			{
-				if (count > 0)
+				// Get the last mdat box info
+				if (isobmffBuffer.getMdatBoxInfo(mdatCount - 1, mdatStart, mdatSize))
 				{
-					size_t start = 0;
-					size_t size = 0;
-					// Get the last mdat box info
-					if (isobmffBuffer.getMdatBoxInfo(count - 1, start, size))
-					{
-						// Calculate chunk boundary offset
-						chunkBoundaryOffset = bufferOffset + start + size;
-						found = true;
-					}
+					AAMPLOG_DEBUG("[%d] MDAT box count=%zu and start=%zu , size=%zu", type, mdatCount, mdatStart, mdatSize);
 				}
-				AAMPLOG_DEBUG("IdentifyMp4ChunkBoundary: mdat box count=%zu and chunkBoundaryOffset=%zu", count, chunkBoundaryOffset);
+				else
+				{
+					// Not expected
+					AAMPLOG_WARN("[%d] Failed to get MDAT box info for index=%zu (count=%zu)", type, mdatCount - 1, mdatCount);
+				}
+			}
+			else if (isobmffBuffer.getChunkedMdatBoxInfo(mdatStart, mdatSize))
+			{
+				AAMPLOG_DEBUG("[%d] Chunked MDAT box found start=%zu, size=%zu", type, mdatStart, mdatSize);
+			}
+			// start could be 0 if mdat is the first box in buffer
+			if (mdatSize > 0)
+			{
+				// Calculate chunk boundary offset
+				chunkBoundaryOffset = bufferOffset + mdatStart + mdatSize;
+				found = true;
 			}
 		}
 	}
@@ -1061,10 +1072,10 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 				if (context->chunkBoundary == 0)
 				{
 					size_t chunkBoundaryOffset = 0;
-					if (IdentifyMp4ChunkBoundary(context->buffer, context->bufferOffset, chunkBoundaryOffset))
+					if (IdentifyMp4ChunkBoundary(context->mediaType, context->buffer, context->bufferOffset, chunkBoundaryOffset))
 					{
 						context->chunkBoundary = chunkBoundaryOffset;
-						AAMPLOG_INFO("[%d] Identified chunk boundary at offset %zu", context->mediaType, context->chunkBoundary);
+						AAMPLOG_INFO("[%d] Identified chunk boundary at offset %zu, buffer len %zu", context->mediaType, context->chunkBoundary, context->buffer->GetLen());
 					}
 				}
 				if (context->chunkBoundary > 0)
@@ -4352,6 +4363,18 @@ void PrivateInstanceAAMP::SetCMCDTrackData(AampMediaType mediaType)
 }
 
 /**
+ * @brief Check if download has timed out after receiving some data based on curl code and abort reason
+ */
+static inline bool HasDownloadTimedOutWithData(CURLcode curlCode, CurlAbortReason abortReason)
+{
+	// Not checking for eCURL_ABORT_REASON_START_TIMEOUT
+	return (curlCode == CURLE_OPERATION_TIMEDOUT) ||
+			curlCode == CURLE_PARTIAL_FILE ||
+			abortReason == eCURL_ABORT_REASON_STALL_TIMEDOUT ||
+			abortReason == eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT;
+}
+
+/**
  * @brief Download a file from the CDN
  */
 bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaType, AampGrowableBuffer *buffer, std::string& effectiveUrl, int * http_error, double *downloadTimeS, const char *range, unsigned int curlInstance, bool resetBuffer, BitsPerSecond *bitrate, int * fogError, double fragmentDurationS, ProfilerBucketType bucketType, int maxInitDownloadTimeMS)
@@ -4577,9 +4600,8 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 
 			while(downloadAttempt < maxDownloadAttempt)
 			{
-				context.chunkedDownload = false;
-				context.m_ChunkedBytesRemaining = 0; // reset
-				context.m_ChunkedTransferState = ChunkedTransferState::READING_CHUNK_SIZE; // reset
+				// Reset context values specific to each download attempt
+				context.ResetForNewDownload();
 				progressCtx.downloadStartTime = NOW_STEADY_TS_MS;
 
 				progressCtx.downloadUpdatedTime = -1;
@@ -4740,6 +4762,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						res == CURLE_WRITE_ERROR &&
 						context.abortReason == eCURL_ABORT_REASON_FIRST_CHUNK_SLOW)
 				{
+					// This is early chunk abort case in low latency mode
 					// Handling this differently to avoid loopAgain logic for slow first chunk case
 					// Marking as timeout to trigger ABR ramp down and also update bandwidth metrics.
 					AAMPLOG_INFO("Curl download aborted due to slow first chunk detection");
@@ -4748,11 +4771,12 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				}
 				else if (mAampLLDashServiceData.lowLatencyMode &&
 						context.bufferOffset > 0 &&
-						(res == CURLE_OPERATION_TIMEDOUT || res == CURLE_PARTIAL_FILE))
+						HasDownloadTimedOutWithData(res, progressCtx.abortReason))
 				{
 					// Download timed out in low latency chunk mode injection.
-					// Here we have injected some chunks already, so treat it as success to avoid rampdown and to update bandwidth metrics.
-					// Rampdown in this case, will cause video looping due to duplicate mp4 chunks with same timestamps
+					// With bufferOffset > 0, we have injected some chunks already, so treat it as success to update bandwidth metrics.
+					// Rampdown in this case, will cause video looping due to duplicate mp4 chunks with same timestamps.
+					// HasDownloadTimedOut check to ensure we are not treating non-timeout errors as success.
 					AAMPLOG_WARN("Curl download timed out in low latency mode after injecting chunks, treating as success to avoid rampdown");
 					res = CURLE_OK;
 					http_code = 206; // Partial content

--- a/test/utests/fakes/FakeIsoBmffBuffer.cpp
+++ b/test/utests/fakes/FakeIsoBmffBuffer.cpp
@@ -280,3 +280,15 @@ bool IsoBmffBuffer::getMdatBoxInfo(size_t index, size_t &start, size_t &size)
         return false;
     }
 }
+
+bool IsoBmffBuffer::getChunkedMdatBoxInfo(size_t &start, size_t &size) const
+{
+    if (g_mockIsoBmffBuffer)
+    {
+        return g_mockIsoBmffBuffer->getChunkedMdatBoxInfo(start, size);
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/test/utests/mocks/MockIsoBmffBuffer.h
+++ b/test/utests/mocks/MockIsoBmffBuffer.h
@@ -46,6 +46,7 @@ public:
 	MOCK_METHOD(bool, setTrickmodeTimescale, (uint32_t));
     MOCK_METHOD(bool, setMediaHeaderDuration, (uint64_t));
     MOCK_METHOD(bool, getMdatBoxInfo, (size_t, size_t&, size_t&));
+    MOCK_METHOD(bool, getChunkedMdatBoxInfo, (size_t&, size_t&), (const));
 };
 
 extern MockIsoBmffBuffer *g_mockIsoBmffBuffer;

--- a/test/utests/tests/IsoBmffBufferTests/IsoBmffBufferTests.cpp
+++ b/test/utests/tests/IsoBmffBufferTests/IsoBmffBufferTests.cpp
@@ -1173,3 +1173,88 @@ TEST_F(IsoBmffBufferTests, setMediaHeaderDurationNegative)
 	// No MDHD box
 	EXPECT_EQ(mIsoBmffBuffer->setMediaHeaderDuration(0), false);
 }
+
+/**
+ * @brief Test getMdatBoxInfo with chunked MDAT
+ * Verify that getMdatBoxInfo returns false when buffer contains a chunked (incomplete) MDAT box.
+ * The chunked MDAT box has a header claiming 128 bytes but only 32 bytes are actually present.
+ */
+TEST_F(IsoBmffBufferTests, getMdatBoxInfoWithChunkedMdatTest)
+{
+	// Set up buffer with chunked MDAT (header claims more data than available)
+	AAMPLOG_WARN("setBuffer");
+	mIsoBmffBuffer->setBuffer(const_cast<uint8_t*>(chunkedMdatTestData), sizeof(chunkedMdatTestData));
+	bool bParse = mIsoBmffBuffer->parseBuffer();
+	AAMPLOG_WARN("parseBuffer returned %d", bParse);
+	EXPECT_TRUE(bParse);
+
+	// Verify there are no complete MDAT boxes (chunked box not counted)
+	size_t mdatCount = 0;
+	bool countResult = mIsoBmffBuffer->getMdatBoxCount(mdatCount);
+	EXPECT_FALSE(countResult);  // Should return false as there are no complete mdat boxes
+	EXPECT_EQ(mdatCount, 0);
+
+	// Attempt to get MDAT box info - should fail since MDAT is incomplete
+	size_t mdatStart = 999;  // Initialize with sentinel value
+	size_t mdatSize = 999;   // Initialize with sentinel value
+	bool result = mIsoBmffBuffer->getMdatBoxInfo(0, mdatStart, mdatSize);
+	EXPECT_FALSE(result);
+	// Values should remain unchanged when function returns false
+	EXPECT_EQ(mdatStart, 999);
+	EXPECT_EQ(mdatSize, 999);
+}
+
+/**
+ * @brief Test getMdatBoxInfo with complete MDAT
+ * Verify that getMdatBoxInfo returns true and provides correct offset and size
+ * for a complete MDAT box.
+ */
+TEST_F(IsoBmffBufferTests, getMdatBoxInfoWithCompleteMdatTest)
+{
+	// Set up buffer with complete MDAT box
+	mIsoBmffBuffer->setBuffer(const_cast<uint8_t*>(completeMdatTestData), sizeof(completeMdatTestData));
+	bool bParse = mIsoBmffBuffer->parseBuffer();
+	EXPECT_TRUE(bParse);
+
+	// Verify there is exactly 1 complete MDAT box
+	size_t mdatCount = 0;
+	bool countResult = mIsoBmffBuffer->getMdatBoxCount(mdatCount);
+	EXPECT_TRUE(countResult);
+	EXPECT_EQ(mdatCount, 1);
+
+	// Get MDAT box info - should succeed
+	size_t mdatStart = 0;
+	size_t mdatSize = 0;
+	bool result = mIsoBmffBuffer->getMdatBoxInfo(0, mdatStart, mdatSize);
+	EXPECT_TRUE(result);
+
+	// Verify the offset and size are correct
+	// MDAT starts after the 8-byte moof box
+	EXPECT_EQ(mdatStart, COMPLETE_MOOF_SIZE);
+	EXPECT_EQ(mdatSize, COMPLETE_MDAT_SIZE);
+}
+
+/**
+ * @brief Test getChunkedMdatBoxInfo with chunked MDAT
+ * Verify that getChunkedMdatBoxInfo returns true and provides correct offset and size
+ * for a chunked (incomplete) MDAT box.
+ */
+TEST_F(IsoBmffBufferTests, getChunkedMdatBoxInfoTest)
+{
+	// Set up buffer with chunked MDAT
+	mIsoBmffBuffer->setBuffer(const_cast<uint8_t*>(chunkedMdatTestData), sizeof(chunkedMdatTestData));
+	bool bParse = mIsoBmffBuffer->parseBuffer();
+	EXPECT_TRUE(bParse);
+
+	// Get chunked MDAT box info - should succeed
+	size_t mdatStart = 0;
+	size_t mdatSize = 0;
+	bool result = mIsoBmffBuffer->getChunkedMdatBoxInfo(mdatStart, mdatSize);
+	EXPECT_TRUE(result);
+
+	// Verify the offset and size are correct
+	// MDAT starts after the 8-byte moof box
+	EXPECT_EQ(mdatStart, CHUNKED_MOOF_SIZE);
+	// Size should be the declared size from the MDAT header (not the actual available data size, 128 bytes)
+	EXPECT_EQ(mdatSize, CHUNKED_MDAT_DECLARED_SIZE);
+}

--- a/test/utests/tests/IsoBmffBufferTests/testFiles/helperTestData.h
+++ b/test/utests/tests/IsoBmffBufferTests/testFiles/helperTestData.h
@@ -233,4 +233,48 @@ const uint8_t setMediaHeaderDurationTestData[] = {
 	0x55, 0xC4, 0x00, 0x00  // language and pre_defined
 };
 
+// Test data for complete MDAT box (moof + full mdat)
+constexpr uint32_t MOOF_TYPE = 0x6D6F6F66; // 'moof'
+constexpr uint32_t MDAT_TYPE = 0x6D646174; // 'mdat'
+constexpr uint32_t COMPLETE_MOOF_SIZE = 8;  // Minimal moof box (header only)
+constexpr uint32_t COMPLETE_MDAT_SIZE = 64;
+
+const uint8_t completeMdatTestData[] = {
+	// moof box (minimal - header only, no payload to avoid parser infinite loop)
+	(COMPLETE_MOOF_SIZE >> 24) & 0xFF, (COMPLETE_MOOF_SIZE >> 16) & 0xFF, (COMPLETE_MOOF_SIZE >> 8) & 0xFF, COMPLETE_MOOF_SIZE & 0xFF,
+	(MOOF_TYPE >> 24) & 0xFF, (MOOF_TYPE >> 16) & 0xFF, (MOOF_TYPE >> 8) & 0xFF, MOOF_TYPE & 0xFF,
+
+	// mdat box (complete)
+	(COMPLETE_MDAT_SIZE >> 24) & 0xFF, (COMPLETE_MDAT_SIZE >> 16) & 0xFF, (COMPLETE_MDAT_SIZE >> 8) & 0xFF, COMPLETE_MDAT_SIZE & 0xFF,
+	(MDAT_TYPE >> 24) & 0xFF, (MDAT_TYPE >> 16) & 0xFF, (MDAT_TYPE >> 8) & 0xFF, MDAT_TYPE & 0xFF,
+	// mdat payload (56 bytes of media data)
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20,
+	0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+	0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F, 0x30,
+	0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38
+};
+
+// Test data for chunked MDAT box (moof + partial mdat)
+// MDAT header claims 128 bytes but only 32 bytes are present
+constexpr uint32_t CHUNKED_MOOF_SIZE = 8;  // Minimal moof box (header only)
+constexpr uint32_t CHUNKED_MDAT_DECLARED_SIZE = 128;  // Size declared in header
+constexpr uint32_t CHUNKED_MDAT_ACTUAL_SIZE = 32;     // Actual data available (including 8-byte header)
+
+const uint8_t chunkedMdatTestData[] = {
+	// moof box (minimal - header only, no payload to avoid parser infinite loop)
+	(CHUNKED_MOOF_SIZE >> 24) & 0xFF, (CHUNKED_MOOF_SIZE >> 16) & 0xFF, (CHUNKED_MOOF_SIZE >> 8) & 0xFF, CHUNKED_MOOF_SIZE & 0xFF,
+	(MOOF_TYPE >> 24) & 0xFF, (MOOF_TYPE >> 16) & 0xFF, (MOOF_TYPE >> 8) & 0xFF, MOOF_TYPE & 0xFF,
+
+	// mdat box (chunked - header says 128 bytes but only 32 bytes present)
+	(CHUNKED_MDAT_DECLARED_SIZE >> 24) & 0xFF, (CHUNKED_MDAT_DECLARED_SIZE >> 16) & 0xFF, (CHUNKED_MDAT_DECLARED_SIZE >> 8) & 0xFF, CHUNKED_MDAT_DECLARED_SIZE & 0xFF,
+	(MDAT_TYPE >> 24) & 0xFF, (MDAT_TYPE >> 16) & 0xFF, (MDAT_TYPE >> 8) & 0xFF, MDAT_TYPE & 0xFF,
+	// mdat payload (only 24 bytes present, but header claims 120 more bytes)
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18
+};
+
 #endif // HELPERTESTDATA_H

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -971,8 +971,6 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 // Test HandleSSLWriteCallback when ParseBuffer API call fails in chunkInjection mode
 TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
 {
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithParseBufferFailure - Setting up");
-
 	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
 	AampLLDashServiceData llData;
 	llData.lowLatencyMode = true;
@@ -992,9 +990,11 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
 		.Times(0);
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
-		.WillRepeatedly(Return(false));
+		.WillOnce(Return(false));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
-		.WillRepeatedly(Return(false)); // return no mdat for now
+		.Times(0);
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
+		.Times(0);
 	p_aamp->mDownloadsEnabled = true;
 	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
 
@@ -1011,13 +1011,9 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
 	context.bufferOffset = 0;
 	context.chunkBoundary = 0;
 
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithParseBufferFailure - Calling HandleSSLWriteCallback");
-
 	// Call with valid context - ptr is not NULL, so data processing happens
 	char testData[] = "test data with parse failure";
 	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
-
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithParseBufferFailure - Result: %zu", result);
 	// Result should be size*nmemb
 	EXPECT_EQ(result, strlen(testData));
 	// Verify that bufferOffset and chunkBoundary remain unchanged
@@ -1028,8 +1024,6 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
 // Test HandleSSLWriteCallback when no mdat detected in chunkInjection mode
 TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 {
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithoutMdat - Setting up");
-
 	// Enable LL DASH chunk mode to trigger CacheFragmentChunk calls
 	AampLLDashServiceData llData;
 	llData.lowLatencyMode = true;
@@ -1049,9 +1043,11 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 		.Times(0);
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
-		.WillRepeatedly(Return(true));
+		.WillOnce(Return(true));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
-		.WillRepeatedly(Return(false)); // return no mdat for now
+		.WillOnce(Return(false)); // return no mdat for now
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
+		.WillOnce(Return(false)); // return no mdat info
 	p_aamp->mDownloadsEnabled = true;
 	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
 
@@ -1068,13 +1064,9 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 	context.bufferOffset = 0;
 	context.chunkBoundary = 0;
 
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithoutMdat - Calling HandleSSLWriteCallback");
-
 	// Call with valid context - ptr is not NULL, so data processing happens
 	char testData[] = "test data with zero mdat";
 	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
-
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithoutMdat - Result: %zu", result);
 	// Result should be size*nmemb
 	EXPECT_EQ(result, strlen(testData));
 	// Verify that bufferOffset and chunkBoundary remain unchanged
@@ -1082,12 +1074,12 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 	EXPECT_EQ(context.chunkBoundary, 0);
 }
 
-// Test HandleSSLWriteCallback when full mdat is received in chunkInjection mode
-// Done in 2 iterations to simulate data arriving in parts
-TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMp4ChunkBoundary)
+// Test HandleSSLWriteCallback when a chunked (incomplete) MDAT box is received
+// in chunkInjection mode and detected via getChunkedMdatBoxInfo() rather than
+// as a complete MDAT counted by getMdatBoxCount(). The 2 iterations simulate
+// the chunked MDAT data arriving over multiple callbacks.
+TEST_F(PrivAampTests, HandleSSLWriteCallbackWithPartialMp4Chunk)
 {
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Setting up");
-
 	// RAII guard to ensure memory copying is disabled on test exit (success or failure)
 	MemoryCopyingGuard guard;
 
@@ -1126,41 +1118,36 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMp4ChunkBoundary)
 	context.bufferOffset = startBufferOffset;
 	context.chunkBoundary = 0;
 
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Calling HandleSSLWriteCallback");
-
-	// Call HandleSSLWriteCallback twice with incremental data to simulate full mdat reception
-	char testDataPart1[] = "test data with mdat full chunk part 1";
-	char testDataPart2[] = "test data with mdat full chunk part 2";
+	// Call HandleSSLWriteCallback twice with incremental data to simulate partial (chunked) mdat reception
+	char testDataPart1[] = "test data with partial mdat chunk part 1";
+	char testDataPart2[] = "test data with partial mdat chunk part 2";
 	size_t totalBufSize = strlen(testDataPart1) + strlen(testDataPart2);
-	// Lets assume mdat starts from offset 10 to end of buffer
-	size_t mdatStart = 10;
+	// Lets assume mdat starts from offset 20 to end of buffer
+	size_t mdatStart = 20;
 	size_t mdatSize = totalBufSize - mdatStart;
 	size_t chunkBoundary = startBufferOffset + mdatStart + mdatSize;
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
-		.WillRepeatedly(Return(true));
+		.WillOnce(Return(true));
 	// Return mdat count as 1
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
+		.WillOnce(Return(false));
+	// Return chunked mdat info
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
 		.WillOnce(DoAll(
-			SetArgReferee<0>(static_cast<size_t>(1)),
-			Return(true)
-		));
-	// Return mdat info
-	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxInfo(0, _, _))
-		.WillOnce(DoAll(
-			SetArgReferee<1>(static_cast<size_t>(mdatStart)), // mdat start
-			SetArgReferee<2>(static_cast<size_t>(mdatSize)), // mdat size
+			SetArgReferee<0>(static_cast<size_t>(mdatStart)), // mdat start
+			SetArgReferee<1>(static_cast<size_t>(mdatSize)), // mdat size
 			Return(true)
 		));
 
-	// In this test, CacheFragmentChunk() should be called exactly once when full mdat is received
+	// In this test, CacheFragmentChunk() should be called exactly once when chunked mdat boundary is detected
 	// Lets make this a strict check using expected values
 	EXPECT_CALL(*g_mockMediaStreamContext,
 		CacheFragmentChunk(eMEDIATYPE_VIDEO, buffer.GetPtr() + startBufferOffset, chunkBoundary - startBufferOffset, _, _))
 		.Times(1);
 
 	size_t result1 = p_aamp->HandleSSLWriteCallback(testDataPart1, strlen(testDataPart1), 1, &context);
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Intermediate Result: %zu", result1);
+	// Result should be size*nmemb
 	EXPECT_EQ(result1, strlen(testDataPart1));
 	// bufferOffset should still be startBufferOffset
 	EXPECT_EQ(context.bufferOffset, startBufferOffset);
@@ -1169,7 +1156,6 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMp4ChunkBoundary)
 	EXPECT_EQ(buffer.GetLen(), startBufferOffset + strlen(testDataPart1));
 
 	size_t result = p_aamp->HandleSSLWriteCallback(testDataPart2, strlen(testDataPart2), 1, &context);
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMp4ChunkBoundary - Result: %zu", result);
 	// Result should be size*nmemb
 	EXPECT_EQ(result, strlen(testDataPart2));
 	// Verify that bufferOffset is updated to total mdat size
@@ -1183,8 +1169,6 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMp4ChunkBoundary)
 // Test HandleSSLWriteCallback when multiple mdat boxes are received
 TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 {
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMultipleMdatBoxes - Setting up");
-
 	// RAII guard to ensure memory copying is disabled on test exit
 	MemoryCopyingGuard guard;
 
@@ -1233,7 +1217,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 	size_t lastMdatBoundary = thirdMdatStart + thirdMdatSize; // Should use the last mdat
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
-		.WillRepeatedly(Return(true));
+		.WillOnce(Return(true));
 
 	// Return mdat count as 3 (multiple fragments in buffer)
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
@@ -1249,6 +1233,8 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 			SetArgReferee<2>(static_cast<size_t>(thirdMdatSize)),
 			Return(true)
 		));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
+		.Times(0); // Not expected to be called in this test
 
 	// CacheFragmentChunk should be called once with data up to the last mdat boundary
 	EXPECT_CALL(*g_mockMediaStreamContext,
@@ -1256,8 +1242,6 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 		.Times(1);
 
 	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
-
-	AAMPLOG_INFO("Test: HandleSSLWriteCallbackWithMultipleMdatBoxes - Result: %zu", result);
 	EXPECT_EQ(result, strlen(testData));
 
 	// Verify that chunkBoundary was identified as the last mdat boundary


### PR DESCRIPTION
Reason for change: Add chunked MDAT detection and update chunkBoundaryOffset based on chunked MDAT if a complete one is not available
Test Procedure: LLD playback should not have any regressions
Risks: Low