### PR TITLE
VPLAY-12757: Crash occured once during linear channel tuning after device reboot

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -317,7 +317,7 @@ void MediaStreamContext::updateSkipPoint(double position, double duration )
 void MediaStreamContext::ABRProfileChanged(void)
 {
 	// TODO: Use this lock across all the functions which uses shared variables
-	AcquireMediaStreamContextLock();
+	std::lock_guard<std::recursive_mutex> lock(mMediaStreamContextMutex);
 	struct ProfileInfo profileMap = context->GetAdaptationSetAndRepresentationIndicesForProfile(context->currentProfileIndex);
 	// Get AdaptationSet Index and Representation Index from the corresponding profile
 	int adaptIdxFromProfile = profileMap.adaptationSetIndex;
@@ -365,7 +365,6 @@ void MediaStreamContext::ABRProfileChanged(void)
 		AAMPLOG_DEBUG("StreamAbstractionAAMP_MPD:: Not switching ABR %dx%d[%d] ",
 				representation->GetWidth(), representation->GetHeight(), representation->GetBandwidth());
 	}
-	ReleaseMediaStreamContextLock();
 }
 
 /**

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -281,18 +281,6 @@ public:
      */
     bool DownloadFragment(DownloadInfoPtr downloadInfo);
 
-    /**
-     * @fn AcquireMediaStreamContextLock
-     * @brief Acquire lock for MediaStreamContext
-     */
-    inline void AcquireMediaStreamContextLock() { mMediaStreamContextMutex.lock(); }
-
-    /**
-     * @fn ReleaseMediaStreamContextLock
-     * @brief Release lock for MediaStreamContext
-     */
-    inline void ReleaseMediaStreamContextLock() { mMediaStreamContextMutex.unlock(); }
-
     AampMediaType mediaType;
     struct FragmentDescriptor fragmentDescriptor;
     const IAdaptationSet *adaptationSet;
@@ -331,7 +319,7 @@ public:
     bool mReachedFirstFragOnRewind; /**< flag denotes if we reached the first fragment in a period on rewind */
     std::mutex fetchChunkBufferMutex;
     DownloadInfoPtr mActiveDownloadInfo;
-    std::mutex mMediaStreamContextMutex;
+    std::recursive_mutex mMediaStreamContextMutex; /**< Recursive mutex to protect MediaStreamContext state during ABR profile changes and playlist updates */
 }; // MediaStreamContext
 
 #endif /* MEDIASTREAMCONTEXT_H */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10015,9 +10015,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateMPD(bool init)
 					AAMPLOG_INFO("Got Manifest Updated . Continue with Fetcherloop");
 					// mCurrentPeriodIdx, mNumberOfPeriods based on mBasePeriodId
 					// Acquire lock to update current period to sync with ABR changes on video track
-					mMediaStreamContext[eMEDIATYPE_VIDEO]->AcquireMediaStreamContextLock();
+					std::lock_guard<std::recursive_mutex> lock(mMediaStreamContext[eMEDIATYPE_VIDEO]->mMediaStreamContextMutex);
 					ret = IndexNewMPDDocument();
-					mMediaStreamContext[eMEDIATYPE_VIDEO]->ReleaseMediaStreamContextLock();
 				}
 			}
 		}
@@ -13967,6 +13966,8 @@ void StreamAbstractionAAMP_MPD::OnFragmentDownloadComplete(bool status, Download
 		else if (pMediaStreamContext->profileChanged)
 		{ // Profile changed case, reuse the same downloadInfo for init header fetch
 			AAMPLOG_DEBUG("%s Profile changed, reuse downloadInfo for init header fetch", GetMediaTypeName(downloadInfo->mediaType));
+			// Lock the media stream context while fetching and injecting initialization to avoid race conditions
+			std::lock_guard<std::recursive_mutex> lock(pMediaStreamContext->mMediaStreamContextMutex);
 			// The absolute position for init fragment will be taken from latest media stream context last injected duration
 			// This is taken in DownloadFragment after scheduling new init fragment from here.
 			FetchAndInjectInitialization(downloadInfo->mediaType, downloadInfo->isDiscontinuity);


### PR DESCRIPTION
Reason for change: Crash occurred once during linear channel tuning after device reboot.
Risks: Low
Test Procedure: Test with linear
Priority: P1