### PR TITLE
VPLAY-12819: Process crashed while playing app content

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -791,7 +791,7 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 		pInterfacePlayerRDK->TriggerEvent(InterfaceCB::idleCb);
 		pInterfacePlayerRDK->IdleTaskClearFlags(privatePlayer->gstPrivateContext->firstProgressCallbackIdleTask);
 
-		if ( !(pInterfacePlayerRDK->TimerIsRunning( privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId)) )
+		if ( !(pInterfacePlayerRDK->TimerIsRunning( privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId)) && (pInterfacePlayerRDK->callbackMap[InterfaceCB::progressCb] != nullptr) )
 		{
 			double  reportProgressInterval = pInterfacePlayerRDK->m_gstConfigParam->progressTimer;
 			reportProgressInterval *= 1000; //convert s to ms


### PR DESCRIPTION
VPLAY-12819: Process crashed while playing app content
Reason for Change : added null pointer check before adding progress callback timer

Test Procedure: see ticket
Priority : p1
Risks: Low