### PR TITLE
VPLAY-12070: protect stream abstraction in retune callback (#766)

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8241,6 +8241,19 @@ void PrivateInstanceAAMP::ScheduleRetune(PlaybackErrorType errorType, AampMediaT
 
 		lock.unlock();
 
+		// Take a local copy of the stream abstraction to check for tune
+		// NOTE - this copy is taken outside of the mutex protection as it is only used to see if it has changed while waiting
+		// for the mutex (i.e. checks to see if a 'retune' occurred). It should NOT be dereferenced as it may be invalid after the lock
+		const StreamAbstractionAAMP *oldStreamAbstraction = mpStreamAbstractionAAMP;
+		std::lock_guard<std::recursive_mutex> guard(mStreamLock); // protect mpStreamAbstractionAAMP (this must cover calls to AdditionalTuneFailLogEntries)
+
+		// Check that the stream abstraction has not changed while waiting for the mutex (we have not done some form of tune).
+		if (oldStreamAbstraction != mpStreamAbstractionAAMP)
+		{
+			AAMPLOG_WARN("PrivateInstanceAAMP: Ignore reTune due to stream changed");
+			return;
+		}
+
 		if (mpStreamAbstractionAAMP && mpStreamAbstractionAAMP->IsStreamerStalled())
 		{
 			AAMPLOG_WARN("PrivateInstanceAAMP: Ignore reTune due to playback stall");
@@ -8361,6 +8374,19 @@ void PrivateInstanceAAMP::ScheduleRetune(PlaybackErrorType errorType, AampMediaT
 		//pipeline error during trickplay
 		if(errorType == eGST_ERROR_GST_PIPELINE_INTERNAL)
 		{
+			// Take a local copy of the stream abstraction to check for tune
+			// NOTE - this copy is taken outside of the mutex protection as it is only used to see if it has changed while waiting
+			// for the mutex (i.e. checks to see if a 'retune' occurred). It should NOT be dereferenced as it may be invalid after the lock
+			const StreamAbstractionAAMP *oldStreamAbstraction = mpStreamAbstractionAAMP;
+			std::lock_guard<std::recursive_mutex> guard(mStreamLock); // protect mpStreamAbstractionAAMP (this must cover calls to AdditionalTuneFailLogEntries)
+
+			// Check that the stream abstraction has not changed while waiting for the mutex (we have not done some form of tune).
+			if (oldStreamAbstraction != mpStreamAbstractionAAMP)
+			{
+				AAMPLOG_WARN("PrivateInstanceAAMP: Ignore reTune due to stream changed");
+				return;
+			}
+
 			AAMPLOG_WARN("Processing retune for GstPipeline Internal Error and rate %f", rate);
 			SendAnomalyEvent(ANOMALY_WARNING, "%s GstPipeline Internal Error", GetMediaTypeName(trackType));
 			gLock.lock();


### PR DESCRIPTION
VPLAY-12070: protect stream abstraction in retune callback (#766)

Reason for change: If a SetRate() is received during the retune callback, the stream
                   abstraction can get deleted causing a segfault
Test Procedure: Follow trickmode tests on ticket
Risks: Low