### PR TITLE
VPLAY-11554 WPEWebProcess crash due to lockup in GetManifestEndDelta …

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1761,6 +1761,13 @@ public:
 	}
 
 	/**
+	 *   @fn UnblockWaitForCachedFragmentChunk
+	 *
+	 *   @return void
+	 */
+	void UnblockWaitForCachedFragmentChunk();
+
+	/**
 	 *   @brief Get available thumbnail bitrates.
 	 *
 	 *   @return available thumbnail bitrates.

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7684,6 +7684,7 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		double bufferedDuration = 0.0;
 		if (mpStreamAbstractionAAMP)
 		{
+			mpStreamAbstractionAAMP->UnblockWaitForCachedFragmentChunk(); // avoid mutex lock if waiting for cached fragments
 			bufferedDuration = mpStreamAbstractionAAMP->GetBufferedVideoDurationSec();
 		}
 		double latency = GetCurrentLatency();

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3722,6 +3722,25 @@ bool StreamAbstractionAAMP::CheckForRampDownLimitReached()
 }
 
 /**
+ * @brief Unblocks all waiting tracks by calling AbortWaitForCachedFragmentChunk() on each track.
+ *
+ * Iterates over all track types and invokes AbortWaitForCachedFragmentChunk()
+ * on each MediaTrack, ensuring that any threads waiting for cached fragments
+ * are unblocked.
+ */
+void StreamAbstractionAAMP::UnblockWaitForCachedFragmentChunk()
+{
+	for ( int type = eTRACK_VIDEO; type <= eTRACK_AUX_AUDIO; type++)
+	{
+		MediaTrack *track = GetMediaTrack((TrackType)type);
+		if(track)
+		{
+			track->AbortWaitForCachedFragmentChunk();
+		}
+	}
+}
+
+/**
  *  @brief Get buffered video duration in seconds
  */
 double StreamAbstractionAAMP::GetBufferedVideoDurationSec()

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -71,6 +71,10 @@ void StreamAbstractionAAMP::RefreshSubtitles()
 {
 }
 
+void StreamAbstractionAAMP::UnblockWaitForCachedFragmentChunk()
+{
+}
+
 long StreamAbstractionAAMP::GetVideoBitrate(void)
 {
 	return 0;


### PR DESCRIPTION
…(#630)

VPLAY-11554 WPEWebProcess crash due to lockup in GetManifestEndDelta

Reason for change: Avoid deadlock in GetManifestEndDelta() on stop
Test Procedure: see ticket
Risks: Low