### PR TITLE
VPLAY-11433 : Enhancement Request: Utilize Existing Player Source Field in PCTune_split to Indicate VIPA vs Non-VIPA Playback

### DIFF
--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -298,7 +298,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 	}
 	if (!appName.empty())
 	{
-		if (gpGlobalConfig->IsConfigSet(eAAMPConfig_UseFireboltSDK))
+		if (gpGlobalConfig && gpGlobalConfig->IsConfigSet(eAAMPConfig_UseFireboltSDK))
 		{
 			appName += "_VIPA";
 		}

--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -275,7 +275,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 	}
 	enabled = false;
 	unsigned int licenseAcqNWTime = bucketDuration(PROFILE_BUCKET_LA_NETWORK);
-	char tuneTimeStrPrefix[64];
+	char tuneTimeStrPrefix[128];
 	memset(tuneTimeStrPrefix, '\0', sizeof(tuneTimeStrPrefix));
 	int mTotalTime;
  	int mTimedMetadataStartTime = static_cast<int> (mTuneEndMetrics.mTimedMetadataStartTime - tuneStartMonotonicBase);
@@ -298,6 +298,10 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 	}
 	if (!appName.empty())
 	{
+		if (gpGlobalConfig->IsConfigSet(eAAMPConfig_UseFireboltSDK))
+		{
+			appName += "_VIPA";
+		}
 		snprintf(tuneTimeStrPrefix, sizeof(tuneTimeStrPrefix), "%s PLAYER[%d] APP: %s IP_AAMP_TUNETIME", playerActiveMode.c_str(),playerId,appName.c_str());
 	}
 	else


### PR DESCRIPTION
…ld in PCTune_split to Indicate VIPA vs Non-VIPA Playback

Reason for Change :  To better collect and analyze tune metrics, use the existing player source string field to differentiate VIPA Playback

Test Procedure: Tune to linear/VOD content , verify Tune log
Priority : p1
Risks: Low