### PR TITLE
VPLAY-12662:Crash occurred once during linear channel tuning to LLD

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10009,7 +10009,10 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateMPD(bool init)
 				{
 					AAMPLOG_INFO("Got Manifest Updated . Continue with Fetcherloop");
 					// mCurrentPeriodIdx, mNumberOfPeriods based on mBasePeriodId
+					// Acquire lock to update current period to sync with ABR changes on video track
+					mMediaStreamContext[eMEDIATYPE_VIDEO]->AcquireMediaStreamContextLock();
 					ret = IndexNewMPDDocument();
+					mMediaStreamContext[eMEDIATYPE_VIDEO]->ReleaseMediaStreamContextLock();
 				}
 			}
 		}


### PR DESCRIPTION
Reason for change: The crash was due to the MPD update and ABR changes happening at the same time. The fix is to acquire a lock before updating the current period index to ensure that the ABR changes for video are synchronized with the MPD updates.
Risks: Low
Test Procedure: Test with LLD channels
Priority: P1
Signed-off-by: Nandakishor U M <nu641001@gmail.com>