### PR TITLE
VPLAY-12547 AampGrowableBuffer GetPtr() returns nulptr when capacity …

### DIFF
--- a/AampGrowableBuffer.h
+++ b/AampGrowableBuffer.h
@@ -79,9 +79,9 @@ public:
 	 * @note The internal buffer is cleared after extraction. Uses move semantics for zero-copy transfer.
 	 */
 	std::vector<uint8_t> ExtractVector( void );
-	
-	char *GetPtr( void ) { return buffer.empty() ? nullptr : reinterpret_cast<char*>(buffer.data()); }
-	const char *GetPtr( void ) const { return buffer.empty() ? nullptr : reinterpret_cast<const char*>(buffer.data()); }
+
+	char *GetPtr( void ) { return buffer.capacity() ? reinterpret_cast<char*>(buffer.data()) : nullptr; }
+	const char *GetPtr( void ) const { return buffer.capacity() ? reinterpret_cast<const char*>(buffer.data()) : nullptr; }
 	size_t GetLen( void ) const { return buffer.size(); } // accessor function for current logical growable buffer size
 	size_t GetAvail( void ) const { return buffer.capacity(); } // should be opaque, but used in logging
 	void SetLen( size_t l ) { assert(l<=buffer.capacity()); buffer.resize(l); }

--- a/test/utests/tests/AampGrowableBuffer/FunctionalTests.cpp
+++ b/test/utests/tests/AampGrowableBuffer/FunctionalTests.cpp
@@ -30,23 +30,23 @@ using ::testing::Return;
 
 class FunctionalTests : public ::testing::Test {
 protected:
-    FunctionalTests()
-    {
-        callMalloc = [](size_t size){ return malloc(size); };
-        callRealloc = [](gpointer ptr, size_t size){ return realloc(ptr, size); };
-        callFree = [](gpointer ptr){ free(ptr); return; };
-    }
+	FunctionalTests()
+	{
+		callMalloc = [](size_t size){ return malloc(size); };
+		callRealloc = [](gpointer ptr, size_t size){ return realloc(ptr, size); };
+		callFree = [](gpointer ptr){ free(ptr); return; };
+	}
 
-    void SetUp() override
-    {
-        g_mockGLib = new NiceMock<MockGLib>();
-    }
+	void SetUp() override
+	{
+		g_mockGLib = new NiceMock<MockGLib>();
+	}
 
-    void TearDown() override
-    {
-        delete g_mockGLib;
-        g_mockGLib = nullptr;
-    }
+	void TearDown() override
+	{
+		delete g_mockGLib;
+		g_mockGLib = nullptr;
+	}
 
 public:
 	std::function<gpointer (size_t)>callMalloc;
@@ -56,134 +56,144 @@ public:
 
 TEST_F(FunctionalTests, FreeTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
 
-    // Arrange: Allocate memory for the buffer and add some data
-    // No g_malloc expectation needed - std::vector manages its own memory
-    buffer.ReserveBytes(10);
-    buffer.AppendBytes("Test Data", 9);
+	// Arrange: Allocate memory for the buffer and add some data
+	// No g_malloc expectation needed - std::vector manages its own memory
+	buffer.ReserveBytes(10);
+	buffer.AppendBytes("Test Data", 9);
 
-    // Act: Call the Free function
-    // No g_free expectation needed - std::vector RAII handles cleanup
-    buffer.Free();
+	// Act: Call the Free function
+	// No g_free expectation needed - std::vector RAII handles cleanup
+	buffer.Free();
 
-    // Assert: Check that properties are reset and memory is freed
-    EXPECT_EQ(buffer.GetPtr(), nullptr); // Check if pointer is null
-    EXPECT_EQ(buffer.GetLen(), 0);       // Check if length is reset
+	// Assert: Check that properties are reset and memory is freed
+	EXPECT_EQ(buffer.GetPtr(), nullptr); // Check if pointer is null
+	EXPECT_EQ(buffer.GetLen(), 0);       // Check if length is reset
 }
 
 TEST_F(FunctionalTests, ReserveBytesTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
-    // Arrange: The buffer is set up in the fixture's SetUp()
-    // Act: Call the ReserveBytes function
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
+	// Arrange: The buffer is set up in the fixture's SetUp()
+	// Act: Call the ReserveBytes function
 
-    // No g_malloc expectation needed - std::vector manages its own memory
-    size_t numBytesToReserve = 10;
-    buffer.ReserveBytes(numBytesToReserve);
+	// No g_malloc expectation needed - std::vector manages its own memory
+	size_t numBytesToReserve = 10;
+	buffer.ReserveBytes(numBytesToReserve);
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    // Assert: Check the effects of the ReserveBytes function
-    // Buffer has reserved capacity but is still empty (size == 0)
-    EXPECT_EQ(buffer.GetPtr(), nullptr);       // Buffer is empty, so pointer is null
-    EXPECT_EQ(buffer.GetLen(), 0);             // Check if length remains 0
-    EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
+	// Assert: Check the effects of the ReserveBytes function
+	EXPECT_NE(buffer.GetPtr(), nullptr);
+	EXPECT_EQ(buffer.GetLen(), 0);             // Check if length remains 0
+	EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
 }
 
 TEST_F(FunctionalTests, AppendBytesTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
- 
-    // Arrange: The buffer is set up in the fixture's SetUp()
-    const char* srcData = "Hello, World!";
-    size_t srcLen = strlen(srcData);
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
 
-    // No g_realloc expectation needed - std::vector manages its own memory
+	// Arrange: The buffer is set up in the fixture's SetUp()
+	const char* srcData = "Hello, World!";
+	size_t srcLen = strlen(srcData);
 
-    // Act: Call the AppendBytes function
-    buffer.AppendBytes(srcData, srcLen);
+	// No g_realloc expectation needed - std::vector manages its own memory
 
-    // Assert: Check the effects of the AppendBytes function
-    // These aren't null terminated strings, must use memcmp
-    int result = memcmp(buffer.GetPtr(), srcData, srcLen);
+	// Act: Call the AppendBytes function
+	buffer.AppendBytes(srcData, srcLen);
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// Assert: Check the effects of the AppendBytes function
+	// These aren't null terminated strings, must use memcmp
+	int result = memcmp(buffer.GetPtr(), srcData, srcLen);
 
-    EXPECT_EQ(result, 0);                     // Check if data was appended correctly
-    EXPECT_EQ(buffer.GetLen(), srcLen);       // Check if length is set correctly
-    // Note: GetAvail() no longer exists - std::vector manages capacity internally
+	// No g_free expectation needed - std::vector RAII handles cleanup
+
+	EXPECT_EQ(result, 0);                     // Check if data was appended correctly
+	EXPECT_EQ(buffer.GetLen(), srcLen);       // Check if length is set correctly
+	// Note: GetAvail() no longer exists - std::vector manages capacity internally
 }
 
 TEST_F(FunctionalTests, ClearTest)
 {
-    // Create a new buffer for this test
-    AampGrowableBuffer buffer("buffer");
+	// Create a new buffer for this test
+	AampGrowableBuffer buffer("buffer");
 
-    // Arrange: Add some data to the buffer
-    buffer.AppendBytes("Test Data", 9);
+	// Arrange: Add some data to the buffer
+	buffer.AppendBytes("Test Data", 9);
 
-    // Act: Call the Clear function
-    buffer.Clear();
+	// Act: Call the Clear function
+	buffer.Clear();
 
-    // Assert: Check that the length is reset to 0
-    EXPECT_EQ(buffer.GetLen(), 0);
+	// Assert: Check that the length is reset to 0
+	EXPECT_EQ(buffer.GetLen(), 0);
+}
+
+TEST_F(FunctionalTests, ReserveAndClearTest)
+{
+	AampGrowableBuffer buffer("buffer");
+
+	buffer.ReserveBytes(1024);
+
+	buffer.Clear();
+
+	EXPECT_NE(buffer.GetPtr(), nullptr);
 }
 
 TEST_F(FunctionalTests, ReplaceTest)
 {
-    // Create a new buffer for this test
-    AampGrowableBuffer buffer("buffer");
+	// Create a new buffer for this test
+	AampGrowableBuffer buffer("buffer");
 
-    // Arrange: Set up two buffers - the source buffer and the destination buffer
-    AampGrowableBuffer sourceBuffer("buffer");
+	// Arrange: Set up two buffers - the source buffer and the destination buffer
+	AampGrowableBuffer sourceBuffer("buffer");
 
-    // No g_realloc expectation needed - std::vector manages its own memory
-    sourceBuffer.AppendBytes("Hello", 5);
+	// No g_realloc expectation needed - std::vector manages its own memory
+	sourceBuffer.AppendBytes("Hello", 5);
 
-    // Act: Call the Replace function
-    buffer.Replace(&sourceBuffer);
+	// Act: Call the Replace function
+	buffer.Replace(&sourceBuffer);
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    // Assert: Check the effects of the Replace function on the destination buffer
-    EXPECT_EQ(memcmp(buffer.GetPtr(), "Hello", 5), 0);
-    EXPECT_EQ(buffer.GetLen(), 5);                    // Check if length is replaced
-    // Note: GetAvail() no longer exists - std::vector manages capacity internally
+	// Assert: Check the effects of the Replace function on the destination buffer
+	EXPECT_EQ(memcmp(buffer.GetPtr(), "Hello", 5), 0);
+	EXPECT_EQ(buffer.GetLen(), 5);                    // Check if length is replaced
+	// Note: GetAvail() no longer exists - std::vector manages capacity internally
 
-    // Assert: Check the effects of the Replace function on the source buffer
-    EXPECT_EQ(sourceBuffer.GetPtr(), nullptr); // Check if source pointer is reset
-    EXPECT_EQ(sourceBuffer.GetLen(), 0);       // Check if source length is reset
+	// Assert: Check the effects of the Replace function on the source buffer
+	EXPECT_EQ(sourceBuffer.GetPtr(), nullptr); // Check if source pointer is reset
+	EXPECT_EQ(sourceBuffer.GetLen(), 0);       // Check if source length is reset
 }
 
 TEST_F(FunctionalTests, ExtractVectorNonEmptyTest)
 {
-    // Create a new buffer for this test
-    AampGrowableBuffer buffer("buffer");
+	// Create a new buffer for this test
+	AampGrowableBuffer buffer("buffer");
 
-    // Arrange: Add some data to the buffer
-    buffer.AppendBytes("Test Data", 9);
+	// Arrange: Add some data to the buffer
+	buffer.AppendBytes("Test Data", 9);
 
-    // Store pointer and length before transfer (simulating what GStreamer does)
-    const void* dataPtr = buffer.GetPtr();
-    size_t dataLen = buffer.GetLen();
-    
-    // Verify data is present
-    EXPECT_NE(dataPtr, nullptr);
-    EXPECT_EQ(dataLen, 9);
-    
-    // Extract the internal vector and take ownership (returned by value, moved)
-    std::vector<uint8_t> vec = buffer.ExtractVector();
+	// Store pointer and length before transfer (simulating what GStreamer does)
+	const void* dataPtr = buffer.GetPtr();
+	size_t dataLen = buffer.GetLen();
 
-    // Validate the returned vector contains the same data
-    EXPECT_EQ(vec.size(), dataLen);
-    EXPECT_EQ(memcmp(vec.data(), dataPtr, dataLen), 0);
+	// Verify data is present
+	EXPECT_NE(dataPtr, nullptr);
+	EXPECT_EQ(dataLen, 9);
 
-    // No need to delete - vector is automatically cleaned up (RAII)
+	// Extract the internal vector and take ownership (returned by value, moved)
+	std::vector<uint8_t> vec = buffer.ExtractVector();
 
-    // Assert: Check that the properties are reset after extraction
-    EXPECT_EQ(buffer.GetPtr(), nullptr); // Check if the pointer is null
-    EXPECT_EQ(buffer.GetLen(), 0);       // Check if the length is reset
+	// Validate the returned vector contains the same data
+	EXPECT_EQ(vec.size(), dataLen);
+	EXPECT_EQ(memcmp(vec.data(), dataPtr, dataLen), 0);
+
+	// No need to delete - vector is automatically cleaned up (RAII)
+
+	// Assert: Check that the properties are reset after extraction
+	EXPECT_EQ(buffer.GetPtr(), nullptr); // Check if the pointer is null
+	EXPECT_EQ(buffer.GetLen(), 0);       // Check if the length is reset
 }
 
 ////Test case is getting FAIL for UINT_MAX
@@ -202,108 +212,106 @@ TEST_F(FunctionalTests, ExtractVectorNonEmptyTest)
 // These test cases cover larger buffer sizes (1K, 8K, 32K)
 TEST_F(FunctionalTests, Reserve1KBytesTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
-    size_t numBytesToReserve = 1024; // 1K
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
+	size_t numBytesToReserve = 1024; // 1K
 
-    // No g_malloc expectation needed - std::vector manages its own memory
+	// No g_malloc expectation needed - std::vector manages its own memory
 
-    // Act: Call the ReserveBytes function
-    buffer.ReserveBytes(numBytesToReserve);
+	// Act: Call the ReserveBytes function
+	buffer.ReserveBytes(numBytesToReserve);
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    // Assert: Check the effects of the ReserveBytes function
-    // With std::vector, reserve() allocates capacity but buffer remains empty
-    EXPECT_EQ(buffer.GetPtr(), nullptr);          // Buffer is empty (size=0), so pointer is null
-    EXPECT_EQ(buffer.GetLen(), 0);                // Check if length remains 0
-    EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
+	// Assert: Check the effects of the ReserveBytes function
+	EXPECT_NE(buffer.GetPtr(), nullptr);
+	EXPECT_EQ(buffer.GetLen(), 0);                // Check if length remains 0
+	EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
 }
 
 TEST_F(FunctionalTests, Reserve8KBytesTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
-    size_t numBytesToReserve = 8192; // 8K
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
+	size_t numBytesToReserve = 8192; // 8K
 
-    // No g_malloc expectation needed - std::vector manages its own memory
+	// No g_malloc expectation needed - std::vector manages its own memory
 
-    // Act: Call the ReserveBytes function
-    buffer.ReserveBytes(numBytesToReserve);
+	// Act: Call the ReserveBytes function
+	buffer.ReserveBytes(numBytesToReserve);
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-
-    // Assert: Check the effects of the ReserveBytes function
-    EXPECT_EQ(buffer.GetPtr(), nullptr);          // Buffer is empty (size=0), so pointer is null
-    EXPECT_EQ(buffer.GetLen(), 0);                // Check if length remains 0
-    EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
+	// Assert: Check the effects of the ReserveBytes function
+	EXPECT_NE(buffer.GetPtr(), nullptr);
+	EXPECT_EQ(buffer.GetLen(), 0);                // Check if length remains 0
+	EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
 }
 
 TEST_F(FunctionalTests, Reserve32KBytesTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
-    size_t numBytesToReserve = 32768; // 32K
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
+	size_t numBytesToReserve = 32768; // 32K
 
-    // No g_malloc expectation needed - std::vector manages its own memory
+	// No g_malloc expectation needed - std::vector manages its own memory
 
-    // Act: Call the ReserveBytes function
-    buffer.ReserveBytes(numBytesToReserve);
+	// Act: Call the ReserveBytes function
+	buffer.ReserveBytes(numBytesToReserve);
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    // Assert: Check the effects of the ReserveBytes function
-    EXPECT_EQ(buffer.GetPtr(), nullptr);          // Buffer is empty (size=0), so pointer is null
-    EXPECT_EQ(buffer.GetLen(), 0);                // Check if length remains 0
-    EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
+	// Assert: Check the effects of the ReserveBytes function
+	EXPECT_NE(buffer.GetPtr(), nullptr);
+	EXPECT_EQ(buffer.GetLen(), 0);                // Check if length remains 0
+	EXPECT_GE(buffer.GetAvail(), numBytesToReserve); // Capacity should be at least what we reserved
 }
 
 // These test cases cover a series of appends
 TEST_F(FunctionalTests, SeriesOfAppendsTest)
 {
-    AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
-    const char srcData[8192] = "Hello, World!";
-    size_t srcLen = strlen(srcData);
+	AampGrowableBuffer buffer("buffer");  // Create a new buffer for this test
+	const char srcData[8192] = "Hello, World!";
+	size_t srcLen = strlen(srcData);
 
-    // No g_realloc expectation needed - std::vector manages its own memory
+	// No g_realloc expectation needed - std::vector manages its own memory
 
 
-    // Arrange: Reserve a large initial space
-    buffer.ReserveBytes(8192); // Starting with 8K
+	// Arrange: Reserve a large initial space
+	buffer.ReserveBytes(8192); // Starting with 8K
 
-    // Act: Call the AppendBytes function multiple times, increasing the size each time
-    for (int i = 0; i < 10; ++i) {
-        buffer.AppendBytes(srcData, srcLen);
-        srcLen *= 2; // Double the data size with each iteration
-    }
+	// Act: Call the AppendBytes function multiple times, increasing the size each time
+	for (int i = 0; i < 10; ++i) {
+		buffer.AppendBytes(srcData, srcLen);
+		srcLen *= 2; // Double the data size with each iteration
+	}
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    EXPECT_EQ(buffer.GetLen(), 13299);// Total length after 10 appends
-    // Note: GetAvail() no longer exists - std::vector automatically resizes
+	EXPECT_EQ(buffer.GetLen(), 13299);// Total length after 10 appends
+	// Note: GetAvail() no longer exists - std::vector automatically resizes
 }
 
 TEST_F(FunctionalTests, SetLenPositiveTest)
 {
-    AampGrowableBuffer buffer("buffer");    // Create a new buffer for this test
+	AampGrowableBuffer buffer("buffer");    // Create a new buffer for this test
 
-    const char* srcData = "Hello, World!";
-    size_t srcLen = strlen(srcData);
-    size_t srcNewLen = srcLen / 2;          // Reduce the length to half
+	const char* srcData = "Hello, World!";
+	size_t srcLen = strlen(srcData);
+	size_t srcNewLen = srcLen / 2;          // Reduce the length to half
 
-    // No g_realloc expectation needed - std::vector manages its own memory
+	// No g_realloc expectation needed - std::vector manages its own memory
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    buffer.AppendBytes(srcData, srcLen);
+	buffer.AppendBytes(srcData, srcLen);
 
-    // Assert: Check the effects of the AppendBytes function
-    // These aren't null terminated strings, must use memcmp
-    int result = memcmp(buffer.GetPtr(), srcData, srcLen);
+	// Assert: Check the effects of the AppendBytes function
+	// These aren't null terminated strings, must use memcmp
+	int result = memcmp(buffer.GetPtr(), srcData, srcLen);
 
-    EXPECT_EQ(result, 0);                   // Check if data was appended correctly
-    EXPECT_EQ(buffer.GetLen(), srcLen);     // Check if length is set correctly
+	EXPECT_EQ(result, 0);                   // Check if data was appended correctly
+	EXPECT_EQ(buffer.GetLen(), srcLen);     // Check if length is set correctly
 
-    buffer.SetLen(srcNewLen);
-    EXPECT_EQ(buffer.GetLen(), srcNewLen);
+	buffer.SetLen(srcNewLen);
+	EXPECT_EQ(buffer.GetLen(), srcNewLen);
 }
 
 TEST_F(FunctionalTests, SetLenAfterReserveBytesTest)
@@ -313,16 +321,16 @@ TEST_F(FunctionalTests, SetLenAfterReserveBytesTest)
 #endif
 	AampGrowableBuffer buffer("buffer");    // Create a new buffer for this test
 
-    {
-        AampGrowableBuffer testBuf("testBuf");
-        // No g_malloc expectation needed - std::vector manages its own memory
-        testBuf.ReserveBytes(10);
-        testBuf.SetLen(9);
-        EXPECT_EQ(testBuf.GetLen(), 9);
+	{
+		AampGrowableBuffer testBuf("testBuf");
+		// No g_malloc expectation needed - std::vector manages its own memory
+		testBuf.ReserveBytes(10);
+		testBuf.SetLen(9);
+		EXPECT_EQ(testBuf.GetLen(), 9);
 
-        EXPECT_DEATH(testBuf.SetLen(11), _);
-        EXPECT_EQ(testBuf.GetLen(), 9);
-    }
+		EXPECT_DEATH(testBuf.SetLen(11), _);
+		EXPECT_EQ(testBuf.GetLen(), 9);
+	}
 }
 
 TEST_F(FunctionalTests, SetLenAfterAppendBytesTest)
@@ -330,25 +338,25 @@ TEST_F(FunctionalTests, SetLenAfterAppendBytesTest)
 #ifdef __APPLE__ // avoid hang on OSX
 	GTEST_SKIP();
 #endif
-    AampGrowableBuffer buffer("buffer");    // Create a new buffer for this test
+	AampGrowableBuffer buffer("buffer");    // Create a new buffer for this test
 
-    const char* srcData = "Hello, World";
-    size_t srcLen = strlen(srcData);
+	const char* srcData = "Hello, World";
+	size_t srcLen = strlen(srcData);
 
-    // No g_realloc expectation needed - std::vector manages its own memory
+	// No g_realloc expectation needed - std::vector manages its own memory
 
-    // No g_free expectation needed - std::vector RAII handles cleanup
+	// No g_free expectation needed - std::vector RAII handles cleanup
 
-    buffer.AppendBytes(srcData, srcLen);
+	buffer.AppendBytes(srcData, srcLen);
 
-    // Assert: Check the effects of the AppendBytes function
-    // These aren't null terminated strings, must use memcmp
-    int result = memcmp(buffer.GetPtr(), srcData, srcLen);
+	// Assert: Check the effects of the AppendBytes function
+	// These aren't null terminated strings, must use memcmp
+	int result = memcmp(buffer.GetPtr(), srcData, srcLen);
 
-    EXPECT_EQ(result, 0);                   // Check if data was appended correctly
-    EXPECT_EQ(buffer.GetLen(), srcLen);     // Check if length is set correctly
+	EXPECT_EQ(result, 0);                   // Check if data was appended correctly
+	EXPECT_EQ(buffer.GetLen(), srcLen);     // Check if length is set correctly
 
-    // attempt to set length bigger than available size
-    EXPECT_DEATH(buffer.SetLen(100), _);
-    EXPECT_EQ(buffer.GetLen(), srcLen);     // Check that length has not changed
+	// attempt to set length bigger than available size
+	EXPECT_DEATH(buffer.SetLen(100), _);
+	EXPECT_EQ(buffer.GetLen(), srcLen);     // Check that length has not changed
 }


### PR DESCRIPTION
…!= 0 (#954)

VPLAY-12547 AampGrowableBuffer GetPtr() returns nulptr when capacity != 0 (#954)

Reason for Change: addresses a crash issue (VPLAY-12547) where AampGrowableBuffer::GetPtr() was incorrectly returning nullptr after Clear() was called on a buffer with reserved capacity. The issue occurred during download retry scenarios when a buffer was reused - the assert in ReserveBytes() would fail because it expected both empty() && capacity() == 0, but after Clear(), only size was 0 while capacity remained allocated.