### PR TITLE
Revert "Reapply "VPLAY-11062: Bringback with L2 & L3 fixes"

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -686,10 +686,6 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 
 		if (aamp->mpStreamAbstractionAAMP && !(aamp->mbUsingExternalPlayer))
 		{
-			if (aamp->mbDetached)
-			{
-				aamp->enableEventProcessing();
-			}
 			if ( AAMP_SLOWMOTION_RATE != rate && !aamp->mIsIframeTrackPresent && rate != AAMP_NORMAL_PLAY_RATE && rate != 0 && aamp->mMediaFormat != eMEDIAFORMAT_PROGRESSIVE)
 			{
 				AAMPLOG_WARN("Ignoring trickplay. No iframe tracks in stream");
@@ -1167,11 +1163,6 @@ void PlayerInstanceAAMP::SeekInternal(double secondsRelativeToTuneTime, bool kee
 	{
 		AAMPPlayerState state = GetState();
 		aamp->StopPausePositionMonitoring("Seek() called");
-
-		if (aamp->mbDetached)
-		{
-			aamp->enableEventProcessing();
-		}
 
 		if ((aamp->mMediaFormat == eMEDIAFORMAT_HLS || aamp->mMediaFormat == eMEDIAFORMAT_HLS_MP4) && (eSTATE_INITIALIZING == state)  && aamp->mpStreamAbstractionAAMP)
 		{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7383,24 +7383,6 @@ bool PrivateInstanceAAMP::IsPlayEnabled()
 }
 
 /**
- * @brief Enable event processing
- */
-void PrivateInstanceAAMP::enableEventProcessing()
-{
-	// Reset Event Manager State to IDLE to resume event processing
-	mEventManager->SetPlayerState(eSTATE_IDLE);
-}
-
-/**
- * @brief Disable event processing
- */
-void PrivateInstanceAAMP::disableEventProcessing()
-{
-	// Set Event Manager State to RELEASED to avoid further event processing
-	mEventManager->SetPlayerState(eSTATE_RELEASED);
-}
-
-/**
  * @brief Soft stop the player instance.
  *
  */
@@ -7442,7 +7424,6 @@ void PrivateInstanceAAMP::detach()
 		mbDetached=true;
 		mPlayerPreBuffered  = false;
 		mTelemetryInterval = 0;
-		disableEventProcessing();
 		//EnableDownloads();// enable downloads
 	}
 	else

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7431,6 +7431,8 @@ void PrivateInstanceAAMP::detach()
 		AampStreamSinkManager::GetInstance().DeactivatePlayer(this, false);
 	}
 	ReleaseStreamLock();
+	//This will flush pending events and avoids crash.
+	mEventManager->FlushPendingEvents();
 }
 
 /**

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3109,18 +3109,6 @@ public:
 	bool IsPlayEnabled();
 
 	/**
-	 *   @fn enableEventProcessing
-	 *
-	 *   @return void
-	 */
-	void enableEventProcessing();
-	/**
-	 *   @fn disableEventProcessing
-	 *
-	 *   @return void
-	 */
-	void disableEventProcessing();
-	/**
 	 * @fn detach
 	 *
 	 */

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -256,14 +256,6 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl, bool autoPlay, const
 	mFogTSBEnabled = strcasestr(mainManifestUrl, "tsb?");
 }
 
-void PrivateInstanceAAMP::enableEventProcessing()
-{
-}
-
-void PrivateInstanceAAMP::disableEventProcessing()
-{
-}
-
 void PrivateInstanceAAMP::detach()
 {
 }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -263,14 +263,6 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	mFogTSBEnabled = strcasestr(mainManifestUrl, "tsb?");
 }
 
-void PrivateInstanceAAMP::enableEventProcessing()
-{
-}
-
-void PrivateInstanceAAMP::disableEventProcessing()
-{
-}
-
 void PrivateInstanceAAMP::detach()
 {
 }


### PR DESCRIPTION
Reverts rdkcentral/aamp#653
Reason for change: Causing VPLAY-11573 regression and L2 failures.
Procedure: Refer Jira
Risks: No