### PR TITLE
VPLAY-12800:"Technical Fault "Error message is displayed during long run playback of linear channel

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -506,7 +506,7 @@ void AampMPDDownloader::downloadMPDThread1()
 		}
 
 		//Timeout case during live refresh
-		if(!firstDownload && (CURLE_OPERATION_TIMEDOUT == mMPDData->mMPDDownloadResponse->iHttpRetValue  || CURLE_COULDNT_CONNECT == mMPDData->mMPDDownloadResponse->iHttpRetValue))
+		if(!firstDownload && (IsCurlTimeoutFailure(mMPDData->mMPDDownloadResponse->iHttpRetValue) || CURLE_COULDNT_CONNECT == mMPDData->mMPDDownloadResponse->iHttpRetValue))
 		{
 			AAMPLOG_WARN("Refresh every 500ms to handle a manifest timeout error.");
 			//Forcefully go with 500 ms refresh

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -345,19 +345,50 @@ TEST_F(FunctionalTests,
 	ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
 	ASSERT_TRUE(firstManifest->mIsLiveManifest);
 
-	// Wait up to 8 seconds for the second manifest to become available,
-	// instead of polling with a tight loop and usleep.
-	ManifestDownloadResponsePtr secondManifest =
-		mAampMPDDownloader->GetManifest(false, 8000);
+	// Wait up to 8 seconds for the second manifest to become available.
+	// Since GetManifest(false, ...) does not block for new data, poll
+	// until the returned pointer differs from the first manifest or the
+	// deadline is reached.
+	ManifestDownloadResponsePtr secondManifest;
+	{
+		auto deadline = std::chrono::steady_clock::now() +
+			std::chrono::milliseconds(8000);
+		do
+		{
+			secondManifest = mAampMPDDownloader->GetManifest(false, 0);
+			if (!secondManifest ||
+				secondManifest.get() != firstManifest.get())
+			{
+				break;
+			}
+			std::this_thread::sleep_for(
+				std::chrono::milliseconds(50));
+		} while (std::chrono::steady_clock::now() < deadline);
+	}
 	ASSERT_TRUE(secondManifest != nullptr);
 	ASSERT_TRUE(secondManifest.get() != firstManifest.get());
 	ASSERT_TRUE(IsCurlTimeoutFailure(
 		secondManifest->mMPDDownloadResponse->iHttpRetValue));
 
-	// Wait up to 1.8 seconds for the next manifest refresh instead of
-	// polling in a loop with periodic sleeps.
-	ManifestDownloadResponsePtr thirdManifest =
-		mAampMPDDownloader->GetManifest(false, 1800);
+	// Wait up to 1.8 seconds for the next manifest refresh. As above,
+	// poll until a different manifest pointer is observed or the
+	// deadline expires.
+	ManifestDownloadResponsePtr thirdManifest;
+	{
+		auto deadline = std::chrono::steady_clock::now() +
+			std::chrono::milliseconds(1800);
+		do
+		{
+			thirdManifest = mAampMPDDownloader->GetManifest(false, 0);
+			if (!thirdManifest ||
+				thirdManifest.get() != secondManifest.get())
+			{
+				break;
+			}
+			std::this_thread::sleep_for(
+				std::chrono::milliseconds(50));
+		} while (std::chrono::steady_clock::now() < deadline);
+	}
 
 	EXPECT_TRUE(thirdManifest != nullptr);
 	EXPECT_TRUE(thirdManifest.get() != secondManifest.get());

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -345,37 +345,21 @@ TEST_F(FunctionalTests,
 	ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
 	ASSERT_TRUE(firstManifest->mIsLiveManifest);
 
-	ManifestDownloadResponsePtr secondManifest = firstManifest;
-	auto secondStart = std::chrono::steady_clock::now();
-	while (std::chrono::steady_clock::now() - secondStart <
-			std::chrono::seconds(8))
-	{
-		auto current = mAampMPDDownloader->GetManifest(false, 0);
-		if ((current.get() != firstManifest.get()) &&
-			IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
-		{
-			secondManifest = current;
-			break;
-		}
-		usleep(100 * 1000);
-	}
+	// Wait up to 8 seconds for the second manifest to become available,
+	// instead of polling with a tight loop and usleep.
+	ManifestDownloadResponsePtr secondManifest =
+		mAampMPDDownloader->GetManifest(false, 8000);
+	ASSERT_TRUE(secondManifest != nullptr);
 	ASSERT_TRUE(secondManifest.get() != firstManifest.get());
+	ASSERT_TRUE(IsCurlTimeoutFailure(
+		secondManifest->mMPDDownloadResponse->iHttpRetValue));
 
-	auto betweenRefreshStart = std::chrono::steady_clock::now();
-	ManifestDownloadResponsePtr thirdManifest = secondManifest;
-	while (std::chrono::steady_clock::now() - betweenRefreshStart <
-			std::chrono::milliseconds(1800))
-	{
-		auto current = mAampMPDDownloader->GetManifest(false, 0);
-		if ((current.get() != secondManifest.get()) &&
-			IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
-		{
-			thirdManifest = current;
-			break;
-		}
-		usleep(100 * 1000);
-	}
+	// Wait up to 1.8 seconds for the next manifest refresh instead of
+	// polling in a loop with periodic sleeps.
+	ManifestDownloadResponsePtr thirdManifest =
+		mAampMPDDownloader->GetManifest(false, 1800);
 
+	EXPECT_TRUE(thirdManifest != nullptr);
 	EXPECT_TRUE(thirdManifest.get() != secondManifest.get());
 	EXPECT_TRUE(IsCurlTimeoutFailure(
 		thirdManifest->mMPDDownloadResponse->iHttpRetValue));

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -322,63 +322,63 @@ TEST_F(FunctionalTests,
 </MPD>
 )";
 
-    std::shared_ptr<ManifestDownloadConfig> inpData =
-        std::make_shared<ManifestDownloadConfig>(-1);
-    inpData->mTuneUrl = url1;
+	std::shared_ptr<ManifestDownloadConfig> inpData =
+		std::make_shared<ManifestDownloadConfig>(-1);
+	inpData->mTuneUrl = url1;
 
-    std::atomic<int> preProcessCount(0);
-    auto preProcessCallback = [&preProcessCount]() -> std::string
-    {
-        if (preProcessCount.fetch_add(1) == 0)
-        {
-            return std::string(kLiveMpdManifest);
-        }
-        return std::string();
-    };
+	std::atomic<int> preProcessCount(0);
+	auto preProcessCallback = [&preProcessCount]() -> std::string
+	{
+		if (preProcessCount.fetch_add(1) == 0)
+		{
+			return std::string(kLiveMpdManifest);
+		}
+		return std::string();
+	};
 
-    mAampMPDDownloader->Initialize(inpData, appName, preProcessCallback);
-    mAampMPDDownloader->Start();
+	mAampMPDDownloader->Initialize(inpData, appName, preProcessCallback);
+	mAampMPDDownloader->Start();
 
-    ManifestDownloadResponsePtr firstManifest =
-        mAampMPDDownloader->GetManifest(true, 2000);
-    ASSERT_TRUE(firstManifest != nullptr);
-    ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
-    ASSERT_TRUE(firstManifest->mIsLiveManifest);
+	ManifestDownloadResponsePtr firstManifest =
+		mAampMPDDownloader->GetManifest(true, 2000);
+	ASSERT_TRUE(firstManifest != nullptr);
+	ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
+	ASSERT_TRUE(firstManifest->mIsLiveManifest);
 
-    ManifestDownloadResponsePtr secondManifest = firstManifest;
-    auto secondStart = std::chrono::steady_clock::now();
-    while (std::chrono::steady_clock::now() - secondStart <
-            std::chrono::seconds(8))
-    {
-        auto current = mAampMPDDownloader->GetManifest(false, 0);
-        if ((current.get() != firstManifest.get()) &&
-            IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
-        {
-            secondManifest = current;
-            break;
-        }
-        usleep(100 * 1000);
-    }
-    ASSERT_TRUE(secondManifest.get() != firstManifest.get());
+	ManifestDownloadResponsePtr secondManifest = firstManifest;
+	auto secondStart = std::chrono::steady_clock::now();
+	while (std::chrono::steady_clock::now() - secondStart <
+			std::chrono::seconds(8))
+	{
+		auto current = mAampMPDDownloader->GetManifest(false, 0);
+		if ((current.get() != firstManifest.get()) &&
+			IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
+		{
+			secondManifest = current;
+			break;
+		}
+		usleep(100 * 1000);
+	}
+	ASSERT_TRUE(secondManifest.get() != firstManifest.get());
 
-    auto betweenRefreshStart = std::chrono::steady_clock::now();
-    ManifestDownloadResponsePtr thirdManifest = secondManifest;
-    while (std::chrono::steady_clock::now() - betweenRefreshStart <
-            std::chrono::milliseconds(1800))
-    {
-        auto current = mAampMPDDownloader->GetManifest(false, 0);
-        if ((current.get() != secondManifest.get()) &&
-            IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
-        {
-            thirdManifest = current;
-            break;
-        }
-        usleep(100 * 1000);
-    }
+	auto betweenRefreshStart = std::chrono::steady_clock::now();
+	ManifestDownloadResponsePtr thirdManifest = secondManifest;
+	while (std::chrono::steady_clock::now() - betweenRefreshStart <
+			std::chrono::milliseconds(1800))
+	{
+		auto current = mAampMPDDownloader->GetManifest(false, 0);
+		if ((current.get() != secondManifest.get()) &&
+			IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
+		{
+			thirdManifest = current;
+			break;
+		}
+		usleep(100 * 1000);
+	}
 
-    EXPECT_TRUE(thirdManifest.get() != secondManifest.get());
-    EXPECT_TRUE(IsCurlTimeoutFailure(
-        thirdManifest->mMPDDownloadResponse->iHttpRetValue));
+	EXPECT_TRUE(thirdManifest.get() != secondManifest.get());
+	EXPECT_TRUE(IsCurlTimeoutFailure(
+		thirdManifest->mMPDDownloadResponse->iHttpRetValue));
 
-    mAampMPDDownloader->Release();
+	mAampMPDDownloader->Release();
 }

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -28,6 +28,7 @@
 #include "priv_aamp.h"
 #include <thread>
 #include <unistd.h>
+#include <atomic>
 
 using ::testing::_;
 using ::testing::An;
@@ -299,4 +300,85 @@ TEST_F(FunctionalTests, AampMPDDownloader_NotifyLockup)
 
 	EXPECT_NO_THROW(mAampMPDDownloader->UnRegisterCallback());
 	EXPECT_NO_THROW(mAampMPDDownloader->Release());
+}
+
+TEST_F(FunctionalTests,
+    AampMPDDownloader_LiveRefreshRetriesWhenFailureIsTimeoutClass)
+{
+    static const char *kLiveMpdManifest =
+    R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2.000S" maxSegmentDuration="PT0H0M1.92S" minimumUpdatePeriod="PT0H0M3.0S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2024-11-08T12:53:09.725Z">
+    <Period id="901591170" start="PT416006H37M27.854S">
+        <AdaptationSet id="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+            <SegmentTemplate initialization="init-$RepresentationID$.mp4" media="seg-$Number$.m4s" timescale="90000" startNumber="901599260" presentationTimeOffset="20213">
+                <SegmentTimeline>
+                    <S t="1377581813" d="172800" r="14"/>
+                </SegmentTimeline>
+            </SegmentTemplate>
+            <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+        </AdaptationSet>
+    </Period>
+</MPD>
+)";
+
+    std::shared_ptr<ManifestDownloadConfig> inpData =
+        std::make_shared<ManifestDownloadConfig>(-1);
+    inpData->mTuneUrl = url1;
+
+    std::atomic<int> preProcessCount(0);
+    auto preProcessCallback = [&preProcessCount]() -> std::string
+    {
+        if (preProcessCount.fetch_add(1) == 0)
+        {
+            return std::string(kLiveMpdManifest);
+        }
+        return std::string();
+    };
+
+    mAampMPDDownloader->Initialize(inpData, appName, preProcessCallback);
+    mAampMPDDownloader->Start();
+
+    ManifestDownloadResponsePtr firstManifest =
+        mAampMPDDownloader->GetManifest(true, 2000);
+    ASSERT_TRUE(firstManifest != nullptr);
+    ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
+    ASSERT_TRUE(firstManifest->mIsLiveManifest);
+
+    ManifestDownloadResponsePtr secondManifest = firstManifest;
+    auto secondStart = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - secondStart <
+            std::chrono::seconds(8))
+    {
+        auto current = mAampMPDDownloader->GetManifest(false, 0);
+        if ((current.get() != firstManifest.get()) &&
+            IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
+        {
+            secondManifest = current;
+            break;
+        }
+        usleep(100 * 1000);
+    }
+    ASSERT_TRUE(secondManifest.get() != firstManifest.get());
+
+    auto betweenRefreshStart = std::chrono::steady_clock::now();
+    ManifestDownloadResponsePtr thirdManifest = secondManifest;
+    while (std::chrono::steady_clock::now() - betweenRefreshStart <
+            std::chrono::milliseconds(1800))
+    {
+        auto current = mAampMPDDownloader->GetManifest(false, 0);
+        if ((current.get() != secondManifest.get()) &&
+            IsCurlTimeoutFailure(current->mMPDDownloadResponse->iHttpRetValue))
+        {
+            thirdManifest = current;
+            break;
+        }
+        usleep(100 * 1000);
+    }
+
+    EXPECT_TRUE(thirdManifest.get() != secondManifest.get());
+    EXPECT_TRUE(IsCurlTimeoutFailure(
+        thirdManifest->mMPDDownloadResponse->iHttpRetValue));
+
+    mAampMPDDownloader->Release();
 }


### PR DESCRIPTION
Curl error 28 (timeout) should trigger a manifest refresh after 500ms and allow
playback to continue using already downloaded fragments. Due to a regression
introduced in VPLAY-10563, the player was exiting the download after first curl 28 failure.

This change ensures timeout-class failures do not terminate the download thread and instead trigger a manifest refresh after 500ms.