### PR TITLE
VPLAY-11948 : middleware leak found by address sanitizer

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -89,6 +89,8 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	{
 		delete[] mDrmSystem;
 	}
+	/* safe delete configuration parameter */
+	MW_SAFE_DELETE(m_gstConfigParam);
 	mScheduler.StopScheduler();
 	for (int i = 0; i < GST_TRACK_COUNT; i++)
 	{


### PR DESCRIPTION
Reason for Change: Avoid leak of m_gstConfigParam in middleware layer
Test Procedure: refer ticket
Risks: Low
Priority: P1