### PR TITLE
VPLAY-12524: Integrate TimeBasedBufferManager with MediaStreamContex for buffer consumption on skipped segments

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -792,6 +792,12 @@ void MediaStreamContext::OnFragmentDownloadFailed(DownloadInfoPtr dlInfo)
 			{
 				updateSkipPoint((dlInfo->pts + dlInfo->fragmentDurationSec), dlInfo->fragmentDurationSec);
 			}
+			auto timeBasedBufferManager = GetTimeBasedBufferManager();
+			if(timeBasedBufferManager)
+			{
+				// Consume the buffer for the segment duration as segment is skipped
+				timeBasedBufferManager->ConsumeBuffer(dlInfo->fragmentDurationSec);
+			}
 		}
 	}
 }

--- a/test/utests/fakes/FakeAampTimeBasedBufferManager.cpp
+++ b/test/utests/fakes/FakeAampTimeBasedBufferManager.cpp
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 #include "AampTimeBasedBufferManager.hpp"
+#include "MockAampTimeBasedBufferManager.h"
+
+aamp::MockAampTimeBasedBufferManager *g_mockAampTimeBasedBufferManager = nullptr;
 
 namespace aamp
 {
@@ -38,6 +41,10 @@ namespace aamp
 	 */
 	void AampTimeBasedBufferManager::PopulateBuffer(double fragmentDuration)
 	{
+		if (g_mockAampTimeBasedBufferManager != nullptr)
+		{
+			g_mockAampTimeBasedBufferManager->PopulateBuffer(fragmentDuration);
+		}
 	}
 
 	/**
@@ -47,6 +54,10 @@ namespace aamp
 	 */
 	void AampTimeBasedBufferManager::ConsumeBuffer(double timeToConsume)
 	{
+		if (g_mockAampTimeBasedBufferManager != nullptr)
+		{
+			g_mockAampTimeBasedBufferManager->ConsumeBuffer(timeToConsume);
+		}
 	}
 
 	/**
@@ -56,6 +67,10 @@ namespace aamp
 	 */
 	bool AampTimeBasedBufferManager::IsFull() const
 	{
+		if (g_mockAampTimeBasedBufferManager != nullptr)
+		{
+			return g_mockAampTimeBasedBufferManager->IsFull();
+		}
 		return false;
 	}
 
@@ -64,5 +79,9 @@ namespace aamp
 	 */
 	void AampTimeBasedBufferManager::ClearBuffer()
 	{
+		if (g_mockAampTimeBasedBufferManager != nullptr)
+		{
+			g_mockAampTimeBasedBufferManager->ClearBuffer();
+		}
 	}
 } // namespace aamp

--- a/test/utests/mocks/MockAampTimeBasedBufferManager.h
+++ b/test/utests/mocks/MockAampTimeBasedBufferManager.h
@@ -1,0 +1,39 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AAMP_MOCK_TIME_BASED_BUFFER_MANAGER_H
+#define AAMP_MOCK_TIME_BASED_BUFFER_MANAGER_H
+
+#include <gmock/gmock.h>
+
+namespace aamp
+{
+	class MockAampTimeBasedBufferManager
+	{
+	public:
+		MOCK_METHOD(void, PopulateBuffer, (double fragmentDuration));
+		MOCK_METHOD(void, ConsumeBuffer, (double timeToConsume));
+		MOCK_METHOD(bool, IsFull, (), (const));
+		MOCK_METHOD(void, ClearBuffer, ());
+	};
+}
+
+extern aamp::MockAampTimeBasedBufferManager *g_mockAampTimeBasedBufferManager;
+
+#endif /* AAMP_MOCK_TIME_BASED_BUFFER_MANAGER_H */

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -28,6 +28,7 @@
 #include "MockMediaTrack.h"
 #include "MockStreamAbstractionAAMP.h"
 #include "MockPrivateInstanceAAMP.h"
+#include "MockAampTimeBasedBufferManager.h"
 #include "fragmentcollector_mpd.h"
 #include "StreamAbstractionAAMP.h"
 
@@ -59,6 +60,7 @@ protected:
 		g_mockMediaTrack = new StrictMock<MockMediaTrack>();
 		g_mockStreamAbstractionAAMP = new NiceMock<MockStreamAbstractionAAMP>(mPrivateInstanceAAMP);
 		g_mockPrivateInstanceAAMP = new StrictMock<MockPrivateInstanceAAMP>();
+		g_mockAampTimeBasedBufferManager = new StrictMock<aamp::MockAampTimeBasedBufferManager>();
 	}
 
 	void TearDown() override
@@ -83,6 +85,9 @@ protected:
 
 		delete g_mockPrivateInstanceAAMP;
 		g_mockPrivateInstanceAAMP = nullptr;
+
+		delete g_mockAampTimeBasedBufferManager;
+		g_mockAampTimeBasedBufferManager = nullptr;
 	}
 
 public:
@@ -159,6 +164,7 @@ TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(chunkMode));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(chunkMode));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(ptsRestampEnabled));
+	EXPECT_CALL(*g_mockAampTimeBasedBufferManager, ConsumeBuffer(dlInfo->fragmentDurationSec)).Times(chunkMode ? 1 : 0);
 
 	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterFetch(_));
 	if (chunkMode)
@@ -264,6 +270,53 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadFailed_ValidDownloadInfoLowestPr
 		EXPECT_FALSE(mMediaStreamContext->mCheckForRampdown);
 		EXPECT_TRUE(mMediaStreamContext->mSkipSegmentOnError);
 	});
+}
+
+/**
+ * @brief Verify that when rampdown is not possible (lowest profile) and a
+ *        segment is skipped, the time-based buffer is consumed.
+ */
+TEST_F(FragmentDownloadTests, OnFragmentDownloadFailed_LowestProfile_ConsumesTimeBasedBuffer)
+{
+	mMediaStreamContext->mActiveDownloadInfo = std::make_shared<DownloadInfo>();
+	DownloadInfoPtr dlInfo = std::make_shared<DownloadInfo>();
+	dlInfo->url = "http://example.com/fragment";
+	dlInfo->isInitSegment = false;
+	dlInfo->isPlayingAd = false;
+	dlInfo->pts = 123.45;
+	dlInfo->fragmentDurationSec = 5.0;
+
+	// Ensure we take the lowest-profile skip path.
+	mMediaStreamContext->segDLFailCount = 0;
+	mMediaStreamContext->mSkipSegmentOnError = true;
+	mMediaStreamContext->httpErrorCode = 404;
+
+	// Mock necessary method calls and return values
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockAampConfig,
+		GetConfigValue(eAAMPConfig_FragmentDownloadFailThreshold))
+		.WillRepeatedly(Return(10));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_))
+		.WillRepeatedly(Return(false));
+
+	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
+	auto cachedFragment = std::make_shared<CachedFragment>();
+	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
+		.WillOnce(Return(cachedFragment.get()));
+
+	// Return false for CheckForRampDownLimitReached to indicate that the limit is reached
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, CheckForRampDownLimitReached())
+		.WillOnce(Return(false));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, CheckForRampDownProfile(_))
+		.WillOnce(Return(false));
+
+	// Expect the time-based buffer to be consumed for the fragment duration
+	EXPECT_CALL(*g_mockAampTimeBasedBufferManager,
+		ConsumeBuffer(dlInfo->fragmentDurationSec))
+		.Times(1);
+
+	EXPECT_NO_THROW(mMediaStreamContext->OnFragmentDownloadFailed(dlInfo));
 }
 
 /**


### PR DESCRIPTION
Reason for change: To ensure that when segments are skipped in MediaStreamContext, the TimeBasedBufferManager is updated accordingly to reflect the consumed buffer duration.
Risks: Low
Test Procedure: Test with skipped segments and verify buffer consumption
Priority: P1
Signed-off-by: Nandakishor U M <nu641001@gmail.com>