### PR TITLE
Feature/vplay 12147 memory leak in aamp tsb data manager.cpp

### DIFF
--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -837,12 +837,12 @@ bool AampTSBSessionManager::NavigateToNextFragment(TsbFragmentDataPtr& fragment,
 	}
 	else							// Rewind
 	{
-		if (fragment->prev)
+		if (auto prevShared = fragment->prev.lock()) 
 		{
-			fragment = fragment->prev;
+			fragment = prevShared;
 			success = true;
-		}
-		if (!(fragment->prev))
+		}	
+		else
 		{
 			// Don't skip the first fragment in the TSB so BoS is detected correctly
 			AAMPLOG_INFO("Reached beginning of TSB during rewind");

--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -841,7 +841,7 @@ bool AampTSBSessionManager::NavigateToNextFragment(TsbFragmentDataPtr& fragment,
 		{
 			fragment = prevShared;
 			success = true;
-		}	
+		}
 		else
 		{
 			// Don't skip the first fragment in the TSB so BoS is detected correctly

--- a/AampTsbDataManager.cpp
+++ b/AampTsbDataManager.cpp
@@ -129,7 +129,7 @@ TsbFragmentDataPtr AampTsbDataManager::RemoveFragment(bool &deleteInit)
 			}
 			if (deletedFragment->next)
 			{
-				deletedFragment->next->prev = nullptr;
+				deletedFragment->next->prev.reset();
 			}
 			AAMPLOG_INFO("Remove fragment");
 			mTsbFragmentData.erase(it);

--- a/AampTsbDataManager.h
+++ b/AampTsbDataManager.h
@@ -179,7 +179,7 @@ private:
 	/* data */
 public:
 	std::shared_ptr<TsbFragmentData> next; /**< Link list next node for easy access*/
-	std::shared_ptr<TsbFragmentData> prev; /**< Link list previous node for easy access*/
+	std::weak_ptr<TsbFragmentData> prev; /**< Non-owning link to previous node for easy access, and to avoid circular references*/
 	/**
 	 *   @fn constructor
 	 *   @param[in] url - Segment URL as string

--- a/AampTsbReader.cpp
+++ b/AampTsbReader.cpp
@@ -113,7 +113,7 @@ AAMPStatusType AampTsbReader::Init(double &startPosSec, float rate, TuneType tun
 								auto prevFragment = firstFragmentToFetch->prev.lock();
 								if (!prevFragment || firstFragmentToFetch->GetPeriodId() != prevFragment->GetPeriodId())
 								{
-									break; // Break if no previous fragment exists or if at period boundary
+									break; // Break if no previous fragment exists OR if at a period boundary
 								}
 
 								firstFragmentToFetch = prevFragment;

--- a/AampTsbReader.cpp
+++ b/AampTsbReader.cpp
@@ -110,15 +110,13 @@ AAMPStatusType AampTsbReader::Init(double &startPosSec, float rate, TuneType tun
 							double vPTS = other->GetFirstPTS();
 							while (firstFragmentToFetch && firstFragmentToFetch->GetPTS() > vPTS)
 							{
-								if (!firstFragmentToFetch->prev)
+								auto prevFragment = firstFragmentToFetch->prev.lock();
+								if (!prevFragment || firstFragmentToFetch->GetPeriodId() != prevFragment->GetPeriodId())
 								{
-									break; // Break if no previous fragment exists
+									break; // Break if no previous fragment exists or if at period boundary
 								}
-								if (firstFragmentToFetch->GetPeriodId() != firstFragmentToFetch->prev->GetPeriodId())
-								{
-									break; // Break if at period boundary
-								}
-								firstFragmentToFetch = firstFragmentToFetch->prev;
+
+								firstFragmentToFetch = prevFragment;
 							}
 						}
 					}
@@ -211,7 +209,7 @@ TsbFragmentDataPtr AampTsbReader::FindNext()
 			if (mCurrentRate < 0.0) // reverse playback
 			{
 				// For reverse playback, get the previous fragment in the linked list
-				ret = mCurrentFragment->prev;
+				ret = mCurrentFragment->prev.lock();
 			}
 			else // forward or normal playback
 			{
@@ -259,7 +257,7 @@ void AampTsbReader::ReadNext(TsbFragmentDataPtr nextFragmentData)
 		}
 		else if (mCurrentRate < 0.0)
 		{
-			mEosReached = !nextFragmentData->prev;
+			mEosReached = !nextFragmentData->prev.lock();
 		}
 		else
 		{
@@ -296,9 +294,14 @@ void AampTsbReader::ReadNext(TsbFragmentDataPtr nextFragmentData)
 		else
 		{ // read in reverse direction
 			// When nextFragmentData->prev becomes nullptr, eos will be set, and no more reads will happen for this rate as we reached the very first fragment in tsb and segments never gets added to the beginning of tsb.
-			mUpcomingFragmentPosition = (nextFragmentData->prev) ?
-				nextFragmentData->prev->GetAbsolutePosition() :
-				nextFragmentData->GetAbsolutePosition();
+			if (auto prevFragment = nextFragmentData->prev.lock())
+			{
+				mUpcomingFragmentPosition = prevFragment->GetAbsolutePosition();
+			}
+			else
+			{
+				mUpcomingFragmentPosition = nextFragmentData->GetAbsolutePosition();
+			}
 		}
 
 		AAMPLOG_INFO("[%s] Fragment: absPos %lfs next %lfs eos %d initWaiting %d mIsNextFragmentDisc %d mIsPeriodBoundary %d mTrickModePositionEOS %lfs rate %f",
@@ -347,7 +350,7 @@ void AampTsbReader::CheckPeriodBoundary(TsbFragmentDataPtr currFragment)
 	if (mIsPeriodBoundary && (AAMP_NORMAL_PLAY_RATE == mCurrentRate))
 	{
 		// Get the fragment immediately preceding the current one to check for continuity.
-		TsbFragmentDataPtr adjFragment = currFragment->prev;
+		TsbFragmentDataPtr adjFragment = currFragment->prev.lock();
 		if (adjFragment)
 		{
 			// Calculate the expected PTS of the current fragment by adding the

--- a/test/utests/tests/AampTsbSessionManagerTests_Mocked/FunctionalTests.cpp
+++ b/test/utests/tests/AampTsbSessionManagerTests_Mocked/FunctionalTests.cpp
@@ -569,7 +569,7 @@ TEST_F(AampTsbSessionManagerTests, PushNextTsbFragment_SkipFragment_BoS)
 
 	// Mock data manager
 	TsbFragmentDataPtr firstFragment = std::make_shared<TsbFragmentData>(url, media, position, duration, pts, discont, periodId, initFragment, timeScale, PTSOffsetSec);
-	firstFragment->prev = nullptr;
+	firstFragment->prev.reset();
 	EXPECT_CALL(*g_mockTSBReader, FindNext()).WillOnce(Return(firstFragment));
 	EXPECT_CALL(*g_mockTSBReader, ReadNext(firstFragment));
 


### PR DESCRIPTION
The prev and next pointers in TsbFragmentData class create a cyclic dependency on the shared pointers so they can't be automatically released as the usage count will never reach 0. To resolve this I have changed prev to a weak pointer.