### PR TITLE
VPLAY-11984: multi-period video-only test stream crashing (#779)

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -116,7 +116,7 @@ StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *
 	: StreamAbstractionAAMP(aamp, std::move(id3Handler)),
 	mLangList(), seekPosition(seek_pos), mPlayRate(rate), fragmentCollectorThreadID(),tsbReaderThreadID(),
 	mpd(NULL), mNumberOfTracks(0), mCurrentPeriodIdx(0), mEndPosition(0), mIsLiveStream(true), mIsLiveManifest(true),mManifestDnldRespPtr(nullptr),mManifestUpdateHandleFlag(false), mUpdateManifestState(false),
-	mStreamInfo(NULL), mPrevStartTimeSeconds(0), mPrevLastSegurlMedia(""), mPrevLastSegurlOffset(0),
+	mStreamInfo(), mPrevStartTimeSeconds(0), mPrevLastSegurlMedia(""), mPrevLastSegurlOffset(0),
 	mPeriodEndTime(0), mPeriodStartTime(0), mPeriodDuration(0), mMinUpdateDurationMs(DEFAULT_INTERVAL_BETWEEN_MPD_UPDATES_MS),
 	mLastPlaylistDownloadTimeMs(0), mFirstPTS(0), mStartTimeOfFirstPTS(0), mAudioType(eAUDIO_UNKNOWN),
 	mPrevAdaptationSetCount(0), mBitrateIndexVector(), mProfileMaps(), mIsFogTSB(false),
@@ -7146,7 +7146,10 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 	AAMPLOG_INFO("Selected Period index %d, id %s", mCurrentPeriodIdx, period->GetId().c_str());
 	for( int i = 0; i < mMaxTracks; i++ )
 	{
-		mMediaStreamContext[i]->enabled = false;
+		if( mMediaStreamContext[i] )
+		{
+			mMediaStreamContext[i]->enabled = false;
+		}
 	}
 
 	mMultiVideoAdaptationPresent = false;
@@ -7524,14 +7527,14 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 				{
 					mUpdateStreamInfo = false;
 					vector<Representation *> representations = mMPDParseHelper->GetBitrateInfoFromCustomMpd(pMediaStreamContext->adaptationSet);
-					int representationCount = (int)representations.size();
-					if ((representationCount != mBitrateIndexVector.size()) && mStreamInfo)
+					size_t representationCount = representations.size();
+					if (representationCount != mBitrateIndexVector.size())
 					{
-						SAFE_DELETE_ARRAY(mStreamInfo);
+						mStreamInfo.clear();
 					}
-					if (!mStreamInfo)
+					if (mStreamInfo.empty())
 					{
-						mStreamInfo = new StreamInfo[representationCount];
+						mStreamInfo.resize(representationCount);
 					}
 					GetABRManager().clearProfiles();
 					mBitrateIndexVector.clear();
@@ -7654,16 +7657,16 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 							// chosenAdaptationIdxs.insert(0);
 						}
 					}
-					if ( periodChanged && mStreamInfo != nullptr )
+					if ( periodChanged && !mStreamInfo.empty() )
 					{
-						SAFE_DELETE_ARRAY(mStreamInfo);
+						mStreamInfo.clear();
 						// reset representationIndex to -1 to allow updating the currentProfileIndex for period change.
 						pMediaStreamContext->representationIndex = -1;
 						AAMPLOG_WARN("representationIndex set to (-1) to find currentProfileIndex");
 					}
-					if (!mStreamInfo)
+					if (mStreamInfo.empty())
 					{
-						mStreamInfo = new StreamInfo[representationCount];
+						mStreamInfo.resize(representationCount);
 					}
 					GetABRManager().clearProfiles();
 					mBitrateIndexVector.clear();
@@ -7953,6 +7956,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 						else
 						{
 							currentProfileIndex = GetABRManager().getClosestProfileIndexByBandwidth(pMediaStreamContext->fragmentDescriptor.Bandwidth);
+							// Set profileIdxForBandwidthNotification to match the current profile index after stream switch or period change
+							profileIdxForBandwidthNotification = currentProfileIndex;
 						}
 						AAMPLOG_INFO("Desired profile index updated [%d]",currentProfileIndex);
 						// Adaptation Set Index corresponding to a particular profile
@@ -8016,6 +8021,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 			if(0 == pMediaStreamContext->fragmentDescriptor.Bandwidth || !aamp->IsFogTSBSupported())
 			{
 				pMediaStreamContext->fragmentDescriptor.Bandwidth = pMediaStreamContext->representation->GetBandwidth();
+				// Update current bandwidth to handle changes between periods
+				pMediaStreamContext->SetCurrentBandWidth(pMediaStreamContext->fragmentDescriptor.Bandwidth);
 			}
 			pMediaStreamContext->fragmentDescriptor.RepresentationID.assign(pMediaStreamContext->representation->GetId());
 			pMediaStreamContext->fragmentDescriptor.Time = 0;
@@ -10664,7 +10671,7 @@ StreamAbstractionAAMP_MPD::~StreamAbstractionAAMP_MPD()
 
 	aamp->SyncBegin();
 
-	SAFE_DELETE_ARRAY(mStreamInfo);
+	// mStreamInfo is now a vector and will be automatically destroyed
 	deIndexTileInfo(indexedTileInfo);
 	if(!thumbnailtrack.empty())
 	{
@@ -11123,25 +11130,46 @@ int StreamAbstractionAAMP_MPD::GetProfileIndexForBandwidth( BitsPerSecond mTsbBa
  *
  *   @retval stream information corresponding to index.
  */
-StreamInfo* StreamAbstractionAAMP_MPD::GetStreamInfo(int idx)
+StreamInfo *StreamAbstractionAAMP_MPD::GetStreamInfo(int idx)
 {
+	StreamInfo *result = nullptr;
 	bool isFogTsb = mIsFogTSB && !mAdPlayingFromCDN;
 	if (isFogTsb)
 	{
-		return &mStreamInfo[idx];
+		// Direct index access for FOG TSB
+		if (idx >= 0 && idx < static_cast<int>(mStreamInfo.size()))
+		{
+			result = &mStreamInfo[idx];
+		}
+		else
+		{
+			AAMPLOG_ERR("GetStreamInfo: Invalid index %d, available profiles: %zu",
+						idx, mStreamInfo.size());
+		}
 	}
 	else
 	{
-		int userData = 0;
+		// Non-FOG TSB: use ABR manager to get user data index
+		int profileIndex = 0;
 
-		if (GetProfileCount() && !aamp->IsFogTSBSupported()) // avoid calling getUserDataOfProfile() for playlist only URL playback.
+		if (GetProfileCount() && !aamp->IsFogTSBSupported())
 		{
-			userData = GetABRManager().getUserDataOfProfile(idx);
+			profileIndex = GetABRManager().getUserDataOfProfile(idx);
 		}
-		return &mStreamInfo[userData];
-	}
-}
 
+		if (profileIndex >= 0 && profileIndex < static_cast<int>(mStreamInfo.size()))
+		{
+			result = &mStreamInfo[profileIndex];
+		}
+		else
+		{
+			AAMPLOG_ERR("GetStreamInfo: Invalid userData index %d for profile %d, available profiles: %zu",
+						profileIndex, idx, mStreamInfo.size());
+		}
+	}
+
+	return result;
+}
 
 /**
  *   @brief  Get (restamped) PTS of first sample.

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -1149,7 +1149,7 @@ protected:
 	bool mIsLiveStream;    	    	   /**< Stream is live or not; won't change during runtime. */
 	bool mIsLiveManifest;   	   /**< Current manifest is dynamic or static; may change during runtime. eg: Hot DVR. */
 	bool mUpdateManifestState;
-	StreamInfo* mStreamInfo;
+	std::vector<StreamInfo> mStreamInfo;	/**< Stream information for all profiles */
 	bool mUpdateStreamInfo;		   /**< Indicates mStreamInfo needs to be updated */
 	double mPrevStartTimeSeconds;
 	std::string mPrevLastSegurlMedia;

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2325,6 +2325,16 @@ void StreamAbstractionAAMP::UpdateStreamInfoBitrateData(int profileIndex, Stream
 		cacheFragStreamInfo.resolution.width = streamInfo->resolution.width;
 		//AAMPLOG_WARN("stream Info bps(%ld) w(%d) h(%d) fr(%f)", cacheFragStreamInfo.bandwidthBitsPerSecond, cacheFragStreamInfo.resolution.width, cacheFragStreamInfo.resolution.height, cacheFragStreamInfo.resolution.framerate);
 	}
+	else
+	{
+		AAMPLOG_ERR("UpdateStreamInfoBitrateData: Failed to get stream info for profile %d, using default values", profileIndex);
+		// Set default values to prevent undefined behavior
+		cacheFragStreamInfo.bandwidthBitsPerSecond = 0;
+		cacheFragStreamInfo.reason = mBitrateReason;
+		cacheFragStreamInfo.resolution.height = 0;
+		cacheFragStreamInfo.resolution.framerate = 0;
+		cacheFragStreamInfo.resolution.width = 0;
+	}
 }
 
 

--- a/test/utests/mocks/MockABRManager.h
+++ b/test/utests/mocks/MockABRManager.h
@@ -1,0 +1,49 @@
+/*
+* If not stated otherwise in this file or this component's license file the
+* following copyright and licenses apply:
+*
+* Copyright 2025 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef AAMP_MOCK_ABR_MANAGER_H
+#define AAMP_MOCK_ABR_MANAGER_H
+
+#include <gmock/gmock.h>
+#include "abr.h"
+
+class MockABRManager
+{
+public:
+	MOCK_METHOD(int, getProfileCount, ());
+	MOCK_METHOD(int, getBestMatchedProfileIndexByBandWidth, (int bandwidth));
+	MOCK_METHOD(int, getMaxBandwidthProfile, (const std::string& periodId));
+	MOCK_METHOD(BitsPerSecond, getBandwidthOfProfile, (int profileIndex));
+	MOCK_METHOD(void, clearProfiles, ());
+	MOCK_METHOD(void, addProfile, (const ABRManager::ProfileInfo &profile));
+	MOCK_METHOD(int, getRampedDownProfileIndex, (int currentProfileIndex, const std::string& periodId));
+	MOCK_METHOD(int, getUserDataOfProfile, (int currentProfileIndex));
+	MOCK_METHOD(void, setDefaultInitBitrate, (long defaultInitBitrate));
+	MOCK_METHOD(void, updateProfile, ());
+	MOCK_METHOD(int, getDesiredIframeProfile, ());
+	MOCK_METHOD(int, getInitialProfileIndex, (bool chooseMediumProfile, const std::string& periodId));
+	MOCK_METHOD(int, getLowestIframeProfile, ());
+	MOCK_METHOD(int, getProfileIndexByBitrateRampUpOrDown, (int currentProfileIndex, BitsPerSecond currentBandwidth, BitsPerSecond networkBandwidth, int nwConsistencyCnt, const std::string& periodId));
+	MOCK_METHOD(int, getRampedUpProfileIndex, (int currentProfileIndex, const std::string& periodId));
+	MOCK_METHOD(bool, isProfileIndexBitrateLowest, (int currentProfileIndex, const std::string& periodId));
+};
+
+extern MockABRManager *g_mockABRManager;
+
+#endif // AAMP_MOCK_ABR_MANAGER_H

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -37,6 +37,7 @@
 #include "MockIsoBmffProcessor.h"
 #include "MockTSBSessionManager.h"
 #include "MockTSBReader.h"
+#include "MockABRManager.h"
 
 
 using ::testing::_;
@@ -674,6 +675,21 @@ protected:
 		 */
 		void SetFirstPTSForTest(double pts) { mFirstPTS = pts; }
 		double GetFirstPTSForTest() const { return mFirstPTS; }
+
+		/**
+		 * @brief Test-only methods to access the protected mStreamInfo member.
+		 */
+		std::vector<StreamInfo>& GetStreamInfoVector() { return mStreamInfo; }
+		size_t GetStreamInfoSize() const { return mStreamInfo.size(); }
+		void ResizeStreamInfo(size_t size) { mStreamInfo.resize(size); }
+		void ClearStreamInfo() { mStreamInfo.clear(); }
+		StreamInfo& GetStreamInfoAt(size_t index) { return mStreamInfo[index]; }
+
+		/**
+		 * @brief Test-only methods to set protected members.
+		*/
+		void SetIsFogTSB(bool value) { mIsFogTSB = value; }
+		void SetAdPlayingFromCDN(bool value) { mAdPlayingFromCDN = value; }
 	};
 
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
@@ -691,6 +707,7 @@ protected:
 
 		g_mockAampMPDDownloader = new StrictMock<MockAampMPDDownloader>();
 		g_mockAampUtils = new StrictMock<MockAampUtils>();
+		g_mockABRManager = new NiceMock<MockABRManager>();
 
 	}
 
@@ -717,6 +734,9 @@ protected:
 
 		delete g_mockAampUtils;
 		g_mockAampUtils = nullptr;
+
+		delete g_mockABRManager;
+		g_mockABRManager = nullptr;
 	}
 };
 
@@ -2198,6 +2218,163 @@ TEST_F(StreamAbstractionAAMP_MPDTest, GetStreamInfoTest) {
 	int idx=-1;
 	StreamInfo* streamInfo = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(idx);
 	(void)streamInfo;
+}
+
+/**
+ * @brief Test GetStreamInfo in non-FOG TSB mode using proper test class
+ * Sets up the StreamAbstractionAAMP_MPD instance in non-FOG TSB mode and verifies that
+ * GetStreamInfo correctly retrieves StreamInfo via the ABR manager.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, GetStreamInfo_NonFogTsbMode)
+{
+	// Set non-FOG TSB mode (uses ABR manager path)
+	mStreamAbstractionAAMP_MPD->SetIsFogTSB(false);
+	mStreamAbstractionAAMP_MPD->SetAdPlayingFromCDN(false);
+
+	// Populate mStreamInfo vector with 2 elements
+	mStreamAbstractionAAMP_MPD->ResizeStreamInfo(2);
+	mStreamAbstractionAAMP_MPD->GetStreamInfoAt(0).bandwidthBitsPerSecond = 500000;
+	mStreamAbstractionAAMP_MPD->GetStreamInfoAt(1).bandwidthBitsPerSecond = 1000000;
+
+	// Mock expectations for ABR manager calls
+	EXPECT_CALL(*g_mockABRManager, getProfileCount())
+		.WillRepeatedly(Return(2));
+	EXPECT_CALL(*g_mockABRManager, getUserDataOfProfile(1))
+		.WillOnce(Return(1)); // Maps to index 1 in mStreamInfo
+	EXPECT_CALL(*g_mockABRManager, getUserDataOfProfile(2))
+		.WillOnce(Return(-1)); // Invalid user data - should cause nullptr return
+
+	// Test valid index access through ABR manager
+	StreamInfo *result1 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(1);
+	ASSERT_NE(result1, nullptr);
+	EXPECT_EQ(result1->bandwidthBitsPerSecond, 1000000);
+
+	// Test boundary case - ABR manager returns invalid user data
+	StreamInfo *result2 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(2);
+	EXPECT_EQ(result2, nullptr);
+}
+
+/**
+ * @brief Test GetStreamInfo bounds checking with empty vector in FOG TSB mode
+ * Sets up the StreamAbstractionAAMP_MPD instance in FOG TSB mode and verifies that
+ * GetStreamInfo correctly handles out-of-bounds indices when the mStreamInfo vector is empty.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, GetStreamInfo_FogTsb_EmptyVector)
+{
+	// Set FOG TSB mode to enable direct index access with bounds checking
+	mStreamAbstractionAAMP_MPD->SetIsFogTSB(true);
+	mStreamAbstractionAAMP_MPD->SetAdPlayingFromCDN(false);
+
+	// mStreamInfo vector is empty by default
+	EXPECT_EQ(mStreamAbstractionAAMP_MPD->GetStreamInfoSize(), 0);
+
+	// Test accessing invalid indices
+	StreamInfo *result1 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(-1);
+	EXPECT_EQ(result1, nullptr);
+
+	StreamInfo *result2 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(0);
+	EXPECT_EQ(result2, nullptr);
+
+	StreamInfo *result3 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(5);
+	EXPECT_EQ(result3, nullptr);
+}
+
+/**
+ * @brief Test GetStreamInfo bounds checking with populated vector in FOG TSB mode
+ * Sets up the StreamAbstractionAAMP_MPD instance in FOG TSB mode and verifies that
+ * GetStreamInfo correctly handles valid and out-of-bounds indices when the mStreamInfo vector is populated.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, GetStreamInfo_FogTsb_PopulatedVector)
+{
+	// Set FOG TSB mode to enable direct index access with bounds checking
+	mStreamAbstractionAAMP_MPD->SetIsFogTSB(true);
+	mStreamAbstractionAAMP_MPD->SetAdPlayingFromCDN(false);
+
+	// Populate mStreamInfo vector with 3 elements
+	mStreamAbstractionAAMP_MPD->ResizeStreamInfo(3);
+	mStreamAbstractionAAMP_MPD->GetStreamInfoAt(0).bandwidthBitsPerSecond = 500000;
+	mStreamAbstractionAAMP_MPD->GetStreamInfoAt(1).bandwidthBitsPerSecond = 1000000;
+	mStreamAbstractionAAMP_MPD->GetStreamInfoAt(2).bandwidthBitsPerSecond = 2000000;
+
+	// Test valid indices
+	StreamInfo *result1 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(0);
+	ASSERT_NE(result1, nullptr);
+	EXPECT_EQ(result1->bandwidthBitsPerSecond, 500000);
+
+	StreamInfo *result2 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(2);
+	ASSERT_NE(result2, nullptr);
+	EXPECT_EQ(result2->bandwidthBitsPerSecond, 2000000);
+
+	// Test invalid indices (out of bounds)
+	StreamInfo *result3 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(-1);
+	EXPECT_EQ(result3, nullptr);
+
+	StreamInfo *result4 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(3);
+	EXPECT_EQ(result4, nullptr);
+}
+
+/**
+ * @brief Test GetStreamInfo heap overflow prevention scenario in non-FOG TSB mode
+ * Simulates a scenario where the stream info vector size decreases and ensures no heap overflow occurs
+ * when using ABR manager path
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, GetStreamInfo_NonFogTsb_HeapOverflowPrevention)
+{
+	// Set non-FOG TSB mode to enable ABR manager path
+	mStreamAbstractionAAMP_MPD->SetIsFogTSB(false);
+	mStreamAbstractionAAMP_MPD->SetAdPlayingFromCDN(false);
+
+	// First: Set up ad content with 5 profiles
+	mStreamAbstractionAAMP_MPD->ResizeStreamInfo(5);
+	for (int i = 0; i < 5; i++)
+	{
+		mStreamAbstractionAAMP_MPD->GetStreamInfoAt(i).bandwidthBitsPerSecond = (i + 1) * 1000000;
+	}
+
+	// Mock ABR manager to simulate initial state with 5 profiles
+	EXPECT_CALL(*g_mockABRManager, getProfileCount())
+		.WillRepeatedly(Return(5));
+
+	// Set up user data mapping for initial 5 profiles
+	for (int i = 0; i < 5; i++)
+	{
+		EXPECT_CALL(*g_mockABRManager, getUserDataOfProfile(i))
+			.WillRepeatedly(Return(i)); // Maps to index i in mStreamInfo
+	}
+
+	// Verify all profiles are accessible through ABR manager
+	for (int i = 0; i < 5; i++)
+	{
+		StreamInfo *result = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(i);
+		ASSERT_NE(result, nullptr);
+	}
+
+	// Now: Switch to source content with only 1 profile (heap size reduction)
+	mStreamAbstractionAAMP_MPD->ResizeStreamInfo(1);
+	mStreamAbstractionAAMP_MPD->GetStreamInfoAt(0).bandwidthBitsPerSecond = 2000000;
+
+	// Update ABR manager to reflect new profile count
+	EXPECT_CALL(*g_mockABRManager, getProfileCount())
+		.WillRepeatedly(Return(1));
+
+	// Test: Old cached profileIndex=4 should now be safely handled
+	StreamInfo *result = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(4);
+	EXPECT_EQ(result, nullptr); // Should return nullptr due to invalid user data
+
+	// Valid profile should still work
+	StreamInfo *validResult = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(0); // Profile 0 exists
+	ASSERT_NE(validResult, nullptr);
+	EXPECT_EQ(validResult->bandwidthBitsPerSecond, 2000000);
+
+	// Test additional edge cases
+	StreamInfo *invalidResult1 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(1); // Profile 1 doesn't exist
+	EXPECT_EQ(invalidResult1, nullptr);
+
+	// Out of range index
+	EXPECT_CALL(*g_mockABRManager, getUserDataOfProfile(10))
+		.WillRepeatedly(Return(-1));
+	StreamInfo *invalidResult2 = mStreamAbstractionAAMP_MPD->CallGetStreamInfo(10); // Out of range
+	EXPECT_EQ(invalidResult2, nullptr);
 }
 
 TEST_F(StreamAbstractionAAMP_MPDTest, EnableAndSetLiveOffsetForLLDashPlaybackTest)


### PR DESCRIPTION
VPLAY-11984: multi-period video-only test stream crashing with heap-buffer-overflow

Reason for change: Updating profileIdxForBandwidthNotification after period switch to avoid heap-buffer-overflow in multi-period video-only test stream. Risks: Low
Test Procedure: Test with multi-period video-only test stream in VPLAY-11984 Priority: P1

---------