### PR TITLE
VPLAY-12336: Remote keys became Unresponsive & Crashed("28665316") (#980)

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7540,15 +7540,13 @@ bool PrivateInstanceAAMP::IsLiveStream()
  * @brief Stop playback and release resources.
  *
  */
-void PrivateInstanceAAMP::Stop( bool isDestructing )
+void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 {
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
 	mEventManager->FlushPendingEvents();
-	if( !isDestructing )
-	{
-		SetState(eSTATE_STOPPING);
-	}
-	
+	// Set state to STOPPING irrespective of sending state change event or not
+	SetState(eSTATE_STOPPING, sendStateChangeEvent);
+
 	{
 		std::unique_lock<std::mutex> lock(gMutex);
 		auto iter = std::find_if(std::begin(gActivePrivAAMPs), std::end(gActivePrivAAMPs), [this](const gActivePrivAAMP_t& el)
@@ -7676,12 +7674,9 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 	mFirstFragmentTimeOffset = -1;
 	mProgressReportAvailabilityOffset = -1;
 	rate = 1;
-	
-	if( !isDestructing )
-	{
-		SetState(eSTATE_IDLE);
-	}
-	
+	// Set state to IDLE irrespective of sending state change event or not
+	SetState(eSTATE_IDLE, sendStateChangeEvent);
+
 	SetPauseOnStartPlayback(false);
 	mSeekOperationInProgress = false;
 	mTrickplayInProgress = false;
@@ -8277,7 +8272,7 @@ void PrivateInstanceAAMP::ScheduleRetune(PlaybackErrorType errorType, AampMediaT
 /**
  * @brief Set player state
  */
-void PrivateInstanceAAMP::SetState(AAMPPlayerState state)
+void PrivateInstanceAAMP::SetState(AAMPPlayerState state, bool sendStateChangeEvent)
 {
 	//bool sentSync = true;
 
@@ -8298,7 +8293,7 @@ void PrivateInstanceAAMP::SetState(AAMPPlayerState state)
 	}
 
 	mScheduler->SetState(mState);
-	if (mEventManager->IsEventListenerAvailable(AAMP_EVENT_STATE_CHANGED))
+	if (sendStateChangeEvent && mEventManager->IsEventListenerAvailable(AAMP_EVENT_STATE_CHANGED))
 	{
 		if (mState == eSTATE_PREPARING)
 		{

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1764,9 +1764,10 @@ public:
 	/**
 	 * @fn Stop
 	 *
+	 * @param[in] sendStateChangeEvent - Whether to send state change event (default: true)
 	 * @return void
 	 */
-	void Stop( bool isDestructing = false );
+	void Stop( bool sendStateChangeEvent = true );
 
 	/**
 	 * @brief Checking whether TSB enabled or not
@@ -2261,9 +2262,10 @@ public:
 	 *   @fn SetState
 	 *
 	 *   @param[in] state - New state
+	 *   @param[in] sendStateChangeEvent - Whether to send state change event (default: true)
 	 *   @return void
 	 */
-	void SetState(AAMPPlayerState state);
+	void SetState(AAMPPlayerState state, bool sendStateChangeEvent = true);
 
 	/**
 	 *   @fn GetState

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -78,7 +78,7 @@ void PrivateInstanceAAMP::SendEvent(AAMPEventPtr eventData, AAMPEventMode eventM
 {
 }
 
-void PrivateInstanceAAMP::SetState(AAMPPlayerState state)
+void PrivateInstanceAAMP::SetState(AAMPPlayerState state, bool sendStateChangeEvent)
 {
 }
 
@@ -220,7 +220,7 @@ void PrivateInstanceAAMP::SendMediaMetadataEvent()
 {
 }
 
-void PrivateInstanceAAMP::Stop( bool isDestructing )
+void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 {
 }
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -195,15 +195,15 @@ AAMPPlayerState PrivateInstanceAAMP::GetState()
 	return state;
 }
 
-void PrivateInstanceAAMP::SetState(AAMPPlayerState state)
+void PrivateInstanceAAMP::SetState(AAMPPlayerState state, bool sendStateChangeEvent)
 {
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
-		g_mockPrivateInstanceAAMP->SetState(state);
+		g_mockPrivateInstanceAAMP->SetState(state, sendStateChangeEvent);
 	}
 }
 
-void PrivateInstanceAAMP::Stop( bool isDestructing )
+void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 {
 }
 

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -36,7 +36,7 @@ public:
 
 	MOCK_METHOD(AAMPPlayerState, GetState, ());
 
-	MOCK_METHOD(void, SetState, (AAMPPlayerState state));
+	MOCK_METHOD(void, SetState, (AAMPPlayerState state, bool sendStateChangeEvent));
 
 	MOCK_METHOD(bool, GetFile, (std::string remoteUrl, AampMediaType mediaType, AampGrowableBuffer *buffer, std::string& effectiveUrl,
 				int * http_error, double *downloadTime, const char *range, unsigned int curlInstance,

--- a/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
+++ b/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
@@ -530,7 +530,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -1169,7 +1169,7 @@ TEST_F(PlayerInstanceAAMPTests, GetManifestTest) {
 }
 
 TEST_F(PlayerInstanceAAMPTests, GetManifestTest2) {
-    mPrivateInstanceAAMP->SetState(eSTATE_IDLE);
+   mPrivateInstanceAAMP->SetState(eSTATE_IDLE, true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_IDLE));
     mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_DASH;
     std::string result = mPlayerInstance->GetManifest();
@@ -1177,7 +1177,7 @@ TEST_F(PlayerInstanceAAMPTests, GetManifestTest2) {
 }
 
 TEST_F(PlayerInstanceAAMPTests, GetManifestTest3) {
-    mPrivateInstanceAAMP->SetState(eSTATE_ERROR);
+    mPrivateInstanceAAMP->SetState(eSTATE_ERROR, true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_ERROR));
     mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_DASH;
     std::string result = mPlayerInstance->GetManifest();
@@ -1185,7 +1185,7 @@ TEST_F(PlayerInstanceAAMPTests, GetManifestTest3) {
 }
 
 TEST_F(PlayerInstanceAAMPTests, GetManifestTest4) {
-    mPrivateInstanceAAMP->SetState(eSTATE_RELEASED);
+    mPrivateInstanceAAMP->SetState(eSTATE_RELEASED, true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_RELEASED));
     mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_DASH;
     std::string result = mPlayerInstance->GetManifest();
@@ -1193,7 +1193,7 @@ TEST_F(PlayerInstanceAAMPTests, GetManifestTest4) {
 }
 
 TEST_F(PlayerInstanceAAMPTests, GetManifestTest5) {
-    mPrivateInstanceAAMP->SetState(eSTATE_STOPPED);
+    mPrivateInstanceAAMP->SetState(eSTATE_STOPPED, true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_STOPPED));
     mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_DASH;
     std::string result = mPlayerInstance->GetManifest();
@@ -2055,7 +2055,7 @@ TEST_F(PlayerInstanceAAMPTests, GetAvailableVideoTracksTest)
 TEST_F(PlayerInstanceAAMPTests, GetAvailableAudioTracksTest1)
 {
     std::string result;
-    mPrivateInstanceAAMP->SetState(eSTATE_ERROR);
+    mPrivateInstanceAAMP->SetState(eSTATE_ERROR, true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_ERROR));
     std::string availableTracks = mPlayerInstance->GetAvailableAudioTracks();
     EXPECT_STREQ(result.c_str(),availableTracks.c_str());
@@ -2064,7 +2064,7 @@ TEST_F(PlayerInstanceAAMPTests, GetAvailableAudioTracksTest1)
 TEST_F(PlayerInstanceAAMPTests, GetAvailableAudioTracksTest2)
 {
     std::string result;
-    mPrivateInstanceAAMP->SetState(eSTATE_IDLE);
+    mPrivateInstanceAAMP->SetState(eSTATE_IDLE, true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_IDLE));
     std::string availableTracks = mPlayerInstance->GetAvailableAudioTracks();
     EXPECT_STREQ(result.c_str(),availableTracks.c_str());
@@ -2413,7 +2413,7 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_ResumeFromLive) {
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetPositionMilliseconds()).WillRepeatedly(Return(seek_pos_seconds));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING, true)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, false)).Times(1);
 
     mPlayerInstance->SetRate(1.0);
@@ -2435,7 +2435,7 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_ResumeFromTSB) {
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, StopDownloads()).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(true));
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(_)).Times(0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(_, true)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(_, _)).Times(0);
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, NotifyPlaybackPaused(false)).Times(1);
 	EXPECT_CALL(*g_mockAampGstPlayer, Pause(false, false)).Times(1);
@@ -2459,7 +2459,7 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_TrickPlayWhenPausedFromTSB)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, StopDownloads()).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(true));
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(_)).Times(0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(_, true)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifySpeedChanged(2.0,_)).Times(1);
 	//calling AAMPGstPlayer::Pause(false,false) would cause the pipeline to play at x1

--- a/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
@@ -55,7 +55,7 @@ protected:
 		g_mockAampStreamSinkManager = new NiceMock<MockAampStreamSinkManager>();
 
 		mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
-		mPrivateInstanceAAMP->SetState(eSTATE_PLAYING);
+		mPrivateInstanceAAMP->SetState(eSTATE_PLAYING, true);
 
 		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
 

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -61,7 +61,7 @@ protected:
 		g_mockAampStreamSinkManager = new NiceMock<MockAampStreamSinkManager>();
 
 		mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
-		mPrivateInstanceAAMP->SetState(eSTATE_PLAYING);
+		mPrivateInstanceAAMP->SetState(eSTATE_PLAYING, true);
 
 		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
 
@@ -681,7 +681,7 @@ TEST_F(SetPreferredTextLanguagesTests, SetTsbSessionManagerNull)
 	testp_aamp->preferredTextLanguagesList.push_back("lang0");
 	testp_aamp->subtitles_muted = false;
 	testp_aamp->SetLocalAAMPTsb(true);
-	testp_aamp->SetState(eSTATE_PLAYING);
+	testp_aamp->SetState(eSTATE_PLAYING, true);
 
 	/* Call SetPreferredTextLanguages() changing the preferred languages list.
 	 * There should be a retune.
@@ -737,7 +737,7 @@ TEST_F(SetPreferredTextLanguagesTests, ChangePrefTextLangWithTSB)
 	testp_aamp->subtitles_muted = false;
 	testp_aamp->SetLocalAAMPTsb(true);
 	testp_aamp->SetTsbSessionManager();
-	testp_aamp->SetState(eSTATE_PLAYING);
+	testp_aamp->SetState(eSTATE_PLAYING, true);
 	g_mockTSBSessionManager = new NiceMock<MockTSBSessionManager>(testp_aamp.get());
 
 	/* Call SetPreferredTextLanguages() changing the preferred languages list.

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -251,21 +251,21 @@ public:
 	void CallNotifyFirstBufferProcessed()
 	{
 		bool mFirstVideoFrameDisplayedEnabled = false;
-		SetState(eSTATE_SEEKING);
+		SetState(eSTATE_SEEKING, true);
 		NotifyFirstBufferProcessed(std::string());
 	}
 	void CallNotifyFirstVideoFrameDisplayed()
 	{
 		TestablePrivAamp::mPauseOnFirstVideoFrameDisp = true;
 		TuneHelper(eTUNETYPE_SEEKTOLIVE,true);
-		SetState(eSTATE_PAUSED);
+		SetState(eSTATE_PAUSED, true);
 		NotifyFirstVideoFrameDisplayed();
 	}
 	void CallNotifyFirstVideoFrameDisplayed_1()
 	{
 		TestablePrivAamp::mPauseOnFirstVideoFrameDisp = true;
 		TuneHelper(eTUNETYPE_SEEKTOLIVE,true);
-		SetState(eSTATE_SEEKING);
+		SetState(eSTATE_SEEKING, true);
 		NotifyFirstVideoFrameDisplayed();
 	}
 	void CallGetContentTypString()
@@ -429,7 +429,7 @@ TEST_F(PrivAampPrivTests, SetPreferredLanguagesPlayingLiveAampTsbTest)
 	testp_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 	testp_aamp->SetContentType("LINEAR_TV");
 	testp_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
-	testp_aamp->SetState(eSTATE_PLAYING);
+	testp_aamp->SetState(eSTATE_PLAYING, true);
 
 	EXPECT_CALL(*g_mockAampJsonObject, isString(_)).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampJsonObject, get("languages", An<std::string&>())).WillOnce(DoAll(testing::SetArgReferee<1>("lang1"), Return(true)));
@@ -486,7 +486,7 @@ TEST_F(PrivAampPrivTests, SetPreferredLanguagesPlayingFromAampTsbTest)
 	testp_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 	testp_aamp->SetContentType("LINEAR_TV");
 	testp_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
-	testp_aamp->SetState(eSTATE_PLAYING);
+	testp_aamp->SetState(eSTATE_PLAYING, true);
 
 	EXPECT_CALL(*g_mockAampJsonObject, isString(_)).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockAampJsonObject, get("languages", An<std::string&>())).WillOnce(DoAll(testing::SetArgReferee<1>("lang1"), Return(true)));
@@ -2152,7 +2152,7 @@ TEST_F(PrivAampTests,EndOfStreamReachedTest)
 
 TEST_F(PrivAampTests,EndOfStreamReachedTest_1)
 {
-	p_aamp->SetState(eSTATE_BUFFERING);
+	p_aamp->SetState(eSTATE_BUFFERING, true);
 	p_aamp->EndOfStreamReached(eMEDIATYPE_VIDEO);
 }
 
@@ -2277,7 +2277,7 @@ TEST_F(PrivAampTests,SetVideoRectangleTest_1)
 
 TEST_F(PrivAampTests,SetVideoRectangleTest_2)
 {
-	p_aamp->SetState(eSTATE_PAUSED);
+	p_aamp->SetState(eSTATE_PAUSED, true);
 
 	p_aamp->mMediaFormat = eMEDIAFORMAT_OTA;
 	p_aamp->SetVideoRectangle(100,200,300,400);
@@ -2404,7 +2404,7 @@ TEST_F(PrivAampTests,UnlockGetPositionMsTest)
 
 TEST_F(PrivAampTests,GetPositionRelativeToSeekMillisecondsTest)
 {
-	p_aamp->SetState(eSTATE_SEEKING);
+	p_aamp->SetState(eSTATE_SEEKING, true);
 	long long val  = p_aamp->GetPositionRelativeToSeekMilliseconds();
 	EXPECT_EQ(val,0);
 }
@@ -2412,7 +2412,7 @@ TEST_F(PrivAampTests,GetPositionRelativeToSeekMillisecondsTest)
 TEST_F(PrivAampTests,GetPositionRelativeToSeekMillisecondsTest_1)
 {
 	p_aamp->seek_pos_seconds = 123450;
-	p_aamp->SetState(eSTATE_SEEKING);
+	p_aamp->SetState(eSTATE_SEEKING, true);
 	long long val  = p_aamp->GetPositionRelativeToSeekMilliseconds();
 	EXPECT_EQ(val,0);
 }
@@ -2560,7 +2560,7 @@ TEST_F(PrivAampTests, NotifyFirstFrameReceivedTest)
 
 TEST_F(PrivAampTests,NotifyFirstFrameReceivedTest_1)
 {
-	p_aamp->SetState(eSTATE_IDLE);
+	p_aamp->SetState(eSTATE_IDLE, true);
 	p_aamp->NotifyFirstFrameReceived(0);
 }
 
@@ -2576,7 +2576,7 @@ TEST_F(PrivAampTests,NotifyFirstFrameReceivedTest_2)
 
 TEST_F(PrivAampTests,NotifyFirstFrameReceivedTest_3)
 {
-	p_aamp->SetState(eSTATE_PLAYING);
+	p_aamp->SetState(eSTATE_PLAYING, true);
 
 	TuneType tuneType = eTUNETYPE_NEW_NORMAL;
 	p_aamp->TuneHelper(tuneType, true);
@@ -2603,7 +2603,7 @@ TEST_F(PrivAampTests,ScheduleRetuneTest)
 
 TEST_F(PrivAampTests,ScheduleRetuneTest_1)
 {
-	p_aamp->SetState(eSTATE_IDLE);
+	p_aamp->SetState(eSTATE_IDLE, true);
 	TuneType tuneType = eTUNETYPE_SEEKTOLIVE;
 	p_aamp->TuneHelper(tuneType, true);
 		p_aamp->ScheduleRetune(eGST_ERROR_PTS,eMEDIATYPE_VIDEO);
@@ -2613,19 +2613,19 @@ TEST_F(PrivAampTests,ScheduleRetuneTest_1)
 
 TEST_F(PrivAampTests,ScheduleRetuneTest_2)
 {
-	p_aamp->SetState(eSTATE_PLAYING);
+	p_aamp->SetState(eSTATE_PLAYING, true);
 	p_aamp->ScheduleRetune(eGST_ERROR_VIDEO_BUFFERING,eMEDIATYPE_VIDEO);
 	EXPECT_EQ(p_aamp->mDiscontinuityTuneOperationId,0);
 }
 
 TEST_F(PrivAampTests,GetStateTest)
 {
-	p_aamp->SetState(eSTATE_IDLE);
+	p_aamp->SetState(eSTATE_IDLE, true);
 
 	AAMPPlayerState state = p_aamp->GetState();
 
 	state = p_aamp->GetState();
-	p_aamp->SetState(eSTATE_PLAYING);
+	p_aamp->SetState(eSTATE_PLAYING, true);
 
 	state = p_aamp->GetState();
 }
@@ -2648,7 +2648,7 @@ TEST_F(PrivAampTests,NotifyFragmentCachingCompleteTest)
 
 TEST_F(PrivAampTests,NotifyFragmentCachingCompleteTest_1)
 {
-	p_aamp->SetState(eSTATE_BUFFERING);
+	p_aamp->SetState(eSTATE_BUFFERING, true);
 
 	AAMPPlayerState state = p_aamp->GetState();
 	EXPECT_EQ(state,5);
@@ -2825,7 +2825,7 @@ TEST_F(PrivAampTests, NotifyFirstBufferProcessedTest_VideoRectangleEmpty)
 
 TEST_F(PrivAampTests,NotifyFirstBufferProcessedTest_1)
 {
-	p_aamp->SetState(eSTATE_IDLE);
+	p_aamp->SetState(eSTATE_IDLE, true);
 
 	AAMPPlayerState state = p_aamp->GetState();
 	EXPECT_EQ(state,0);
@@ -2833,7 +2833,7 @@ TEST_F(PrivAampTests,NotifyFirstBufferProcessedTest_1)
 
 TEST_F(PrivAampTests,NotifyFirstBufferProcessedTest_2)
 {
-	p_aamp->SetState(eSTATE_SEEKING);
+	p_aamp->SetState(eSTATE_SEEKING, true);
 
 	TuneType tuneType = eTUNETYPE_NEW_NORMAL;
 	p_aamp->TuneHelper(tuneType, false);//true
@@ -2844,7 +2844,7 @@ TEST_F(PrivAampTests,NotifyFirstBufferProcessedTest_2)
 
 TEST_F(PrivAampTests,NotifyFirstBufferProcessedTest_3)
 {
-	p_aamp->SetState(eSTATE_SEEKING);
+	p_aamp->SetState(eSTATE_SEEKING, true);
 
 	TuneType tuneType = eTUNETYPE_NEW_NORMAL;
 	p_aamp->TuneHelper(tuneType, true);
@@ -3489,7 +3489,7 @@ TEST_F(PrivAampTests,UpdateMaxDRMSessionsTest1)
 }
 TEST_F(PrivAampTests,UpdateMaxDRMSessionsTest2)
 {
-	p_aamp->SetState(eSTATE_SEEKING);
+	p_aamp->SetState(eSTATE_SEEKING, true);
 	p_aamp->UpdateMaxDRMSessions();
 }
 TEST_F(PrivAampTests,GetVideoPlaybackQualityTest)
@@ -3946,7 +3946,7 @@ TEST_F(PrivAampTests,UpdateVideoEndMetricsTest15)
 TEST_F(PrivAampTests,NotifyFirstBufferProcessedTest1)
 {
 	//covering if condition when state == eSTATE_IDLE
-	p_aamp->SetState(eSTATE_IDLE);
+	p_aamp->SetState(eSTATE_IDLE, true);
 	p_aamp->NotifyFirstBufferProcessed(std::string());
 }
 TEST_F(PrivAampPrivTests,NotifyFirstBufferProcessedTest2)
@@ -4004,7 +4004,7 @@ TEST_F(PrivAampTests,IsFirstVideoFrameDisplayedRequiredTest1)
 TEST_F(PrivAampTests,NotifyFirstVideoFrameDisplayedTest1)
 {
 	p_aamp->TuneHelper(eTUNETYPE_SEEKTOLIVE,true);
-	p_aamp->SetState(eSTATE_IDLE);
+	p_aamp->SetState(eSTATE_IDLE, true);
 	p_aamp->NotifyFirstVideoFrameDisplayed();
 }
 TEST_F(PrivAampPrivTests,NotifyFirstVideoFrameDisplayedTest2)
@@ -4019,7 +4019,7 @@ TEST_F(PrivAampPrivTests,NotifyFirstVideoFrameDisplayedTest3)
 TEST_F(PrivAampTests,NotifyFirstVideoFrameDisplayedTest3)
 {
 	p_aamp->TuneHelper(eTUNETYPE_SEEKTOLIVE,true);
-	p_aamp->SetState(eSTATE_PAUSED);
+	p_aamp->SetState(eSTATE_PAUSED, true);
 	p_aamp->SetStateBufferingIfRequired();
 	p_aamp->NotifyFirstVideoFrameDisplayed();
 }
@@ -4144,7 +4144,7 @@ TEST_F(PrivAampTests,SendErrorEventTest11)
 {
 	p_aamp->mFogTSBEnabled = true;
 	p_aamp->IsFogTSBSupported();
-	p_aamp->SetState(eSTATE_INITIALIZED);
+	p_aamp->SetState(eSTATE_INITIALIZED, true);
 	p_aamp->SendErrorEvent(AAMP_TUNE_FAILURE_UNKNOWN,"DESCRIPTION",true,11,12,13,"responseString");
 }
 
@@ -4160,6 +4160,41 @@ TEST_F(PrivAampTests,stopTest_11)
 	p_aamp->mFogTSBEnabled = true;
 	p_aamp->IsFogTSBSupported();
 	p_aamp->Stop();
+}
+
+TEST_F(PrivAampTests, Stop_StateTransition_WithStateChangeEvent)
+{
+	// Setup: Register for AAMP_EVENT_STATE_CHANGED event
+	EXPECT_CALL(*g_mockAampEventManager, IsEventListenerAvailable(AAMP_EVENT_STATE_CHANGED))
+		.WillRepeatedly(Return(true));
+
+	// Expect: AAMP_EVENT_STATE_CHANGED should be sent for both STOPPING and IDLE states
+	EXPECT_CALL(*g_mockAampEventManager, SendEvent(AnEventOfType(AAMP_EVENT_STATE_CHANGED), _))
+		.Times(2);
+
+	// Action: Call Stop with sendStateChangeEvent = true
+	p_aamp->Stop(true);
+
+	// Verify: Final state should be IDLE after Stop() completes
+	AAMPPlayerState finalState = p_aamp->GetState();
+	EXPECT_EQ(finalState, eSTATE_IDLE);
+}
+
+TEST_F(PrivAampTests, Stop_StateTransition_WithoutStateChangeEvent)
+{
+	// Setup: Register for AAMP_EVENT_STATE_CHANGED event
+	EXPECT_CALL(*g_mockAampEventManager, IsEventListenerAvailable(AAMP_EVENT_STATE_CHANGED))
+		.WillRepeatedly(Return(true));
+
+	// Expect: AAMP_EVENT_STATE_CHANGED should NOT be sent when sendStateChangeEvent = false
+	EXPECT_CALL(*g_mockAampEventManager, SendEvent(AnEventOfType(AAMP_EVENT_STATE_CHANGED), _)).Times(0);
+
+	// Action: Call Stop with sendStateChangeEvent = false
+	p_aamp->Stop(false);
+
+	// Verify: Final state should be IDLE even without sending events
+	AAMPPlayerState finalState = p_aamp->GetState();
+	EXPECT_EQ(finalState, eSTATE_IDLE);
 }
 
 TEST_F(PrivAampTests,GetLastDownloadedManifestTest1)
@@ -4443,7 +4478,7 @@ TEST_F(PrivAampPrivTests, TuneHelperWithAampTsbConfigureFlushSequence)
 	testp_aamp->SetLocalAAMPTsbInjection(true);
 	testp_aamp->mAbsoluteEndPosition = ABS_END_POS;
 	testp_aamp->culledSeconds = SEEK_POS;
-	testp_aamp->SetState(eSTATE_PLAYING);
+	testp_aamp->SetState(eSTATE_PLAYING, true);
 	::testing::Sequence s;
 	AampLLDashServiceData stAampLLDashServiceData;
 	stAampLLDashServiceData.lowLatencyMode = true;

--- a/test/utests/tests/PrivateInstanceAAMP/LocalTSBTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/LocalTSBTests.cpp
@@ -354,7 +354,7 @@ TEST_F(LocalTSBTests, ScheduleRetuneTest)
 				});
 
 	mPrivateInstanceAAMP->Tune(testUrl, true, "LINEAR_TV");
-	mPrivateInstanceAAMP->SetState(eSTATE_PLAYING);
+	mPrivateInstanceAAMP->SetState(eSTATE_PLAYING, true);
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableCurlStore)).WillRepeatedly(Return(true));// uninteresting expect call
 
 	//trickplay case

--- a/test/utests/tests/PrivateInstanceAAMP/PauseAtTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/PauseAtTests.cpp
@@ -352,7 +352,7 @@ TEST_F(PauseAtTests, PausePosition_Playback)
     mPrivateInstanceAAMP->mAudioOnlyPb = false;
     mPrivateInstanceAAMP->durationSeconds = 3600;
 
-    mPrivateInstanceAAMP->SetState(eSTATE_PLAYING);
+    mPrivateInstanceAAMP->SetState(eSTATE_PLAYING, true);
 
     ASSERT_FALSE(mPrivateInstanceAAMP->mbDownloadsBlocked);
 
@@ -424,7 +424,7 @@ TEST_F(PauseAtTests, PausePosition_Trickmode)
     mPrivateInstanceAAMP->mAudioOnlyPb = false;
     mPrivateInstanceAAMP->durationSeconds = 3600;
 
-    mPrivateInstanceAAMP->SetState(eSTATE_PLAYING);
+    mPrivateInstanceAAMP->SetState(eSTATE_PLAYING, true);
 
     ASSERT_FALSE(mPrivateInstanceAAMP->mbDownloadsBlocked);
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioOnlyTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioOnlyTests.cpp
@@ -274,7 +274,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSelectionTests.cpp
@@ -236,7 +236,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -237,7 +237,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -467,7 +467,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -314,7 +314,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(mManifestUrl.c_str());
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/LinearFOGTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/LinearFOGTests.cpp
@@ -304,7 +304,7 @@ public:
 				mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 				/* Initialize MPD. */
-				EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+				EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 
 				EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 						.Times(AnyNumber())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/StreamSelectionTest.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/StreamSelectionTest.cpp
@@ -530,7 +530,7 @@ public:
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING))
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true))
 			.Times(AnyNumber());
 
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/subtitleTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/subtitleTests.cpp
@@ -251,7 +251,7 @@ public:
 		mStreamAbstractionAAMP_MPD->SetCDAIObject(mCdaiObj);
 		mPrivateInstanceAAMP->SetManifestUrl(TEST_MANIFEST_URL);
 		/* Initialize MPD. */
-		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING));
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_PREPARING, true));
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
 			.Times(AnyNumber())
 			.WillRepeatedly(Return(eSTATE_PREPARING));


### PR DESCRIPTION
VPLAY-12336: Remote keys became Unresponsive & Crashed("28665316")

Reason for change: During Stop(), set state to STOPPING & IDLE irrespective of sending events to avoid unnecessary execution. Modified PrivateInstanceAAMP::Stop() accordingly to send event based on new sendStateChangeEvent flag.

This fixes a regression from VPLAY-12336

Test Procedure: Refer Jira
Risks: Medium

---------