### PR TITLE
VPLAY-12548: Factor chunk duration in buffer calculation

### DIFF
--- a/AampDownloadInfo.hpp
+++ b/AampDownloadInfo.hpp
@@ -97,9 +97,10 @@ struct DownloadInfo
 	uint64_t fragmentNumber;	   /**< Fragment number, incremented with each new segment in track, corresponds to $Number& in segment template */
 	uint32_t timeScale;			   /**< Fragment Time scale, divide fragment time or duration by timeScale to convert to seconds */
 	std::string url;			   /**< URL of the fragment */
-	BitsPerSecond bandwidth;			   /**< Bandwidth of the fragment at the time of job submission */
+	BitsPerSecond bandwidth;	   /**< Bandwidth of the fragment at the time of job submission */
 	AampTime ptsOffset;			   /**< Period specific PTS offset used for restamping */
 	URLBitrateMap uriList;		   /**< List of all possible URLs with their respective bitrates */
+	double chunkDurationSec;	   /**< Duration of the chunks processed from the fragment in seconds, used for chunked transfer */
 
 	/**
 	 * @brief Default constructor
@@ -122,7 +123,8 @@ struct DownloadInfo
 		  timeScale(1),
 		  bandwidth(0),
 		  ptsOffset(0),
-		  uriList()
+		  uriList(),
+		  chunkDurationSec(0)
 	{
 	}
 
@@ -164,7 +166,8 @@ struct DownloadInfo
 		  bandwidth(bandwidth),
 		  ptsOffset(ptsOffset),
 		  uriList(std::move(uriList)),
-		  url("")
+		  url(""),
+		  chunkDurationSec(0)
 	{
 	}
 };

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -205,7 +205,7 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 /**
  *  @brief Cache Fragment Chunk
  */
-bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime)
+bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime, uint64_t durationInTicks)
 {
 	AAMPLOG_DEBUG("[%s] Chunk Buffer Length %zu Remote URL %s", name, size, remoteUrl.c_str());
 
@@ -229,6 +229,16 @@ bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char
 		{
 			cachedFragment->absPosition = mActiveDownloadInfo->absolutePosition;
 			cachedFragment->timeScale = mActiveDownloadInfo->timeScale;
+			cachedFragment->duration = (double)durationInTicks / (double)cachedFragment->timeScale;
+			mActiveDownloadInfo->chunkDurationSec += cachedFragment->duration;
+			// Only update when absPosition is set to avoid messing up the values.
+			if (cachedFragment->absPosition > 0)
+			{
+				AAMPLOG_DEBUG("[%s] Updating last downloaded position[chunkDuration:%f]. Previous: %f, New: %f",
+					name, mActiveDownloadInfo->chunkDurationSec, lastDownloadedPosition.load(),
+					cachedFragment->absPosition + mActiveDownloadInfo->chunkDurationSec);
+				lastDownloadedPosition.store(cachedFragment->absPosition + mActiveDownloadInfo->chunkDurationSec);
+			}
 		}
 		/* The value of PTSOffsetSec in the context can get updated at the start of a period before
 		 * the last segment from the previous period has been injected, hence we copy it

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -133,8 +133,9 @@ public:
      * @param size CURL provided chunk data size
      * @param remoteUrl url of fragment
      * @param dnldStartTime of the download
+     * @param durationInTicks duration of the chunk in ticks
      */
-    bool CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime);
+    bool CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime, uint64_t durationInTicks);
 
     /**
      * @fn CacheFragmentData

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -281,6 +281,7 @@ struct CurlCallbackContext
 	CurlAbortReason abortReason = eCURL_ABORT_REASON_NONE; /**< Reason for aborting the curl download  */
 	bool earlyAbortEnabled = false; /**< Flag to enable early abort logic for chunk downloads */
 	BitsPerSecond profileBps = 0; /**< Current video profile bits per second used for early abort calculation*/
+	uint64_t chunkDurationInTicks = 0; /**< Duration of the current chunk in ticks, used while caching chunks */
 
 	// Default constructor
 	CurlCallbackContext() {}
@@ -310,6 +311,7 @@ struct CurlCallbackContext
 		chunkBoundary = 0;
 		abortReason = eCURL_ABORT_REASON_NONE;
 		dataTransferStartTime = -1;
+		chunkDurationInTicks = 0;
 	}
 };
 

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -91,7 +91,7 @@ bool IsoBmffBuffer::ParseChunkData(const char* name, char* &unParsedBuffer, uint
 		int lastMDatIndex = UpdateBufferData(parsedBoxCount, unParsedBuffer, unParsedBufferSize, parsedBufferSize);
 
 		uint64_t fPts = 0;
-		double totalChunkDuration = getTotalChunkDuration( lastMDatIndex);
+		uint64_t totalChunkDuration = getTotalChunkDurationInTicks(lastMDatIndex);
 
 		//get PTS of buffer
 		bool bParse = getFirstPTS(fPts);
@@ -100,7 +100,7 @@ bool IsoBmffBuffer::ParseChunkData(const char* name, char* &unParsedBuffer, uint
 			AAMPLOG_TRACE("[%s] fPts %" PRIu64,name, fPts);
 		}
 		fpts = (double) fPts/(timeScale*1.0);
-		fduration = totalChunkDuration/(timeScale*1.0);
+		fduration = (double) totalChunkDuration/(timeScale*1.0);
 	}
 	return true;
 }
@@ -715,9 +715,9 @@ int IsoBmffBuffer::UpdateBufferData(size_t parsedBoxCount, char* &unParsedBuffer
 /**
  *  @brief Get list of box handles in a parsed buffer
  */
-double IsoBmffBuffer::getTotalChunkDuration(int lastMDatIndex)
+uint64_t IsoBmffBuffer::getTotalChunkDurationInTicks(int lastMDatIndex)
 {
-	double totalChunkDuration = 0.0;
+	uint64_t totalChunkDuration = 0;
 	uint64_t fDuration = 0;
 	std::vector<Box*> *pBoxes = getParsedBoxes();
 	for(int i=0;i<lastMDatIndex;i++)
@@ -728,7 +728,7 @@ double IsoBmffBuffer::getTotalChunkDuration(int lastMDatIndex)
 		{
 			getSampleDuration(box, fDuration);
 			totalChunkDuration += fDuration;
-			AAMPLOG_TRACE("fDuration = %" PRIu64 ", totalChunkDuration = %f", fDuration, totalChunkDuration);
+			AAMPLOG_TRACE("fDuration = %" PRIu64 ", totalChunkDuration = %" PRIu64, fDuration, totalChunkDuration);
 		}
 	}
 	return totalChunkDuration;
@@ -1290,4 +1290,24 @@ bool IsoBmffBuffer::getChunkedMdatBoxInfo(size_t &start, size_t &size) const
 		ret = true;
 	}
 	return ret;
+}
+
+/**
+ * @fn getLastMdatBoxIndex
+ * @brief Get the index of the last mdat box in the parsed buffer, including the chunked box if it is an mdat box
+ *
+ * @return index of mdat box w.r.t to the full mp4 box, -1 if index is out of bound
+ */
+int IsoBmffBuffer::getLastMdatBoxIndex() const
+{
+	int index = -1;
+	// Chunked box is also handled here
+	for (size_t i = 0; i < boxes.size(); i++)
+	{
+		if (IS_TYPE(boxes.at(i)->getType(), Box::MDAT))
+		{
+			index = i;
+		}
+	}
+	return index;
 }

--- a/isobmff/isobmffbuffer.h
+++ b/isobmff/isobmffbuffer.h
@@ -183,10 +183,11 @@ public:
 	int UpdateBufferData(size_t parsedBoxCount, char* &unParsedBuffer, size_t &unParsedBufferSize, size_t & parsedBufferSize);
 
 	/**
-	 * @fn UpdateBufferData
-	 * @return true if parsed or false
+	 * @fn getTotalChunkDurationInTicks
+	 * @param[in] lastMDatIndex - index of mdat box w.r.t to the full mp4 box
+	 * @return total chunk duration in ticks, 0 if no chunk duration found
 	 */
-	double getTotalChunkDuration(int lastMDatIndex);
+	uint64_t getTotalChunkDurationInTicks(int lastMDatIndex);
 
 	/**
 	 * @fn setBuffer
@@ -520,5 +521,12 @@ public:
 	 * @return true if chunked mdat box is present. false otherwise
 	 */
 	bool getChunkedMdatBoxInfo(size_t &start, size_t &size) const;
+
+	/**
+	 * @fn getLastMdatBoxIndex
+	 *
+	 * @return index of mdat box w.r.t to the full mp4 box, -1 if index is out of bound
+	 */
+	int getLastMdatBoxIndex() const;
 };
 #endif /* __ISOBMFFBUFFER_H__ */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -714,12 +714,14 @@ static int ReadConfigNumericHelper(std::string buf, const char* prefixPtr, T& va
  * @param[in] buffer - buffer to scan
  * @param[in] bufferOffset - offset in buffer to start scanning from
  * @param[out] chunkBoundaryOffset - offset of chunk boundary if found
+ * @param[out] chunkDurationInTicks - duration of chunk if boundary found
  * @retval true if chunk boundary found
  */
-static bool IdentifyMp4ChunkBoundary(AampMediaType type, AampGrowableBuffer *buffer, size_t bufferOffset, size_t &chunkBoundaryOffset)
+static bool IdentifyMp4ChunkBoundary(AampMediaType type, AampGrowableBuffer *buffer, size_t bufferOffset, size_t &chunkBoundaryOffset, uint64_t &chunkDurationInTicks)
 {
 	bool found = false;
 	chunkBoundaryOffset = 0;
+	chunkDurationInTicks = 0;
 
 	IsoBmffBuffer isobmffBuffer;
 	isobmffBuffer.setBuffer(reinterpret_cast<uint8_t*>(buffer->GetPtr()) + bufferOffset, buffer->size() - bufferOffset);
@@ -758,6 +760,14 @@ static bool IdentifyMp4ChunkBoundary(AampMediaType type, AampGrowableBuffer *buf
 				// Calculate chunk boundary offset
 				chunkBoundaryOffset = bufferOffset + mdatStart + mdatSize;
 				found = true;
+
+				// Get the index of last MDAT box w.r.t to the full mp4 box. MDAT should be preceded by a MOOF.
+				// This is expected by the getTotalChunkDurationInTicks API.
+				int mdatIndex = isobmffBuffer.getLastMdatBoxIndex();
+				if (mdatIndex > 0)
+				{
+					chunkDurationInTicks = isobmffBuffer.getTotalChunkDurationInTicks(mdatIndex);
+				}
 			}
 		}
 	}
@@ -1120,10 +1130,16 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 				if (context->chunkBoundary == 0)
 				{
 					size_t chunkBoundaryOffset = 0;
-					if (IdentifyMp4ChunkBoundary(context->mediaType, context->buffer, context->bufferOffset, chunkBoundaryOffset))
+					// Read the chunk duration in ticks as well, which is needed for accurate buffer management
+					// In case of multiple mdat boxes in the buffer, chunkDurationInTicks will be the total duration of all the chunks in the buffer until the last mdat box
+					uint64_t chunkDurationInTicks = 0;
+					if (IdentifyMp4ChunkBoundary(context->mediaType, context->buffer, context->bufferOffset, chunkBoundaryOffset, chunkDurationInTicks))
 					{
 						context->chunkBoundary = chunkBoundaryOffset;
-						AAMPLOG_INFO("[%d] Identified chunk boundary at offset %zu, buffer len %zu", context->mediaType, context->chunkBoundary, context->buffer->size());
+						context->chunkDurationInTicks = chunkDurationInTicks;
+						AAMPLOG_INFO("[%d] Identified chunk boundary at offset %zu, buffer len %zu duration %" PRIu64,
+								context->mediaType, context->chunkBoundary,
+								context->buffer->size(), context->chunkDurationInTicks);
 					}
 				}
 				if (context->chunkBoundary > 0)
@@ -1154,7 +1170,8 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 														bufferPtr,
 														bufferLen,
 														context->remoteUrl,
-														context->downloadStartTime);
+														context->downloadStartTime,
+														context->chunkDurationInTicks);
 								context->processDelay += aamp_GetCurrentTimeMS() - startTime;
 								lock.lock();
 								// Update buffer offset and reset chunkBoundary
@@ -1163,6 +1180,7 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 								// is the first byte of the next chunk (not yet processed)
 								context->bufferOffset = context->chunkBoundary;
 								context->chunkBoundary = 0;
+								context->chunkDurationInTicks = 0;
 							}
 							else
 							{

--- a/test/utests/fakes/FakeIsoBmffBuffer.cpp
+++ b/test/utests/fakes/FakeIsoBmffBuffer.cpp
@@ -162,11 +162,11 @@ int IsoBmffBuffer::UpdateBufferData(size_t parsedBoxCount, char *&unParsedBuffer
 	}
 }
 
-double IsoBmffBuffer::getTotalChunkDuration(int lastMDatIndex)
+uint64_t IsoBmffBuffer::getTotalChunkDurationInTicks(int lastMDatIndex)
 {
 	if (g_mockIsoBmffBuffer)
 	{
-		return g_mockIsoBmffBuffer->getTotalChunkDuration(lastMDatIndex);
+		return g_mockIsoBmffBuffer->getTotalChunkDurationInTicks(lastMDatIndex);
 	}
 	else
 	{
@@ -290,5 +290,17 @@ bool IsoBmffBuffer::getChunkedMdatBoxInfo(size_t &start, size_t &size) const
     else
     {
         return false;
+    }
+}
+
+int IsoBmffBuffer::getLastMdatBoxIndex() const
+{
+    if (g_mockIsoBmffBuffer)
+    {
+        return g_mockIsoBmffBuffer->getLastMdatBoxIndex();
+    }
+    else
+    {
+        return -1;
     }
 }

--- a/test/utests/fakes/FakeMediaStreamContext.cpp
+++ b/test/utests/fakes/FakeMediaStreamContext.cpp
@@ -22,11 +22,11 @@
 
 MockMediaStreamContext *g_mockMediaStreamContext = nullptr;
 
-bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime)
+bool MediaStreamContext::CacheFragmentChunk(AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime, uint64_t durationInTicks)
 {
 	if (g_mockMediaStreamContext != nullptr)
 	{
-		return g_mockMediaStreamContext->CacheFragmentChunk(actualType, ptr, size, remoteUrl, dnldStartTime);
+		return g_mockMediaStreamContext->CacheFragmentChunk(actualType, ptr, size, remoteUrl, dnldStartTime, durationInTicks);
 	}
 	return false;
 }

--- a/test/utests/mocks/MockIsoBmffBuffer.h
+++ b/test/utests/mocks/MockIsoBmffBuffer.h
@@ -41,12 +41,13 @@ public:
     MOCK_METHOD(size_t, getParsedBoxesSize, ());
     MOCK_METHOD(bool, getChunkedfBoxMetaData, (uint32_t &, std::string &, uint32_t &));
     MOCK_METHOD(int, UpdateBufferData, (size_t , char* &, size_t &, size_t& ));
-    MOCK_METHOD(double, getTotalChunkDuration, (int));
+    MOCK_METHOD(uint64_t, getTotalChunkDurationInTicks, (int));
     MOCK_METHOD(bool, ParseChunkData, (const char* , char* &, uint32_t,	size_t & , size_t &, double& , double &));
-	MOCK_METHOD(bool, setTrickmodeTimescale, (uint32_t));
+    MOCK_METHOD(bool, setTrickmodeTimescale, (uint32_t));
     MOCK_METHOD(bool, setMediaHeaderDuration, (uint64_t));
     MOCK_METHOD(bool, getMdatBoxInfo, (size_t, size_t&, size_t&));
     MOCK_METHOD(bool, getChunkedMdatBoxInfo, (size_t&, size_t&), (const));
+    MOCK_METHOD(int, getLastMdatBoxIndex, (), (const));
 };
 
 extern MockIsoBmffBuffer *g_mockIsoBmffBuffer;

--- a/test/utests/mocks/MockMediaStreamContext.h
+++ b/test/utests/mocks/MockMediaStreamContext.h
@@ -28,7 +28,7 @@ class MockMediaStreamContext
 public:
 	MOCK_METHOD(bool, CacheFragment, (std::string fragmentUrl, unsigned int curlInstance, double position, double duration, const char *range, bool initSegment, bool discontinuity, bool playingAd, uint32_t scale));
 	MOCK_METHOD(bool, CacheTsbFragment, (std::shared_ptr<CachedFragment> fragment));
-	MOCK_METHOD(bool, CacheFragmentChunk, (AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime));
+	MOCK_METHOD(bool, CacheFragmentChunk, (AampMediaType actualType, const char *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime, uint64_t durationInTicks));
 	MOCK_METHOD(bool, IsLocalTSBInjection, ());
 };
 

--- a/test/utests/tests/MediaStreamContextTests/MediaStreamContextTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/MediaStreamContextTests.cpp
@@ -26,6 +26,7 @@
 #include "AampDRMLicPreFetcherInterface.h"
 #include "AampConfig.h"
 #include "MockAampConfig.h"
+#include "MockMediaTrack.h"
 
 #include "fragmentcollector_mpd.h"
 #include "StreamAbstractionAAMP.h"
@@ -45,6 +46,7 @@ class MediaStreamContextTest : public testing::Test
         mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
         mMediaStreamContext = new MediaStreamContext(eTRACK_VIDEO,mStreamAbstractionAAMP_MPD,mPrivateInstanceAAMP,"SAMPLETEXT");
         g_mockAampConfig = new MockAampConfig();
+        g_mockMediaTrack = new NiceMock<MockMediaTrack>();
     }
     
     void TearDown() override
@@ -60,6 +62,9 @@ class MediaStreamContextTest : public testing::Test
         
         delete g_mockAampConfig;
         g_mockAampConfig = nullptr;
+
+        delete g_mockMediaTrack;
+        g_mockMediaTrack = nullptr;
     }
     public:
     StreamAbstractionAAMP_MPD *mStreamAbstractionAAMP_MPD;
@@ -75,8 +80,8 @@ TEST_F(MediaStreamContextTest, GetContextTest)
 
 TEST_F(MediaStreamContextTest, CacheFragmentChunkTest)
 {
-    //Act:call CacheFragmentChunk fucntion
-    bool retResult = mMediaStreamContext->CacheFragmentChunk(eMEDIATYPE_VIDEO,NULL, 12345678,"remoteUrl",123456789);
+    //Act:call CacheFragmentChunk function
+    bool retResult = mMediaStreamContext->CacheFragmentChunk(eMEDIATYPE_VIDEO,NULL, 12345678,"remoteUrl",123456789, 1234);
     EXPECT_FALSE(retResult);
 }
 
@@ -201,4 +206,35 @@ TEST_F(MediaStreamContextTest, DefaultDurationTest)
     int durationValue = mMediaStreamContext->GetDefaultDurationBetweenPlaylistUpdates();
     //Assert:check durationValue variable value
     EXPECT_EQ(durationValue,6000);
+}
+
+TEST_F(MediaStreamContextTest, CacheFragmentChunkTestWithDurationInTicks)
+{
+    char testData[] = "This is a test data buffer";
+    size_t testDataSize = sizeof(testData) - 1; // Exclude null terminator
+    std::string remoteUrl = "http://example.com";
+    uint64_t dnldStartTime = 123456789;
+    uint64_t durationInTicks = 90000; // 1 second duration at 90kHz timescale
+    uint32_t timeScale = 90000; // 90kHz timescale
+    double durationInSeconds = (double)durationInTicks / (double)timeScale;
+    double absTime = 10000;
+
+    DownloadInfoPtr downloadInfo = std::make_shared<DownloadInfo>();
+    downloadInfo->absolutePosition = absTime;
+    downloadInfo->timeScale = timeScale;
+    mMediaStreamContext->mActiveDownloadInfo = downloadInfo;
+
+    CachedFragment cachedFragment;
+    EXPECT_CALL(*g_mockMediaTrack, GetFetchChunkBuffer(true))
+        .WillOnce(Return(&cachedFragment));
+
+    bool result = mMediaStreamContext->CacheFragmentChunk(eMEDIATYPE_VIDEO, testData, testDataSize, remoteUrl, dnldStartTime, durationInTicks);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(cachedFragment.type, eMEDIATYPE_VIDEO);
+    EXPECT_EQ(cachedFragment.absPosition, absTime);
+    EXPECT_EQ(cachedFragment.timeScale, timeScale);
+    EXPECT_EQ(cachedFragment.duration, durationInSeconds);
+    // Confirm chunkDuration is updated in DownloadInfo
+    EXPECT_EQ(downloadInfo->chunkDurationSec, durationInSeconds);
+    EXPECT_EQ(mMediaStreamContext->lastDownloadedPosition.load(), absTime + durationInSeconds);
 }

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -898,7 +898,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedNoUnderflow)
 		.WillRepeatedly(Return(false));
 
 	// Check that AAMP is NOT injecting segments if playback is paused by the user
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _, _))
 		.Times(0);
 
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedNoUnderflow - Calling HandleSSLWriteCallback");
@@ -960,7 +960,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackPipelinePausedWithUnderflow)
 		.WillRepeatedly(Return(false));
 
 	// Check that AAMP is injecting segments if playback is paused due to underflow
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _, _))
 		.WillOnce(Return(true));
 
 	AAMPLOG_INFO("Test: HandleSSLWriteCallbackPipelinePausedWithUnderflow - Calling HandleSSLWriteCallback");
@@ -992,7 +992,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
 	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 	// In this test, parseBuffer() fails, so no mdat box is detected and CacheFragmentChunk() should not be called
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _, _))
 		.Times(0);
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
@@ -1000,6 +1000,8 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithParseBufferFailure)
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getMdatBoxCount(_))
 		.Times(0);
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
+		.Times(0);
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getLastMdatBoxIndex())
 		.Times(0);
 	p_aamp->mDownloadsEnabled = true;
 	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
@@ -1045,7 +1047,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 	// In this test, complete mdat is not detected, so CacheFragmentChunk() should not be called
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _, _))
 		.Times(0);
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
@@ -1054,6 +1056,8 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithoutMdat)
 		.WillOnce(Return(false)); // return no mdat for now
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
 		.WillOnce(Return(false)); // return no mdat info
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getLastMdatBoxIndex())
+		.Times(0);
 	p_aamp->mDownloadsEnabled = true;
 	p_aamp->mMediaDownloadsEnabled[eMEDIATYPE_VIDEO] = true;
 
@@ -1132,6 +1136,8 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithPartialMp4Chunk)
 	size_t mdatStart = 20;
 	size_t mdatSize = totalBufSize - mdatStart;
 	size_t chunkBoundary = startBufferOffset + mdatStart + mdatSize;
+	int mdatIndex = 10;
+	uint64_t mdatDuration = 90000; // 1 second duration at 90kHz timescale
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
 		.WillOnce(Return(true));
@@ -1145,12 +1151,10 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithPartialMp4Chunk)
 			SetArgReferee<1>(static_cast<size_t>(mdatSize)), // mdat size
 			Return(true)
 		));
-
-	// In this test, CacheFragmentChunk() should be called exactly once when chunked mdat boundary is detected
-	// Lets make this a strict check using expected values
-	EXPECT_CALL(*g_mockMediaStreamContext,
-		CacheFragmentChunk(eMEDIATYPE_VIDEO, reinterpret_cast<const char*>(buffer.data()) + startBufferOffset, chunkBoundary - startBufferOffset, _, _))
-		.Times(1);
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getLastMdatBoxIndex())
+		.WillOnce(Return(mdatIndex));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getTotalChunkDurationInTicks(mdatIndex))
+		.WillOnce(Return(mdatDuration)); // 1 second duration at 90kHz timescale
 
 	size_t result1 = p_aamp->HandleSSLWriteCallback(testDataPart1, strlen(testDataPart1), 1, &context);
 	// Result should be size*nmemb
@@ -1160,6 +1164,13 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithPartialMp4Chunk)
 	// chunkBoundary should be updated to mdat start + mdat size
 	EXPECT_EQ(context.chunkBoundary, chunkBoundary);
 	EXPECT_EQ(buffer.size(), startBufferOffset + strlen(testDataPart1));
+
+	// In this test, CacheFragmentChunk() should be called exactly once when buffer reaches chunk boundary.
+	// This happens in the second call to HandleSSLWriteCallback when the complete chunked mdat is received in the buffer. The first call should not trigger CacheFragmentChunk() as the chunk is not complete yet.
+	// Lets make this a strict check using expected values
+	EXPECT_CALL(*g_mockMediaStreamContext,
+		CacheFragmentChunk(eMEDIATYPE_VIDEO, reinterpret_cast<const char*>(buffer.data()) + startBufferOffset, chunkBoundary - startBufferOffset, _, _, mdatDuration))
+		.Times(1);
 
 	size_t result = p_aamp->HandleSSLWriteCallback(testDataPart2, strlen(testDataPart2), 1, &context);
 	// Result should be size*nmemb
@@ -1221,6 +1232,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 	size_t thirdMdatStart = 300;
 	size_t thirdMdatSize = 150;
 	size_t lastMdatBoundary = thirdMdatStart + thirdMdatSize; // Should use the last mdat
+	uint64_t totalChunkDuration = 90000; // 1 second duration at 90kHz timescale
 
 	EXPECT_CALL(*g_mockIsoBmffBuffer, parseBuffer(_, _))
 		.WillOnce(Return(true));
@@ -1241,11 +1253,10 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 		));
 	EXPECT_CALL(*g_mockIsoBmffBuffer, getChunkedMdatBoxInfo(_, _))
 		.Times(0); // Not expected to be called in this test
-
-	// CacheFragmentChunk should be called once with data up to the last mdat boundary
-	EXPECT_CALL(*g_mockMediaStreamContext,
-		CacheFragmentChunk(eMEDIATYPE_VIDEO, _, lastMdatBoundary, _, _))
-		.Times(1);
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getLastMdatBoxIndex())
+		.WillOnce(Return(2));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getTotalChunkDurationInTicks(2))
+		.WillOnce(Return(totalChunkDuration)); // 1 second duration at 90kHz timescale
 
 	size_t result = p_aamp->HandleSSLWriteCallback(testData, strlen(testData), 1, &context);
 	EXPECT_EQ(result, strlen(testData));
@@ -1255,6 +1266,11 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithMultipleMdatBoxes)
 
 	// Now send more data to complete the chunk
 	std::vector<char> additionalData(500, 'X');
+
+	// CacheFragmentChunk should be called once with data up to the last mdat boundary
+	EXPECT_CALL(*g_mockMediaStreamContext,
+		CacheFragmentChunk(eMEDIATYPE_VIDEO, _, lastMdatBoundary, _, _, totalChunkDuration))
+		.Times(1);
 
 	size_t result2 = p_aamp->HandleSSLWriteCallback(additionalData.data(), additionalData.size(), 1, &context);
 	EXPECT_EQ(result2, additionalData.size());
@@ -1289,7 +1305,7 @@ TEST_F(PrivAampTests, HandleSSLWriteCallbackWithChunkEarlyAbort)
 	EXPECT_CALL(*g_mockMediaStreamContext, IsLocalTSBInjection())
 		.WillRepeatedly(Return(false));
 	// In this test, CheckForChunkEarlyAbort() returns true, so CacheFragmentChunk() should not be called
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragmentChunk(_, _, _, _, _, _))
 		.Times(0);
 
 	// No need to mock IsoBmffBuffer APIs


### PR DESCRIPTION
Reason for change: Update lastDownloadedDuration with the chunk duration for improved accuracy of buffered duration. Chunk duration in ticks are updated when chunk boundaries are identified by downloader
Test Procedure: Check buffer values are updated
in between chunk downloads with LLD
Risks: Low