### PR TITLE
VPLAY-11126 [AAMP TSB] TsbReader waits for fragments in a tight loop

### DIFF
--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -63,6 +63,7 @@ AampTSBSessionManager::AampTSBSessionManager(PrivateInstanceAAMP *aamp)
 		, mCurrentWritePosition(0)
 		, mLastAdReservationMetaDataProcessed()
 		, mLastAdPlacementMetaDataProcessed()
+		, mStopWaitingForVideoTsb(false)
 {
 }
 
@@ -106,6 +107,8 @@ void AampTSBSessionManager::Init()
 			// Initialize TSB readers
 			InitializeTsbReaders();
 			mStopThread_.store(false);
+			// Clear flag, mReadMutex does not need to be locked because the threads that access this variable are not running yet.
+			mStopWaitingForVideoTsb = false;
 			// Start monitoring the write queue in a separate thread
 			mWriteThread = std::thread(&AampTSBSessionManager::ProcessWriteQueue, this);
 			mInitialized_ = true;
@@ -374,6 +377,20 @@ TsbFragmentDataPtr AampTSBSessionManager::RemoveFragmentDeleteInit(AampMediaType
 	return removedFragment;
 }
 
+void AampTSBSessionManager::NotifyVideoTsbWaiters()
+{
+	std::unique_lock<std::mutex> lock(mReadMutex);
+	mStopWaitingForVideoTsb = true;
+	mNewVideoTsbContentCV.notify_one();
+}
+
+void AampTSBSessionManager::WaitForVideoTsbContentOrAbort()
+{
+	std::unique_lock<std::mutex> lock(mReadMutex);
+	mNewVideoTsbContentCV.wait(lock, [this]() { return mStopWaitingForVideoTsb; });
+	mStopWaitingForVideoTsb = false;
+}
+
 /**
  * @brief Monitors the write queue and writes any pending data to AAMP TSB
  */
@@ -450,7 +467,14 @@ void AampTSBSessionManager::ProcessWriteQueue()
 							}
 						}
 					}
+
 					UnlockReadMutex();
+
+					if (mediatype == eMEDIATYPE_VIDEO)
+					{
+						NotifyVideoTsbWaiters();
+					}
+
 				}
 				else if (status == TSB::Status::ALREADY_EXISTS)
 				{

--- a/AampTSBSessionManager.h
+++ b/AampTSBSessionManager.h
@@ -89,6 +89,14 @@ public:
 	 */
 	void ProcessWriteQueue();
 	/**
+	 * @brief Wait for new TSB video fragment to be available or abort signal. Abort signal is set when downloads are disabled.
+	 */
+	void WaitForVideoTsbContentOrAbort();
+	/**
+	 * @brief Notifies waiting threads when new video TSB content is available or downloads are disabled
+	 */
+	void NotifyVideoTsbWaiters();
+	/**
 	 * @brief Set TSB length
 	 *
 	 * @param[in] length
@@ -407,6 +415,7 @@ private:
 	std::mutex mWriteQueueMutex;			// Mutex to synchronize access to the write queue.
 	std::mutex mReadMutex;					// Mutex to synchronize access to the data manager from reader and writer.
 	std::condition_variable mWriteThreadCV; // Condition variable to signal when data is available in the write queue
+	std::condition_variable mNewVideoTsbContentCV;	// Conditional variable used to signal when content has been written to the TSB
 	std::queue<TSBWriteData> mWriteQueue;	// Queue to store write data.
 	double mLastVideoPos;
 	double mStoreEndPosition; 		/**< Last reported TSB Store end position*/
@@ -414,6 +423,7 @@ private:
 	AampTime  mCurrentWritePosition; /**< The last fragment position written to the TSB */
 	std::shared_ptr<AampTsbMetaData> mLastAdReservationMetaDataProcessed; /**< Last ad reservation metadata processed */
 	std::shared_ptr<AampTsbMetaData> mLastAdPlacementMetaDataProcessed; /**< Last ad placement metadata processed */
+	bool mStopWaitingForVideoTsb;			// Flag to signal video TSB reader to stop waiting (new content available or downloads disabled)
 public:
 	PrivateInstanceAAMP *mAamp; /**< AAMP player's private instance */
 	std::shared_ptr<IsoBmffHelper> mIsoBmffHelper; /**< ISO BMFF helper object */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10262,9 +10262,9 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
  * @param[out] waitForFreeFrag - waitForFreeFragmentAvailable flag
  * @param[out] bCacheFullState - cache status for track
  *
- * @return void
+ * @return bool - true if a segment was found and cached, false otherwise
  */
-void StreamAbstractionAAMP_MPD::AdvanceTsbFetch(int trackIdx, bool trickPlay, double delta, bool &waitForFreeFrag, bool &bCacheFullState)
+bool StreamAbstractionAAMP_MPD::AdvanceTsbFetch(int trackIdx, bool trickPlay, double delta, bool &waitForFreeFrag, bool &bCacheFullState)
 {
 	class MediaStreamContext *pMediaStreamContext = mMediaStreamContext[trackIdx];
 	AampMediaType mediaType = (AampMediaType) trackIdx;
@@ -10275,6 +10275,7 @@ void StreamAbstractionAAMP_MPD::AdvanceTsbFetch(int trackIdx, bool trickPlay, do
 		tsbReader = tsbSessionManager->GetTsbReader(mediaType);
 	}
 	bool isAllowNextFrag = true;
+	bool fragmentCached {false};
 	int  maxCachedFragmentsPerTrack = (int)pMediaStreamContext->GetCachedFragmentChunksSize();
 
 	if (waitForFreeFrag && !trickPlay)
@@ -10305,7 +10306,7 @@ void StreamAbstractionAAMP_MPD::AdvanceTsbFetch(int trackIdx, bool trickPlay, do
 			// profile not changed and not at EOS
 			if(!pMediaStreamContext->profileChanged && tsbReader->TrackEnabled() && !tsbReader->IsEos())
 			{
-				bool fragmentCached = tsbSessionManager->PushNextTsbFragment(pMediaStreamContext, maxCachedFragmentsPerTrack - pMediaStreamContext->numberOfFragmentChunksCached);
+				fragmentCached = tsbSessionManager->PushNextTsbFragment(pMediaStreamContext, maxCachedFragmentsPerTrack - pMediaStreamContext->numberOfFragmentChunksCached);
 				AAMPLOG_TRACE("[%s] Fragment %s", GetMediaTypeName((AampMediaType)trackIdx), fragmentCached ? "cached" : "not cached");
 			}
 			if(pMediaStreamContext->numberOfFragmentChunksCached != maxCachedFragmentsPerTrack && bCacheFullState)
@@ -10313,6 +10314,7 @@ void StreamAbstractionAAMP_MPD::AdvanceTsbFetch(int trackIdx, bool trickPlay, do
 				bCacheFullState = false;
 			}
 	}
+	return fragmentCached;
 }
 
 /**
@@ -10343,14 +10345,17 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 		{
 			while (!exitLoop)
 			{
+				bool segmentFound {false};
 				for (int trackIdx = (mNumberOfTracks - 1); trackIdx >= 0; trackIdx--)
 				{
 					cacheFullStatus[trackIdx] = true;
 					if (!tsbSessionManager->GetTsbReader((AampMediaType) trackIdx)->IsEos())
 					{
-						AdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, cacheFullStatus[trackIdx]);
+						bool trackSegmentFound = AdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, cacheFullStatus[trackIdx]);
+						segmentFound = segmentFound || trackSegmentFound;
 					}
 				}
+
 				if(abortTsbReader)
 				{
 					AAMPLOG_INFO("Exit TsbReader due to abort");
@@ -10383,7 +10388,7 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 						exitLoop = true;
 						break;
 					}
-					AAMPLOG_TRACE("EOS from both tracks - Wait for next fragment");
+					AAMPLOG_INFO("EOS from both tracks - Wait for next fragment");
 					aamp->interruptibleMsSleep(500);
 				}
 				if(cacheFullStatus[eMEDIATYPE_VIDEO] || (vEOS && !aEOS))
@@ -10399,9 +10404,21 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 					}
 				}
 				else
-				{	// This sleep will hit when there is no content to download and cache is not full
-					// and refresh interval timeout not reached . To Avoid tight loop adding a min delay
-					aamp->interruptibleMsSleep(50);
+				{
+					if (segmentFound)
+					{
+						aamp->interruptibleMsSleep(50);				//To Avoid tight loop adding a small delay
+					}
+					// AAMP could reach the end of the TSB only when doing FF (rate > AAMP_NORMAL_PLAY_RATE)
+					else if (aamp->rate > AAMP_NORMAL_PLAY_RATE)
+					{
+						// All the segments in TSB have been sent to gstreamer, wait for new fragments to be available in TSB
+						tsbSessionManager->WaitForVideoTsbContentOrAbort();
+					}
+					else
+					{
+						AAMPLOG_WARN("No segment found for rate <= AAMP_NORMAL_PLAY_RATE");
+					}
 				}
 			} // Loop 2 : TSB FetchLoop
 		}

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -643,9 +643,9 @@ protected:
 	 * @param[out] waitForFreeFrag - waitForFreeFragmentAvailable flag
 	 * @param[out] bCacheFullState - cache status for track
 	 *
-	 * @return void
+	 * @return bool - true if a segment was found and cached, false otherwise
 	 */
-	void AdvanceTsbFetch(int trackIdx, bool trickPlay, double delta, bool &waitForFreeFrag, bool &bCacheFullState);
+	bool AdvanceTsbFetch(int trackIdx, bool trickPlay, double delta, bool &waitForFreeFrag, bool &bCacheFullState);
 
 	/**
 	 * @fn FetcherLoop

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7295,6 +7295,11 @@ void PrivateInstanceAAMP::DisableDownloads(void)
 		mDownloadsEnabled = false;
 		mDownloadsDisabled.notify_all();
 	}
+	// Unblock thread waiting on this condition.
+	if (mTSBSessionManager)
+	{
+		mTSBSessionManager->NotifyVideoTsbWaiters();
+	}
 	// Notify playlist downloader threads
 	if(mpStreamAbstractionAAMP)
 	{

--- a/test/utests/fakes/FakeTSBSessionManager.cpp
+++ b/test/utests/fakes/FakeTSBSessionManager.cpp
@@ -246,3 +246,11 @@ TsbFragmentDataPtr AampTSBSessionManager::RemoveFragmentDeleteInit(AampMediaType
 {
 	return nullptr;
 }
+
+void AampTSBSessionManager::WaitForVideoTsbContentOrAbort()
+{
+}
+
+void AampTSBSessionManager::NotifyVideoTsbWaiters()
+{
+}

--- a/test/utests/tests/AampTsbSessionManagerTests_Mocked/FunctionalTests.cpp
+++ b/test/utests/tests/AampTsbSessionManagerTests_Mocked/FunctionalTests.cpp
@@ -581,3 +581,33 @@ TEST_F(AampTsbSessionManagerTests, PushNextTsbFragment_SkipFragment_BoS)
 
 	EXPECT_TRUE(mAampTSBSessionManager->PushNextTsbFragment(mMediaStreamContext.get(), numFreeFragments));
 }
+
+// Test NotifyVideoTsbWaiters functionality
+TEST_F(AampTsbSessionManagerTests, NotifyVideoTsbWaiters)
+{
+	// Spawn a thread that waits for and consume the notification
+	std::thread consumerThread([this]() {
+		mAampTSBSessionManager->WaitForVideoTsbContentOrAbort();
+	});
+
+	// Brief sleep to allow thread to enter waiting state
+	// Note: This is a timing assumption, but std::thread provides no "is waiting" status check
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+	mAampTSBSessionManager->NotifyVideoTsbWaiters();
+
+	consumerThread.join();
+}
+
+// Test that WaitForVideoTsbContentOrAbort returns immediately when notification is already raised
+TEST_F(AampTsbSessionManagerTests, NotifyVideoTsbWaiters_BeforeWait)
+{
+	mAampTSBSessionManager->NotifyVideoTsbWaiters();
+
+	// Spawn a thread that waits for the notification
+	std::thread consumerThread([this]() {
+		mAampTSBSessionManager->WaitForVideoTsbContentOrAbort();
+	});
+
+	consumerThread.join();
+}

--- a/test/utests/tests/FragmentCollectorMpdTests/FragmentCollectorMpdTestCases.cpp
+++ b/test/utests/tests/FragmentCollectorMpdTests/FragmentCollectorMpdTestCases.cpp
@@ -41,9 +41,9 @@ public:
 		: StreamAbstractionAAMP_MPD(aamp, seekTime, rate) {}
 	
 	// Expose protected method for testing
-	void TestAdvanceTsbFetch(int trackIdx, bool trickPlay, double delta, bool &waitForFreeFrag, bool &bCacheFullState)
+	bool TestAdvanceTsbFetch(int trackIdx, bool trickPlay, double delta, bool &waitForFreeFrag, bool &bCacheFullState)
 	{
-		AdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, bCacheFullState);
+		return AdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, bCacheFullState);
 	}
 	
 	// Helper method to set mMediaStreamContext for testing
@@ -127,7 +127,9 @@ TEST_F(StreamAbstractionAAMP_MPD_Test, AdvanceTsbFetchTest)
 	EXPECT_CALL(*g_mockTSBSessionManager, PushNextTsbFragment(mediaStreamContext, _)).WillOnce(Return(true));
 
 	// Call the protected method through testable wrapper
-	mMpdStream->TestAdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, bCacheFullState);
+	bool result = mMpdStream->TestAdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, bCacheFullState);
+
+	EXPECT_TRUE(result);
 }
 
 /**
@@ -161,5 +163,7 @@ TEST_F(StreamAbstractionAAMP_MPD_Test, AdvanceTsbFetchTest_DisabledTrack_NoPushF
 	EXPECT_CALL(*g_mockTSBSessionManager, PushNextTsbFragment(mediaStreamContext, _)).Times(0);
 
 	// Call the protected method through testable wrapper
-	mMpdStream->TestAdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, bCacheFullState);
+	bool result = mMpdStream->TestAdvanceTsbFetch(trackIdx, trickPlay, delta, waitForFreeFrag, bCacheFullState);
+
+	EXPECT_FALSE(result);
 }


### PR DESCRIPTION
Reason for Change: When TsbReader tries to read the fragments that are not downloaded yet by the FetcherLoop, it enters into a quick tight loop. Fix here implements producer consumer design and wait for a conditional variable until new fragment is available.

Test Procedure: - Refer Ticket

Risks:low