### PR TITLE
VPLAY-11948: Add safe deletion for m_gstConfigParam to fix memory leak

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -89,6 +89,8 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	{
 		delete[] mDrmSystem;
 	}
+	/* safe delete configuration parameter */
+	MW_SAFE_DELETE(m_gstConfigParam);
 	mScheduler.StopScheduler();
 	for (int i = 0; i < GST_TRACK_COUNT; i++)
 	{


### PR DESCRIPTION

Reason for change: Avoid memory leak in middleware component
Test Procedure:
refer ticket
Risks: Low
Priority: P1