### PR TITLE
VPLAY-12570: Limit buffering of AD fragments to live window

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9700,9 +9700,26 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 				for (int trackIdx = (mNumberOfTracks - 1); trackIdx >= 0; trackIdx--)
 				{
 					auto timeBasedBuffer = mMediaStreamContext[trackIdx]->GetTimeBasedBufferManager();
-					if (!mMediaStreamContext[trackIdx]->eos && timeBasedBuffer && !timeBasedBuffer->IsFull())
+					// For live stream in ad break, avoid fetching next segment if current fragment time is exceeding the live edge
+					// This is to avoid unnecessary fetch and also to avoid fetching segments which are not expected to be played
+					const bool exceedsLiveEdge = mCdaiObject &&
+							(AdState::IN_ADBREAK_AD_PLAYING == mCdaiObject->mAdState) &&
+							(mMediaStreamContext[trackIdx]->fragmentTime >= aamp->mAbsoluteEndPosition);
+
+					if (!mMediaStreamContext[trackIdx]->eos && timeBasedBuffer && !timeBasedBuffer->IsFull() && !exceedsLiveEdge)
 					{
 						AdvanceTrack(trackIdx, trickPlay, delta);
+					}
+					else
+					{
+						if (exceedsLiveEdge)
+						{
+							AAMPLOG_TRACE("Download skipped for trackIdx %d, eos %d, isFull %d, exceedsLiveEdge %d, fragmentTime %f, absoluteEndPos %f",
+									trackIdx, mMediaStreamContext[trackIdx]->eos,
+									timeBasedBuffer ? timeBasedBuffer->IsFull() : -1,
+									exceedsLiveEdge, mMediaStreamContext[trackIdx]->fragmentTime,
+									aamp->mAbsoluteEndPosition);
+						}
 					}
 				}
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -1785,6 +1785,52 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
 }
 
 /**
+ * @brief FetcherLoop tests.
+ *
+ * Verifies that when playing ad content at the live edge, AdvanceTrack is skipped
+ * if the fragment time exceeds the live edge.
+ */
+TEST_F(FetcherLoopTests, FetcherLoopSkipsAdvanceTrackWhenExceedsLiveEdge)
+{
+	std::string videoInitFragmentUrl;
+	AAMPStatusType status;
+
+	videoInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_p0_init.mp4");
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(videoInitFragmentUrl, _, _, _, _, true, _, _, _))
+		.Times(AnyNumber())
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, false, _, _, _))
+		.Times(0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection())
+		.WillRepeatedly(Return(false));
+
+	status = InitializeMPD(mLiveManifest, eTUNETYPE_SEEK, 0.0);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	mTestableStreamAbstractionAAMP_MPD->InvokeInitializeWorkers();
+
+	auto *cdaiObj = mTestableStreamAbstractionAAMP_MPD->GetCDAIObject();
+	ASSERT_NE(cdaiObj, nullptr);
+	cdaiObj->mAdState = AdState::IN_ADBREAK_AD_PLAYING;
+
+	mPrivateInstanceAAMP->mAbsoluteEndPosition = 10.0;
+	MediaTrack *track = mTestableStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	ASSERT_NE(track, nullptr);
+	auto *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
+	pMediaStreamContext->fragmentTime = 11.0;
+
+	int downloadsCounter = 0;
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.Times(AnyNumber())
+		.WillRepeatedly([&downloadsCounter]()
+			{
+				return (++downloadsCounter < 3);
+			});
+
+	mTestableStreamAbstractionAAMP_MPD->InvokeFetcherLoop();
+}
+
+/**
  * @brief BasicFetcherLoop tests.
  *
  * The tests verify the basic fetcher loop functionality for a Live multi-period MPD.


### PR DESCRIPTION
Reason for change: To avoid unnecessary fetch of ad fragments which are not expected to be played during live ad break, we should limit the buffering of ad fragments to live window.
Risks: Low
Test Procedure: Test with CDAI content and ensure ad fragment downloads are spaced out throughout ad break
Priority: P1
Signed-off-by: Nandakishor U M <nu641001@gmail.com>