### PR TITLE
VPLAY-12795 L2 1006 unreliable stdout mixup

### DIFF
--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -317,7 +317,7 @@ bool Aampcli::SetSessionId(std::string sid)
 	if (mPlayerSessionID.size() >= playerId)
 	{
 		mPlayerSessionID[playerId] = std::move(sid);
-		std::cout << "[AAMPCLI] SessionId - " << playerId << " # " << mPlayerSessionID[playerId] << std::endl;
+		AAMPCLI_PRINTF("[AAMPCLI] SessionId - %d # %s\n", playerId, mPlayerSessionID[playerId].c_str());
 	}
 
 	return true;


### PR DESCRIPTION
Reason for change: L2 1006 is unreliable
Use AAMPCLI_PRINTF(...) instead of std::cout to give less opportunity of thread switch part way through writing a log line