### PR TITLE
VPLAY-12834 ParseSegmentIndexBox incorrect index

### DIFF
--- a/AampBoxReader.h
+++ b/AampBoxReader.h
@@ -1,0 +1,125 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**************************************
+ * @file AampBoxReader.h
+ * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
+ **************************************/
+
+#ifndef __AAMP_BOX_READER_H__
+#define __AAMP_BOX_READER_H__
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+/**
+ * @class BoxReader
+ * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
+ *
+ * Provides typed Read<T>() and Skip<T>() operations over a raw byte
+ * buffer. The caller is responsible for validating the box size field
+ * before reading individual fields; no bounds checking is performed.
+ *
+ * Example usage:
+ * @code
+ *   BoxReader reader{buffer};
+ *   auto size      = reader.Read<uint32_t>();
+ *   auto type      = reader.Read<uint32_t>();
+ *   auto timescale = reader.Read<uint32_t>();
+ *   reader.Skip(12 * segmentIndex);
+ * @endcode
+ */
+class BoxReader final
+{
+public:
+	/**
+	 * @brief Construct a BoxReader positioned at @p data.
+	 * @param data  Pointer to the first byte to read. Must not be null.
+	 */
+	constexpr explicit BoxReader(const uint8_t *data) noexcept
+		: mCursor{data}
+	{
+	}
+
+	/// Non-copyable — cursor state should not be accidentally duplicated.
+	BoxReader(const BoxReader &)            = delete;
+	BoxReader &operator=(const BoxReader &) = delete;
+
+	/// Movable so callers can transfer ownership when needed.
+	BoxReader(BoxReader &&)            = default;
+	BoxReader &operator=(BoxReader &&) = default;
+
+	/**
+	 * @brief Read a big-endian integer field and advance the cursor.
+	 *
+	 * @tparam T  Unsigned integral type. sizeof(T) determines the field
+	 *            width. Supported widths: 1, 2, 4, 8 bytes.
+	 * @return    The value read, converted to host byte order.
+	 */
+	template <typename T>
+	[[nodiscard]] T Read() noexcept
+	{
+		static_assert(std::is_integral_v<T>,
+					  "BoxReader::Read<T> requires an integral type");
+		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+					  sizeof(T) == 4 || sizeof(T) == 8,
+					  "BoxReader::Read<T> supports 1/2/4/8-byte types only");
+
+		uint64_t val{0};
+		for (size_t i = 0; i < sizeof(T); ++i)
+		{
+			val = (val << 8) | static_cast<uint8_t>(mCursor[i]);
+		}
+		mCursor += sizeof(T);
+		return static_cast<T>(val);
+	}
+
+	/**
+	 * @brief Skip a typed field without reading it.
+	 *
+	 * @tparam T  Integral type whose sizeof determines the skip width.
+	 *            Supported widths: 1, 2, 4, 8 bytes.
+	 */
+	template <typename T>
+	void Skip() noexcept
+	{
+		static_assert(std::is_integral_v<T>,
+					  "BoxReader::Skip<T> requires an integral type");
+		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+					  sizeof(T) == 4 || sizeof(T) == 8,
+					  "BoxReader::Skip<T> supports 1/2/4/8-byte types only");
+
+		mCursor += sizeof(T);
+	}
+
+	/**
+	 * @brief Skip a runtime number of bytes.
+	 * @param n  Number of bytes to advance the cursor.
+	 */
+	void Skip(size_t n) noexcept
+	{
+		mCursor += n;
+	}
+
+private:
+	const uint8_t *mCursor; ///< Current read position within the buffer.
+};
+
+#endif /* __AAMP_BOX_READER_H__ */

--- a/AampMPDUtils.cpp
+++ b/AampMPDUtils.cpp
@@ -296,6 +296,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 {
 	if ((!start) || (size < 4))
 	{
+		AAMPLOG_WARN("Invalid parameters in ParseSegmentIndexBox: start=%p, size=%zu", start, size);
 		return false;
 	}
 
@@ -342,7 +343,10 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 	else
 	{
 		AAMPLOG_WARN("Unsupported version in ParseSegmentIndexBox %u found, 0 or 1 expected", version);
-		if (firstOffset) *firstOffset = 0;
+		if (firstOffset) 
+		{
+			*firstOffset = 0;
+		}
 		return false;
 	}
 

--- a/AampMPDUtils.cpp
+++ b/AampMPDUtils.cpp
@@ -252,7 +252,8 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 		return false;
 	}
 
-	auto version   = reader.Read<uint32_t>();    // version (8b) + flags (24b)
+	// version is the top 8 bits; lower 24 bits are flags (ignored)
+	const auto version = static_cast<uint8_t>(reader.Read<uint32_t>() >> 24);
 	reader.Skip<uint32_t>();                     // reference_ID
 	auto timescale = reader.Read<uint32_t>();    // timescale
 
@@ -277,7 +278,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 		return true;
 	}
 
-	if (segmentIndex < static_cast<int>(reference_count))
+	if (segmentIndex >= 0 && segmentIndex < static_cast<int>(reference_count))
 	{
 		reader.Skip(SIDX_ENTRY_SIZE * segmentIndex);
 

--- a/AampMPDUtils.cpp
+++ b/AampMPDUtils.cpp
@@ -19,6 +19,7 @@
 
 #include "AampMPDUtils.h"
 #include <inttypes.h>
+#include <type_traits>
 
 /**
  * @brief Get xml node form reader
@@ -211,6 +212,76 @@ double ComputeFragmentDuration( uint32_t duration, uint32_t timeScale )
 	return newduration;
 }
 
+namespace
+{
+/**
+ * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
+ *
+ * Provides typed Read<T>() and Skip<T>() operations.
+ * The caller is responsible for validating the box size field before
+ * reading individual fields.
+ */
+class BoxReader final
+{
+public:
+	constexpr explicit BoxReader(const uint8_t *data) noexcept
+		: mCursor{data}
+	{
+	}
+
+	/**
+	 * @brief Read a big-endian integer field and advance the cursor.
+	 * @tparam T  Integral type whose sizeof determines the field width.
+	 * @return    The value read in host byte order.
+	 */
+	template <typename T>
+	[[nodiscard]] T Read() noexcept
+	{
+		static_assert(std::is_integral_v<T>,
+					  "Read<T> requires an integral type");
+		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+					  sizeof(T) == 4 || sizeof(T) == 8,
+					  "Read<T> only supports 1/2/4/8-byte types");
+
+		uint64_t val{0};
+		for (size_t i = 0; i < sizeof(T); ++i)
+		{
+			val = (val << 8) | static_cast<uint8_t>(mCursor[i]);
+		}
+		mCursor += sizeof(T);
+		return static_cast<T>(val);
+	}
+
+	/**
+	 * @brief Skip a field without reading it.
+	 * @tparam T  Integral type whose sizeof determines the skip width.
+	 */
+	template <typename T>
+	void Skip() noexcept
+	{
+		static_assert(std::is_integral_v<T>,
+					  "Skip<T> requires an integral type");
+		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+					  sizeof(T) == 4 || sizeof(T) == 8,
+					  "Skip<T> only supports 1/2/4/8-byte types");
+
+		mCursor += sizeof(T);
+	}
+
+	/**
+	 * @brief Skip a runtime number of bytes.
+	 * @param n  Number of bytes to advance.
+	 */
+	void Skip(size_t n) noexcept
+	{
+		mCursor += n;
+	}
+
+private:
+	const uint8_t *mCursor;
+};
+} // namespace
+
 /**
  * @brief Parse segment index box
  * @note The SegmentBase indexRange attribute points to Segment Index Box location with segments and random access points.
@@ -223,7 +294,7 @@ double ComputeFragmentDuration( uint32_t duration, uint32_t timeScale )
  */
 bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, unsigned int *referenced_size, float *referenced_duration, unsigned int *firstOffset)
 {
-	if (!start)
+	if ((!start) || (size < 4))
 	{
 		return false;
 	}
@@ -245,9 +316,9 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 	auto type = reader.Read<uint32_t>();
 	if (type != SIDX_BOX_TYPE)
 	{
-		AAMPLOG_WARN("Wrong type in ParseSegmentIndexBox %c%c%c%c found, %zu expected",
+		AAMPLOG_WARN("Wrong type in ParseSegmentIndexBox %c%c%c%c found, sidx expected",
 					 (type >> 24) & 0xff, (type >> 16) & 0xff,
-					 (type >> 8) & 0xff, type & 0xff, size);
+					 (type >> 8) & 0xff, type & 0xff);
 		if (firstOffset) *firstOffset = 0;
 		return false;
 	}
@@ -263,10 +334,16 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 		reader.Skip<uint32_t>();                 // earliest_presentation_time
 		first_offset = reader.Read<uint32_t>();  // first_offset
 	}
-	else
+	else if (version == 1)
 	{
 		reader.Skip<uint64_t>();                 // earliest_presentation_time
 		first_offset = reader.Read<uint64_t>();  // first_offset
+	}
+	else
+	{
+		AAMPLOG_WARN("Unsupported version in ParseSegmentIndexBox %u found, 0 or 1 expected", version);
+		if (firstOffset) *firstOffset = 0;
+		return false;
 	}
 
 	reader.Skip<uint16_t>();                     // reserved
@@ -294,7 +371,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 }
 
 /**
-
+ * @brief Replace matching token with given number
  * @param str String in which operation to be performed
  * @param from token
  * @param toNumber number to replace token

--- a/AampMPDUtils.cpp
+++ b/AampMPDUtils.cpp
@@ -225,13 +225,16 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 {
 	if (!start)
 	{
-		// If the fragment pointer is NULL then return from here, no need to process it further.
 		return false;
 	}
 
+	constexpr int SIDX_ENTRY_SIZE = 12;
+	constexpr uint32_t SIDX_BOX_TYPE =
+		('s' << 24) | ('i' << 16) | ('d' << 8) | 'x';
+
 	const uint8_t **f = &start;
 
-	unsigned int len = Read32(f);
+	auto len = Read32(f);
 	if (len != size)
 	{
 		AAMPLOG_WARN("Wrong size in ParseSegmentIndexBox %d found, %zu expected", len, size);
@@ -239,8 +242,8 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 		return false;
 	}
 
-	unsigned int type = Read32(f);
-	if (type != 'sidx')
+	auto type = Read32(f);
+	if (type != SIDX_BOX_TYPE)
 	{
 		AAMPLOG_WARN("Wrong type in ParseSegmentIndexBox %c%c%c%c found, %zu expected",
 					 (type >> 24) % 0xff, (type >> 16) & 0xff, (type >> 8) & 0xff, type & 0xff, size);
@@ -248,43 +251,46 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 		return false;
 	}
 
-	unsigned int version = Read32(f); (void) version;
-	unsigned int reference_ID = Read32(f); (void)reference_ID;
-	unsigned int timescale = Read32(f);
-	uint64_t earliest_presentation_time;
-	uint64_t first_offset;
-	if( version==0 )
+	auto version = Read32(f);
+	// Skip reference_ID (4 bytes)
+	*f += 4;
+	auto timescale = Read32(f);
+
+	uint64_t first_offset{0};
+	if (version == 0)
 	{
-		earliest_presentation_time = Read32(f);
-		(void)earliest_presentation_time; // unused
+		// Skip earliest_presentation_time (4 bytes)
+		*f += 4;
 		first_offset = Read32(f);
 	}
 	else
 	{
-		earliest_presentation_time = Read64(f);
-		(void)earliest_presentation_time; // unused
+		// Skip earliest_presentation_time (8 bytes)
+		*f += 8;
 		first_offset = Read64(f);
 	}
-	unsigned int reserved = Read16(f); (void)reserved;
-	unsigned int reference_count = Read16(f);
+
+	// Skip reserved (2 bytes)
+	*f += 2;
+	auto reference_count = Read16(f);
+
 	if (firstOffset)
 	{
-		*firstOffset = (unsigned int)first_offset;
+		*firstOffset = static_cast<unsigned int>(first_offset);
 		return true;
 	}
-	if( segmentIndex<reference_count )
+
+	if (segmentIndex < static_cast<int>(reference_count))
 	{
-		start += 12*segmentIndex;
-		*referenced_size = Read32(f)&0x7fffffff;
+		*f += SIDX_ENTRY_SIZE * segmentIndex;
+		*referenced_size = Read32(f) & 0x7fffffff;
 		// top bit is "reference_type"
 
-		*referenced_duration = Read32(f)/(float)timescale;
+		*referenced_duration = Read32(f) / static_cast<float>(timescale);
 
-		unsigned int flags = Read32(f);
-		(void)flags;
-		// starts_with_SAP (1 bit)
-		// SAP_type (3 bits)
-		// SAP_delta_time (28 bits)
+		// Skip SAP flags (4 bytes):
+		// starts_with_SAP (1 bit) | SAP_type (3 bits) | SAP_delta_time (28 bits)
+		*f += 4;
 
 		return true;
 	}

--- a/AampMPDUtils.cpp
+++ b/AampMPDUtils.cpp
@@ -18,8 +18,8 @@
 */
 
 #include "AampMPDUtils.h"
+#include "AampBoxReader.h"
 #include <inttypes.h>
-#include <type_traits>
 
 /**
  * @brief Get xml node form reader
@@ -211,76 +211,6 @@ double ComputeFragmentDuration( uint32_t duration, uint32_t timeScale )
 	}
 	return newduration;
 }
-
-namespace
-{
-/**
- * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
- *
- * Provides typed Read<T>() and Skip<T>() operations.
- * The caller is responsible for validating the box size field before
- * reading individual fields.
- */
-class BoxReader final
-{
-public:
-	constexpr explicit BoxReader(const uint8_t *data) noexcept
-		: mCursor{data}
-	{
-	}
-
-	/**
-	 * @brief Read a big-endian integer field and advance the cursor.
-	 * @tparam T  Integral type whose sizeof determines the field width.
-	 * @return    The value read in host byte order.
-	 */
-	template <typename T>
-	[[nodiscard]] T Read() noexcept
-	{
-		static_assert(std::is_integral_v<T>,
-					  "Read<T> requires an integral type");
-		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
-					  sizeof(T) == 4 || sizeof(T) == 8,
-					  "Read<T> only supports 1/2/4/8-byte types");
-
-		uint64_t val{0};
-		for (size_t i = 0; i < sizeof(T); ++i)
-		{
-			val = (val << 8) | static_cast<uint8_t>(mCursor[i]);
-		}
-		mCursor += sizeof(T);
-		return static_cast<T>(val);
-	}
-
-	/**
-	 * @brief Skip a field without reading it.
-	 * @tparam T  Integral type whose sizeof determines the skip width.
-	 */
-	template <typename T>
-	void Skip() noexcept
-	{
-		static_assert(std::is_integral_v<T>,
-					  "Skip<T> requires an integral type");
-		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
-					  sizeof(T) == 4 || sizeof(T) == 8,
-					  "Skip<T> only supports 1/2/4/8-byte types");
-
-		mCursor += sizeof(T);
-	}
-
-	/**
-	 * @brief Skip a runtime number of bytes.
-	 * @param n  Number of bytes to advance.
-	 */
-	void Skip(size_t n) noexcept
-	{
-		mCursor += n;
-	}
-
-private:
-	const uint8_t *mCursor;
-};
-} // namespace
 
 /**
  * @brief Parse segment index box

--- a/AampMPDUtils.cpp
+++ b/AampMPDUtils.cpp
@@ -232,47 +232,44 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 	constexpr uint32_t SIDX_BOX_TYPE =
 		('s' << 24) | ('i' << 16) | ('d' << 8) | 'x';
 
-	const uint8_t **f = &start;
+	BoxReader reader{start};
 
-	auto len = Read32(f);
+	auto len = reader.Read<uint32_t>();
 	if (len != size)
 	{
-		AAMPLOG_WARN("Wrong size in ParseSegmentIndexBox %d found, %zu expected", len, size);
+		AAMPLOG_WARN("Wrong size in ParseSegmentIndexBox %u found, %zu expected", len, size);
 		if (firstOffset) *firstOffset = 0;
 		return false;
 	}
 
-	auto type = Read32(f);
+	auto type = reader.Read<uint32_t>();
 	if (type != SIDX_BOX_TYPE)
 	{
 		AAMPLOG_WARN("Wrong type in ParseSegmentIndexBox %c%c%c%c found, %zu expected",
-					 (type >> 24) % 0xff, (type >> 16) & 0xff, (type >> 8) & 0xff, type & 0xff, size);
+					 (type >> 24) & 0xff, (type >> 16) & 0xff,
+					 (type >> 8) & 0xff, type & 0xff, size);
 		if (firstOffset) *firstOffset = 0;
 		return false;
 	}
 
-	auto version = Read32(f);
-	// Skip reference_ID (4 bytes)
-	*f += 4;
-	auto timescale = Read32(f);
+	auto version   = reader.Read<uint32_t>();    // version (8b) + flags (24b)
+	reader.Skip<uint32_t>();                     // reference_ID
+	auto timescale = reader.Read<uint32_t>();    // timescale
 
 	uint64_t first_offset{0};
 	if (version == 0)
 	{
-		// Skip earliest_presentation_time (4 bytes)
-		*f += 4;
-		first_offset = Read32(f);
+		reader.Skip<uint32_t>();                 // earliest_presentation_time
+		first_offset = reader.Read<uint32_t>();  // first_offset
 	}
 	else
 	{
-		// Skip earliest_presentation_time (8 bytes)
-		*f += 8;
-		first_offset = Read64(f);
+		reader.Skip<uint64_t>();                 // earliest_presentation_time
+		first_offset = reader.Read<uint64_t>();  // first_offset
 	}
 
-	// Skip reserved (2 bytes)
-	*f += 2;
-	auto reference_count = Read16(f);
+	reader.Skip<uint16_t>();                     // reserved
+	auto reference_count = reader.Read<uint16_t>();
 
 	if (firstOffset)
 	{
@@ -282,15 +279,13 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 
 	if (segmentIndex < static_cast<int>(reference_count))
 	{
-		*f += SIDX_ENTRY_SIZE * segmentIndex;
-		*referenced_size = Read32(f) & 0x7fffffff;
+		reader.Skip(SIDX_ENTRY_SIZE * segmentIndex);
+
+		*referenced_size = reader.Read<uint32_t>() & 0x7fffffff;
 		// top bit is "reference_type"
 
-		*referenced_duration = Read32(f) / static_cast<float>(timescale);
-
-		// Skip SAP flags (4 bytes):
-		// starts_with_SAP (1 bit) | SAP_type (3 bits) | SAP_delta_time (28 bits)
-		*f += 4;
+		*referenced_duration = reader.Read<uint32_t>() /
+							   static_cast<float>(timescale);
 
 		return true;
 	}
@@ -298,56 +293,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 }
 
 /**
- * @brief read unsigned multi-byte value and update buffer pointer
- * @param[in] pptr buffer
- * @param[in] n word size in bytes
- * @retval 32 bit value
- */
-uint64_t ReadWordHelper( const uint8_t **pptr, int n )
-{
-	const uint8_t *ptr = *pptr;
-	uint64_t rc = 0;
-	while( n-- )
-	{
-		rc <<= 8;
-		rc |= *ptr++;
-	}
-	*pptr = ptr;
-	return rc;
-}
 
-/**
- * @brief Read 16 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-unsigned int Read16( const uint8_t **pptr)
-{
-	return (unsigned int)ReadWordHelper(pptr,2);
-}
-
-/**
- * @brief Read 32 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-unsigned int Read32( const uint8_t **pptr)
-{
-	return (unsigned int)ReadWordHelper(pptr,4);
-}
-
-/**
- * @brief Read 64 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-uint64_t Read64( const uint8_t **pptr)
-{
-	return ReadWordHelper(pptr,8);
-}
-
-/**
- * @brief Replace matching token with given number
  * @param str String in which operation to be performed
  * @param from token
  * @param toNumber number to replace token

--- a/AampMPDUtils.h
+++ b/AampMPDUtils.h
@@ -29,6 +29,7 @@
 #include "libdash/xml/DOMParser.h"
 #include <libxml/xmlreader.h>
 #include <thread>
+#include <type_traits>
 #include "AampLogManager.h"
 #include "AampUtils.h"
 #include "AampMPDPeriodInfo.h"
@@ -96,33 +97,72 @@ void ConstructFragmentURL( std::string& fragmentUrl, const FragmentDescriptor *f
 bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, unsigned int *referenced_size, float *referenced_duration, unsigned int *firstOffset);
 
 /**
- * @brief Read 16 word helper function
- * @param pptr pointer to read from
- * @retval word value
+ * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
+ *
+ * Provides typed Read<T>() and Skip<T>() operations that replace the
+ * legacy Read16/Read32/Read64 free functions and raw pointer arithmetic.
+ * The caller is responsible for validating the box size field before
+ * reading individual fields.
  */
-unsigned int Read16( const uint8_t **pptr);
+class BoxReader final
+{
+public:
+	constexpr explicit BoxReader(const uint8_t *data) noexcept
+		: mCursor{data}
+	{
+	}
 
-/**
- * @brief Read 32 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-unsigned int Read32( const uint8_t **pptr);
+	/**
+	 * @brief Read a big-endian integer field and advance the cursor.
+	 * @tparam T  Integral type whose sizeof determines the field width.
+	 * @return    The value read in host byte order.
+	 */
+	template <typename T>
+	[[nodiscard]] T Read() noexcept
+	{
+		static_assert(std::is_integral_v<T>,
+					  "Read<T> requires an integral type");
+		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+					  sizeof(T) == 4 || sizeof(T) == 8,
+					  "Read<T> only supports 1/2/4/8-byte types");
 
-/**
- * @brief Read 64 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-uint64_t Read64( const uint8_t **pptr);
+		uint64_t val{0};
+		for (size_t i = 0; i < sizeof(T); ++i)
+		{
+			val = (val << 8) | static_cast<uint8_t>(mCursor[i]);
+		}
+		mCursor += sizeof(T);
+		return static_cast<T>(val);
+	}
 
-/**
- * @brief read unsigned multi-byte value and update buffer pointer
- * @param[in] pptr buffer
- * @param[in] n word size in bytes
- * @retval 32 bit value
- */
-uint64_t ReadWordHelper( const uint8_t **pptr, int n );
+	/**
+	 * @brief Skip a field without reading it.
+	 * @tparam T  Integral type whose sizeof determines the skip width.
+	 */
+	template <typename T>
+	void Skip() noexcept
+	{
+		static_assert(std::is_integral_v<T>,
+					  "Skip<T> requires an integral type");
+		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
+					  sizeof(T) == 4 || sizeof(T) == 8,
+					  "Skip<T> only supports 1/2/4/8-byte types");
+
+		mCursor += sizeof(T);
+	}
+
+	/**
+	 * @brief Skip a runtime number of bytes.
+	 * @param n  Number of bytes to advance.
+	 */
+	void Skip(size_t n) noexcept
+	{
+		mCursor += n;
+	}
+
+private:
+	const uint8_t *mCursor;
+};
 
 /**
  * @brief Replace matching token with given number

--- a/AampMPDUtils.h
+++ b/AampMPDUtils.h
@@ -29,7 +29,6 @@
 #include "libdash/xml/DOMParser.h"
 #include <libxml/xmlreader.h>
 #include <thread>
-#include <type_traits>
 #include "AampLogManager.h"
 #include "AampUtils.h"
 #include "AampMPDPeriodInfo.h"
@@ -95,73 +94,6 @@ void ConstructFragmentURL( std::string& fragmentUrl, const FragmentDescriptor *f
  * @retval true on success
  */
 bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, unsigned int *referenced_size, float *referenced_duration, unsigned int *firstOffset);
-
-/**
- * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
- *
- * Provides typed Read<T>() and Skip<T>() operations.
- * The caller is responsible for validating the box size field before
- * reading individual fields.
- */
-class BoxReader final
-{
-public:
-	constexpr explicit BoxReader(const uint8_t *data) noexcept
-		: mCursor{data}
-	{
-	}
-
-	/**
-	 * @brief Read a big-endian integer field and advance the cursor.
-	 * @tparam T  Integral type whose sizeof determines the field width.
-	 * @return    The value read in host byte order.
-	 */
-	template <typename T>
-	[[nodiscard]] T Read() noexcept
-	{
-		static_assert(std::is_integral_v<T>,
-					  "Read<T> requires an integral type");
-		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
-					  sizeof(T) == 4 || sizeof(T) == 8,
-					  "Read<T> only supports 1/2/4/8-byte types");
-
-		uint64_t val{0};
-		for (size_t i = 0; i < sizeof(T); ++i)
-		{
-			val = (val << 8) | static_cast<uint8_t>(mCursor[i]);
-		}
-		mCursor += sizeof(T);
-		return static_cast<T>(val);
-	}
-
-	/**
-	 * @brief Skip a field without reading it.
-	 * @tparam T  Integral type whose sizeof determines the skip width.
-	 */
-	template <typename T>
-	void Skip() noexcept
-	{
-		static_assert(std::is_integral_v<T>,
-					  "Skip<T> requires an integral type");
-		static_assert(sizeof(T) == 1 || sizeof(T) == 2 ||
-					  sizeof(T) == 4 || sizeof(T) == 8,
-					  "Skip<T> only supports 1/2/4/8-byte types");
-
-		mCursor += sizeof(T);
-	}
-
-	/**
-	 * @brief Skip a runtime number of bytes.
-	 * @param n  Number of bytes to advance.
-	 */
-	void Skip(size_t n) noexcept
-	{
-		mCursor += n;
-	}
-
-private:
-	const uint8_t *mCursor;
-};
 
 /**
  * @brief Replace matching token with given number

--- a/AampMPDUtils.h
+++ b/AampMPDUtils.h
@@ -99,8 +99,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 /**
  * @brief Lightweight cursor for reading big-endian ISOBMFF box fields.
  *
- * Provides typed Read<T>() and Skip<T>() operations that replace the
- * legacy Read16/Read32/Read64 free functions and raw pointer arithmetic.
+ * Provides typed Read<T>() and Skip<T>() operations.
  * The caller is responsible for validating the box size field before
  * reading individual fields.
  */

--- a/test/utests/fakes/FakeAampMPDUtils.cpp
+++ b/test/utests/fakes/FakeAampMPDUtils.cpp
@@ -68,48 +68,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 }
 
 /**
- * @brief Read 16 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-unsigned int Read16( const uint8_t **pptr)
-{
-	return 0;
-}
 
-/**
- * @brief Read 32 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-unsigned int Read32( const uint8_t **pptr)
-{
-	return 0;
-}
-
-/**
- * @brief Read 64 word helper function
- * @param pptr pointer to read from
- * @retval word value
- */
-uint64_t Read64( const uint8_t **pptr)
-{
-	return 0;
-}
-
-/**
- * @brief read unsigned multi-byte value and update buffer pointer
- * @param[in] pptr buffer
- * @param[in] n word size in bytes
- * @retval 32 bit value
- */
-uint64_t ReadWordHelper( const uint8_t **pptr, int n )
-{
-	return 0;
-}
-
-/**
- * @brief Replace matching token with given number
  * @param str String in which operation to be performed
  * @param from token
  * @param toNumber number to replace token

--- a/test/utests/fakes/FakeAampMPDUtils.cpp
+++ b/test/utests/fakes/FakeAampMPDUtils.cpp
@@ -68,7 +68,7 @@ bool ParseSegmentIndexBox( const uint8_t *start, size_t size, int segmentIndex, 
 }
 
 /**
-
+ * @brief Replace matching token with given number
  * @param str String in which operation to be performed
  * @param from token
  * @param toNumber number to replace token

--- a/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
@@ -268,6 +268,54 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_NullStart_ReturnsFalse)
 }
 
 /**
+ * @brief Size less than 4 bytes returns false without reading any data.
+ *
+ * The function must guard against reading the 4-byte size field when
+ * the buffer is too short to contain it.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_SizeLessThanFour_ReturnsFalse)
+{
+	constexpr uint32_t TIMESCALE = 1000;
+	constexpr uint32_t REF_SIZE  = 100;
+	constexpr uint32_t DURATION  = 1000;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
+
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	// Sizes 0, 1, 2, 3 must all be rejected before any field is read
+	for (size_t sz = 0; sz < 4; ++sz)
+	{
+		EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sz, 0,
+										  &refSize, &refDuration, nullptr))
+			<< "Expected false for size=" << sz;
+	}
+}
+
+/**
+ * @brief A version byte other than 0 or 1 returns false.
+ *
+ * The version+flags field is a full 32-bit value. The top 8 bits are
+ * the version. Any version other than 0 or 1 is unsupported and must
+ * cause the parser to return false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_InvalidVersion_ReturnsFalse)
+{
+	constexpr uint32_t TIMESCALE      = 1000;
+	constexpr uint32_t REF_SIZE       = 100;
+	constexpr uint32_t DURATION       = 1000;
+	constexpr uint32_t INVALID_VERSION = 2u; // only 0 and 1 are valid
+
+	// Build a v0 box then overwrite byte 8 (the version byte) with 2
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
+	sidx[8] = static_cast<uint8_t>(INVALID_VERSION);
+
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									  &refSize, &refDuration, nullptr));
+}
+
+/**
  * @brief Version-0 box with non-zero flags is parsed correctly.
  *
  * The version+flags field has version=0 in the top byte and non-zero
@@ -337,7 +385,10 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_NegativeIndex_ReturnsFalse)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_WrongSize_ReturnsFalse)
 {
-	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	constexpr uint32_t TIMESCALE = 1000;
+	constexpr uint32_t REF_SIZE  = 100;
+	constexpr uint32_t DURATION  = 1000;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
 	// Pass a size that does not match the box header
@@ -350,7 +401,10 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_WrongSize_ReturnsFalse)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_WrongSize_ZeroesFirstOffset)
 {
-	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	constexpr uint32_t TIMESCALE = 1000;
+	constexpr uint32_t REF_SIZE  = 100;
+	constexpr uint32_t DURATION  = 1000;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
 	unsigned int firstOff = 99;
 	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size() + 1, 0,
 									  nullptr, nullptr, &firstOff));

--- a/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <string.h>
 #include <vector>
-#include <utility>
 
 //include the google test dependencies
 #include <gtest/gtest.h>

--- a/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
@@ -150,15 +150,22 @@ struct SidxEntry
  *   reserved(2) | reference_count(2) |
  *   [ referenced_size(4) | subsegment_duration(4) | SAP_flags(4) ] * N
  *
+ * The @p flags parameter populates the lower 24 bits of the version+flags
+ * field (version byte is always 0). Defaults to 0 for the common case.
+ *
  * @param[in] timescale    Timescale for duration calculation.
  * @param[in] entries      Vector of reference entries.
- * @param[in] firstOffset  Value for the first_offset field.
+ * @param[in] firstOffset  Value for the first_offset field (default 0).
+ * @param[in] flags        24-bit flags value in the lower bits of the
+ *                         version+flags field (default 0). The version
+ *                         byte (top 8 bits) is always 0.
  * @return                 Byte vector containing the complete SIDX box.
  */
 static std::vector<uint8_t> BuildSidxBoxV0(
 	uint32_t timescale,
 	const std::vector<SidxEntry> &entries,
-	uint32_t firstOffset = 0)
+	uint32_t firstOffset = 0,
+	uint32_t flags = 0)
 {
 	constexpr uint32_t HEADER_SIZE = 32;
 	constexpr uint32_t ENTRY_SIZE  = 12;
@@ -170,58 +177,11 @@ static std::vector<uint8_t> BuildSidxBoxV0(
 
 	WriteBE32(p,      boxSize);
 	p[4] = 's'; p[5] = 'i'; p[6] = 'd'; p[7] = 'x';
-	WriteBE32(p + 8,  0);           // version 0 + flags 0
-	WriteBE32(p + 12, 1);           // reference_ID
-	WriteBE32(p + 16, timescale);
-	WriteBE32(p + 20, 0);           // earliest_presentation_time
-	WriteBE32(p + 24, firstOffset);
-	WriteBE16(p + 28, 0);           // reserved
-	WriteBE16(p + 30, static_cast<uint16_t>(entryCount));
-
-	uint8_t *ep = p + HEADER_SIZE;
-	for (const auto &entry : entries)
-	{
-		WriteBE32(ep,     entry.referencedSize & 0x7FFFFFFF);
-		WriteBE32(ep + 4, entry.subsegmentDuration);
-		WriteBE32(ep + 8, 0);  // SAP flags
-		ep += ENTRY_SIZE;
-	}
-
-	return buf;
-}
-
-/**
- * @brief Build a version-0 SIDX box with non-zero flags in the version+flags field.
- *
- * The version byte (top 8 bits) is 0; the lower 24 bits carry arbitrary flags.
- * A correct parser must isolate the version byte and not treat the flags as
- * part of the version.
- *
- * @param[in] flags       24-bit flags value (lower 24 bits only).
- * @param[in] timescale   Timescale for duration calculation.
- * @param[in] entries     Vector of reference entries.
- * @return                Byte vector containing the complete SIDX box.
- */
-static std::vector<uint8_t> BuildSidxBoxV0WithFlags(
-	uint32_t flags,
-	uint32_t timescale,
-	const std::vector<SidxEntry> &entries)
-{
-	constexpr uint32_t HEADER_SIZE = 32;
-	constexpr uint32_t ENTRY_SIZE  = 12;
-	const auto entryCount = static_cast<uint32_t>(entries.size());
-	const uint32_t boxSize = HEADER_SIZE + entryCount * ENTRY_SIZE;
-
-	std::vector<uint8_t> buf(boxSize, 0);
-	auto *p = buf.data();
-
-	WriteBE32(p,      boxSize);
-	p[4] = 's'; p[5] = 'i'; p[6] = 'd'; p[7] = 'x';
-	WriteBE32(p + 8,  flags & 0x00FFFFFFu); // version=0, flags=non-zero
+	WriteBE32(p + 8,  flags & 0x00FFFFFFu); // version=0, optional flags
 	WriteBE32(p + 12, 1);                   // reference_ID
 	WriteBE32(p + 16, timescale);
-	WriteBE32(p + 20, 0);                   // earliest_presentation_time (32-bit, v0)
-	WriteBE32(p + 24, 0);                   // first_offset (32-bit, v0)
+	WriteBE32(p + 20, 0);                   // earliest_presentation_time
+	WriteBE32(p + 24, firstOffset);
 	WriteBE16(p + 28, 0);                   // reserved
 	WriteBE16(p + 30, static_cast<uint16_t>(entryCount));
 
@@ -321,7 +281,7 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_V0WithNonZeroFlags_ParsedCorrectly)
 	constexpr uint32_t REF_SIZE  = 5000;
 	constexpr uint32_t DURATION  = 2000;
 
-	auto sidx = BuildSidxBoxV0WithFlags(FLAGS, TIMESCALE, {{REF_SIZE, DURATION}});
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}}, 0, FLAGS);
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
 	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
@@ -362,7 +322,10 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_V1_ParsedCorrectly)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_NegativeIndex_ReturnsFalse)
 {
-	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	constexpr uint32_t TIMESCALE = 1000;
+	constexpr uint32_t REF_SIZE  = 100;
+	constexpr uint32_t DURATION  = 1000;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
 	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), -1,
@@ -413,8 +376,11 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_WrongType_ReturnsFalse)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_FirstOffset_ReturnsCorrectValue)
 {
+	constexpr uint32_t TIMESCALE      = 1000;
+	constexpr uint32_t REF_SIZE       = 100;
+	constexpr uint32_t DURATION       = 1000;
 	constexpr uint32_t EXPECTED_OFFSET = 42;
-	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}}, EXPECTED_OFFSET);
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}}, EXPECTED_OFFSET);
 	unsigned int firstOff = 0;
 	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
 									 nullptr, nullptr, &firstOff));
@@ -478,10 +444,13 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_MultipleEntries_CorrectIndexing)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_IndexEqualToCount_ReturnsFalse)
 {
-	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}, {200, 2000}});
+	constexpr uint32_t TIMESCALE = 1000;
+	const std::vector<SidxEntry> entries = {{100, 1000}, {200, 2000}};
+	auto sidx = BuildSidxBoxV0(TIMESCALE, entries);
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
-	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 2,
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(),
+									  static_cast<int>(entries.size()),
 									  &refSize, &refDuration, nullptr));
 }
 
@@ -490,10 +459,14 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_IndexEqualToCount_ReturnsFalse)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_IndexFarOutOfRange_ReturnsFalse)
 {
-	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	constexpr uint32_t TIMESCALE      = 1000;
+	constexpr uint32_t REF_SIZE       = 100;
+	constexpr uint32_t DURATION       = 1000;
+	constexpr int      OUT_OF_RANGE   = 99;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
-	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 99,
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), OUT_OF_RANGE,
 									  &refSize, &refDuration, nullptr));
 }
 
@@ -537,7 +510,8 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_LargeEntryCount_AllCorrect)
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_ZeroEntries_ReturnsFalse)
 {
-	auto sidx = BuildSidxBoxV0(1000, {});
+	constexpr uint32_t TIMESCALE = 1000;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {});
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
 	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,

--- a/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
@@ -18,9 +18,12 @@
 */
 
 #include <cstdlib>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <string.h>
+#include <vector>
+#include <utility>
 
 //include the google test dependencies
 #include <gtest/gtest.h>
@@ -99,4 +102,304 @@ TEST(AampMPDUtils, ComputeFragmentDurationTest1)
 
 	double result = ComputeFragmentDuration(duration,timeScale);
 	EXPECT_DOUBLE_EQ(result,2.0);
+}
+
+// ---------------------------------------------------------------------------
+// ParseSegmentIndexBox test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Write a big-endian 32-bit value into a byte buffer.
+ * @param[out] dest  Destination pointer (must have >= 4 bytes available).
+ * @param[in]  val   Value to write.
+ */
+static void WriteBE32(uint8_t *dest, uint32_t val)
+{
+	dest[0] = static_cast<uint8_t>((val >> 24) & 0xFF);
+	dest[1] = static_cast<uint8_t>((val >> 16) & 0xFF);
+	dest[2] = static_cast<uint8_t>((val >> 8)  & 0xFF);
+	dest[3] = static_cast<uint8_t>( val        & 0xFF);
+}
+
+/**
+ * @brief Write a big-endian 16-bit value into a byte buffer.
+ * @param[out] dest  Destination pointer (must have >= 2 bytes available).
+ * @param[in]  val   Value to write.
+ */
+static void WriteBE16(uint8_t *dest, uint16_t val)
+{
+	dest[0] = static_cast<uint8_t>((val >> 8) & 0xFF);
+	dest[1] = static_cast<uint8_t>( val       & 0xFF);
+}
+
+/**
+ * @brief Represents a single SIDX reference entry for test construction.
+ */
+struct SidxEntry
+{
+	uint32_t referencedSize;
+	uint32_t subsegmentDuration;
+};
+
+/**
+ * @brief Build a version-0 SIDX box in memory for testing.
+ *
+ * Layout (version 0, all big-endian):
+ *   size(4) | 'sidx'(4) | version+flags(4) | reference_ID(4) |
+ *   timescale(4) | earliest_presentation_time(4) | first_offset(4) |
+ *   reserved(2) | reference_count(2) |
+ *   [ referenced_size(4) | subsegment_duration(4) | SAP_flags(4) ] * N
+ *
+ * @param[in] timescale    Timescale for duration calculation.
+ * @param[in] entries      Vector of reference entries.
+ * @param[in] firstOffset  Value for the first_offset field.
+ * @return                 Byte vector containing the complete SIDX box.
+ */
+static std::vector<char> BuildSidxBoxV0(
+	uint32_t timescale,
+	const std::vector<SidxEntry> &entries,
+	uint32_t firstOffset = 0)
+{
+	constexpr uint32_t HEADER_SIZE = 32;
+	constexpr uint32_t ENTRY_SIZE  = 12;
+	const auto entryCount = static_cast<uint32_t>(entries.size());
+	const uint32_t boxSize = HEADER_SIZE + entryCount * ENTRY_SIZE;
+
+	std::vector<char> buf(boxSize, 0);
+	auto *p = reinterpret_cast<uint8_t *>(buf.data());
+
+	WriteBE32(p,      boxSize);
+	p[4] = 's'; p[5] = 'i'; p[6] = 'd'; p[7] = 'x';
+	WriteBE32(p + 8,  0);           // version 0 + flags 0
+	WriteBE32(p + 12, 1);           // reference_ID
+	WriteBE32(p + 16, timescale);
+	WriteBE32(p + 20, 0);           // earliest_presentation_time
+	WriteBE32(p + 24, firstOffset);
+	WriteBE16(p + 28, 0);           // reserved
+	WriteBE16(p + 30, static_cast<uint16_t>(entryCount));
+
+	uint8_t *ep = p + HEADER_SIZE;
+	for (const auto &entry : entries)
+	{
+		WriteBE32(ep,     entry.referencedSize & 0x7FFFFFFF);
+		WriteBE32(ep + 4, entry.subsegmentDuration);
+		WriteBE32(ep + 8, 0);  // SAP flags
+		ep += ENTRY_SIZE;
+	}
+
+	return buf;
+}
+
+// ---------------------------------------------------------------------------
+// ParseSegmentIndexBox tests
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Null start pointer returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_NullStart_ReturnsFalse)
+{
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(nullptr, 0, 0, &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Mismatched size field in box header returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_WrongSize_ReturnsFalse)
+{
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	// Pass a size that does not match the box header
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size() + 1, 0,
+									  &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Mismatched size field zeroes firstOffset and returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_WrongSize_ZeroesFirstOffset)
+{
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	unsigned int firstOff = 99;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size() + 1, 0,
+									  nullptr, nullptr, &firstOff));
+	EXPECT_EQ(firstOff, 0u);
+}
+
+/**
+ * @brief Wrong box type returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_WrongType_ReturnsFalse)
+{
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	// Corrupt the type field ('sidx' at bytes 4-7)
+	sidx[4] = 'f'; sidx[5] = 'r'; sidx[6] = 'e'; sidx[7] = 'e';
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									  &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Request firstOffset returns the correct value and exits early.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_FirstOffset_ReturnsCorrectValue)
+{
+	constexpr uint32_t EXPECTED_OFFSET = 42;
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}}, EXPECTED_OFFSET);
+	unsigned int firstOff = 0;
+	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									 nullptr, nullptr, &firstOff));
+	EXPECT_EQ(firstOff, EXPECTED_OFFSET);
+}
+
+/**
+ * @brief Parse the first segment entry (index 0).
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_Index0_ReturnsCorrectValues)
+{
+	constexpr uint32_t TIMESCALE = 1000;
+	constexpr uint32_t REF_SIZE = 5000;
+	constexpr uint32_t DURATION = 2000;
+	auto sidx = BuildSidxBoxV0(TIMESCALE, {{REF_SIZE, DURATION}});
+
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									 &refSize, &refDuration, nullptr));
+	EXPECT_EQ(refSize, REF_SIZE);
+	EXPECT_FLOAT_EQ(refDuration,
+					 static_cast<float>(DURATION) / static_cast<float>(TIMESCALE));
+}
+
+/**
+ * @brief Parse multiple entries — key regression test for the *f += fix.
+ *
+ * Before the fix, `start += 12*segmentIndex` could produce incorrect
+ * results if the pointer aliasing through `f` were ever broken.  The
+ * corrected `*f += SIDX_ENTRY_SIZE * segmentIndex` is consistent with
+ * every other cursor operation in the function.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_MultipleEntries_CorrectIndexing)
+{
+	constexpr uint32_t TIMESCALE = 48000;
+	const std::vector<SidxEntry> entries = {
+		{10000, 48000},
+		{20000, 96000},
+		{30000, 144000}
+	};
+	auto sidx = BuildSidxBoxV0(TIMESCALE, entries);
+
+	for (int i = 0; i < static_cast<int>(entries.size()); ++i)
+	{
+		unsigned int refSize = 0;
+		float refDuration = 0.0f;
+		EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), i,
+										 &refSize, &refDuration, nullptr))
+			<< "Failed for segment index " << i;
+		EXPECT_EQ(refSize, entries[i].referencedSize)
+			<< "Wrong referenced_size for segment index " << i;
+		EXPECT_FLOAT_EQ(refDuration,
+						 static_cast<float>(entries[i].subsegmentDuration) /
+						 static_cast<float>(TIMESCALE))
+			<< "Wrong referenced_duration for segment index " << i;
+	}
+}
+
+/**
+ * @brief Segment index equal to reference_count returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_IndexEqualToCount_ReturnsFalse)
+{
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}, {200, 2000}});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 2,
+									  &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Segment index far out of range returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_IndexFarOutOfRange_ReturnsFalse)
+{
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 99,
+									  &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Verify every entry in a large SIDX box is correctly indexed.
+ *
+ * This catches cumulative offset errors or off-by-one issues that only
+ * manifest when many entries must be skipped.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_LargeEntryCount_AllCorrect)
+{
+	constexpr uint32_t TIMESCALE = 90000;
+	constexpr int ENTRY_COUNT = 50;
+	std::vector<SidxEntry> entries;
+	entries.reserve(ENTRY_COUNT);
+	for (int i = 0; i < ENTRY_COUNT; ++i)
+	{
+		entries.push_back({static_cast<uint32_t>(1000 * (i + 1)),
+						   static_cast<uint32_t>(90000 * (i + 1))});
+	}
+	auto sidx = BuildSidxBoxV0(TIMESCALE, entries);
+
+	for (int i = 0; i < ENTRY_COUNT; ++i)
+	{
+		unsigned int refSize = 0;
+		float refDuration = 0.0f;
+		EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), i,
+										 &refSize, &refDuration, nullptr))
+			<< "Failed for segment index " << i;
+		EXPECT_EQ(refSize, entries[i].referencedSize)
+			<< "Wrong referenced_size for segment index " << i;
+		EXPECT_FLOAT_EQ(refDuration,
+						 static_cast<float>(entries[i].subsegmentDuration) /
+						 static_cast<float>(TIMESCALE))
+			<< "Wrong referenced_duration for segment index " << i;
+	}
+}
+
+/**
+ * @brief Zero reference_count SIDX box with index 0 returns false.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_ZeroEntries_ReturnsFalse)
+{
+	auto sidx = BuildSidxBoxV0(1000, {});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									  &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Last valid entry in a multi-entry box is returned correctly.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_LastEntry_ReturnsCorrectValues)
+{
+	constexpr uint32_t TIMESCALE = 44100;
+	const std::vector<SidxEntry> entries = {
+		{1000, 44100},
+		{2000, 88200},
+		{3000, 132300}
+	};
+	auto sidx = BuildSidxBoxV0(TIMESCALE, entries);
+
+	const int lastIdx = static_cast<int>(entries.size()) - 1;
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), lastIdx,
+									 &refSize, &refDuration, nullptr));
+	EXPECT_EQ(refSize, entries[lastIdx].referencedSize);
+	EXPECT_FLOAT_EQ(refDuration,
+					 static_cast<float>(entries[lastIdx].subsegmentDuration) /
+					 static_cast<float>(TIMESCALE));
 }

--- a/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
@@ -155,7 +155,7 @@ struct SidxEntry
  * @param[in] firstOffset  Value for the first_offset field.
  * @return                 Byte vector containing the complete SIDX box.
  */
-static std::vector<char> BuildSidxBoxV0(
+static std::vector<uint8_t> BuildSidxBoxV0(
 	uint32_t timescale,
 	const std::vector<SidxEntry> &entries,
 	uint32_t firstOffset = 0)
@@ -165,8 +165,8 @@ static std::vector<char> BuildSidxBoxV0(
 	const auto entryCount = static_cast<uint32_t>(entries.size());
 	const uint32_t boxSize = HEADER_SIZE + entryCount * ENTRY_SIZE;
 
-	std::vector<char> buf(boxSize, 0);
-	auto *p = reinterpret_cast<uint8_t *>(buf.data());
+	std::vector<uint8_t> buf(boxSize, 0);
+	auto *p = buf.data();
 
 	WriteBE32(p,      boxSize);
 	p[4] = 's'; p[5] = 'i'; p[6] = 'd'; p[7] = 'x';

--- a/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDUtils/FunctionalTests.cpp
@@ -190,6 +190,109 @@ static std::vector<uint8_t> BuildSidxBoxV0(
 	return buf;
 }
 
+/**
+ * @brief Build a version-0 SIDX box with non-zero flags in the version+flags field.
+ *
+ * The version byte (top 8 bits) is 0; the lower 24 bits carry arbitrary flags.
+ * A correct parser must isolate the version byte and not treat the flags as
+ * part of the version.
+ *
+ * @param[in] flags       24-bit flags value (lower 24 bits only).
+ * @param[in] timescale   Timescale for duration calculation.
+ * @param[in] entries     Vector of reference entries.
+ * @return                Byte vector containing the complete SIDX box.
+ */
+static std::vector<uint8_t> BuildSidxBoxV0WithFlags(
+	uint32_t flags,
+	uint32_t timescale,
+	const std::vector<SidxEntry> &entries)
+{
+	constexpr uint32_t HEADER_SIZE = 32;
+	constexpr uint32_t ENTRY_SIZE  = 12;
+	const auto entryCount = static_cast<uint32_t>(entries.size());
+	const uint32_t boxSize = HEADER_SIZE + entryCount * ENTRY_SIZE;
+
+	std::vector<uint8_t> buf(boxSize, 0);
+	auto *p = buf.data();
+
+	WriteBE32(p,      boxSize);
+	p[4] = 's'; p[5] = 'i'; p[6] = 'd'; p[7] = 'x';
+	WriteBE32(p + 8,  flags & 0x00FFFFFFu); // version=0, flags=non-zero
+	WriteBE32(p + 12, 1);                   // reference_ID
+	WriteBE32(p + 16, timescale);
+	WriteBE32(p + 20, 0);                   // earliest_presentation_time (32-bit, v0)
+	WriteBE32(p + 24, 0);                   // first_offset (32-bit, v0)
+	WriteBE16(p + 28, 0);                   // reserved
+	WriteBE16(p + 30, static_cast<uint16_t>(entryCount));
+
+	uint8_t *ep = p + HEADER_SIZE;
+	for (const auto &entry : entries)
+	{
+		WriteBE32(ep,     entry.referencedSize & 0x7FFFFFFFu);
+		WriteBE32(ep + 4, entry.subsegmentDuration);
+		WriteBE32(ep + 8, 0);  // SAP flags
+		ep += ENTRY_SIZE;
+	}
+
+	return buf;
+}
+
+/**
+ * @brief Build a version-1 SIDX box in memory for testing.
+ *
+ * Version 1 uses 64-bit earliest_presentation_time and first_offset fields,
+ * making the header 40 bytes instead of 32.
+ *
+ * Layout (version 1, all big-endian):
+ *   size(4) | 'sidx'(4) | version+flags(4) | reference_ID(4) |
+ *   timescale(4) | earliest_presentation_time(8) | first_offset(8) |
+ *   reserved(2) | reference_count(2) |
+ *   [ referenced_size(4) | subsegment_duration(4) | SAP_flags(4) ] * N
+ *
+ * @param[in] timescale    Timescale for duration calculation.
+ * @param[in] entries      Vector of reference entries.
+ * @param[in] firstOffset  Value for the first_offset field.
+ * @return                 Byte vector containing the complete SIDX box.
+ */
+static std::vector<uint8_t> BuildSidxBoxV1(
+	uint32_t timescale,
+	const std::vector<SidxEntry> &entries,
+	uint64_t firstOffset = 0)
+{
+	constexpr uint32_t HEADER_SIZE = 40; // 4+4+4+4+4+8+8+2+2
+	constexpr uint32_t ENTRY_SIZE  = 12;
+	const auto entryCount = static_cast<uint32_t>(entries.size());
+	const uint32_t boxSize = HEADER_SIZE + entryCount * ENTRY_SIZE;
+
+	std::vector<uint8_t> buf(boxSize, 0);
+	auto *p = buf.data();
+
+	WriteBE32(p,      boxSize);
+	p[4] = 's'; p[5] = 'i'; p[6] = 'd'; p[7] = 'x';
+	WriteBE32(p + 8,  0x01000000u); // version=1, flags=0
+	WriteBE32(p + 12, 1);           // reference_ID
+	WriteBE32(p + 16, timescale);
+	// earliest_presentation_time (64-bit, offset 20)
+	WriteBE32(p + 20, 0);
+	WriteBE32(p + 24, 0);
+	// first_offset (64-bit, offset 28)
+	WriteBE32(p + 28, static_cast<uint32_t>(firstOffset >> 32));
+	WriteBE32(p + 32, static_cast<uint32_t>(firstOffset & 0xFFFFFFFFu));
+	WriteBE16(p + 36, 0); // reserved
+	WriteBE16(p + 38, static_cast<uint16_t>(entryCount));
+
+	uint8_t *ep = p + HEADER_SIZE;
+	for (const auto &entry : entries)
+	{
+		WriteBE32(ep,     entry.referencedSize & 0x7FFFFFFFu);
+		WriteBE32(ep + 4, entry.subsegmentDuration);
+		WriteBE32(ep + 8, 0);  // SAP flags
+		ep += ENTRY_SIZE;
+	}
+
+	return buf;
+}
+
 // ---------------------------------------------------------------------------
 // ParseSegmentIndexBox tests
 // ---------------------------------------------------------------------------
@@ -202,6 +305,68 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_NullStart_ReturnsFalse)
 	unsigned int refSize = 0;
 	float refDuration = 0.0f;
 	EXPECT_FALSE(ParseSegmentIndexBox(nullptr, 0, 0, &refSize, &refDuration, nullptr));
+}
+
+/**
+ * @brief Version-0 box with non-zero flags is parsed correctly.
+ *
+ * The version+flags field has version=0 in the top byte and non-zero
+ * values in the lower 24 bits (flags). The parser must isolate the top
+ * 8-bit version and treat this as a v0 box (32-bit time fields), not v1.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_V0WithNonZeroFlags_ParsedCorrectly)
+{
+	constexpr uint32_t TIMESCALE = 1000;
+	constexpr uint32_t FLAGS     = 0x000001u; // non-zero flags, version still 0
+	constexpr uint32_t REF_SIZE  = 5000;
+	constexpr uint32_t DURATION  = 2000;
+
+	auto sidx = BuildSidxBoxV0WithFlags(FLAGS, TIMESCALE, {{REF_SIZE, DURATION}});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									 &refSize, &refDuration, nullptr));
+	EXPECT_EQ(refSize, REF_SIZE);
+	EXPECT_FLOAT_EQ(refDuration,
+					 static_cast<float>(DURATION) / static_cast<float>(TIMESCALE));
+}
+
+/**
+ * @brief Version-1 SIDX box (64-bit time fields) is parsed correctly.
+ *
+ * Version 1 uses 8-byte earliest_presentation_time and first_offset.
+ * Verifies that the parser selects the correct (64-bit) read path and
+ * returns the right size/duration for the requested entry.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_V1_ParsedCorrectly)
+{
+	constexpr uint32_t TIMESCALE = 90000;
+	constexpr uint32_t REF_SIZE  = 12000;
+	constexpr uint32_t DURATION  = 90000;  // 1 second
+
+	auto sidx = BuildSidxBoxV1(TIMESCALE, {{REF_SIZE, DURATION}});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_TRUE(ParseSegmentIndexBox(sidx.data(), sidx.size(), 0,
+									 &refSize, &refDuration, nullptr));
+	EXPECT_EQ(refSize, REF_SIZE);
+	EXPECT_FLOAT_EQ(refDuration,
+					 static_cast<float>(DURATION) / static_cast<float>(TIMESCALE));
+}
+
+/**
+ * @brief Negative segment index returns false without UB.
+ *
+ * A negative segmentIndex must be rejected before the skip arithmetic,
+ * which would otherwise convert a negative product to a huge size_t.
+ */
+TEST(AampMPDUtils, ParseSegmentIndexBox_NegativeIndex_ReturnsFalse)
+{
+	auto sidx = BuildSidxBoxV0(1000, {{100, 1000}});
+	unsigned int refSize = 0;
+	float refDuration = 0.0f;
+	EXPECT_FALSE(ParseSegmentIndexBox(sidx.data(), sidx.size(), -1,
+									  &refSize, &refDuration, nullptr));
 }
 
 /**
@@ -276,12 +441,11 @@ TEST(AampMPDUtils, ParseSegmentIndexBox_Index0_ReturnsCorrectValues)
 }
 
 /**
- * @brief Parse multiple entries — key regression test for the *f += fix.
+ * @brief Parse multiple SIDX entries and verify correct indexing.
  *
- * Before the fix, `start += 12*segmentIndex` could produce incorrect
- * results if the pointer aliasing through `f` were ever broken.  The
- * corrected `*f += SIDX_ENTRY_SIZE * segmentIndex` is consistent with
- * every other cursor operation in the function.
+ * Ensures that ParseSegmentIndexBox correctly handles multiple entries
+ * in the SIDX box and, for each requested segment index, returns the
+ * expected referenced_size and referenced_duration values.
  */
 TEST(AampMPDUtils, ParseSegmentIndexBox_MultipleEntries_CorrectIndexing)
 {


### PR DESCRIPTION
Turns out it wasn't a bug, just confusing code.
Since 
const char **f = &start;
So *f and start are effectively the same thing.

Refactored to bring it forward to modern cpp, and remove confusing code

Added L1 tests