### PR TITLE
VPLAY-10959: Audio loss observed while performing Multiple trickplay,…

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -5205,7 +5205,6 @@ void StreamAbstractionAAMP_HLS::Stop(bool clearChannelData)
 		{
 			aamp->mDRMLicenseManager->notifyCleanup();
 		}
-		aamp->mDRMLicenseManager->setSessionMgrState(SessionMgrState::eSESSIONMGR_INACTIVE);
 	}
 	if(!clearChannelData)
 	{

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10909,7 +10909,6 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 				aamp->mDRMLicenseManager->notifyCleanup();
 			}
 		}
-		aamp->mDRMLicenseManager->setSessionMgrState(SessionMgrState::eSESSIONMGR_INACTIVE);
 		if(tsbReaderThreadID.joinable())
 		{
 			abortTsbReader = true;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7808,6 +7808,10 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 	{
 		/** Reset the license fetcher only DRM handle is deleting **/
 		mDRMLicenseManager->Stop();
+
+		// Set Session Manager State to Inactive after StreamSink has been stopped
+		// to avoid any race condition between data still being streamed and DRM session manager
+		mDRMLicenseManager->setSessionMgrState(SessionMgrState::eSESSIONMGR_INACTIVE);
 	}
 
 	SAFE_DELETE(mCdaiObject);

--- a/test/utests/fakes/FakeAampLicManager.cpp
+++ b/test/utests/fakes/FakeAampLicManager.cpp
@@ -118,6 +118,10 @@ void AampDRMLicenseManager::clearFailedKeyIds()
 
 void AampDRMLicenseManager::setSessionMgrState(SessionMgrState state)
 {
+    if(g_mockAampLicenseManager)
+    {
+        g_mockAampLicenseManager->setSessionMgrState(state);
+    }
 }
 
 void AampDRMLicenseManager::SetSendErrorOnFailure(bool sendErrorOnFailure)

--- a/test/utests/mocks/MockAampLicManager.h
+++ b/test/utests/mocks/MockAampLicManager.h
@@ -28,6 +28,7 @@ class MockAampLicenseManager
 public:
     MOCK_METHOD(void, setVideoWindowSize, (int width, int height));
     MOCK_METHOD(DrmSession*, createDrmSession, (std::shared_ptr<DrmHelper> drmHelper, DrmCallbacks* aampInstance,  DrmMetaDataEventPtr eventHandle, int streamTypeIn));
+    MOCK_METHOD(void, setSessionMgrState, (SessionMgrState state));
 };
 
 extern MockAampLicenseManager *g_mockAampLicenseManager;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -2702,6 +2702,7 @@ TEST_F(PrivAampTests,DISABLED_stopTest)
 
 TEST_F(PrivAampTests,stopTest_1)
 {
+	EXPECT_CALL(*g_mockAampLicenseManager, setSessionMgrState(SessionMgrState::eSESSIONMGR_INACTIVE));
 	p_aamp->Stop();
 	EXPECT_FALSE(p_aamp->mAutoResumeTaskPending);
 	EXPECT_FALSE(p_aamp->IsFogTSBSupported());


### PR DESCRIPTION
… on LLD Channels (#854)

VPLAY-10959: Audio loss observed while performing Multiple trickplay, on LLD Channels (#854)

Reason for Change: Fix gstreamer error, occuring due to drm session manager state moving to to inactive whilst data being still being streamed

Test Guidance: see ticket

Risk: low