### PR TITLE
VPLAY-12637 [Rogers] [VIPA] AAMP does not return all available CC tracks

### DIFF
--- a/TextTrackInfo.h
+++ b/TextTrackInfo.h
@@ -108,7 +108,8 @@ struct TextTrackInfo
             (accessibilityType == track.accessibilityType) &&
             (label == track.label) &&
             (accessibilityItem == track.accessibilityItem) &&
-            (mType == track.mType));
+            (mType == track.mType) &&
+            (instreamId == track.instreamId));
     }
 
     bool operator < (const TextTrackInfo& track) const


### PR DESCRIPTION
Reason for change: AAMP does not return all the available CEA-708
 Closed Captions tracks in a Multiview stream

Changes:
* Added support to return all the available CEA-708 Closed Captions tracks in a Multiview stream

Test Procedure: Refer JIRA ticket

Risks: low