### PR TITLE
VPLAY-12406 [CDAI][DE]Player freeze observed for a few seconds after …

### DIFF
--- a/AampMPDParseHelper.cpp
+++ b/AampMPDParseHelper.cpp
@@ -231,7 +231,7 @@ void AampMPDParseHelper::UpdateBoundaryPeriod(bool IsTrickMode)
 			continue;
 		}
 		break;
-	}	
+	}
 }
 /**
 * @brief Get content protection from representation/adaptation field
@@ -262,8 +262,8 @@ bool AampMPDParseHelper::IsPeriodEncrypted(int iPeriodIndex)
 		AAMPLOG_WARN("Invalid PeriodIndex given %d",iPeriodIndex);
 		return false;
 	}
-	
-	// check in the queue if already stored for data 
+
+	// check in the queue if already stored for data
 	if(mPeriodEncryptionMap.find(iPeriodIndex) != mPeriodEncryptionMap.end())
 	{
 		retVal =  mPeriodEncryptionMap[iPeriodIndex];
@@ -272,7 +272,7 @@ bool AampMPDParseHelper::IsPeriodEncrypted(int iPeriodIndex)
 	{
 		vector<IPeriod *> periods = mMPDInstance->GetPeriods();
 		IPeriod *period	=	periods.at(iPeriodIndex);
-		
+
 		if(period != NULL)
 		{
 			size_t numAdaptationSets = period->GetAdaptationSets().size();
@@ -280,13 +280,13 @@ bool AampMPDParseHelper::IsPeriodEncrypted(int iPeriodIndex)
 			{
 				const IAdaptationSet *adaptationSet = period->GetAdaptationSets().at(iAdaptationSet);
 				if(adaptationSet != NULL)
-				{				
+				{
 					if(0 != GetContentProtection(adaptationSet).size())
 					{
 						mPeriodEncryptionMap[iPeriodIndex] = true;
 						retVal = true;
 						break;
-					}				
+					}
 				}
 			}
 		}
@@ -299,16 +299,16 @@ bool AampMPDParseHelper::IsPeriodEncrypted(int iPeriodIndex)
  * @brief Check if Period is empty or not
  * @retval Return true on empty Period
  */
-bool AampMPDParseHelper::IsEmptyPeriod(int iPeriodIndex, bool checkIframe) 
+bool AampMPDParseHelper::IsEmptyPeriod(int iPeriodIndex, bool checkIframe)
 {
-	bool isEmptyPeriod = true;		
+	bool isEmptyPeriod = true;
 	if(iPeriodIndex >= mNumberOfPeriods || iPeriodIndex < 0)
 	{
 		AAMPLOG_WARN("Invalid PeriodIndex given %d",iPeriodIndex);
 		return isEmptyPeriod;
 	}
 
-	// check in the queue if already stored for data 
+	// check in the queue if already stored for data
 	std::pair<int,bool> key = std::make_pair(iPeriodIndex, checkIframe);
 	if(mPeriodEmptyMap.find(key) != mPeriodEmptyMap.end())
 	{
@@ -318,7 +318,7 @@ bool AampMPDParseHelper::IsEmptyPeriod(int iPeriodIndex, bool checkIframe)
 	else
 	{
 		vector<IPeriod *> periods = mMPDInstance->GetPeriods();
-		IPeriod *period	=	periods.at(iPeriodIndex);		
+		IPeriod *period	=	periods.at(iPeriodIndex);
 		if(period != NULL)
 		{
 			const std::vector<IAdaptationSet *> adaptationSets = period->GetAdaptationSets();
@@ -333,7 +333,7 @@ bool AampMPDParseHelper::IsEmptyPeriod(int iPeriodIndex, bool checkIframe)
 				{
 					if (IsIframeTrack(adaptationSet))
 					{
-						isEmptyPeriod = false;						
+						isEmptyPeriod = false;
 						break;
 					}
 				}
@@ -552,7 +552,7 @@ double AampMPDParseHelper::GetPeriodStartTime(int periodIndex,uint64_t mLastPlay
 							{
 								mLiveTimeFragmentSync = true;
 							}
-							
+
 							double duration = (aamp_GetPeriodDuration(periodIndex, mLastPlaylistDownloadTimeMs) / 1000);
 							double liveTime = (double)mLastPlaylistDownloadTimeMs / 1000.0;
 							if(mHasServerUtcTime)
@@ -572,7 +572,7 @@ double AampMPDParseHelper::GetPeriodStartTime(int periodIndex,uint64_t mLastPlay
 				else if (periodIndex > 0 && !mMPDInstance->GetPeriods().at(periodIndex-1)->GetDuration().empty())
 				{
 					string durationStr = mMPDInstance->GetPeriods().at(periodIndex -1)->GetDuration();
-					double previousPeriodStart = GetPeriodStartTime(periodIndex - 1,mLastPlaylistDownloadTimeMs); 
+					double previousPeriodStart = GetPeriodStartTime(periodIndex - 1,mLastPlaylistDownloadTimeMs);
 					double durationTotal = ParseISO8601Duration(durationStr.c_str());
 					periodStart = previousPeriodStart + (durationTotal / 1000);
 				}
@@ -647,7 +647,7 @@ double AampMPDParseHelper::GetPeriodEndTime(int periodIndex, uint64_t mLastPlayl
 					return periodEndTime;
 				}
 			}
-			
+
 			string startTimeStr = period->GetStart();
                         periodDurationMs = GetPeriodDuration(periodIndex,mLastPlaylistDownloadTimeMs,checkIFrame,IsUninterruptedTSB);
 			if((mMPDInstance->GetAvailabilityStarttime().empty()) && !(mMPDInstance->GetType() == "static"))
@@ -808,6 +808,72 @@ bool AampMPDParseHelper::aamp_HasSegmentTimeline(IPeriod * period)
 }
 
 /**
+ * @brief  A helper function to check if period has segment timeline and segments for video track
+ * @param period period of segment
+ * @return True if period has segment timeline for video otherwise false
+ */
+bool AampMPDParseHelper::aamp_HasSegmentTimeAndSegments(IPeriod *period)
+{
+	auto segmentTemplates = GetSegmentTemplateForVideo(period);
+	if (segmentTemplates && segmentTemplates->HasSegmentTemplate())
+	{
+		const ISegmentTimeline *segmentTimeline = segmentTemplates->GetSegmentTimeline();
+		if (segmentTimeline != nullptr)
+		{
+			std::vector<ITimeline *> &timelines = segmentTimeline->GetTimelines();
+			return timelines.size() > 0;
+		}
+	}
+	return false;
+}
+
+/**
+ * @brief  A helper function to check if period has segment template for video track
+ * @param period period of segment
+ * @return True if period has segment template for video otherwise false
+ */
+bool AampMPDParseHelper::aamp_HasSegmentTemplate(IPeriod * period)
+{
+	auto segmentTemplates = GetSegmentTemplateForVideo(period);
+	return (segmentTemplates && segmentTemplates->HasSegmentTemplate());
+}
+
+/**
+ * @brief  A helper function to get segment template for video track
+ * @param period period of segment
+ * @return SegmentTemplates structure for video track if present, otherwise empty SegmentTemplates
+ */
+std::shared_ptr<SegmentTemplates> AampMPDParseHelper::GetSegmentTemplateForVideo(IPeriod * period)
+{
+	std::shared_ptr<SegmentTemplates> segmentTemplates = nullptr;
+	const std::vector<IAdaptationSet *> adaptationSets = period->GetAdaptationSets();
+	if (adaptationSets.empty())
+	{
+		return segmentTemplates;
+	}
+
+	for (auto &adaptationSet : adaptationSets)
+	{
+		if (IsContentType(adaptationSet, eMEDIATYPE_VIDEO))
+		{
+			const ISegmentTemplate *adaptationSetTemplate = adaptationSet->GetSegmentTemplate();
+			const std::vector<IRepresentation *>& representations = adaptationSet->GetRepresentation();
+			if (!representations.empty())
+			{
+				const ISegmentTemplate *representationTemplate = representations.at(0)->GetSegmentTemplate();
+				if (adaptationSetTemplate || representationTemplate)
+				{
+					segmentTemplates = std::make_shared<SegmentTemplates>(representationTemplate, adaptationSetTemplate);
+					break;
+				}
+			}
+		}
+	}
+	return segmentTemplates;
+}
+
+
+/**
  * @brief Get duration of current period
  * @retval current period's duration
  */
@@ -952,7 +1018,7 @@ double AampMPDParseHelper::aamp_GetPeriodDuration(int periodIndex, uint64_t mpdD
 	double durationMs = 0;
 	vector<IPeriod *> periods = mMPDInstance->GetPeriods();
 	IPeriod *period	=	periods.at(periodIndex);
-	
+
 	std::string tempString = period->GetDuration();
 	if(!tempString.empty())
 	{
@@ -1086,7 +1152,7 @@ double AampMPDParseHelper::aamp_GetPeriodDuration(int periodIndex, uint64_t mpdD
 										{
 											durationMs = ParseISO8601Duration(tsbDepth.c_str());
 										}
-										//If MPD@timeShiftBufferDepth is not present, the period duration is should be based on the MPD@availabilityStartTime; and should not result in a value of 0. 
+										//If MPD@timeShiftBufferDepth is not present, the period duration is should be based on the MPD@availabilityStartTime; and should not result in a value of 0.
 										else
 										{
 											durationMs = mpdDownloadTime - (mAvailabilityStartTime * 1000);
@@ -1167,6 +1233,57 @@ double AampMPDParseHelper::aamp_GetPeriodDuration(int periodIndex, uint64_t mpdD
 				AAMPLOG_WARN("firstAdaptation is null");  //CID:84261 - Null Returns
 			}
 		}
+	}
+	return durationMs;
+}
+
+/**
+ *   @brief  Get Period Duration from start time of this period and next
+ *   @param  periodIndex Index of the period (modified to point to the next non-empty period if found)
+ *   @retval period duration in milliseconds, 0 if not obtainable
+ */
+double AampMPDParseHelper::GetPeriodDurationFromStart(int &periodIndex)
+{
+	// Get duration of current period based on "start" attribute of
+	// the current period and the next period.
+	// Empty following periods can occur so also check for segments in the
+	// following periods until we find a valid start time to calculate duration
+	// or we reach the end of periods.
+
+	double durationMs = 0;
+	vector<IPeriod *> periods = mMPDInstance->GetPeriods();
+	std::string periodStartStr = periods.at(periodIndex)->GetStart();
+	if (!periodStartStr.empty())
+	{
+		double periodStart = ParseISO8601Duration(periodStartStr.c_str());
+		for (int p = periodIndex + 1; p < periods.size(); p++)
+		{
+			std::string nextPeriodStartStr = periods.at(p)->GetStart();
+			bool hasSegments = aamp_HasSegmentTimeAndSegments(periods.at(p));
+
+			if (hasSegments && !nextPeriodStartStr.empty())
+			{
+				// We can calculate period duration by subtracting start time from next period start time.
+				double nextPeriodStart = ParseISO8601Duration(nextPeriodStartStr.c_str());
+				durationMs = nextPeriodStart - periodStart;
+				if (durationMs <= 0)
+				{
+					AAMPLOG_WARN("Invalid period duration periodStartTime %lf nextPeriodStart %lf durationMs %lf", periodStart, nextPeriodStart, durationMs);
+					durationMs = 0;
+					break;
+				}
+				periodIndex = p;
+				break;
+			}
+			else
+			{
+				AAMPLOG_TRACE("Start time or segments missing from period %s hasSegments %d", periods.at(p)->GetId().c_str(), hasSegments);
+			}
+		}
+	}
+	else
+	{
+		AAMPLOG_TRACE("Start time missing in period %s", periods.at(periodIndex)->GetId().c_str());
 	}
 	return durationMs;
 }
@@ -1342,7 +1459,7 @@ uint64_t AampMPDParseHelper::GetDurationFromRepresentation()
 		{
 			AAMPLOG_WARN("mpd is null");  //CID:82158 - Null Returns
 		}
-		
+
 		if(period != NULL)
 		{
 			const std::vector<IAdaptationSet *> adaptationSets = period->GetAdaptationSets();
@@ -1619,7 +1736,7 @@ uint64_t AampMPDParseHelper::GetFirstSegmentStartTime(IPeriod * period)
 		}
 	}
 	SegmentTemplates segmentTemplates(representation,adaptationSet);
-	
+
 	if( segmentTemplates.HasSegmentTemplate() )
 	{
 		const ISegmentTimeline *segmentTimeline = segmentTemplates.GetSegmentTimeline();

--- a/AampMPDParseHelper.h
+++ b/AampMPDParseHelper.h
@@ -76,11 +76,11 @@ class PeriodElement
 private:
 	const IRepresentation *pRepresentation; // primary (representation)
 	const IAdaptationSet *pAdaptationSet; // secondary (adaptation set)
-	
+
 public:
 	PeriodElement(const PeriodElement &other) = delete;
 	PeriodElement& operator=(const PeriodElement& other) = delete;
-	
+
 	PeriodElement(const IAdaptationSet *adaptationSet, const IRepresentation *representation ):
 	pAdaptationSet(NULL),pRepresentation(NULL)
 	{
@@ -90,7 +90,7 @@ public:
 	~PeriodElement()
 	{
 	}
-	
+
 	std::string GetMimeType()
 	{
 		std::string mimeType;
@@ -109,7 +109,7 @@ class SegmentTemplates
 private:
 	const ISegmentTemplate *segmentTemplate1; // primary (representation)
 	const ISegmentTemplate *segmentTemplate2; // secondary (adaptation set)
-	
+
 public:
 	SegmentTemplates(const SegmentTemplates &other) = delete;
 	SegmentTemplates& operator=(const SegmentTemplates& other) = delete;
@@ -127,7 +127,7 @@ public:
 	{
 		return segmentTemplate1 || segmentTemplate2;
 	}
-	
+
 	std::string Getmedia()
 	{
 		std::string media;
@@ -135,7 +135,7 @@ public:
 		if( media.empty() && segmentTemplate2 ) media = segmentTemplate2->Getmedia();
 		return media;
 	}
-	
+
 	const ISegmentTimeline *GetSegmentTimeline()
 	{
 		const ISegmentTimeline *segmentTimeline = NULL;
@@ -143,7 +143,7 @@ public:
 		if( !segmentTimeline && segmentTemplate2 ) segmentTimeline = segmentTemplate2->GetSegmentTimeline();
 		return segmentTimeline;
 	}
-	
+
 	uint32_t GetTimescale()
 	{
 		uint32_t timeScale = 0;
@@ -160,7 +160,7 @@ public:
 		if( duration==0 && segmentTemplate2 ) duration = segmentTemplate2->GetDuration();
 		return duration;
 	}
-	
+
 	long GetStartNumber()
 	{
 		long startNumber = 0;
@@ -176,7 +176,7 @@ public:
 		if( presentationOffset==0 && segmentTemplate2) presentationOffset = segmentTemplate2->GetPresentationTimeOffset();
 		return presentationOffset;
 	}
-	
+
 	std::string Getinitialization()
 	{
 		std::string initialization;
@@ -216,37 +216,37 @@ public :
 	 *  @brief Copy assignment operator
 	 */
 	AampMPDParseHelper& operator=(const AampMPDParseHelper&) = delete;
-	
+
 	/**
 	*   @fn Initialize
-	*   @brief  Initialize the parser with MPD instance 
+	*   @brief  Initialize the parser with MPD instance
 	* 	@param[in] instance - MPD instance to parse
  	* 	@retval None
 	*/
 	void Initialize(dash::mpd::IMPD *instance);
 	/**
 	*   @fn Clear
-	*   @brief  Clear the parsed values in the helper 
+	*   @brief  Clear the parsed values in the helper
  	* 	@retval None
 	*/
 	void Clear();
 	/**
 	*   @fn IsLiveManifest
-	*   @brief  Returns if Manifest is Live Stream or not 
+	*   @brief  Returns if Manifest is Live Stream or not
  	* 	@retval bool . True if Live , False if VOD
 	*/
 	bool IsLiveManifest() { return mIsLiveManifest;}
 	/**
 	*   @fn GetMinUpdateDurationMs
-	*   @brief  Returns MinUpdateDuration from the manifest  
+	*   @brief  Returns MinUpdateDuration from the manifest
  	* 	@retval uint64_t Minimum Update Duration
 	*/
 	uint64_t GetMinUpdateDurationMs() { return mMinUpdateDurationMs;}
 	/**
 	*   @fn GetAvailabilityStartTime
-	*   @brief  Returns AvailabilityStartTime from the manifest  
+	*   @brief  Returns AvailabilityStartTime from the manifest
  	* 	@retval double . AvailabilityStartTime
-	*/	
+	*/
 	double GetAvailabilityStartTime() { return mAvailabilityStartTime;}
 	/**
 	*
@@ -257,37 +257,37 @@ public :
 	double GetPublishTime() { return mPublishTime; }
 	/**
 	*   @fn GetSegmentDurationSeconds
-	*   @brief  Returns SegmentDuration from the manifest  
+	*   @brief  Returns SegmentDuration from the manifest
  	* 	@retval uint64_t . SegmentDuration
 	*/
 	uint64_t GetSegmentDurationSeconds() { return mSegmentDurationSeconds;}
 	/**
 	*   @fn GetTSBDepth
-	*   @brief  Returns TSBDepth from the manifest  
+	*   @brief  Returns TSBDepth from the manifest
  	* 	@retval double . TSB Depth
 	*/
 	double GetTSBDepth() { return mTSBDepth;}
 	/**
 	*   @fn GetPresentationOffsetDelay
-	*   @brief  Returns PresentationOffsetDelay from the manifest  
+	*   @brief  Returns PresentationOffsetDelay from the manifest
  	* 	@retval double . OffsetDelay
 	*/
 	double GetPresentationOffsetDelay() { return mPresentationOffsetDelay;}
 	/**
 	*   @fn GetMediaPresentationDuration
-	*   @brief  Returns mediaPresentationDuration from the manifest  
+	*   @brief  Returns mediaPresentationDuration from the manifest
  	* 	@retval uint64_t . duration
 	*/
 	uint64_t GetMediaPresentationDuration()  {  return mMediaPresentationDuration;}
 	/**
 	*   @fn GetNumberOfPeriods
-	*   @brief  Returns Number of Periods from the manifest  
- 	* 	@retval int  
+	*   @brief  Returns Number of Periods from the manifest
+ 	* 	@retval int
 	*/
 	int GetNumberOfPeriods() { return mNumberOfPeriods;}
 	/**
 	*   @fn IsFogMPD
-	*   @brief  Returns Check if the manifest is from Fog  
+	*   @brief  Returns Check if the manifest is from Fog
  	* 	@retval bool . True if Fog , False if not Fog MPD
 	*/
 	bool IsFogMPD() { return mIsFogMPD;}
@@ -301,18 +301,18 @@ public :
 	/**
 	 * @fn GetContentProtection
 	 * @param[In] adaptation set and media type
-	 */	
+	 */
 	std::vector<IDescriptor*> GetContentProtection(const IAdaptationSet *adaptationSet);
 	/**
 	 * @fn IsEmptyPeriod
 	 * @param period period to check whether it is empty
-	 * @param checkIframe check only for Iframe Adaptation	 
+	 * @param checkIframe check only for Iframe Adaptation
 	 * @retval Return true on empty Period
 	 */
 	bool IsEmptyPeriod(int iPeriodIndex, bool checkIframe);
 	/**
 	 * @fn IsEmptyAdaptation
-	 * @param Adaptation Adaptation to check whether it is empty	 
+	 * @param Adaptation Adaptation to check whether it is empty
 	 */
 	bool IsEmptyAdaptation(IAdaptationSet *adaptationSet);
 	/**
@@ -327,13 +327,13 @@ public :
 	 *   @retval period duration in milliseconds
 	 */
 	double aamp_GetPeriodDuration(int periodIndex, uint64_t mpdDownloadTime);
-	
+
 	/**
  	  * @brief Check if adaptation set is of a given media type
 	  * @retval true if adaptation set is of the given media type
 	  */
 	bool IsContentType(const IAdaptationSet *adaptationSet, AampMediaType mediaType );
-	
+
 	/**
 	 * @fn GetPeriodDuration
 	 * @param mpd : pointer manifest
@@ -360,7 +360,7 @@ public :
 	bool GetLiveTimeFragmentSync() {return mLiveTimeFragmentSync;}
 
 	/**
-	 * @brief SetHasServerUtcTime 
+	 * @brief SetHasServerUtcTime
 	 * @param True - if UTCTiming element is available in the manifest else false
 	 */
 	void SetHasServerUtcTime(bool hasServerUtcTime) { mHasServerUtcTime = hasServerUtcTime; }
@@ -474,6 +474,36 @@ public :
     bool aamp_HasSegmentTimeline(IPeriod * period);
 
 	/**
+	 * @brief  A helper function to check if period has segment timeline and segments for video track
+	 * @param period period of segment
+	 * @return True if period has segment timeline for video otherwise false
+	 */
+	bool aamp_HasSegmentTimeAndSegments(IPeriod *period);
+
+	/**
+	 * @brief  A helper function to  check if period has segment template for video track
+	 * @param period period of segment
+	 * @return True if period has segment template for video otherwise false
+	 */
+	bool aamp_HasSegmentTemplate(IPeriod *period);
+
+	/**
+	 * @brief A helper function to get segment template for video
+	 * @param[in] period for current period
+	 *
+	 * @return segment template for video track
+	 */
+	std::shared_ptr<SegmentTemplates> GetSegmentTemplateForVideo(IPeriod *period);
+
+	/**
+	 *   @brief  Get Period Duration from start time of this period and next
+	 *   @param[in,out]  periodIndex, returns next non-empty period index
+	 *
+	 *   @retval period duration in milliseconds, 0 if not obtainable
+	 */
+	double GetPeriodDurationFromStart(int &periodIndex);
+
+	/**
 	 * @brief Get the MPD instance.
 	 *
 	 * @return const dash::mpd::IMPD* A pointer to the MPD instance.
@@ -515,7 +545,7 @@ private:
 	PeriodEncryptedMap	mPeriodEncryptionMap;
 	/* Container to store Period Empty map for MPD */
 	PeriodEmptyMap		mPeriodEmptyMap;
-	
+
 	bool mLiveTimeFragmentSync;
 	/*To check whether UTCTiming element is available in the manifest */
 	bool mHasServerUtcTime;

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -371,7 +371,7 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 								//matches the current periodId.This avoid incorrect calculation in split period cases
 								//where an ad spans next into the next period which could otherwise result in a negative value.
 								if( abObj.ads->at(mPlacementObj.curAdIdx).basePeriodId == periodId )
-								{ 
+								{
 									periodDurationAvailable -= abObj.ads->at(mPlacementObj.curAdIdx).basePeriodOffset;
 									if (periodDurationAvailable < 0)
 									{
@@ -517,6 +517,8 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 								// No ads left to place. lets mark the adbreak as complete
 								setAdMarkers(p2AdData.duration,periodDelta);
 								AAMPLOG_INFO("[CDAI] Current Ad completely placed.end period:%s end period offset:%" PRIu64 " adjustEndPeriodOffset:%d",periodId.c_str(),abObj.endPeriodOffset,abObj.adjustEndPeriodOffset);
+								//Remember segment number when the Ad ends so we know when subsequent segments added
+								mWaitForManifestUpdate = mPlacementObj.curEndNumber;
 								break;
 							}
 						}
@@ -569,45 +571,45 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 				else
 				{
 					// get current period duration
-					uint64_t currPeriodDuration = adMPDParseHelper->aamp_GetPeriodDuration(iter, 0);
-					int diff = (int)(currPeriodDuration - abObj.endPeriodOffset);
-					//--> Inserted Ads finishes < 2 seconds in new period : Channel play-back starts from new period.
-					if (diff < OFFSET_ALIGN_FACTOR)
+					uint64_t currPeriodDuration = adMPDParseHelper->GetPeriodDurationFromStart(iter);
+					int64_t diff = static_cast<int64_t>(currPeriodDuration) - static_cast<int64_t>(abObj.endPeriodOffset);
+					//Take copy because we do not want to change the value of mWaitForManifestUpdate via pass by ref.
+					uint64_t WaitForManifestUpdate_copy = mWaitForManifestUpdate;
+					int64_t periodDelta = static_cast<int64_t>(adMPDParseHelper->GetPeriodNewContentDurationMs(periods.at(iter), WaitForManifestUpdate_copy));
+
+					if ( currPeriodDuration == 0 && periodDelta < OFFSET_ALIGN_FACTOR )
 					{
-						// If the current period is not closed, we have to wait for it.
-						// This is because in following iterations, the current period could be updated such that
-						// diff > OFFSET_ALIGN_FACTOR, in which case its a partial ad.
-						// diff < OFFSET_ALIGN_FACTOR, in which case we have to align to next period.
-						// So check if next period available with valid duration
-						for (iter = iter+1; iter < periods.size(); iter++)
-						{
-							if (adMPDParseHelper->aamp_GetPeriodDuration(iter, 0) > 0)
-							{
-								break;
-							}
-						}
-						if (iter < periods.size())
-						{
-							auto nextPeriod = periods.at(iter);
-							// done with Adjustment
-							abObj.adjustEndPeriodOffset = false;
-							// Aligning to next period start
-							abObj.endPeriodOffset = 0;
-							abObj.endPeriodId = nextPeriod->GetId();
-							abObj.mAdBreakPlaced = true;
-							AAMPLOG_INFO("[CDAI] diff [%d] close to period end [%" PRIu64 "],Aligning to next-period:%s",
-											diff, currPeriodDuration, abObj.endPeriodId.c_str());
-						}
-						else
-						{
-							AAMPLOG_INFO("[CDAI] diff [%d] close to period end [%" PRIu64 "], but next period not available, waiting",
-											diff, currPeriodDuration);
-						}
+						// Cannot determine the duration of the period where the ads were inserted because the start time of
+						// the following period is not available.
+						// AND less than 2Sec of segments has been added to the period since the AD finished.
+						// This may be for a couple of reasons
+						// 1) The current period duration is significantly longer that the inserted ADs
+						// 2) Just closing the current period and the next period start not added to manifest.
+
+						AAMPLOG_INFO("[CDAI] Next period start not available. Waiting at currentPeriod %s periodDelta %" PRIi64,
+							 periods.at(iter)->GetId().c_str(), periodDelta);
+
+					}
+					else if (currPeriodDuration != 0 && diff < OFFSET_ALIGN_FACTOR )
+					{
+						// Ads have finished close to end of the period
+
+						auto nextPeriod = periods.at(iter);
+						// done with Adjustment
+						abObj.adjustEndPeriodOffset = false;
+						// Aligning to next period start
+						abObj.endPeriodOffset = 0;
+						abObj.endPeriodId = nextPeriod->GetId();
+						abObj.mAdBreakPlaced = true;
+						AAMPLOG_INFO("[CDAI] diff %" PRIi64 " close to period end duration %" PRIu64 ",Aligning to next-period:%s",
+									 diff, currPeriodDuration, abObj.endPeriodId.c_str());
 					}
 					// --> Inserted Ads finishes >= 2 seconds in current period : Channel playback starts from that position in the current period.
+					// OR we do not know when current period ends, have not established duration
 					else
 					{
-						AAMPLOG_INFO("[CDAI] diff [%d] NOT close to period end, period:%s duration[%" PRIu64 "]", diff, mPlacementObj.pendingAdbrkId.c_str(), currPeriodDuration);
+						AAMPLOG_INFO("[CDAI] diff %" PRIi64 " NOT close to period end, endPeriodId:%s duration %" PRIu64 " periodDelta %" PRIi64,
+							diff, abObj.endPeriodId.c_str(), currPeriodDuration, periodDelta);
 						// done with Adjustment
 						abObj.adjustEndPeriodOffset = false;
 						// adbrk duration not equal to src period duration continue to play source period for remaining duration
@@ -639,7 +641,7 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 					}
 					AAMPLOG_MIL("[CDAI] Detected split period: %s", splitStr.str().c_str());
 				}
-				//Printing the placement positions
+				//Printing the placement positions. Long log lines get truncated
 				std::stringstream ss;
 				ss<<"{AdbreakId: "<<mPlacementObj.pendingAdbrkId;
 				ss<<", duration: "<<abObj.adsDuration;

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -82,7 +82,7 @@ public:
 	}
 
 	/**
-	 * @fn SetAlternateContents 
+	 * @fn SetAlternateContents
 	 *
 	 * @param[in] periodId - Adbreak's unique identifier; the first period id
 	 * @param[in] adId - Individual Ad's id
@@ -366,7 +366,7 @@ public:
 	bool                                           mExitFulfillAdLoop;    /**< Flag to exit the Ad fulfillment loop */
 	std::mutex                                     mAdPlacementMtx;       /**< Mutex protecting Ad placement */
 	std::condition_variable                        mAdPlacementCV;        /**< Condition variable for Ad placement */
-
+	uint64_t                                       mWaitForManifestUpdate;/**< segment position in manifest at end of Ad */
 	/**
 	 * @fn PrivateCDAIObjectMPD
 	 *

--- a/test/utests/fakes/FakeAampMPDParseHelper.cpp
+++ b/test/utests/fakes/FakeAampMPDParseHelper.cpp
@@ -88,7 +88,7 @@ bool AampMPDParseHelper::IsPeriodEncrypted(int iPeriodIndex)
  * @brief Check if Period is empty or not
  * @retval Return true on empty Period
  */
-bool AampMPDParseHelper::IsEmptyPeriod(int iPeriodIndex, bool checkIframe) 
+bool AampMPDParseHelper::IsEmptyPeriod(int iPeriodIndex, bool checkIframe)
 {
 	return false;
 }
@@ -116,6 +116,11 @@ bool AampMPDParseHelper::IsIframeTrack(IAdaptationSet *adaptationSet)
  *   @retval period duration in milliseconds
  */
 double AampMPDParseHelper::aamp_GetPeriodDuration(int periodIndex, uint64_t mpdDownloadTime)
+{
+	return 0.0;
+}
+
+double AampMPDParseHelper::GetPeriodDurationFromStart(int &periodIndex)
 {
 	return 0.0;
 }

--- a/test/utests/tests/AampMPDParseHelper/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDParseHelper/FunctionalTests.cpp
@@ -233,7 +233,7 @@ TEST_F(FunctionalTests, Live_TSBEmpty_PerioDurationTest)
    </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -276,7 +276,7 @@ TEST_F(FunctionalTests, SinglePeriod_withDurationTag)
  </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -321,7 +321,7 @@ TEST_F(FunctionalTests, SinglePeriod_withoutDurationTag)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -755,7 +755,7 @@ TEST_F(FunctionalTests, SinglePeriod_withStartTimeTag_Live)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -770,7 +770,7 @@ TEST_F(FunctionalTests, SinglePeriod_withStartTimeTag_Live)
 	double periodStartTime = ParseHelper->GetPeriodStartTime(0,mpdDownloadTime);
 
 	// Check period startTime for index 0
-	// StartTime from the format "PT25S" 
+	// StartTime from the format "PT25S"
 	EXPECT_EQ(periodStartTime, 25);
 }
 
@@ -791,7 +791,7 @@ TEST_F(FunctionalTests, SinglePeriod_withoutStartTimeTag_Live)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -804,7 +804,7 @@ TEST_F(FunctionalTests, SinglePeriod_withoutStartTimeTag_Live)
 	uint64_t mpdDownloadTime ;
 	mpdDownloadTime  = ISO8601DateTimeToUTCSeconds(currentTimeISO.c_str());
 	double periodStartTime = ParseHelper->GetPeriodStartTime(0,mpdDownloadTime);
- 
+
 	EXPECT_EQ(periodStartTime, 0);
 }
 
@@ -841,7 +841,7 @@ TEST_F(FunctionalTests, MultiPeriod_withoutStartTag_Live)
 	</Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -878,7 +878,7 @@ TEST_F(FunctionalTests, PeriodEndTime1)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -916,7 +916,7 @@ TEST_F(FunctionalTests, PeriodEndTime_TestCase2)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -933,7 +933,7 @@ TEST_F(FunctionalTests, PeriodEndTime_TestCase2)
 	// To Check period Endime for index 0
 	// If it's the last period either use (in this strict order!) the media presentation duration or the period's duration- As per this priority given to mpd duration 60s and periodStart 0s =>periodEndTime = periodStart + duration =60
 	EXPECT_EQ(periodEndTime,60);
-	
+
 }
 
 
@@ -960,7 +960,7 @@ TEST_F(FunctionalTests, PeriodEndTime_TestCase3)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -1000,7 +1000,7 @@ TEST_F(FunctionalTests, PeriodEndTime_TestCase4)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -1034,7 +1034,7 @@ TEST_F(FunctionalTests, PeriodEndTime_TestCase5)
   </Period>
 </MPD>
 )";
-	
+
 	mManifest = manifest;
 	string currentTimeISO = "2023-01-01T00:10:00Z";
 	ManifestDownloadResponsePtr respData = nullptr;
@@ -1214,4 +1214,463 @@ TEST_F(FunctionalTests, TestForAbsoluteTime)
 	// Check if periodStart time parsed from MPD is as given in MPD
 
 	EXPECT_EQ(periodStartTime, 1721828763.00);
+}
+
+/*
+* Set of tests to test the various functions related to period start time calculation for a live asset
+* Specifically added for GetPeriodDurationFromStart() which should only return a
+* non zero value if the duration can be determined.
+*/
+TEST_F(FunctionalTests, Multiperiod_StartTimeLive1)
+{
+	dash::mpd::IMPD *mpd;
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="dynamic" id="9081974761380831163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT0H0M4.000S" maxSegmentDuration="PT0H0M2.016S" minimumUpdatePeriod="PT0H0M1.920S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2026-01-15T21:02:05.609Z">
+  <Period id="921098606" start="PT426410H58M28.193S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="643474069">
+      <Event presentationTime="643474069" duration="19098000">
+        <scte35:Signal>
+          <scte35:Binary>/DA3AAFvo8NFAP/wBQb+trbfUAAhAh9DVUVJCJPQ/3//AAEjaZABCTE0MzkwNTAyMzQAAAAAR2eV9g==</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="10002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="20002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098980" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+      <Representation id="root_video3" bandwidth="1328400" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+      <Representation id="root_video2" bandwidth="1996000" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="20002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="10002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098980" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video1" bandwidth="4459600" codecs="hvc1.1.6.L120.90" width="1280" height="720" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="30002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="10002,20002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098980" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video0" bandwidth="6052400" codecs="hvc1.1.6.L123.90" width="1920" height="1080" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="3" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098944" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659825267" d="181440" r="0"/>
+          <S t="660006707" d="161280" r="0"/>
+          <S t="660167987" d="181440" r="0"/>
+          <S t="660349427" d="161280" r="0"/>
+          <S t="660510707" d="181440" r="1"/>
+          <S t="660873587" d="161280" r="0"/>
+          <S t="661034867" d="181440" r="0"/>
+          <S t="661216307" d="161280" r="0"/>
+          <S t="661377587" d="181440" r="0"/>
+          <S t="661559027" d="161280" r="0"/>
+          <S t="661720307" d="181440" r="1"/>
+          <S t="662083187" d="161280" r="0"/>
+          <S t="662244467" d="181440" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio110" bandwidth="215200" codecs="ec-3" audioSamplingRate="48000"/>
+    </AdaptationSet>
+    <AdaptationSet id="4" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098833" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659833738" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio130" bandwidth="126400" codecs="mp4a.40.5" audioSamplingRate="24000"/>
+    </AdaptationSet>
+    <AdaptationSet id="30050" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" codingDependency="false" maxPlayoutRate="24">
+
+      <EssentialProperty schemeIdUri="http://dashif.org/guidelines/trickmode" value="10002 20002 30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" id="1" value="alternate"/>
+      <SegmentTemplate initialization="blah/track-iframe-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-iframe-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098974" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="iframe0" bandwidth="605240" codecs="hvc1.1.6.L123.90" width="1920" height="1080" frameRate="50000/1000"/>
+    </AdaptationSet>
+  </Period>
+</MPD>
+)";
+	mManifest = manifest;
+	string currentTimeISO = "2023-01-01T00:10:00Z";
+	ManifestDownloadResponsePtr respData = nullptr;
+	respData = GetManifestForMPDDownloader();
+	mpd = respData->mMPDInstance.get();
+	ParseHelper->Initialize(mpd);
+
+	EXPECT_NE(mpd, nullptr);
+	EXPECT_EQ(mpd->GetPeriods().size(), 1);
+
+	EXPECT_EQ(ParseHelper->IsLiveManifest(),true);
+	uint64_t mpdDownloadTime ;
+	mpdDownloadTime  = ISO8601DateTimeToUTCSeconds(currentTimeISO.c_str());
+	double periodDuration = ParseHelper->aamp_GetPeriodDuration(0,mpdDownloadTime);
+	// Check period duration
+	EXPECT_NEAR(periodDuration, 28800, 1); // = (14+1)*172800/90000 = 28800 milliseconds
+
+	double periodDuration1 = ParseHelper->GetPeriodDuration(0,mpdDownloadTime, false, false);
+	// Check period duration
+	EXPECT_NEAR(periodDuration1, 28800, 1);
+
+	int periodIdx = 0;
+	double periodDuration2 = ParseHelper->GetPeriodDurationFromStart(periodIdx);
+	EXPECT_EQ(periodIdx, 0);
+	EXPECT_EQ(periodDuration2, 0); //Cannot determine duration of period since no 2nd period and 1st period may be still ongoing
+}
+
+TEST_F(FunctionalTests, Multiperiod_StartTimeLive2)
+{
+	dash::mpd::IMPD *mpd;
+
+	//Harvested manifest with 30S TSB, Has 2 periods,
+	//2nd period has just been added so has no segments or start time
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="dynamic" id="9081974761380831163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT0H0M4.000S" maxSegmentDuration="PT0H0M2.016S" minimumUpdatePeriod="PT0H0M1.920S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2026-01-15T21:02:05.609Z">
+  <Period id="921098606" start="PT426410H58M28.193S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="643474069">
+      <Event presentationTime="643474069" duration="19098000">
+        <scte35:Signal>
+          <scte35:Binary>/DA3AAFvo8NFAP/wBQb+trbfUAAhAh9DVUVJCJPQ/3//AAEjaZABCTE0MzkwNTAyMzQAAAAAR2eV9g==</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="10002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="20002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098980" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+      <Representation id="root_video3" bandwidth="1328400" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+      <Representation id="root_video2" bandwidth="1996000" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="20002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="10002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098980" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video1" bandwidth="4459600" codecs="hvc1.1.6.L120.90" width="1280" height="720" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="30002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+       <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="10002,20002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098980" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video0" bandwidth="6052400" codecs="hvc1.1.6.L123.90" width="1920" height="1080" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="3" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098944" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659825267" d="181440" r="0"/>
+          <S t="660006707" d="161280" r="0"/>
+          <S t="660167987" d="181440" r="0"/>
+          <S t="660349427" d="161280" r="0"/>
+          <S t="660510707" d="181440" r="1"/>
+          <S t="660873587" d="161280" r="0"/>
+          <S t="661034867" d="181440" r="0"/>
+          <S t="661216307" d="161280" r="0"/>
+          <S t="661377587" d="181440" r="0"/>
+          <S t="661559027" d="161280" r="0"/>
+          <S t="661720307" d="181440" r="1"/>
+          <S t="662083187" d="161280" r="0"/>
+          <S t="662244467" d="181440" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio110" bandwidth="215200" codecs="ec-3" audioSamplingRate="48000"/>
+    </AdaptationSet>
+    <AdaptationSet id="4" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098833" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659833738" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio130" bandwidth="126400" codecs="mp4a.40.5" audioSamplingRate="24000"/>
+    </AdaptationSet>
+    <AdaptationSet id="30050" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1" codingDependency="false" maxPlayoutRate="24">
+
+      <EssentialProperty schemeIdUri="http://dashif.org/guidelines/trickmode" value="10002 20002 30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" id="1" value="alternate"/>
+      <SegmentTemplate initialization="blah/track-iframe-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-iframe-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098974" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="659818069" d="172800" r="14"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="iframe0" bandwidth="605240" codecs="hvc1.1.6.L123.90" width="1920" height="1080" frameRate="50000/1000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="921098607">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="662572069">
+      <Event presentationTime="662572069" duration="0">
+        <scte35:Signal>
+          <scte35:Binary>/DAwAAFvo8NFAP/wBQb+t9pI4AAaAhhDVUVJCJPQ/3+/AQkxNDM5MDUwMjM1AABavf9e</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
+  </Period>
+  <SupplementalProperty schemeIdUri="urn:scte:dash:powered-by" value="blah"/>
+</MPD>
+)";
+	mManifest = manifest;
+	string currentTimeISO = "2023-01-01T00:10:00Z";
+	ManifestDownloadResponsePtr respData = nullptr;
+	respData = GetManifestForMPDDownloader();
+	mpd = respData->mMPDInstance.get();
+	ParseHelper->Initialize(mpd);
+
+	EXPECT_NE(mpd, nullptr);
+	EXPECT_EQ(mpd->GetPeriods().size(), 2);
+
+	EXPECT_EQ(ParseHelper->IsLiveManifest(),true);
+	uint64_t mpdDownloadTime ;
+	mpdDownloadTime  = ISO8601DateTimeToUTCSeconds(currentTimeISO.c_str());
+	double periodDuration = ParseHelper->aamp_GetPeriodDuration(0,mpdDownloadTime);
+	// Check period duration
+	EXPECT_NEAR(periodDuration, 28800, 1); // = (14+1)*172800/90000 = 28800 milliseconds
+
+	double periodDuration1 = ParseHelper->GetPeriodDuration(0,mpdDownloadTime, false, false);
+	// Check period duration
+	EXPECT_NEAR(periodDuration1, 28800, 1);
+
+	int periodIdx = 0;
+	double periodDuration2 = ParseHelper->GetPeriodDurationFromStart(periodIdx);
+	EXPECT_EQ(periodIdx, 0);
+	EXPECT_EQ(periodDuration2, 0); //Cannot determine duration of period since start time missing from 2nd period
+}
+TEST_F(FunctionalTests, Multiperiod_StartTimeLive3)
+{
+	dash::mpd::IMPD *mpd;
+
+	//Harvested manifest with 30S TSB, Has 2 periods both with start time but 2nd has no segments yet.
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="dynamic" id="9081974761380831163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT0H0M4.000S" maxSegmentDuration="PT0H0M2.134S" minimumUpdatePeriod="PT0H0M1.920S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2026-01-15T21:02:11.365Z">
+  <Period id="921098606" start="PT426410H58M28.193S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="643474069">
+      <Event presentationTime="643474069" duration="19098000">
+        <scte35:Signal>
+          <scte35:Binary>/DA3AAFvo8NFAP/wBQb+trbfUAAhAh9DVUVJCJPQ/3//AAEjaZABCTE0MzkwNTAyMzQAAAAAR2eV9g==</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="10002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="20002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098983" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="660336469" d="172800" r="11"/>
+          <S t="662410069" d="162000" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+      <Representation id="root_video3" bandwidth="1328400" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+      <Representation id="root_video2" bandwidth="1996000" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="3" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098947" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="660349427" d="161280" r="0"/>
+          <S t="660510707" d="181440" r="1"/>
+          <S t="660873587" d="161280" r="0"/>
+          <S t="661034867" d="181440" r="0"/>
+          <S t="661216307" d="161280" r="0"/>
+          <S t="661377587" d="181440" r="0"/>
+          <S t="661559027" d="161280" r="0"/>
+          <S t="661720307" d="181440" r="1"/>
+          <S t="662083187" d="161280" r="0"/>
+          <S t="662244467" d="181440" r="0"/>
+          <S t="662425907" d="161280" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio110" bandwidth="215200" codecs="ec-3" audioSamplingRate="48000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="921098607" start="PT426411H2M0.300S">
+  </Period>
+  <SupplementalProperty schemeIdUri="urn:scte:dash:powered-by" value="blah"/>
+</MPD>
+)";
+
+	mManifest = manifest;
+	string currentTimeISO = "2023-01-01T00:10:00Z";
+	ManifestDownloadResponsePtr respData = nullptr;
+	respData = GetManifestForMPDDownloader();
+	mpd = respData->mMPDInstance.get();
+	ParseHelper->Initialize(mpd);
+	EXPECT_NE(mpd, nullptr);
+	EXPECT_EQ(mpd->GetPeriods().size(), 2);
+	EXPECT_EQ(ParseHelper->IsLiveManifest(),true);
+
+	uint64_t mpdDownloadTime ;
+	mpdDownloadTime  = ISO8601DateTimeToUTCSeconds(currentTimeISO.c_str());
+	double periodDuration = ParseHelper->aamp_GetPeriodDuration(0,mpdDownloadTime);
+	// Check period duration
+	EXPECT_NEAR(periodDuration, 24840, 1); //Duration by adding up segments
+
+	double periodDuration1 = ParseHelper->GetPeriodDuration(0,mpdDownloadTime, false, false);
+	// Check period duration
+	EXPECT_NEAR(periodDuration1, 24747, 1);
+
+	// start time but no segments in 2nd period cannot calculate duration
+	int periodIdx = 0;
+	double periodDuration2 = ParseHelper->GetPeriodDurationFromStart(periodIdx);
+	EXPECT_EQ(periodIdx, 0);
+	EXPECT_NEAR(periodDuration2, 0 , 1);
+}
+
+TEST_F(FunctionalTests, Multiperiod_StartTimeLive4)
+{
+	dash::mpd::IMPD *mpd;
+
+	//Harvested manifest with 30S TSB, Has 3 periods both with start time and segments.
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="dynamic" id="9081974761380831163" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT0H0M4.000S" maxSegmentDuration="PT0H0M2.134S" minimumUpdatePeriod="PT0H0M1.920S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2026-01-15T21:02:11.365Z">
+  <Period id="921098606" start="PT426410H58M28.193S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="643474069">
+      <Event presentationTime="643474069" duration="19098000">
+        <scte35:Signal>
+          <scte35:Binary>/DA3AAFvo8NFAP/wBQb+trbfUAAhAh9DVUVJCJPQ/3//AAEjaZABCTE0MzkwNTAyMzQAAAAAR2eV9g==</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="10002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="20002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098983" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="660336469" d="172800" r="11"/>
+          <S t="662410069" d="162000" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+      <Representation id="root_video3" bandwidth="1328400" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+      <Representation id="root_video2" bandwidth="1996000" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="3" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-header.mp4" media="blah-eac3/track-audio-periodid-921098606-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098947" presentationTimeOffset="643474069">
+        <SegmentTimeline>
+          <S t="660349427" d="161280" r="0"/>
+          <S t="660510707" d="181440" r="1"/>
+          <S t="660873587" d="161280" r="0"/>
+          <S t="661034867" d="181440" r="0"/>
+          <S t="661216307" d="161280" r="0"/>
+          <S t="661377587" d="181440" r="0"/>
+          <S t="661559027" d="161280" r="0"/>
+          <S t="661720307" d="181440" r="1"/>
+          <S t="662083187" d="161280" r="0"/>
+          <S t="662244467" d="181440" r="0"/>
+          <S t="662425907" d="161280" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio110" bandwidth="215200" codecs="ec-3" audioSamplingRate="48000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="921098999" start="PT426411H2M0.300S">
+  <!-- Empty period as can occur -->
+  </Period>
+  <Period id="921098607" start="PT426411H2M0.300S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="662572069">
+      <Event presentationTime="662572069" duration="0">
+        <scte35:Signal>
+          <scte35:Binary>/DAwAAFvo8NFAP/wBQb+t9pI4AAaAhhDVUVJCJPQ/3+/AQkxNDM5MDUwMjM1AABavf9e</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="10002" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <SupplementalProperty schemeIdUri="urn:mpeg:dash:adaptation-set-switching:2016" value="20002,30002" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah/track-video-periodid-921098607-repid-$RepresentationID$-tc-0-header.mp4" media="blah/track-video-periodid-921098607-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098996" presentationTimeOffset="662572069">
+        <SegmentTimeline>
+          <S t="662572069" d="183600" r="0"/>
+          <S t="662755669" d="172800" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+      <Representation id="root_video3" bandwidth="1328400" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+      <Representation id="root_video2" bandwidth="1996000" codecs="hvc1.1.6.L93.90" width="960" height="540" frameRate="50000/1000"/>
+    </AdaptationSet>
+    <AdaptationSet id="3" contentType="audio" mimeType="audio/mp4" lang="de">
+      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="blah-eac3/track-audio-periodid-921098607-repid-$RepresentationID$-tc-0-header.mp4" media="blah-eac3/track-audio-periodid-921098607-repid-$RepresentationID$-tc-0-frag-$Number$.mp4" timescale="90000" startNumber="921098960" presentationTimeOffset="662572069">
+        <SegmentTimeline>
+          <S t="662587187" d="181440" r="0"/>
+          <S t="662768627" d="161280" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="root_audio110" bandwidth="215200" codecs="ec-3" audioSamplingRate="48000"/>
+    </AdaptationSet>
+  </Period>
+  <SupplementalProperty schemeIdUri="urn:scte:dash:powered-by" value="blah"/>
+</MPD>
+)";
+
+	mManifest = manifest;
+	string currentTimeISO = "2023-01-01T00:10:00Z";
+	ManifestDownloadResponsePtr respData = nullptr;
+	respData = GetManifestForMPDDownloader();
+	mpd = respData->mMPDInstance.get();
+	ParseHelper->Initialize(mpd);
+	EXPECT_NE(mpd, nullptr);
+	EXPECT_EQ(mpd->GetPeriods().size(), 3);
+	EXPECT_EQ(ParseHelper->IsLiveManifest(),true);
+
+	uint64_t mpdDownloadTime ;
+	mpdDownloadTime  = ISO8601DateTimeToUTCSeconds(currentTimeISO.c_str());
+	double periodDuration = ParseHelper->aamp_GetPeriodDuration(0,mpdDownloadTime);
+	// Check period duration
+	EXPECT_NEAR(periodDuration, 24840, 1); //Duration by adding up segments
+
+	double periodDuration1 = ParseHelper->GetPeriodDuration(0,mpdDownloadTime, false, false);
+	// Check period duration
+	EXPECT_NEAR(periodDuration1, 24747, 1);
+
+	// Duration calculated by start(n+1) - start(n) I.E "PT426410H58M28.193S" - "PT426411H2M0.300S"
+	int periodIdx = 0;
+	double periodDuration2 = ParseHelper->GetPeriodDurationFromStart(periodIdx);
+	EXPECT_EQ(periodIdx, 2);
+	EXPECT_NEAR(periodDuration2, 212107, 1);
 }

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -203,10 +203,10 @@ public:
 
 /**
  * @brief Tests the functionality of inserting into the period map.
- * 
+ *
  * This test case verifies that the insertion of elements into the period map is working correctly.
  * It checks if the elements are inserted in the expected order and if the map size is updated accordingly.
- * 
+ *
  * @note This test case is part of the AdManagerMPDTests fixture.
  */
 TEST_F(AdManagerMPDTests, InsertToPeriodMapTest)
@@ -225,11 +225,11 @@ TEST_F(AdManagerMPDTests, InsertToPeriodMapTest)
 
 /**
  * @brief Tests the functionality of pruning the period maps.
- * 
+ *
  * This test case verifies that the `PrunePeriodMaps` function correctly removes ad breaks and periods
  * that are not present in the provided list of new period IDs.
  * This test case also verifies that the `ClearMaps` function correctly removes all ad breaks and periods
- * 
+ *
  * @note This test case is part of the AdManagerMPDTests fixture.
  */
 TEST_F(AdManagerMPDTests, PrunePeriodMapsTest)
@@ -271,10 +271,10 @@ TEST_F(AdManagerMPDTests, PrunePeriodMapsTest)
 
 /**
  * @brief Tests the functionality of the UpdatePlacementObj function when adBrkId equals endPeriodId.
- * 
+ *
  * This test case verifies that the `UpdatePlacementObj` function correctly sets the next placement object
  * when the ad break ID is the same as the end period ID.
- * 
+ *
  * @note This test case is part of the AdManagerMPDTests fixture.
  */
 TEST_F(AdManagerMPDTests, UpdatePlacementObjTest)
@@ -325,7 +325,7 @@ TEST_F(AdManagerMPDTests, UpdatePlacementObjTest)
 }
 
 /**
- * @brief Tests the functionality of the SetAlternateContents method 
+ * @brief Tests the functionality of the SetAlternateContents method
  * 1. when adId and url are empty.
  * 2. when adId and url are not empty and ad break object doesn't exists.
  */
@@ -942,12 +942,12 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_13)
 
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdResolvedEvent(adId, false, 0, 0, expectedError))
         .Times(1);
-    
+
     // Create initial ad break
-    
+
     // Try to add the ad that should fail with timeout
     mPrivateCDAIObjectMPD->SetAlternateContents(periodId, adId, url, startMS, breakdur);
-    
+
     // Wait for async operations
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
@@ -964,7 +964,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_13)
 
 /**
  * @brief Test error scenario for FulFillAdObject when manifest contains multiple periods.
- * 
+ *
  * This test ensures that if the ad manifest contains more than one period,
  * FulFillAdObject triggers SendAdResolvedEvent with eCDAI_ERROR_INVALID_MEDIA.
  */
@@ -980,7 +980,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_14)
 
     // Create an ad break object and add the test ad
     mPrivateCDAIObjectMPD->SetAlternateContents(periodId, "", "", startMS, breakdur);
- 
+
     // Prepare manifest with multiple periods - should trigger error
     const char *manifest =
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
@@ -992,7 +992,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_14)
         "</MPD>";
 
     InitializeAdMPD(manifest);
-    
+
     // Expect error event due to multiple periods
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdResolvedEvent(adId, false, 0, 0, expectedError)).Times(1);
 
@@ -1002,7 +1002,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_14)
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     // Assert
-    // mAdBreak updated and placementObj not created 
+    // mAdBreak updated and placementObj not created
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdObjThreadID.joinable());
     EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, "");
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
@@ -1483,7 +1483,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration, 0); // in ms
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, "testPeriodId2");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodId, "testPeriodId1");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodOffset, 0);
 }
@@ -1638,7 +1638,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
       </Representation>
     </AdaptationSet>
   </Period>
-  <Period id="testPeriodId1" start="PT30S">
+  <Period id="testPeriodId1" start="PT34S">
     <AdaptationSet id="1" contentType="video">
       <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
         <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
@@ -1678,13 +1678,13 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].endPeriodOffset, 30000); // placement completed and ending in same period ID
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 34000); // in ms
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced); // adBreak placed
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 34000); // in ms
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, "testPeriodId0");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0);
 
 
   // Update with same mpd again, and the params should not change
@@ -1697,7 +1697,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 34000); // in ms
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, "testPeriodId0");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0);
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced); // adBreak placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodOffset, 0);
@@ -1730,10 +1730,12 @@ R"(<?xml version="1.0" encoding="utf-8"?>
     </AdaptationSet>
   </Period>
   <Period id="testPeriodId1" start="PT30S">
+   <!-- This is an empty period that can appear in the manifest -->
   </Period>
 </MPD>
 )";
 
+//segments = (9+1)*2 + (3+1)*1 + (2+1)*2 = 30 Seconds
   static const char *manifest2 =
 R"(<?xml version="1.0" encoding="utf-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:00Z" maxSegmentDuration="PT2S" minBufferTime="PT4.000S" minimumUpdatePeriod="P100Y" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" publishTime="2023-01-01T00:01:00Z" timeShiftBufferDepth="PT5M" type="dynamic">
@@ -1751,6 +1753,18 @@ R"(<?xml version="1.0" encoding="utf-8"?>
     </AdaptationSet>
   </Period>
   <Period id="testPeriodId1" start="PT30S">
+  <!-- This is an empty period that can appear in the manifest -->
+  </Period>
+    <Period id="testPeriodId2" start="PT30S">
+        <AdaptationSet id="0" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p0_init.mp4" media="video_p0_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="75000" d="5000" r="0" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
   </Period>
 </MPD>
 )";
@@ -1763,6 +1777,11 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.push_back(mPrivateCDAIObjectMPD->mPlacementObj);
   mPrivateCDAIObjectMPD->mPlacementObj.curEndNumber = 9;
   mPrivateCDAIObjectMPD->mPlacementObj.adNextOffset = 18000;
+  // Have placed 18.0 Seconds of Ad and we know the period is at least 21.0 seconds long
+  // Increase Ad to 20.0 or provide Ad of 20.0 Seconds??
+  // From manifest1 we cannot determine when the period ends
+  // Expect add insertion to complete and
+  // [PlaceAds][612][CDAI] diff [-20000] NOT close to period end, period:testPeriodId0 duration[0]
 
   // Add ads to the adBreak
   mPrivateCDAIObjectMPD->mAdBreaks = {
@@ -1796,7 +1815,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 21000); // in ms
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, "testPeriodId0");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodId,periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodOffset, 0);
 }
@@ -1986,7 +2005,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 10000); // in ms
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed, true);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].endPeriodOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].endPeriodId, "testPeriodId2"); // next period
@@ -2145,7 +2164,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 20000); // in ms
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, periodId);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].offset2Ad[0].adStartOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed, true);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodId, "testPeriodId1");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).basePeriodOffset, 0);
@@ -2459,7 +2478,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,15000); //periodmap of periodid1 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.openPeriodId, periodId2); // open period changed to periodId2
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adNextOffset, 18000); // 3sec from periodId2 also placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adStartOffset, 15000); // ad starts from 15sec in periodId2
@@ -2478,7 +2497,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration,15000); //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId1); //adbreak share from periodId1
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 15000); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 15000);
 
 }
 
@@ -2622,19 +2641,19 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, true);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).placed, true);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 2); // periodId2 map created
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,15000); //periodmap of periodid1 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[10000].adIdx, 1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[10000].adStartOffset, 0);
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration,15000); //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 1);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 5000); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 5000);
+
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].endPeriodId, periodId3);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].endPeriodOffset, 0);
@@ -2779,23 +2798,23 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   mPrivateCDAIObjectMPD->PlaceAds(mAdMPDParseHelper);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mSplitPeriod, true); // split period identified
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 2); // periodId2 map created
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,15000); //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, true); // ad1 is placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).placed, true); // ad2 is placed
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].endPeriodId, periodId3);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].endPeriodOffset, 0);
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration,15000); //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 1);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 0); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 0);
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodId, "testPeriodId1");
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).basePeriodOffset, 0);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodId, "testPeriodId2");
@@ -2932,17 +2951,17 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, false);
   EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak not placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 2); // periodId2 map created
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,15000); //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
+
   //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 15000); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 15000);
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.openPeriodId, periodId2); // open period changed to periodId2
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adNextOffset, 18000); // 3sec from periodId2 also placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adStartOffset, 15000); // ad starts from 15sec in periodId2
@@ -3157,17 +3176,17 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   mPrivateCDAIObjectMPD->PlaceAds(mAdMPDParseHelper);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mSplitPeriod, true); // split period is identified only once periodDelta becomes zero
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 2); // periodId2 map created
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,10000); //periodmap of periodid1
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0); 
-  
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration,10000); //periodmap of periodid2 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
+
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].duration,10000); //periodmap of periodid2
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 10000); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 10000);
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.openPeriodId, periodId2); // open period changed to periodId2
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adNextOffset, 20000); // 10sec from periodId2 also placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.adStartOffset, 10000); // ad starts from 10sec in periodId2
@@ -3175,12 +3194,12 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   ProcessSourceMPD(manifest3);
   mPrivateCDAIObjectMPD->PlaceAds(mAdMPDParseHelper);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 3); // periodId3 map created
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId3].duration,10000); //periodmap of periodid3
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId3].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId3].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId3].offset2Ad[0].adStartOffset, 20000); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId3].offset2Ad[0].adStartOffset, 20000);
+
   //mPlacementObj is reset after placing ads, no EXPECT calls for same
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, true);
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak placed
@@ -3271,8 +3290,8 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   //periodmap of periodid1 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx,0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0); 
-  
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adStartOffset, 0);
+
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak placed
   EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mSplitPeriod); // should not be marked as split period
 
@@ -3284,7 +3303,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].adBreakId, periodId2);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adIdx, 0);
-  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 0); 
+  EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId2].offset2Ad[0].adStartOffset, 0);
 }
 
 /**
@@ -3473,7 +3492,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(0).placed, true); // since periodDelta==0, it advances to periodId2
   EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].mAdBreakPlaced); // adBreak not placed
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap.size(), 2); // periodId2 map created
-  
+
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration,15000); //periodmap of periodid1 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, periodId1);
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].offset2Ad[0].adIdx, 0);
@@ -3663,7 +3682,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).invalid, true); //invalid since its tiny period
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodId, ""); // second ad in break is not set
   EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId1].ads->at(1).basePeriodOffset, -1); // second ad in break is not placed
-  
+
   // periodmap is reset as endPeriodOffset is less than 2*OFFSET_ALIGN_FACTOR
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].duration, 0); //periodmap of periodid2 duration
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId1].adBreakId, ""); // periodmap is reset


### PR DESCRIPTION
…D… (#918)

VPLAY-12406 [CDAI][DE]Player freeze observed for a few seconds after DAI ad playback

Reason for Change: Adjusts CDAI MPD ad-break end alignment logic to address short player freezes observed after DAI ad playback.
- Updates PlaceAds() end-period adjustment to move playback to the next non-empty period when available, instead of waiting.
- Simplifies the “near period end” decision logic around adjustEndPeriodOffset.
- Minor formatting cleanup in the period duration adjustment block.

---------