### PR TITLE
VPLAY-12634 [VIPA] CEA-708 CC track selection failure on Multiview (#…

### DIFF
--- a/middleware/closedcaptions/PlayerCCManager.cpp
+++ b/middleware/closedcaptions/PlayerCCManager.cpp
@@ -643,6 +643,7 @@ int PlayerCCManagerBase::SetTrack(const std::string &track, const CCFormat forma
 	unsigned int trackNum = 0;
 	CCFormat finalFormat = eCLOSEDCAPTION_FORMAT_DEFAULT;
 	mTrack = track;
+	mTrackFormat = format;
 
 	// Check if track is CCx or SERVICEx or track number
 	// Could be from 1 -> 63
@@ -735,6 +736,7 @@ void PlayerCCManagerBase::RestoreCC()
 			mEnabled, mTrickplayStarted, mParentalCtrlLocked, (CheckCCHandle()) ? "set" : "not set");
 
 	std::string trackId = GetTrack();
+	CCFormat trackFormat = mTrackFormat;
 
 	const auto& textTracks = getLastTextTracks();
 	bool matchFound = false;
@@ -755,6 +757,7 @@ void PlayerCCManagerBase::RestoreCC()
 		{
 			std::string defaultTrack = textTracks.front().instreamId;
 			trackId = defaultTrack.empty() ? "CC1" : defaultTrack;
+			trackFormat = eCLOSEDCAPTION_FORMAT_DEFAULT;
 			MW_LOG_WARN("PlayerCCManagerBase::matching id not found, selecting %s as default", trackId.c_str());
 		}
 	}
@@ -762,9 +765,10 @@ void PlayerCCManagerBase::RestoreCC()
 	{
 		MW_LOG_WARN("PlayerCCManagerBase::tracklist empty selecting CC1 as default");
 		trackId = "CC1";
+		trackFormat = eCLOSEDCAPTION_FORMAT_DEFAULT;
 	}
 
-	SetTrack(trackId);
+	SetTrack(trackId, trackFormat);
 }
 
 /**
@@ -853,6 +857,7 @@ void PlayerCCManagerBase::ResetState()
 
 	mOptions = "";
 	mTrack = "";
+	mTrackFormat = eCLOSEDCAPTION_FORMAT_DEFAULT;
 	mLastTextTracks.clear();
 	mEnabled = false;
 	mTrickplayStarted = false;

--- a/middleware/closedcaptions/PlayerCCManager.h
+++ b/middleware/closedcaptions/PlayerCCManager.h
@@ -251,6 +251,7 @@ protected:
 	** or are added to. */
 	std::string mOptions{};                /**< CC rendering styles */
 	std::string mTrack{};                  /**< CC track */
+	CCFormat mTrackFormat{eCLOSEDCAPTION_FORMAT_DEFAULT}; /**< CC track format */
 	std::vector<CCTrackInfo> mLastTextTracks;
 	bool mEnabled{false};                  /**< true if CC rendering enabled, false otherwise */
 	bool mTrickplayStarted{false};         /**< If a trickplay is going on or not */

--- a/middleware/closedcaptions/rialto/PlayerRialtoCCManager.cpp
+++ b/middleware/closedcaptions/rialto/PlayerRialtoCCManager.cpp
@@ -26,6 +26,7 @@
 #include "PlayerRialtoCCManager.h"
 #include "PlayerLogManager.h" // Included for MW_LOG
 #include <glib-object.h>  // Included for g_object_set
+#include <cctype> // std::isdigit()
 
 /**
  * @brief stores Handle
@@ -48,7 +49,7 @@ int PlayerRialtoCCManager::Initialize(void * handle)
 	else if (changedHandle)
 	{
 		// Configure the new handle.
-		(void) SetTrack(GetTrack());
+		(void) SetTrack(GetTrack(), mTrackFormat);
 	}
 
 	return 0;
@@ -109,13 +110,34 @@ void PlayerRialtoCCManager::Release(int id)
  */
 int PlayerRialtoCCManager::SetTrack(const std::string &track, const CCFormat format)
 {
+	// Cache the original track string and the format so the prefix (if any)
+	// can be re-applied correctly from the cached values.
 	mTrack = track;	// For PlayerCCManager::GetTrack()
+	mTrackFormat = format;
 
 	MW_LOG_INFO("PlayerRialtoCCManager::set track \"%s\"", track.c_str());
 
 	if (nullptr != mSubtitleControlHandle)
 	{
-		g_object_set(mSubtitleControlHandle, "text-track-identifier", track.c_str(), NULL);
+		// We expect 'track' to have an alphabetic prefix. If it does not,
+		// add one based on 'format'.
+		std::string textTrackIdentifier;
+		if (!track.empty() && std::isdigit(static_cast<unsigned char>(track[0])))
+		{
+			if (eCLOSEDCAPTION_FORMAT_608 == format)
+			{
+				textTrackIdentifier = "CC";
+			}
+			else if (eCLOSEDCAPTION_FORMAT_708 == format)
+			{
+				textTrackIdentifier = "SERVICE";
+			}
+		}
+		textTrackIdentifier += track;
+
+		MW_LOG_INFO("PlayerRialtoCCManager::set track (modified) \"%s\"", textTrackIdentifier.c_str());
+
+		g_object_set(mSubtitleControlHandle, "text-track-identifier", textTrackIdentifier.c_str(), NULL);
 	}
 	else
 	{


### PR DESCRIPTION
…1010)

VPLAY-12634  [VIPA] CEA-708 Closed Captions track selection fails on Multiview stream

Reason for Change: This pull request fixes a CEA-708 closed caption track selection issue on multiview streams by ensuring that the track format (608/708) is properly cached and used when adding format-specific prefixes to numeric track identifiers in the Rialto closed caption manager.

Test Guidance: refer ticket

Risk: low
---------