### PR TITLE
VPLAY-12689 No Progress Events in VOD DAI Ad with Single Pipeline

### DIFF
--- a/AampStreamSinkManager.cpp
+++ b/AampStreamSinkManager.cpp
@@ -24,6 +24,7 @@
 
 #include "AampStreamSinkManager.h"
 #include "priv_aamp.h"
+#include "StreamAbstractionAAMP.h"
 
 AampStreamSinkManager::AampStreamSinkManager() :
 	mGstPlayer(nullptr),
@@ -397,6 +398,28 @@ void AampStreamSinkManager::ActivatePlayer(PrivateInstanceAAMP *aamp)
 	// This is because PrivateInstanceAAMP::GetPositionRelativeToSeekMilliseconds() calls
 	// GetStreamSink, which also locks mStreamSinkMutex.
 	double position = aamp->GetPositionMs() / 1000.00;
+	// Initialize flushPosition with current playback position,
+	// as a fallback mechanism when streamAbstraction is null
+	double flushPosition = position;
+
+	// Access mpStreamAbstractionAAMP under the PrivateInstanceAAMP stream lock
+	aamp->AcquireStreamLock();
+	StreamAbstractionAAMP *streamAbstraction = aamp->mpStreamAbstractionAAMP;
+	if (streamAbstraction != nullptr)
+	{
+		//Update flushPosition from aamp->mpStreamAbstractionAAMP
+		if (aamp->mMediaFormat == eMEDIAFORMAT_PROGRESSIVE)
+		{
+			flushPosition = streamAbstraction->GetStreamPosition();
+		}
+		else
+		{
+			flushPosition = streamAbstraction->GetFirstPTS();
+		}
+	}
+	aamp->ReleaseStreamLock();
+
+	AAMPLOG_INFO("flushPosition:%lf, position:%lf", flushPosition, position);
 
 	std::lock_guard<std::mutex> lock(mStreamSinkMutex);
 	
@@ -428,7 +451,7 @@ void AampStreamSinkManager::ActivatePlayer(PrivateInstanceAAMP *aamp)
 					AAMPLOG_WARN("AampStreamSinkManager(%p) Single Pipeline mode, setting active PLAYER[%d]", this, aamp->mPlayerId);
 
 					mActiveGstPlayersMap.insert({aamp, mGstPlayer});
-					SetActive(aamp, position);
+					SetActive(aamp, flushPosition);
 				}
 				else
 				{

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -68,7 +68,15 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData) {  }
 
 void StreamAbstractionAAMP_MPD::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &auxAudioOutputFormat, StreamOutputFormat &subtitleOutputFormat) {  }
 
-double StreamAbstractionAAMP_MPD::GetFirstPTS() { return 0; }
+double StreamAbstractionAAMP_MPD::GetFirstPTS()
+{
+	if (g_mockStreamAbstractionAAMP_MPD)
+	{
+		return g_mockStreamAbstractionAAMP_MPD->GetFirstPTS();
+	}
+
+	return 0;
+}
 
 double StreamAbstractionAAMP_MPD::GetMidSeekPosOffset() {
 

--- a/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
@@ -40,6 +40,7 @@ public:
 	MOCK_METHOD(bool, DoEarlyStreamSinkFlush, (bool newTune, float rate), (override));
 	MOCK_METHOD(Accessibility, getAccessibilityNode, (AampJsonObject &accessNode));
 	MOCK_METHOD(std::vector<AudioTrackInfo>&, GetAvailableAudioTracks, (bool allTrack), (override));
+	MOCK_METHOD(double, GetFirstPTS, (), (override));
 
   };
 

--- a/test/utests/tests/AampStreamSinkManagerTests/CMakeLists.txt
+++ b/test/utests/tests/AampStreamSinkManagerTests/CMakeLists.txt
@@ -36,7 +36,7 @@ include_directories(${AAMP_ROOT}/middleware/vendor)
 set(TEST_SOURCES AampStreamSinkManagerTests.cpp
                  FunctionalTests.cpp)
 
-set(AAMP_SOURCES ${AAMP_ROOT}/AampStreamSinkManager.cpp )
+set(AAMP_SOURCES ${AAMP_ROOT}/AampStreamSinkManager.cpp ${AAMP_ROOT}/CachedFragment.cpp)
 
 add_executable(${EXEC_NAME}
                ${TEST_SOURCES}

--- a/test/utests/tests/AampStreamSinkManagerTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampStreamSinkManagerTests/FunctionalTests.cpp
@@ -27,6 +27,7 @@
 #include "aampgstplayer.h"
 #include "MockAampGstPlayer.h"
 #include "MockStreamSink.h"
+#include "MockStreamAbstractionAAMP.h"
 #include "MockPrivateInstanceAAMP.h"
 
 using ::testing::_;
@@ -61,7 +62,11 @@ protected:
 
         g_mockPrivateInstanceAAMP = new NiceMock<MockPrivateInstanceAAMP>();
 
+        g_mockStreamAbstractionAAMP = new NiceMock<MockStreamAbstractionAAMP>(mPrivateInstanceAAMP2);
+
         g_mockAampGstPlayer = new MockAAMPGstPlayer( mPrivateInstanceAAMP1);
+
+        mPrivateInstanceAAMP2->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
 
         const auto id3_callback = std::bind(&PrivateInstanceAAMP::ID3MetadataHandler, mPrivateInstanceAAMP1, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5);
         mId3HandlerCallback1 = id3_callback;
@@ -78,6 +83,10 @@ protected:
 
         delete gpGlobalConfig;
         gpGlobalConfig = nullptr;
+
+        mPrivateInstanceAAMP2->mpStreamAbstractionAAMP = nullptr;
+        delete g_mockStreamAbstractionAAMP;
+        g_mockStreamAbstractionAAMP = nullptr;
 
         delete mPrivateInstanceAAMP2;
         mPrivateInstanceAAMP2 = nullptr;
@@ -327,13 +336,55 @@ TEST_F(AampStreamSinkManagerTests, ChangeAampTests)
     EXPECT_CALL(*g_mockAampGstPlayer, ChangeAamp(mPrivateInstanceAAMP1, _)).Times(0);
     AampStreamSinkManager::GetInstance().ActivatePlayer(mPrivateInstanceAAMP1);
 
-    /* ActivatePlayer() calls PrivateInstanceAAMP::GetPositionMs() to get the current position of the
-    second AAMP private instance and AAMPGstPlayer::Flush() with the position in seconds. */
-    long long positionMs = 5000;
-    EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetPositionMs()).WillOnce(Return(positionMs));
-    double positionSec = (positionMs / 1000.0);
+    mPrivateInstanceAAMP2->mMediaFormat = eMEDIAFORMAT_DASH;
+    /* ActivatePlayer() calls GetFirstPTS() of StreamAbstractionAAMP to get the
+    flush position of the second AAMP private instance and
+    AAMPGstPlayer::Flush() gets called with this position in seconds. */
+    double flushPosition = 5.0;
+    EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetFirstPTS()).WillOnce(Return(flushPosition));
+
     EXPECT_CALL(*g_mockAampGstPlayer, ChangeAamp(mPrivateInstanceAAMP2, _)).Times(1);
-    EXPECT_CALL(*g_mockAampGstPlayer, Flush(positionSec, _, true)).Times(1);
+    EXPECT_CALL(*g_mockAampGstPlayer, Flush(flushPosition, _, true)).Times(1);
+    AampStreamSinkManager::GetInstance().ActivatePlayer(mPrivateInstanceAAMP2);
+}
+
+/*
+    @brief: - verifies that progressive ActivatePlayer() uses stream position
+    Test Procedure
+    Initialize AampStreamSinkManager into single pipeline mode.
+    Create 1 sink, it will be the active sink.
+    For second player with progressive format, verify GetStreamPosition() is used
+*/
+TEST_F(AampStreamSinkManagerTests, ChangeAampTests_ProgressiveUsesStreamPosition)
+{
+    EXPECT_CALL(*g_mockAampGstPlayer, ChangeAamp(mPrivateInstanceAAMP1, _))
+        .Times(0);
+    EXPECT_CALL(*g_mockAampGstPlayer, ChangeAamp(mPrivateInstanceAAMP2, _))
+        .Times(0);
+
+    AampStreamSinkManager::GetInstance().CreateStreamSink(
+        mPrivateInstanceAAMP1, mId3HandlerCallback1);
+    AampStreamSinkManager::GetInstance().SetSinglePipelineMode(
+        mPrivateInstanceAAMP1);
+
+    AampStreamSinkManager::GetInstance().CreateStreamSink(
+        mPrivateInstanceAAMP2, mId3HandlerCallback2);
+
+    EXPECT_CALL(*g_mockAampGstPlayer, ChangeAamp(mPrivateInstanceAAMP1, _))
+        .Times(0);
+    AampStreamSinkManager::GetInstance().ActivatePlayer(mPrivateInstanceAAMP1);
+
+    mPrivateInstanceAAMP2->mMediaFormat = eMEDIAFORMAT_PROGRESSIVE;
+    /* ActivatePlayer() calls GetStreamPosition() of StreamAbstractionAAMP to get the
+    flush position of the second AAMP private instance and
+    AAMPGstPlayer::Flush() gets called with this position in seconds. */
+    double flushPosition = 7.0;
+    EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetStreamPosition())
+        .WillOnce(Return(flushPosition));
+
+    EXPECT_CALL(*g_mockAampGstPlayer, ChangeAamp(mPrivateInstanceAAMP2, _))
+        .Times(1);
+    EXPECT_CALL(*g_mockAampGstPlayer, Flush(flushPosition, _, true)).Times(1);
     AampStreamSinkManager::GetInstance().ActivatePlayer(mPrivateInstanceAAMP2);
 }
 


### PR DESCRIPTION
Unlike Sky, the VOD content and ads used by Rogers don't have a PTS starting
from 0 in the manifest segment timeline so this defect was causing a problem
in Rogers content but not Sky content.

  Reason for change: Progress reporting is not happening in
     one of the Rogers platforms when ad playback is in progress. This is
     because when VOD ads are played, the player may not be in active state
     when TuneHelper() gets called. This can cause the actual Flush operation
     not happening in TuneHelper after DoEarlyStreamSinkFlush() call.
     In such cases, Flush() happens at a later stage, when the player
     is set to activate state through ActivatePlayer() call. But the position used
     in ActivatePlayer() is not the flush position calculated in TuneHelper(),
     thus preventing aamp to perform seek to the correct position.

  Changes:
    * Use the same flush position used in TuneHelper() in ActivatePlayer() as well

  Test Procedure: Refer JIRA ticket

  Risks: low