### PR TITLE
VPLAY-12815 : [VIPA] IVOD content not playing from live edge when pos…

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1225,6 +1225,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, mCurrentVideoTrackId(-1)
 	, mIsTrackIdMismatch(false)
 	, mIsDefaultOffset(false)
+	, mPlayFromLive(false)
 	, mNextPeriodDuration(0)
 	, mNextPeriodStartTime(0)
 	, mNextPeriodScaledPtoStartTime(0)
@@ -6018,6 +6019,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	}
 
 	mIsDefaultOffset = (AAMP_DEFAULT_PLAYBACK_OFFSET == seek_pos_seconds);
+	mPlayFromLive = false;
 	if (mIsDefaultOffset)
 	{
 		// eTUNETYPE_NEW_NORMAL
@@ -6029,6 +6031,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 		// eTUNETYPE_NEW_NORMAL
 		// behavior is play live streams from 'live' point and VOD streams skip to the end (this will
 		// be corrected later for vod)
+		mPlayFromLive = true; // IVOD/CDVR case play from live(offset = -1), so set the flag to true
 		seek_pos_seconds = 0;
 	}
 	else
@@ -9190,7 +9193,9 @@ double PrivateInstanceAAMP::GetMidSeekPosOffset()
 }
 
 /**
- * @brief Check if Live Adjust is required for current content. ( For "vod/ivod/ip-dvr/cdvr/eas", Live Adjust is not required ).
+ * @brief Check if Live Adjust is required for current content.
+ * Returns true for live content (LINEAR_TV, SLE) and for IVOD/CDVR when playing from live edge (offset=-1 with dynamic manifest).
+ * Returns false for VOD, IP-DVR, EAS, and completed IVOD/CDVR recordings.
  */
 bool PrivateInstanceAAMP::IsLiveAdjustRequired()
 {
@@ -9199,8 +9204,19 @@ bool PrivateInstanceAAMP::IsLiveAdjustRequired()
 	switch (mContentType)
 	{
 		case ContentType_IVOD:
-		case ContentType_VOD:
 		case ContentType_CDVR:
+			// IVOD within live window should use live adjustment
+			// Check if manifest is dynamic AND play from live was requested
+			if (mIsLiveStream && mPlayFromLive)
+			{
+				retValue = true;  // Treat as live
+			}
+			else
+			{
+				retValue = false; // Treat as VOD
+			}
+			break;
+		case ContentType_VOD:
 		case ContentType_IPDVR:
 		case ContentType_EAS:
 			retValue = false;

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1114,6 +1114,7 @@ public:
 	bool mIsTrackIdMismatch;				/**< Indicate track_id mismatch in the trak box between periods */
 
 	bool mIsDefaultOffset; 					/**< Playback offset is not specified and we are using the default value/behavior */
+	bool mPlayFromLive;                     /**< Set to true when offset=-1 is passed from application to play IVOD/CDVR content from live edge */
 	bool mEncryptedPeriodFound;				/**< Will be set if an encrypted pipeline is found while pipeline is clear*/
 	bool mPipelineIsClear;					/**< To keep the status of pipeline (whether configured for clear or not)*/
 
@@ -2609,7 +2610,10 @@ public:
 	/**
 	 *   @fn IsLiveAdjustRequired
 	 *
-	 *   @return False if the content is either vod/ivod/cdvr/ip-dvr/eas
+	 *   @return True if live adjustment is required for the content.
+	 *           Returns true for live content (LINEAR_TV, SLE) and for IVOD/CDVR content 
+	 *           when playing from live edge (offset=-1 with dynamic manifest).
+	 *           Returns false for VOD, IP-DVR, EAS, and completed IVOD/CDVR recordings.
 	 */
 	bool IsLiveAdjustRequired();
 


### PR DESCRIPTION
…itionSeconds is not supplied in load request

Reason for Change :
IVOD and CDVR hot recording content not playing from the live edge when offset=-1 is explicitly passed. Both content types now correctly apply live adjustment when:
- Manifest is dynamic (mIsLiveStream=true)
- explicitly requests live playback (offset=-1)

Test Procedure: Play IVOD and CDVR hot recording with offset = -1
Priority : p1
Risks: Low