### PR TITLE
VPLAY-12115: [AAMP] Aamp tune Version is displayed 7.10 Instead of 7.…

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -30,7 +30,7 @@
 #define AAMP_CFG_PATH "/opt/aamp.cfg"
 #define AAMP_JSON_PATH "/opt/aampcfg.json"
 
-#define AAMP_VERSION "7.10"
+#define AAMP_VERSION "7.11"
 #define AAMP_TUNETIME_VERSION 8
 
 //Stringification of Macro : use two levels of macros


### PR DESCRIPTION
Reason for change: Changed AAMP version to 7.11
Test Procedure: Refer Jira
Risks: No