### PR TITLE
VPLAY-12345 Implement non-invasive PTS restamping in mp4demux

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -373,7 +373,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "debugChunkTransfer", eAAMPConfig_DebugChunkTransfer, false},
 	{true, "utcSyncOnStartup", eAAMPConfig_UTCSyncOnStartup, true},
 	{false, "disableWebVTT", eAAMPConfig_DisableWebVTT, false},
-	{false,"enablePTSReStampLogging", eAAMPConfig_EnablePTSReStampLogging, false},
+	{false, "enablePTSReStampLogging", eAAMPConfig_EnablePTSReStampLogging, false},
 
 };
 

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -373,6 +373,8 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "debugChunkTransfer", eAAMPConfig_DebugChunkTransfer, false},
 	{true, "utcSyncOnStartup", eAAMPConfig_UTCSyncOnStartup, true},
 	{false, "disableWebVTT", eAAMPConfig_DisableWebVTT, false},
+	{false,"enablePTSReStampLogging", eAAMPConfig_EnablePTSReStampLogging, false},
+
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -228,6 +228,7 @@ typedef enum
 	eAAMPConfig_DebugChunkTransfer,					/**< app-managed chunked transfer protocol */
 	eAAMPConfig_UTCSyncOnStartup,					/**< Perform sync at startup */
 	eAAMPConfig_DisableWebVTT,					/**< Config to disable/exclude WebVTT tracks (default: WebVTT enabled) */
+	eAAMPConfig_EnablePTSReStampLogging,		/**< Config to enable logging for PTS restamping in Mp4Demuxer */
 	eAAMPConfig_BoolMaxValue				/**< Max value of bool config always last element */	
 
 } AAMPConfigSettingBool;

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -26,14 +26,21 @@
 #include "AampLogManager.h"
 #include "AampUtils.h"
 
+
 /**
- * @brief MP4 Demuxer constructor
+ * @brief MP4 Demuxer Constructor
+ * @param[in] aamp - Pointer to the PrivateInstanceAAMP
+ * @param[in] type - Media type (audio/video/subtitle)
+ * @param[in] enablePtsRestamp - Flag to enable PTS restamping
  */
-AampMp4Demuxer::AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type) :
-	MediaProcessor(), mMp4Demux(aamp_utils::make_unique<Mp4Demux>()), mAamp(aamp), mMediaType(type)
+AampMp4Demuxer::AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bool enablePtsRestamp) :
+	MediaProcessor(), mMp4Demux(aamp_utils::make_unique<Mp4Demux>()), mAamp(aamp),
+	mMediaType(type), mEnablePtsRestamp(enablePtsRestamp)
 {
-	AAMPLOG_WARN("Created AampMp4Demuxer(%p) for type %d", this, type);
+	AAMPLOG_WARN("Created AampMp4Demuxer(%p) for type %d, PTS restamp: %s", this, type, enablePtsRestamp ? "enabled" : "disabled");
 	// TODO: Should we limit the media types here to only video/audio?
+	// Make restamp logging configurable as it might cause log flooding, since logs will come for each demuxed frames per fragment
+	mEnablePtsRestampLogging = mAamp->mConfig->IsConfigSet(eAAMPConfig_EnablePTSReStampLogging);
 }
 
 /**
@@ -44,7 +51,6 @@ AampMp4Demuxer::~AampMp4Demuxer()
 	AAMPLOG_DEBUG("AampMp4Demuxer destructor");
 	// std::unique_ptr automatically handles cleanup
 }
-
 
 /**
  * @fn sendSegment
@@ -77,8 +83,26 @@ bool AampMp4Demuxer::sendSegment(AampGrowableBuffer* pBuffer, double position, d
 			auto samples = mMp4Demux->GetSamples();
 			if (samples.size() > 0)
 			{
+				uint32_t timeScale = mMp4Demux->GetTimeScale();
 				for (auto& sample : samples)
 				{
+					// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.
+					if (mEnablePtsRestamp)
+					{
+						double beforeDTS = sample.mDts;
+						sample.mPts += fragmentPTSoffset;
+						sample.mDts += fragmentPTSoffset;
+						// Log the restamping if enabled. This can be helpful for debugging and verifying correct behavior, but may cause log flooding for large segments.
+						if (mEnablePtsRestampLogging)
+						{
+							AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
+							GetMediaTypeName(mMediaType),
+							timeScale,
+							beforeDTS * timeScale,
+							sample.mDts * timeScale,
+							sample.mDuration * timeScale);
+						}
+					}
 					mAamp->SendStreamTransfer(mMediaType, sample);
 				}
 			}

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -83,7 +83,6 @@ bool AampMp4Demuxer::sendSegment(AampGrowableBuffer* pBuffer, double position, d
 			auto samples = mMp4Demux->GetSamples();
 			if (samples.size() > 0)
 			{
-				uint32_t timeScale = mMp4Demux->GetTimeScale();
 				for (auto& sample : samples)
 				{
 					// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.
@@ -95,6 +94,7 @@ bool AampMp4Demuxer::sendSegment(AampGrowableBuffer* pBuffer, double position, d
 						// Log the restamping if enabled. This can be helpful for debugging and verifying correct behavior, but may cause log flooding for large segments.
 						if (mEnablePtsRestampLogging)
 						{
+							uint32_t timeScale = mMp4Demux->GetTimeScale();
 							AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
 							GetMediaTypeName(mMediaType),
 							timeScale,

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -37,7 +37,7 @@ AampMp4Demuxer::AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bo
 	MediaProcessor(), mMp4Demux(aamp_utils::make_unique<Mp4Demux>()), mAamp(aamp),
 	mMediaType(type), mEnablePtsRestamp(enablePtsRestamp)
 {
-	AAMPLOG_WARN("Created AampMp4Demuxer(%p) for type %d, PTS restamp: %s", this, type, enablePtsRestamp ? "enabled" : "disabled");
+	AAMPLOG_MIL("Created AampMp4Demuxer(%p) for type %d, PTS restamp: %s", this, type, enablePtsRestamp ? "enabled" : "disabled");
 	// TODO: Should we limit the media types here to only video/audio?
 	// Make restamp logging configurable as it might cause log flooding, since logs will come for each demuxed frames per fragment
 	mEnablePtsRestampLogging = mAamp->mConfig->IsConfigSet(eAAMPConfig_EnablePTSReStampLogging);

--- a/mp4demux/AampMp4Demuxer.h
+++ b/mp4demux/AampMp4Demuxer.h
@@ -32,13 +32,18 @@
 
 class AampMp4Demuxer : public MediaProcessor
 {
-
 public:
-    AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type);
-    ~AampMp4Demuxer();
+	/**
+	 * @brief MP4 Demuxer Constructor
+	 * @param[in] aamp - Pointer to the PrivateInstanceAAMP
+	 * @param[in] type - Media type (audio/video/subtitle)
+	 * @param[in] enablePtsRestamp - Flag to enable PTS restamping
+	 */
+	AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bool enablePtsRestamp);
+	~AampMp4Demuxer();
 
 
-    AampMp4Demuxer(const AampMp4Demuxer&) = delete;
+	AampMp4Demuxer(const AampMp4Demuxer&) = delete;
 	AampMp4Demuxer& operator=(const AampMp4Demuxer&) = delete;
 
 	/**
@@ -51,7 +56,7 @@ public:
 	 */
 	void setPtsOffset( double ptsOffset ) override { };
 
-    /**
+	/**
 	 * @fn sendSegment
 	 *
 	 * @param[in] pBuffer - Pointer to the AampGrowableBuffer
@@ -76,7 +81,7 @@ public:
 	 */
 	void setRate(double rate, PlayMode mode) override { };
 
-    /**
+	/**
 	 * @brief Enable or disable throttle
 	 *
 	 * @param[in] enable - throttle enable/disable
@@ -92,7 +97,7 @@ public:
 	 */
 	void setFrameRateForTM (int frameRate) override { }
 
-    /**
+	/**
 	 * @brief Abort all operations
 	 *
 	 * @return void
@@ -106,7 +111,7 @@ public:
 	 */
 	void reset() override { }
 
-    /**
+	/**
 	 * @brief Function to abort wait for injecting the segment
 	 */
 	void abortInjectionWait() override { }
@@ -124,9 +129,12 @@ public:
 	void setTrackOffset(double offset) override { }
 
 private:
-    std::unique_ptr<Mp4Demux> mMp4Demux;
-    PrivateInstanceAAMP* mAamp;
+	std::unique_ptr<Mp4Demux> mMp4Demux;
+	PrivateInstanceAAMP* mAamp;
 	AampMediaType mMediaType;
+	bool mEnablePtsRestamp; // Flag to enable PTS restamping
+	// A separate flag to enable logging for PTS restamping for better control.
+	bool mEnablePtsRestampLogging {false}; // Flag to enable logging for PTS restamping
 };
 
 #endif /* __AAMPMP4DEMUXER_H__ */

--- a/mp4demux/AampMp4Demuxer.h
+++ b/mp4demux/AampMp4Demuxer.h
@@ -39,7 +39,7 @@ public:
 	 * @param[in] type - Media type (audio/video/subtitle)
 	 * @param[in] enablePtsRestamp - Flag to enable PTS restamping
 	 */
-	AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bool enablePtsRestamp);
+	AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bool enablePtsRestamp = false);
 	~AampMp4Demuxer();
 
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1079,7 +1079,7 @@ bool MediaTrack::ProcessFragmentChunk()
 			}
 			else
 			{
-				if( !ISCONFIGSET(eAAMPConfig_UseMp4Demux) )
+				if (!ISCONFIGSET(eAAMPConfig_UseMp4Demux))
 				{
 					int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
 					(void)mIsoBmffHelper->RestampPts(parsedBufferChunk, ptsOffset, cachedFragment->uri,
@@ -1373,7 +1373,7 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 				 * Ignore restamping for mp4demux here as the restamping will be done in the mp4demux
 				 * after parsing the segment before sending to gstreamer.
 				 */
-				if( !ISCONFIGSET(eAAMPConfig_UseMp4Demux) )
+				if (!ISCONFIGSET(eAAMPConfig_UseMp4Demux))
 				{
 					if (!cachedFragment->initFragment)
 					{

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1079,10 +1079,13 @@ bool MediaTrack::ProcessFragmentChunk()
 			}
 			else
 			{
-				int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
-				(void)mIsoBmffHelper->RestampPts(parsedBufferChunk, ptsOffset, cachedFragment->uri,
+				if( !ISCONFIGSET(eAAMPConfig_UseMp4Demux) )
+				{
+					int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
+					(void)mIsoBmffHelper->RestampPts(parsedBufferChunk, ptsOffset, cachedFragment->uri,
 												 name, cachedFragment->timeScale);
-				fpts += cachedFragment->PTSOffsetSec;
+					fpts += cachedFragment->PTSOffsetSec;
+				}
 			}
 		}
 
@@ -1366,18 +1369,26 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 			}
 			else
 			{
-				if (!cachedFragment->initFragment)
+				/*
+				 * Ignore restamping for mp4demux here as the restamping will be done in the mp4demux
+				 * after parsing the segment before sending to gstreamer.
+				 */
+				if( !ISCONFIGSET(eAAMPConfig_UseMp4Demux) )
 				{
-					// We could skip RestampPts when PTSOffsetSec==0 but the RestampPts log line
-					// would then be missing and it is important for l2 tests
-					int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
-					(void)mIsoBmffHelper->RestampPts(cachedFragment->fragment, ptsOffset,
-													 cachedFragment->uri, name,
-													 cachedFragment->timeScale);
-				}
-				else
-				{
-					ClearMediaHeaderDuration(cachedFragment);
+					if (!cachedFragment->initFragment)
+					{
+						// We could skip RestampPts when PTSOffsetSec==0 but the RestampPts log line
+						// would then be missing and it is important for l2 tests
+						int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
+
+						(void)mIsoBmffHelper->RestampPts(cachedFragment->fragment, ptsOffset,
+														cachedFragment->uri, name,
+														cachedFragment->timeScale);
+					}
+					else
+					{
+						ClearMediaHeaderDuration(cachedFragment);
+					}
 				}
 			}
 		}
@@ -4197,7 +4208,7 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - Using Mp4Demux", track->name);
 				if (i != eMEDIATYPE_SUBTITLE)
 				{
-					track->playContext = std::make_shared<AampMp4Demuxer>(aamp, (AampMediaType)i);
+					track->playContext = std::make_shared<AampMp4Demuxer>(aamp, (AampMediaType)i, ISCONFIGSET(eAAMPConfig_EnablePTSReStamp));
 				}
 				else
 				{

--- a/test/utests/fakes/FakeAampMp4Demuxer.cpp
+++ b/test/utests/fakes/FakeAampMp4Demuxer.cpp
@@ -31,8 +31,9 @@
 /**
  * @brief Fake MP4 Demuxer constructor
  */
-AampMp4Demuxer::AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type) :
-    MediaProcessor(), mMp4Demux(nullptr), mAamp(aamp), mMediaType(type)
+AampMp4Demuxer::AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bool enablePtsRestamp) :
+    MediaProcessor(), mMp4Demux(nullptr), mAamp(aamp), mMediaType(type),
+    mEnablePtsRestamp(enablePtsRestamp)
 {
 }
 

--- a/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
@@ -41,6 +41,8 @@ using ::testing::NiceMock;
 using ::testing::AnyNumber;
 using ::testing::Invoke;
 
+AampConfig *gpGlobalConfig{nullptr};
+
 /**
  * @class AampMp4DemuxerBaseTests
  * @brief Test fixture for AampMp4Demuxer functional tests
@@ -51,25 +53,35 @@ protected:
 	void SetUp() override
 	{
 		// Create mock instances
+		if(gpGlobalConfig == nullptr)
+		{
+			gpGlobalConfig =  new AampConfig();
+		}
+		mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
 		g_mockPrivateInstanceAAMP = new NiceMock<MockPrivateInstanceAAMP>();
 		g_mockMp4Demux = new NiceMock<MockMp4Demux>();
 
 		// Create the demuxer instance with mocked AAMP
-		mDemuxer = new AampMp4Demuxer(reinterpret_cast<PrivateInstanceAAMP*>(g_mockPrivateInstanceAAMP), eMEDIATYPE_VIDEO);
+		mDemuxer = new AampMp4Demuxer(mPrivateInstanceAAMP, eMEDIATYPE_VIDEO, false);
 	}
 
 	void TearDown() override
 	{
 		delete mDemuxer;
+		mDemuxer = nullptr;
+		delete mPrivateInstanceAAMP;
+		mPrivateInstanceAAMP = nullptr;
 		delete g_mockPrivateInstanceAAMP;
-		delete g_mockMp4Demux;
 		g_mockPrivateInstanceAAMP = nullptr;
+		delete g_mockMp4Demux;
 		g_mockMp4Demux = nullptr;
+		delete gpGlobalConfig;
+		gpGlobalConfig = nullptr;
 	}
 
 	AampMp4Demuxer* mDemuxer;
+	PrivateInstanceAAMP* mPrivateInstanceAAMP;
 };
-
 /**
  * @brief Test AampMp4Demuxer constructor and destructor
  */
@@ -79,7 +91,7 @@ TEST_F(AampMp4DemuxerTests, ConstructorDestructor)
 	EXPECT_NE(mDemuxer, nullptr);
 
 	// Test different media types
-	AampMp4Demuxer audioDemuxer(reinterpret_cast<PrivateInstanceAAMP*>(g_mockPrivateInstanceAAMP), eMEDIATYPE_AUDIO);
+	AampMp4Demuxer audioDemuxer(mPrivateInstanceAAMP, eMEDIATYPE_AUDIO, false);
 	EXPECT_TRUE(true); // Constructor should complete without throwing
 }
 
@@ -167,7 +179,7 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithEmptyBuffer)
 TEST_F(AampMp4DemuxerTests, SendSegmentDifferentMediaTypes)
 {
 	// Test with audio
-	AampMp4Demuxer *audDemuxer = new AampMp4Demuxer(reinterpret_cast<PrivateInstanceAAMP*>(g_mockPrivateInstanceAAMP), eMEDIATYPE_AUDIO);
+	AampMp4Demuxer *audDemuxer = new AampMp4Demuxer(mPrivateInstanceAAMP, eMEDIATYPE_AUDIO, false);
 
 	AampGrowableBuffer buffer("audioBuffer");
 	const char* audioData = "audio_data";
@@ -292,5 +304,49 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithParseFailure)
 
 	// Verify results
 	EXPECT_FALSE(result);
+	EXPECT_FALSE(ptsError);
+}
+
+/**
+ * @brief Test sendSegment with PTS restamping enabled
+ */
+TEST_F(AampMp4DemuxerTests, SendSegmentWithPtsRestampEnabled)
+{
+	AampMp4Demuxer restampDemuxer(mPrivateInstanceAAMP, eMEDIATYPE_VIDEO, true);
+
+	AampGrowableBuffer buffer("videoBuffer");
+	const char* videoData = "video_data";
+	buffer.assign(videoData, videoData + strlen(videoData));
+
+	constexpr uint32_t kTimeScale{90000};
+	constexpr double kBasePts{10.0};
+	constexpr double kBaseDts{9.5};
+	constexpr double kFragmentPtsOffset{2.5};
+
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_, _))
+		.WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetTimeScale())
+		.WillOnce(Return(kTimeScale));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce(Invoke([=]() {
+			std::vector<AampMediaSample> mockSamples;
+			AampMediaSample sample;
+			sample.mPts = kBasePts;
+			sample.mDts = kBaseDts;
+			mockSamples.push_back(std::move(sample));
+			return mockSamples;
+		}));
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_VIDEO, _))
+		.WillOnce(Invoke([=](AampMediaType /*mediaType*/, AampMediaSample& sample) {
+			EXPECT_DOUBLE_EQ(sample.mPts, kBasePts + kFragmentPtsOffset);
+			EXPECT_DOUBLE_EQ(sample.mDts, kBaseDts + kFragmentPtsOffset);
+		}));
+
+	bool ptsError = false;
+	bool result = restampDemuxer.sendSegment(&buffer, 10.0, 5.0, kFragmentPtsOffset,
+			false, false, nullptr, ptsError);
+
+	EXPECT_TRUE(result);
 	EXPECT_FALSE(ptsError);
 }

--- a/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
@@ -318,15 +318,15 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithPtsRestampEnabled)
 	const char* videoData = "video_data";
 	buffer.assign(videoData, videoData + strlen(videoData));
 
-	constexpr uint32_t kTimeScale{90000};
 	constexpr double kBasePts{10.0};
 	constexpr double kBaseDts{9.5};
 	constexpr double kFragmentPtsOffset{2.5};
-
+	
 	EXPECT_CALL(*g_mockMp4Demux, Parse(_, _))
 		.WillOnce(Return(true));
-	EXPECT_CALL(*g_mockMp4Demux, GetTimeScale())
-		.WillOnce(Return(kTimeScale));
+	// GetTimeScale only called (while logging) when eAAMPConfig_EnablePTSReStampLogging set
+	//	EXPECT_CALL(*g_mockMp4Demux, GetTimeScale())
+	//		.WillOnce(Return(90000));
 	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
 		.WillOnce(Invoke([=]() {
 			std::vector<AampMediaSample> mockSamples;

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -574,6 +574,8 @@ TEST_P(MediaTrackDashPlaybackPtsRestampTests, PlaybackTest)
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
 		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
+		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
 		.WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentCached))
@@ -594,7 +596,7 @@ TEST_P(MediaTrackDashPlaybackPtsRestampTests, PlaybackTest)
 
 	ASSERT_TRUE(videoTrack.InjectFragment());
 
-	// Media segment
+	// Media segment (normal case: UseMp4Demux disabled)
 	testFragment.initFragment = false;
 	testFragment.duration = FRAGMENT_DURATION.inSeconds();
 	bufferedFragment = AddFragmentToBuffer(videoTrack, testFragment, lowLatencyMode, aampTsb);
@@ -604,16 +606,44 @@ TEST_P(MediaTrackDashPlaybackPtsRestampTests, PlaybackTest)
 	EXPECT_CALL(*g_mockIsoBmffHelper, SetPtsAndDuration(_, _, _)).Times(0);
 	if (lowLatencyMode)
 	{
-		// Check that the PTS that is (eventually) passed on to GStreamer is as expected
+		// In chunk mode, PTS offset is applied to fpts/fdts
+		// (FIRST_PTS + PTS_OFFSET_SEC) and also passed separately to
+		// GStreamer via the fragmentPTSoffset argument
 		double expectedPts = FIRST_PTS.inSeconds() + PTS_OFFSET_SEC;
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP,
 					SendStreamTransfer(eMEDIATYPE_VIDEO,
-									   AampGrowableBufferPtrEq(&(testFragment.fragment)),
-									   expectedPts, expectedPts, _, _, _, _));
+									AampGrowableBufferPtrEq(&(testFragment.fragment)),
+									expectedPts, expectedPts, _, _, _, _));
 	}
-
 	ASSERT_TRUE(videoTrack.InjectFragment());
 	ASSERT_DOUBLE_EQ(videoTrack.GetTotalInjectedDuration(), FRAGMENT_DURATION.inSeconds());
+
+	// Media segment (UseMp4Demux enabled: RestampPts should NOT be called)	
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux)).WillRepeatedly(Return(true));
+	testFragment = CachedFragment{};
+	testFragment.initFragment = false;
+	testFragment.duration = FRAGMENT_DURATION.inSeconds();
+	testFragment.position = FIRST_PTS.inSeconds();
+	testFragment.PTSOffsetSec = PTS_OFFSET_SEC;
+	testFragment.timeScale = PLAYBACK_TIMESCALE;
+	testFragment.uri = expectedUri;
+	testFragment.fragment.AppendBytes(FRAGMENT_TEST_DATA, FRAGMENT_TEST_DATA_SIZE);
+	bufferedFragment = AddFragmentToBuffer(videoTrack, testFragment, lowLatencyMode, aampTsb);
+	videoTrack.numberOfFragmentsCached = 1;
+	ASSERT_NE(bufferedFragment, nullptr);
+	ASSERT_GT(bufferedFragment->fragment.size(), 0);
+	EXPECT_CALL(*g_mockIsoBmffHelper, RestampPts(_, _, _, _, _)).Times(0);
+	EXPECT_CALL(*g_mockIsoBmffHelper, SetPtsAndDuration(_, _, _)).Times(0);
+	if (lowLatencyMode)
+	{
+		// In chunk mode, PTS offset is passed separately to GStreamer
+		double expectedPts = FIRST_PTS.inSeconds();
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+					SendStreamTransfer(eMEDIATYPE_VIDEO,
+									AampGrowableBufferPtrEq(&(testFragment.fragment)),
+									expectedPts, expectedPts, _, _, _, _));
+	}
+	ASSERT_TRUE(videoTrack.InjectFragment());
 }
 
 AampTsbTestData aampTsbTestData[] =


### PR DESCRIPTION
Reason for change: As per the scope of the ticket ,if the ptsRestamp = true, and useMP4demux = true, we need not follow the existing invasive PTS restamp logic(modifying the BaseMediaDecodeTime), instead we are directly retrieving the pts and dts values of each sample, we need to add the ptsoffset value correspondingly
Risks: Low
Test Procedure: Refer jira ticket
Priority: P1