### PR TITLE
VPLAY-12067 - [Linear] Crash occurred in PreFetchThread

### DIFF
--- a/AampDRMLicPreFetcher.cpp
+++ b/AampDRMLicPreFetcher.cpp
@@ -46,6 +46,7 @@ AampLicensePreFetcher::AampLicensePreFetcher(PrivateInstanceAAMP *aamp) : mPreFe
 		mSendErrorOnFailure(true),
 		mPrivAAMP(aamp),
 		mFetchInstance(nullptr),
+		mFetchInstanceMutex(),
 		mVssPreFetchThread(),
 		mVssFetchQueue(),
 		mQVssMutex(),
@@ -218,10 +219,26 @@ bool AampLicensePreFetcher::Term()
 			mVssFetchQueue.pop_front();
 		}
 	}
-	
+
 	mTrackStatus.fill(false);
-	mFetchInstance = nullptr;
+	SetLicenseFetcher(nullptr);
 	return ret;
+}
+
+/**
+ * @brief Set license fetcher instance in a thread-safe manner.
+ *
+ * Sets the license fetcher instance used by the prefetcher.
+ * This method is thread-safe and uses a mutex (mFetchInstanceMutex)
+ * to protect mFetchInstance from concurrent access.
+ *
+ * @param fetcherInstance Pointer to the AampLicenseFetcher instance to set.
+ * @note Thread-safe: uses mutual exclusion to protect mFetchInstance.
+ */
+void AampLicensePreFetcher::SetLicenseFetcher(AampLicenseFetcher *fetcherInstance)
+{
+	std::lock_guard<std::mutex> lock(mFetchInstanceMutex);
+	mFetchInstance = fetcherInstance;
 }
 
 /**
@@ -421,31 +438,34 @@ void AampLicensePreFetcher::NotifyDrmFailure(LicensePreFetchObjectPtr fetchObj, 
 		}
 	}
 
-	if (skipErrorEvent && mFetchInstance)
 	{
-		mFetchInstance->UpdateFailedDRMStatus(fetchObj.get());
-	}
-	else
-	{
-		if (!selfAbort)
+		std::lock_guard<std::mutex> lock(mFetchInstanceMutex);
+		if (skipErrorEvent && mFetchInstance)
 		{
-			//Set the isRetryEnabled flag to true if the failure is due to
-			//SEC_CLIENT_RESULT_HTTP_RESULT_FAILURE_TIMEOUT (error -7). This
-			//error is caused by a network failure, so the tune may succeed
-			//on a retry attempt.
-			//For other DRM failures, the flag should be set to false.
-			isRetryEnabled = ((failure == AAMP_TUNE_LICENCE_REQUEST_FAILED) && (event->getResponseCode() == SECCLIENT_RESULT_HTTP_FAILURE_TIMEOUT))
+			mFetchInstance->UpdateFailedDRMStatus(fetchObj.get());
+		}
+		else
+		{
+			if (!selfAbort)
+			{
+				//Set the isRetryEnabled flag to true if the failure is due to
+				//SEC_CLIENT_RESULT_HTTP_RESULT_FAILURE_TIMEOUT (error -7). This
+				//error is caused by a network failure, so the tune may succeed
+				//on a retry attempt.
+				//For other DRM failures, the flag should be set to false.
+				isRetryEnabled = ((failure == AAMP_TUNE_LICENCE_REQUEST_FAILED) && (event->getResponseCode() == SECCLIENT_RESULT_HTTP_FAILURE_TIMEOUT))
 				      || ((failure != AAMP_TUNE_AUTHORIZATION_FAILURE)
 				      && (failure != AAMP_TUNE_LICENCE_REQUEST_FAILED)
 				      && (failure != AAMP_TUNE_LICENCE_TIMEOUT)
 				      && (failure != AAMP_TUNE_DEVICE_NOT_PROVISIONED)
 				      && (failure != AAMP_TUNE_HDCP_COMPLIANCE_ERROR));
-			AAMPLOG_WARN("Drm failure:%d response: %d isRetryEnabled:%d ",(int)failure,event->getResponseCode(),isRetryEnabled);
-			mPrivAAMP->SendDRMMetaData(event);	//Send Header response first for failure case.
-			AAMPLOG_ERR("Failed DRM Session sending error event");
-			mPrivAAMP->SendDrmErrorEvent(event, std::move(isRetryEnabled));
-			mPrivAAMP->profiler.SetDrmErrorCode((int)failure);
-			mPrivAAMP->profiler.ProfileError(PROFILE_BUCKET_LA_TOTAL, (int)failure);
+				AAMPLOG_WARN("Drm failure:%d response: %d isRetryEnabled:%d ",(int)failure,event->getResponseCode(),isRetryEnabled);
+				mPrivAAMP->SendDRMMetaData(event);	//Send Header response first for failure case.
+				AAMPLOG_ERR("Failed DRM Session sending error event");
+				mPrivAAMP->SendDrmErrorEvent(event, std::move(isRetryEnabled));
+				mPrivAAMP->profiler.SetDrmErrorCode((int)failure);
+				mPrivAAMP->profiler.ProfileError(PROFILE_BUCKET_LA_TOTAL, (int)failure);
+			}
 		}
 	}
 }

--- a/AampDRMLicPreFetcher.h
+++ b/AampDRMLicPreFetcher.h
@@ -175,7 +175,7 @@ public:
 	 * 
 	 * @return none
 	 */
-	void SetLicenseFetcher(AampLicenseFetcher *fetcherInstance) { mFetchInstance = fetcherInstance; }
+	void SetLicenseFetcher(AampLicenseFetcher *fetcherInstance);
 
 	/**
 	 * @brief Set the Common Key Duration object
@@ -237,6 +237,7 @@ private:
 
 	PrivateInstanceAAMP *mPrivAAMP;                     /** PrivateInstanceAAMP instance*/
 	AampLicenseFetcher *mFetchInstance;                 /** AampLicenseFetcher instance for notifying DRM session status*/
+	std::mutex mFetchInstanceMutex;                     /** Mutex for accessing mFetchInstance*/
 	std::thread mVssPreFetchThread;                     /** Thread for pre-fetching VSS license*/
 	std::deque<LicensePreFetchObjectPtr> mVssFetchQueue;/** Queue for storing VSS content protection objects*/
 	std::mutex mQVssMutex;                              /** Mutex for accessing the mVssFetchQueue*/

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7660,6 +7660,11 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		{
 			ReleaseDynamicDRMToUpdateWait();
 			mDRMLicenseManager->setLicenseRequestAbort(true);
+			// Reset the mFetchInstance in AampLicensePreFetcher as we are going to delete
+			// StreamAbstractionAamp object from TeardownStream(). Otherwise it can
+			// lead to crash as PreFetchThread can call UpdateFailedDRMStatus
+			// of StreamAbstractionAamp.
+			mDRMLicenseManager->SetLicenseFetcher(nullptr);
 		}
 		if (HasSidecarData())
 		{ // has sidecar data

--- a/test/utests/fakes/FakeAampDRMLicPreFetcher.cpp
+++ b/test/utests/fakes/FakeAampDRMLicPreFetcher.cpp
@@ -70,3 +70,7 @@ bool AampLicensePreFetcher::CreateDRMSession(LicensePreFetchObjectPtr fetchObj)
 	return false;
 }
 
+void AampLicensePreFetcher::SetLicenseFetcher(AampLicenseFetcher *fetcherInstance)
+{
+	// Fake implementation - no-op
+}


### PR DESCRIPTION
VPLAY-12067 - [Linear] Crash occurred in PreFetchThread while doing sequential channel change

Reason for change: In sequential channel change scenario, stop can be initiated
  when AampLicensePreFetcher::PreFetchThread is in the middle of processing the
  license request(ie in the middle of executing CreateDRMSession()). This
  operation internally uses StreamAbstractionAamp object(mFetchInstance)
  to call UpdateFailedDRMStatus. As PrivateInstanceAAMP::Stop progresses,
  it can destroy the StreamAbstractionAamp object, but this status will reflect
  in AampLicensePreFetcher at a later point when mDRMLicenseManager->Stop()
  is called. Meanwhile, PreFetchThread is calling UpdateFailedDRMStatus
  on the destroyed object and leading to crash.

Changes:
* Setting mFetchInstance in AampLicensePreFetcher to nullptr before destroying StreamAbstractionAamp object.

Test Procedure: Refer JIRA ticket

Risks: low