### PR TITLE
VPLAY-12512 gst test harness idle callback is hogging 100% of cpu

### DIFF
--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -1499,7 +1499,7 @@ static gboolean myIdleFunc( gpointer arg )
 	AppContext *appContext = (AppContext *)arg;
 	appContext->IdleFunc();
 	// avoid 100% cpu utilization by waiting 10ms for next idle callback
-	g_timeout_add(10, (GSourceFunc)myIdleFunc, arg);
+	g_timeout_add(10, myIdleFunc, arg);
 	return FALSE;
 }
 

--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -1498,7 +1498,9 @@ static gboolean myIdleFunc( gpointer arg )
 {
 	AppContext *appContext = (AppContext *)arg;
 	appContext->IdleFunc();
-	return TRUE;
+	// avoid 100% cpu utilization by waiting 10ms for next idle callback
+	g_timeout_add(10, (GSourceFunc)myIdleFunc, arg);
+	return FALSE;
 }
 
 static gboolean handle_keyboard( GIOChannel * source, GIOCondition cond, AppContext * appContext )

--- a/test/gstTestHarness/gst-test.cpp
+++ b/test/gstTestHarness/gst-test.cpp
@@ -1498,9 +1498,7 @@ static gboolean myIdleFunc( gpointer arg )
 {
 	AppContext *appContext = (AppContext *)arg;
 	appContext->IdleFunc();
-	// avoid 100% cpu utilization by waiting 10ms for next idle callback
-	g_timeout_add(10, myIdleFunc, arg);
-	return FALSE;
+	return TRUE;
 }
 
 static gboolean handle_keyboard( GIOChannel * source, GIOCondition cond, AppContext * appContext )
@@ -1628,7 +1626,8 @@ int my_main(int argc, char **argv)
 	struct AppContext appContext;
 	GIOChannel *io_stdin = g_io_channel_unix_new (fileno (stdin));
 	(void)g_io_add_watch (io_stdin, G_IO_IN, (GIOFunc) handle_keyboard, &appContext);
-	(void)g_idle_add( myIdleFunc, (gpointer)&appContext );
+	// Use g_timeout_add instead of g_idle_add to avoid 100% CPU utilization
+	(void)g_timeout_add( 10, myIdleFunc, (gpointer)&appContext );
 	std::thread myNetworkCommandServer( NetworkCommandServer, &appContext );
 	g_main_loop_run(appContext.main_loop);
 	g_main_loop_unref(appContext.main_loop);


### PR DESCRIPTION
VPLAY-12512 gst test harness idle callback is hogging 100% of cpu

Reason for Change: 10ms delay added between idle callbacks to avoid pegging cpu

Test Guidance: cpu no longer going to 100% when running gst test harness

Risk: None (tool only change)