### PR TITLE
VPLAY-12287 - JS SetCCStatus+Stop sequence should not block on Tune

### DIFF
--- a/AampScheduler.cpp
+++ b/AampScheduler.cpp
@@ -28,7 +28,7 @@
 /**
  * @brief AampScheduler Constructor
  */
-AampScheduler::AampScheduler() : mTaskQueue(), mQMutex(), mQCond(),
+AampScheduler::AampScheduler() : mInterruptableTaskInProgress(false), mTaskQueue(), mQMutex(), mQCond(),
 	mSchedulerRunning(false), mSchedulerThread(), mExMutex(),
 	mExLock(mExMutex, std::defer_lock), mNextTaskId(AAMP_SCHEDULER_ID_DEFAULT),
 	mCurrentTaskId(AAMP_TASK_ID_INVALID), mLockOut(false), mState(eSTATE_IDLE),mPlayerId(-1)
@@ -145,10 +145,20 @@ void AampScheduler::ExecuteAsyncTask()
 						//Unlock so that new entries can be added to queue while function executes
 						queueLock.unlock();
 
+						// extensibility - add slow tasks that we want to be interruptable by an external Stop() here (e.g. seek/setrate) once they are modified for suitability
+						if ( (0 == obj.mTaskName.compare("Tune"))
+						   )
+						{
+							AAMPLOG_WARN("Scheduler found an interruptable task '%s' is about to run, taskId: %d.", obj.mTaskName.c_str(), obj.mId);
+							mInterruptableTaskInProgress=true;
+						}
+
 						AAMPLOG_WARN("SchedulerTask Execution:%s taskId:%d",obj.mTaskName.c_str(),obj.mId);
 						//Execute function
 						obj.mTask(obj.mData);
 						//May be used in a wait() in future loops, it needs to be locked
+
+						mInterruptableTaskInProgress=false;
 						queueLock.lock();
 					}
 				}
@@ -205,13 +215,37 @@ void AampScheduler::StopScheduler()
 }
 
 /**
- * @brief To acquire execution lock for synchronization purposes
+ * @brief To suspend the scheduler, optionally waiting for current task completion first
+ * 
+ * @param[in] duringStop - true if we want to suspend prior to current async task completing (if allowed)
+ * @return bool true if we blocked until current async task was executed (execution mutex was taken)
  */
-void AampScheduler::SuspendScheduler()
+bool AampScheduler::SuspendScheduler(bool duringStop)
 {
-	mExLock.lock();
+	bool currentTaskWasTerminated=false;
+	bool blockOnCurrentTaskCompletion=true;
+
+	if (duringStop)
+	{
+		std::lock_guard<std::mutex>lock(mQMutex);
+		blockOnCurrentTaskCompletion = !mInterruptableTaskInProgress;
+	}
+
+	if (blockOnCurrentTaskCompletion)
+	{
+		// Note: during stop we cannot always wait for the current task to complete (it may be tune).
+		// If called from stop we will potentially lock this later by calling SuspendScheduler(false).
+		mExLock.lock();
+		currentTaskWasTerminated=true;
+	}
+	else
+	{
+		AAMPLOG_WARN("Called from player Stop() and an InterruptableTaskInProgress (e.g. Tune) is in progress. Do not block (mExLock mutex) during completion, to allow abort.");
+		currentTaskWasTerminated=false;
+	}
 	std::lock_guard<std::mutex>lock(mQMutex);
 	mLockOut = true;
+	return currentTaskWasTerminated;
 }
 
 /**

--- a/AampScheduler.h
+++ b/AampScheduler.h
@@ -130,10 +130,11 @@ public:
 
 	/**
 	 * @fn SuspendScheduler
-	 *
-	 * @return void
-	 */
-	void SuspendScheduler();
+	* 
+	* @param[in] duringStop - true if we want to suspend prior to current async task completing (if allowed)
+	* @return bool true if we blocked until current async task was executed (execution mutex was taken)
+	*/
+	bool SuspendScheduler(bool duringStop=false);
 
 	/**
 	 * @fn ResumeScheduler
@@ -163,6 +164,7 @@ protected:
 	 */
 	void ExecuteAsyncTask();
 
+	bool mInterruptableTaskInProgress;	/**< Special case to allow abort (stop) of allowed asynchronous tasks; access under mQMutex */
 	std::deque<AsyncTaskObj> mTaskQueue;	/**< Queue for storing scheduled tasks */
 	std::mutex mQMutex;			/**< Mutex for accessing mTaskQueue */
 	std::condition_variable mQCond;		/**< To notify when a task is queued in mTaskQueue */

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -425,6 +425,12 @@ void AampCurlDownloader::updateCurlParams()
 			CURL_EASY_SETOPT_STRING(mCurl, CURLOPT_POSTFIELDS,(uint8_t * )mDnldCfg->postData.c_str());
 		}
 	}
+
+	#if 0
+	// GNP.. For testing... throttle downloads and ensure specific write callback frequency
+	CURL_EASY_SETOPT_FUNC(mCurl, CURLOPT_BUFFERSIZE, 16384L);   // default 16K. Ensure < CURLOPT_MAX_RECV_SPEED_LARGE & more write callbacks to terminate early
+	CURL_EASY_SETOPT_FUNC(mCurl, CURLOPT_MAX_RECV_SPEED_LARGE, 375000L); // bytes/second cap, if > CURLOPT_BUFFERSIZE; e.g. 375000*8= 3Mbit
+	#endif
 		
 	CURL_EASY_SETOPT_LONG(mCurl, CURLOPT_NOSIGNAL, 1L);
 	//curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback); // unused

--- a/downloader/AampCurlStore.cpp
+++ b/downloader/AampCurlStore.cpp
@@ -165,6 +165,7 @@ static int xferinfo_callback(
 	return ret;
 }
 #else
+#warning CURL version < 7.32.0
 /**
  * @brief
  * @param clientp app-specific as optionally set with CURLOPT_PROGRESSDATA

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -87,7 +87,7 @@ void doFakeTune()
  */
 PlayerInstanceAAMP::PlayerInstanceAAMP(StreamSink* streamSink
 	, std::function< void(const unsigned char *, int, int, int) > exportFrames
-	, bool powerEvt) : aamp(NULL), sp_aamp(nullptr), mJSBinding_DL(),mAsyncRunning(false),mConfig(),mAsyncTuneEnabled(false),mScheduler()
+	, bool powerEvt) : aamp(NULL), sp_aamp(nullptr), mStopInternalMutex(), mStopInProgress(false), mJSBinding_DL(),mAsyncRunning(false),mConfig(),mAsyncTuneEnabled(false),mScheduler()
 {
 //Need to do iarm initialization process before reading the tr181 aamp parameters.
 //Using printf here since AAMP logs can only use after creating the global object
@@ -273,27 +273,53 @@ void PlayerInstanceAAMP::ResetConfiguration()
  */
 void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent)
 {
+	AAMPLOG_WARN("+StopJSt");			/* leave at warn until JS stop during tune is stabilised */
 	if (aamp)
 	{
+		mStopInternalMutex.lock();
+		mStopInProgress=true;			// this will prevent us calling TuneInternal() in async thread and re-enabling downloads
+		mStopInternalMutex.unlock();
+
 		UsingPlayerId playerId(aamp->mPlayerId);
 		AAMPPlayerState state = aamp->GetState();
 
-		// 1. Ensure scheduler is suspended and all tasks if any to be cleaned
-		// 2. Check for state ,if already in Idle / Released , ignore stopInternal
-		// 3. Restart the scheduler , needed if same instance is used for tune again
+		// 1. Ensure scheduler does not run new tasks. If not an interruptable task (e.g. tune) then also block until that is complete.
+		// 2. Check for state ,if already in Idle / Released , ignore StopInternal
+		// 3. If current asynchronous task was not stopped earlier, then pend on it aborting and exiting before returning
+		// 4. Restart the scheduler , needed if same instance is used for tune again
 
-		mScheduler.SuspendScheduler();
-		mScheduler.RemoveAllTasks();
+		bool currentTaskWasTerminated=false;
+
+		currentTaskWasTerminated = mScheduler.SuspendScheduler(true); 	// don't block on current task so that any tune in progress can be aborted, but block new tasks from running
+										// note: does not take async task execution mutex
+
+		AAMPLOG_WARN("*StopJSt");		/* leave at warn until JS stop during tune is stabilised */
 
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
 		if (state != eSTATE_IDLE && state != eSTATE_RELEASED)
 		{
+			// Prevent any Tune() thread from calling StopInternal() at the same time, or we may crash.
+			mStopInternalMutex.lock();
+			// Note: If stopping during tune, this may eventually block on streamLock until tuneInternal releases it. But it will disable downloads to abort earlier.
+			//       mStopInProgress flag should prevent Tune() starting if it has not got that far.
 			StopInternal(sendStateChangeEvent);
+			mStopInternalMutex.unlock();
 		}
 
-		//Release lock
+		if (!currentTaskWasTerminated)
+		{
+			mScheduler.SuspendScheduler();  //  block on current task this time
+							// i.e. ensure active async tasks like tune will end (since stop was requested) before we return
+							// note: takes async task execution mutex
+		}
+		mScheduler.RemoveAllTasks();
 		mScheduler.ResumeScheduler();
+
+		mStopInternalMutex.lock();
+		mStopInProgress=false;
+		mStopInternalMutex.unlock();
 	}
+	AAMPLOG_WARN("-StopJSt");			/* leave at warn until JS stop during tune is stabilised */
 }
 
 /**
@@ -361,10 +387,11 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 										const char* manifestData
 										)
 {
+	AAMPLOG_WARN("+TuneJSt");			/* leave at warn until JS stop during tune is stabilised */
 	if(aamp){
 		UsingPlayerId playerId(aamp->mPlayerId);
 
-	/* Set single pipeline according to the configuration */
+		/* Set single pipeline according to the configuration */
 		aamp->UpdateUseSinglePipeline();
 
 		aamp->StopPausePositionMonitoring("Tune() called");
@@ -382,14 +409,31 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 			}
 		}
 
-		if ((state != eSTATE_IDLE) && (state != eSTATE_RELEASED) && (!IsOTAtoOTA))
+		// Stop also calls StopInternal. It's not re-entrant.
+		bool stopInProgress=false;
+
+		mStopInternalMutex.lock();
+		stopInProgress=mStopInProgress;	// if player stop is being called from JS thread, don't tune. StopInternal() is ok..
+						//  (mutex protected) and ensures that anything this thread does in future is undone
+		
+		if ((state != eSTATE_IDLE) && (state != eSTATE_RELEASED) && (!IsOTAtoOTA) )
 		{
 			//Calling tune without closing previous tune
 			StopInternal(false);
 		}
-		aamp->getAampCacheHandler()->StartPlaylistCache();
-		aamp->Tune(mainManifestUrl, autoPlay, contentType, bFirstAttempt, bFinalAttempt, traceUUID, audioDecoderStreamSync, refreshManifestUrl, mpdStitchingMode, std::move(sid),manifestData);
+		mStopInternalMutex.unlock();
+
+		if (!stopInProgress)
+		{
+			aamp->getAampCacheHandler()->StartPlaylistCache();
+			aamp->Tune(mainManifestUrl, autoPlay, contentType, bFirstAttempt, bFinalAttempt, traceUUID, audioDecoderStreamSync, refreshManifestUrl, mpdStitchingMode, std::move(sid),manifestData);
+		}
+		else
+		{
+			AAMPLOG_WARN("Stop was is in progress, so tune was aborted.");
+		}
 	}
+	AAMPLOG_WARN("-TuneJSt");			/* leave at warn until JS stop during tune is stabilised */
 }
 
 /**
@@ -2611,7 +2655,9 @@ std::string PlayerInstanceAAMP::GetPreferredTextProperties()
  */
 void PlayerInstanceAAMP::SetPreferredLanguages(const char *languageList, const char *preferredRendition, const char *preferredType, const char* codecList, const char* labelList, const Accessibility *accessibilityItem, const char *preferredName)
 {
+	AAMPLOG_TRACE("+SetPreferredLanguagesJSt");
 	aamp->SetPreferredLanguages(languageList, preferredRendition, preferredType, codecList, labelList, accessibilityItem, preferredName);
+	AAMPLOG_TRACE("-SetPreferredLanguagesJSt");
 }
 
 /**
@@ -2932,7 +2978,9 @@ int PlayerInstanceAAMP::GetTextTrack()
  */
 void PlayerInstanceAAMP::SetCCStatus(bool enabled)
 {
+	AAMPLOG_TRACE("+SetCCStatusJSt");
 	aamp->SetCCStatus(enabled);
+	AAMPLOG_TRACE("-SetCCStatusJSt");
 }
 
 /**

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -766,7 +766,9 @@ public: // FIXME: this should be private, but some tests access it
 	class PrivateInstanceAAMP *aamp;  		  /**< AAMP player's private instance */
 
 private:
-	std::shared_ptr<PrivateInstanceAAMP> sp_aamp; 	  /**< shared pointer for aamp resource */
+	std::shared_ptr<PrivateInstanceAAMP> sp_aamp;	  /**< shared pointer for aamp resource */
+	std::mutex mStopInternalMutex;			  /**< only protects StopInternal calls */
+	bool mStopInProgress;				  /**< signals that player stop is in progress; protect with mStopInternalMutex */
 
 public:
 	AampConfig mConfig;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -633,14 +633,7 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 	}
 	else
 	{
-		if(ISCONFIGSET_PRIV(eAAMPConfig_EnableCurlStore) && mOrigManifestUrl.isRemotehost)
-		{
-			ret = (size*nmemb);
-		}
-		else
-		{
-			AAMPLOG_WARN("CurlTrace write_callback - interrupted, ret:%zu", ret);
-		}
+		AAMPLOG_WARN("interrupted");
 	}
 	return ret;
 }
@@ -885,10 +878,11 @@ long getCurrentContentDownloadSpeed(PrivateInstanceAAMP *aamp,
  * @param ultotal total number of bytes libcurl expects to upload
  * @param ulnow number of bytes uploaded so far
  *
- * @retval -1 to cancel in progress download
+ * @retval 1 to cancel in progress download
  */
 int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltotal, double dlnow, double ultotal, double ulnow )
 {
+	int rc = 0;
 	CurlProgressCbContext *context = (CurlProgressCbContext *)clientp;
 	PrivateInstanceAAMP *aamp = context->aamp;
 	AampConfig *mConfig = context->aamp->mConfig;
@@ -898,12 +892,7 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 		context->aamp->CheckABREnabled() &&
 		!(ISCONFIGSET_PRIV(eAAMPConfig_DisableLowLatencyABR)))
 	{
-		//AAMPLOG_WARN("[%d] dltotal: %.0f , dlnow: %.0f, ultotal: %.0f, ulnow: %.0f, time: %.0f\n", context->mediaType,
-		//	dltotal, dlnow, ultotal, ulnow, difftime(time(NULL), 0));
-
-		// int AbrChunkThresholdSize = GETCONFIGVALUE(eAAMPConfig_ABRChunkThresholdSize);
-
-		if (/*(dlnow > AbrChunkThresholdSize) &&*/ (context->downloadNow != dlnow))
+		if( context->downloadNow != dlnow )
 		{
 			long downloadbps = 0;
 
@@ -938,11 +927,10 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 		}
 	}
 
-	int rc = 0;
 	context->aamp->SyncBegin();
 	if (!context->aamp->mDownloadsEnabled && context->aamp->mMediaDownloadsEnabled[context->mediaType])
 	{
-		rc = -1; // CURLE_ABORTED_BY_CALLBACK
+		rc = 1; // CURLE_ABORTED_BY_CALLBACK
 	}
 
 	context->aamp->SyncEnd();
@@ -964,7 +952,7 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 					{ // no change for at least <stallTimeout> seconds - consider download stalled and abort
 						AAMPLOG_WARN("Abort download as mid-download stall detected for %.2f seconds, download size:%.2f bytes", timeElapsedSinceLastUpdate, dlnow);
 						context->abortReason = eCURL_ABORT_REASON_STALL_TIMEDOUT;
-						rc = -1;
+						rc = 1; // CURLE_ABORTED_BY_CALLBACK
 					}
 				}
 				else
@@ -981,7 +969,7 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 			{
 				AAMPLOG_WARN("Abort download as no data received for %.2f seconds", timeElapsedInSec);
 				context->abortReason = eCURL_ABORT_REASON_START_TIMEDOUT;
-				rc = -1;
+				rc = 1; // CURLE_ABORTED_BY_CALLBACK
 			}
 		}
 		if (dlnow > 0 && context->lowBWTimeout> 0 && eMEDIATYPE_VIDEO == context->mediaType)
@@ -999,7 +987,7 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 								predictedTotalDownloadTimeMs/1000.0,
 								aamp->mNetworkTimeoutMs/1000.0 );
 						context->abortReason = eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT;
-						rc = -1;
+						rc = 1; // CURLE_ABORTED_BY_CALLBACK
 					}
 				}
 				else
@@ -1015,7 +1003,7 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 							{
 								AAMPLOG_WARN("Abort download as content is estimated to be expired current BW : %ld bps, min required:%ld bps", downloadbps, currentProfilebps);
 								context->abortReason = eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT;
-								rc = -1;
+								rc = 1; // CURLE_ABORTED_BY_CALLBACK
 							}
 						}
 					}
@@ -1024,18 +1012,9 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 			}
 		}
 	}
-
 	if(rc)
 	{
-		if( !( eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT == context->abortReason || eCURL_ABORT_REASON_START_TIMEDOUT == context->abortReason ||\
-			eCURL_ABORT_REASON_STALL_TIMEDOUT == context->abortReason ) && (ISCONFIGSET_PRIV(eAAMPConfig_EnableCurlStore) && mOrigManifestUrl.isRemotehost ) )
-		{
-			rc = 0;
-		}
-		else
-		{
-			AAMPLOG_WARN("CurlTrace Progress interrupted, ret:%d", rc);
-		}
+		AAMPLOG_WARN( "interrupted" );
 	}
 	return rc;
 }
@@ -1192,6 +1171,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, bitrateList()
 	, userProfileStatus(false)
 	, mApplyCachedVideoMute(false)
+	, mApplyCachedCCStatus(false)
 	, mFirstProgress(false)
 	, mTsbSessionRequestUrl()
 	, mcurrent_keyIdArray()
@@ -5520,6 +5500,20 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 					mApplyCachedVideoMute = false;
 					CacheAndApplySubtitleMute(video_muted);
 				}
+				if (mApplyCachedCCStatus)
+				{
+					AAMPLOG_INFO("SetCCStatus CC muted %d mApplyCachedCCStatus %d", subtitles_muted, mApplyCachedCCStatus);
+					mApplyCachedCCStatus = false;
+					if (mpStreamAbstractionAAMP)
+					{
+						mpStreamAbstractionAAMP->MuteSubtitles(subtitles_muted);
+						if (HasSidecarData())
+						{ // has sidecar data
+							mpStreamAbstractionAAMP->MuteSidecarSubtitles(subtitles_muted);
+						}
+					}
+					SetSubtitleMute(subtitles_muted);
+				}
 				sink->SetAudioVolume(volume);
 				if (mbPlayEnabled)
 				{
@@ -6114,7 +6108,22 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 			CacheAndApplySubtitleMute(video_muted);
 		}
 	}
+	if (mApplyCachedCCStatus)
+	{
+		AAMPLOG_INFO("SetCCStatus CC muted %d mApplyCachedCCStatus %d", subtitles_muted, mApplyCachedCCStatus);
+		mApplyCachedCCStatus = false;
+		if (mpStreamAbstractionAAMP)
+		{
+			mpStreamAbstractionAAMP->MuteSubtitles(subtitles_muted);
+			if (HasSidecarData())
+			{ // has sidecar data
+				mpStreamAbstractionAAMP->MuteSidecarSubtitles(subtitles_muted);
+			}
+		}
+		SetSubtitleMute(subtitles_muted);
+	}
 	ReleaseStreamLock();
+	AAMPLOG_WARN("*TuneJSt - Released stream lock during tune");	/* leave at warn until JS stop during tune is stabilised */
 
 	// To check and apply stored video rectangle properties
 	if (mApplyVideoRect)
@@ -7450,6 +7459,7 @@ bool PrivateInstanceAAMP::IsLiveStream()
 void PrivateInstanceAAMP::Stop()
 {
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
+	mApplyCachedCCStatus = false;
 	mEventManager->SetPlayerState(eSTATE_RELEASED);
 	mEventManager->FlushPendingEvents();
 	{
@@ -7492,6 +7502,9 @@ void PrivateInstanceAAMP::Stop()
 
 	UnblockWaitForDiscontinuityProcessToComplete();
 	StopRateCorrectionWorkerThread();
+
+	// Protect against TearDownStream in another thread
+	AcquireStreamLock();
 	if(mTelemetryInterval > 0)
 	{
 		double bufferedDuration = 0.0;
@@ -7510,9 +7523,10 @@ void PrivateInstanceAAMP::Stop()
 	SetLocalAAMPTsb(false);
 	SetLocalAAMPTsbInjection(false);
 	// Stopping the playback, release all DRM context
+	
+	//AcquireStreamLock();
 	if (mpStreamAbstractionAAMP)
 	{
-		AcquireStreamLock();
 		if (mDRMLicenseManager)
 		{
 			ReleaseDynamicDRMToUpdateWait();
@@ -7522,8 +7536,8 @@ void PrivateInstanceAAMP::Stop()
 		{ // has sidecar data
 			mpStreamAbstractionAAMP->ResetSubtitle();
 		}
-		ReleaseStreamLock();
 	}
+	ReleaseStreamLock();
 	TeardownStream(true,true); //disable download as well
 
 	// stop the mpd update immediately after Stream abstraction delete
@@ -10875,18 +10889,50 @@ int PrivateInstanceAAMP::GetTextTrack()
 void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 {
 	PlayerCCManager::GetInstance()->SetStatus(enabled);
-	AcquireStreamLock();
+
+	auto playerState=GetState();
+	bool streamLockTaken=false;
+	// This process will be blocking if we've already entered a playback state.
+	// This is a workaround where SetCCStatus is called whilst Tune is in progress (StreamLock held) from an EPG Stop call.
+	// Note: CC status can be changed at any time during playback and we do not want to ignore this if StreamLock is currently taken.
+	// The alternative would be to allow TryStreamLock() to have a timeout ~1s, but this might be less predictable.
+	bool allowDeferredApplication = ((playerState == eSTATE_IDLE)         ||
+					 (playerState == eSTATE_INITIALIZING) ||
+					 (playerState == eSTATE_INITIALIZED)  ||
+					 (playerState == eSTATE_PREPARING)    ||
+					 (playerState == eSTATE_PREPARED)
+					);
+
 	subtitles_muted = !enabled;
-	if (mpStreamAbstractionAAMP)
+
+	if(allowDeferredApplication)
 	{
-		mpStreamAbstractionAAMP->MuteSubtitles(subtitles_muted);
-		if (HasSidecarData())
-		{ // has sidecar data
-			mpStreamAbstractionAAMP->MuteSidecarSubtitles(subtitles_muted);
-		}
+		streamLockTaken=TryStreamLock();
 	}
-	SetSubtitleMute(subtitles_muted);
-	ReleaseStreamLock();
+	else
+	{
+		AcquireStreamLock();
+		streamLockTaken=true;
+	}
+
+	if (streamLockTaken)
+	{
+		if (mpStreamAbstractionAAMP)
+		{
+			mpStreamAbstractionAAMP->MuteSubtitles(subtitles_muted);
+			if (HasSidecarData())
+			{ // has sidecar data
+				mpStreamAbstractionAAMP->MuteSidecarSubtitles(subtitles_muted);
+			}
+		}
+		SetSubtitleMute(subtitles_muted);
+		ReleaseStreamLock();
+	}
+	else
+	{
+		AAMPLOG_WARN("CC status value has been cached, subtitles_muted = %d, playerState=%d", subtitles_muted, playerState);
+		mApplyCachedCCStatus=true; // can't do it now, but remember that we want to apply this
+	}
 }
 
 /**

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1139,6 +1139,7 @@ public:
 	bool playerStartedWithTrickPlay; 			/**< To indicate player switch happened in trickplay rate */
 	bool userProfileStatus; 				/**< Select profile based on user list*/
 	bool mApplyCachedVideoMute;				/**< To apply video mute() operations if it has been cached due to tune in progress */
+	bool mApplyCachedCCStatus;				/**< To apply () operations if it has been cached due to tune in progress */
 	std::vector<uint8_t> mcurrent_keyIdArray;		/**< Current KeyID for DRM license */
 	DynamicDrmInfo mDynamicDrmDefaultconfig;		/**< Init drmConfig stored as default config */
 	std::vector<std::string> mDynamicDrmCache;


### PR DESCRIPTION
Reason for change: Allow Stop sequence to proceed and abort a tune. Allow JS Stop command to run if JS Tune() is in progress. Also prevent SetCCStatus JS command from blocking during Tune. This is to improve channel zapping speed, where Stop is called during prior Tune() and is currently blocked.

Test Procedure: Three fast ch changes, delay. Repeat. Check we don't see OTTPENDING or timeouts above AAMP. Check stop occurrs asynchronously if stop is sent during tune. Regression check normal tune and stop times and operation. Check CC is blanked as required after fast/slow channel changes with PG. Check we have not introduced crashes with continuous channel change.

Risk: High