### PR TITLE
VPLAY-12581 : [Rogers-RTK]Seamless audio transition with PTS Restamp …

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6991,7 +6991,7 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	AAMPStatusType ret = eAAMPSTATUS_OK;
 	uint64_t oldMediaSequenceNumber = 0;
 	uint32_t fragmentDuration = 0;
-	double   oldPlaylistPosition,diffInFetchedDuration,diffInInjectedDuration,newInjectedPosition;
+	double   oldPlaylistPosition,diffInFetchedDuration,diffInInjectedDuration;
 	int diffFragmentsDownloaded = 0;
 	double offsetFromStart;
 
@@ -7070,8 +7070,18 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	oldPlaylistPosition = pMediaStreamContext->fragmentTime;
 	oldMediaSequenceNumber = pMediaStreamContext->fragmentDescriptor.Number;
 
+	if(!aamp->IsLocalAAMPTsb())
+	{
+		AAMPLOG_INFO("IsLocalAAMPTsb is false, calculating the offsetFromStart with GetPositionSeconds : %lf and culledSeconds : %lf", aamp->GetPositionSeconds(), aamp->culledSeconds);
+		offsetFromStart = aamp->GetPositionSeconds() - aamp->culledSeconds;
+	}
+	else
+	{
+		AAMPLOG_INFO("IsLocalAAMPTsb is true, calculating the offsetFromStart with GetPositionSeconds : %lf and mCulledSeconds : %lf", aamp->GetPositionSeconds(), mCulledSeconds);
+		offsetFromStart = aamp->GetPositionSeconds() - mCulledSeconds;
+	}
+
 	/* Getting Gstreamer Play position */
-	offsetFromStart = aamp->GetPositionSeconds() - aamp->culledSeconds;
 	AAMPLOG_INFO( "Playlist pos offsetFromStart[%lf] culledSeconds[%lf]",offsetFromStart,aamp->culledSeconds );
 
 	UpdateSeekPeriodOffset(offsetFromStart);
@@ -7104,19 +7114,14 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	pMediaStreamContext->lastSegmentDuration = pMediaStreamContext->fragmentDescriptor.Time;
 	pMediaStreamContext->lastSegmentNumber = pMediaStreamContext->fragmentDescriptor.Number - 1;
 
-
-
-	/* Calculating the start time of the downloaded fragment */
-	newInjectedPosition = ( pMediaStreamContext->fragmentDescriptor.Time - fragmentDuration )/pMediaStreamContext->fragmentDescriptor.TimeScale;
-
 	/*Calculating the difference in Fetched duration, injected duration and diff in Media Sequence number */
 	diffInFetchedDuration = oldPlaylistPosition - pMediaStreamContext->fragmentTime;
-	diffInInjectedDuration = ( pMediaStreamContext->GetLastInjectedPosition() - newInjectedPosition );
+	diffInInjectedDuration = ( pMediaStreamContext->GetLastInjectedPosition() - pMediaStreamContext->fragmentTime );
 	diffFragmentsDownloaded = static_cast<int>(oldMediaSequenceNumber - pMediaStreamContext->fragmentDescriptor.Number);
 
-	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], newInjectedPosition[%lf] diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d]",
+	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d]",
 			oldPlaylistPosition,pMediaStreamContext->fragmentTime,diffInFetchedDuration, pMediaStreamContext->GetLastInjectedPosition(),
-			fragmentDuration, newInjectedPosition, diffInInjectedDuration,oldMediaSequenceNumber, pMediaStreamContext->fragmentDescriptor.Number,diffFragmentsDownloaded);
+			fragmentDuration, diffInInjectedDuration,oldMediaSequenceNumber, pMediaStreamContext->fragmentDescriptor.Number,diffFragmentsDownloaded);
 
 	pMediaStreamContext->resetAbort(false);
 	pMediaStreamContext->OffsetTrackParams(diffInFetchedDuration, diffInInjectedDuration, diffFragmentsDownloaded);

--- a/isobmff/isobmffprocessor.cpp
+++ b/isobmff/isobmffprocessor.cpp
@@ -174,7 +174,7 @@ void IsoBmffProcessor::resetPTSOnSubtitleSwitch(AampGrowableBuffer *pBuffer, dou
 /**
  *  @brief Update PTS and send pts for flush audio
  */
-void IsoBmffProcessor::resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position)
+void IsoBmffProcessor::resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position, double ptsOffset)
 {
 	IsoBmffBuffer buffer;
 	if(isRestampConfigEnabled && (playRate == AAMP_NORMAL_PLAY_RATE))
@@ -211,7 +211,8 @@ void IsoBmffProcessor::resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double
 
 		if(buffer.getFirstPTS(currentPTS))
 		{
-			double pos = (double)currentPTS / (double)currTimeScale;
+			AAMPLOG_INFO("IsoBmffProcessor %s First PTS from buffer is %" PRIu64 " with offset %lf", IsoBmffProcessorTypeName[type], currentPTS, ptsOffset);
+			double pos = ((double)currentPTS  / (double)currTimeScale) + ptsOffset;
 			p_aamp->FlushTrack((AampMediaType)type,pos);
 			AAMPLOG_MIL("Curr PTS %" PRIu64 " TS: %u",currentPTS,currTimeScale);
 		}

--- a/isobmff/isobmffprocessor.h
+++ b/isobmff/isobmffprocessor.h
@@ -155,7 +155,7 @@ public:
 	 * @param[in] reset - true/false
 	 * @return void
 	 */
-	void resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position) override;
+	void resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position, double ptsOffset = 0) override;
 
 	double getFirstPts( AampGrowableBuffer* pBuffer ) override
 	{

--- a/mediaprocessor.h
+++ b/mediaprocessor.h
@@ -138,15 +138,17 @@ public:
           */
 
 	virtual void resetPTSOnSubtitleSwitch(AampGrowableBuffer *pBuffer, double position) {};
-        /**
-          * @brief Reset PTS on audioSwitch
-          *
-          * @param[in] pBuffer - Pointer to the AampGrowableBuffer
-          * @param[in] position - position of fragment
-          * @return void
-          */
 
-	virtual void resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position) {};
+	/**
+	 * @brief Reset PTS on audioSwitch
+	 *
+	 * @param[in] pBuffer - Pointer to the AampGrowableBuffer
+	 * @param[in] position - position of fragment
+	 * @param[in] ptsOffset - offset to be applied for restamping
+	 * @return void
+	 */
+	virtual void resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position, double ptsOffset = 0) {};
+
 	/**
 	 * @brief Abort all operations
 	 *

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -523,7 +523,9 @@ void MediaTrack::UpdateTSAfterFetch(bool IsInitSegment)
 	{
 		if(playContext)
 		{
-			playContext->resetPTSOnAudioSwitch(&cachedFragment->fragment, cachedFragment->position);
+			AAMPLOG_INFO("Resetting PTS on audio track switch with MediaProcessor enabled. position: %f PTSOffsetSec: %f",
+						 cachedFragment->position, cachedFragment->PTSOffsetSec);
+			playContext->resetPTSOnAudioSwitch(&cachedFragment->fragment, cachedFragment->position, cachedFragment->PTSOffsetSec);
 		}
 		else
 		{

--- a/test/utests/fakes/FakeIsoBmffProcessor.cpp
+++ b/test/utests/fakes/FakeIsoBmffProcessor.cpp
@@ -67,7 +67,7 @@ void IsoBmffProcessor::initProcessorForRestamp()
 {
 }
 
-void IsoBmffProcessor::resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position)
+void IsoBmffProcessor::resetPTSOnAudioSwitch(AampGrowableBuffer *pBuffer, double position, double ptsOffset)
 {
 }
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -563,3 +563,85 @@ R"(<?xml version="1.0" encoding="utf-8"?>
     EXPECT_EQ(pMediaStreamContext->adaptationSetIdx,2);
     EXPECT_EQ(pMediaStreamContext->adaptationSetId,3);
 }
+
+/**
+ * @brief Unit test for verifying SwitchAudioTrack behavior in TSB mode
+ *
+ * This test verifies that when IsLocalAAMPTsb() returns true, the offsetFromStart
+ * calculation uses mCulledSeconds instead of aamp->culledSeconds.
+ *
+ * Test Steps:
+ * 1. Define an MPD manifest with multiple audio adaptation sets
+ * 2. Initialize MPD and enable LocalTSB configuration
+ * 3. Enable TSB mode by calling SetLocalAAMPTsb(true)
+ * 4. Set up culledSeconds and mock GetPositionMilliseconds()
+ * 5. Call SwitchAudioTrack() to switch to French audio
+ * 6. Verify the audio track switch succeeds in TSB mode
+ *
+ * Expected Results:
+ * - Audio track switch should work correctly in TSB mode using mCulledSeconds
+ * - The correct adaptation set should be selected (French audio)
+ */
+TEST_F(SwitchAudioTrackTests, SwitchAudioTrackInTSBMode)
+{
+	std::string fragmentUrl;
+	AAMPStatusType status;
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT2M0.0S" minBufferTime="PT4.0S">
+	<Period id="0" start="PT0.0S">
+		<AdaptationSet id="1" contentType="audio" segmentAlignment="true" lang="eng">
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+			<Representation id="English Stereo" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="128000">
+				<SegmentTemplate timescale="48000" media="dash/audio_eng_$Number%03d$.mp4" startNumber="1">
+					<SegmentTimeline>
+						<S t="0" d="96000" r="449" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet id="2" contentType="audio" segmentAlignment="true" lang="fra">
+			<Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+			<Representation id="French Stereo" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="128000">
+				<SegmentTemplate timescale="48000" media="dash/audio_fra_$Number%03d$.mp4" startNumber="1">
+					<SegmentTimeline>
+						<S t="0" d="96000" r="449" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	// Enable LocalTSB configuration for this test
+	mBoolConfigSettings[eAAMPConfig_LocalTSBEnabled] = true;
+
+	status = InitializeMPD(manifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_AUDIO);
+	EXPECT_NE(track, nullptr);
+	MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
+	EXPECT_EQ(pMediaStreamContext->adaptationSetIdx, 0);
+	pMediaStreamContext->enabled = true;
+
+	// Set up TSB mode - this will make IsLocalAAMPTsb() return true
+	mPrivateInstanceAAMP->SetLocalAAMPTsb(true);
+
+	// Set up culled seconds for the test
+	mPrivateInstanceAAMP->culledSeconds = 5.0;
+
+	// Switch to French audio
+	mPrivateInstanceAAMP->preferredLanguagesList.push_back("fra");
+
+	// Mock GetPositionMilliseconds to return a known value (15 seconds = 15000 ms)
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetPositionMilliseconds()).WillRepeatedly(Return(15000.0));
+
+	// Call SwitchAudioTrack which should use the TSB code path
+	mStreamAbstractionAAMP_MPD->SwitchAudioTrack();
+
+	// Verify the audio track was switched to French (adaptation set index 1, ID 2)
+	EXPECT_EQ(pMediaStreamContext->adaptationSetIdx, 1);
+	EXPECT_EQ(pMediaStreamContext->adaptationSetId, 2);
+}


### PR DESCRIPTION
…is not working (#1044)

VPLAY-12581 : [Rogers-RTK]Seamless audio transition with PTS Restamp is not working (#1044)

Reason for change:
1. For PTS Restamp case, position passed to FlushTrack() was incorrect; converted to relative position using PTS offset adjustments - this correction resolved the complete audio loss issue
2. In AAMP TSB mode, culledSeconds is set by the AAMP TSB Manager based on actual fragment position; changed offsetFromStart calculation to be relative to what's actually available in the manifest, not relative to the TSB window start - this resolved the audio loss issue on audio switch
3. diffInInjectedDuration - Fixed timeline domain mismatch calculation

Test Procedure: Test with audio track switching with PTS Restamp enabled

Risks: Low
priority : p1