### PR TITLE
VPLAY-12164 Http 404 for mpd while channel change

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8359,19 +8359,6 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 		mAutoResumeTaskPending = false;
 	}
 	DisableDownloads();
-	//Moved the tsb delete request from XRE to AAMP to avoid the HTTP-404 erros
-	if(IsFogTSBSupported())
-	{
-		std::string remoteUrl = "127.0.0.1:9080/tsb";
-		AampCurlDownloader T1;
-		DownloadResponsePtr respData = std::make_shared<DownloadResponse> ();
-		DownloadConfigPtr inpData = std::make_shared<DownloadConfig> ();
-		inpData->bIgnoreResponseHeader	= true;
-		inpData->eRequestType = eCURL_DELETE;
-		inpData->proxyName        = GetNetworkProxy();
-		T1.Initialize(std::move(inpData));
-		T1.Download(remoteUrl, std::move(respData) );
-	}
 
 	UnblockWaitForDiscontinuityProcessToComplete();
 	StopRateCorrectionWorkerThread();
@@ -8421,6 +8408,21 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 		ReleaseStreamLock();
 	}
 	TeardownStream(true,true); //disable download as well
+	
+	//Moved the tsb delete request from XRE to AAMP to avoid the HTTP-404 erros
+	//Moved the Fog TSB delete to avoid the delay in mpddownloaderinstance release which results in HTTP-404
+	if(IsFogTSBSupported())
+	{
+		std::string remoteUrl = "127.0.0.1:9080/tsb";
+		AampCurlDownloader T1;
+		DownloadResponsePtr respData = std::make_shared<DownloadResponse> ();
+		DownloadConfigPtr inpData = std::make_shared<DownloadConfig> ();
+		inpData->bIgnoreResponseHeader	= true;
+		inpData->eRequestType = eCURL_DELETE;
+		inpData->proxyName        = GetNetworkProxy();
+		T1.Initialize(std::move(inpData));
+		T1.Download(remoteUrl, std::move(respData) );
+	}
 
 	// stop the mpd update immediately after Stream abstraction delete
 	if(mMPDDownloaderInstance != nullptr)


### PR DESCRIPTION
Reason for change: MPD requested to fog through downloadMPDThread1 even after deleting the fog tsb from PrivateInstanceAAMP::Stop() due to the delay between FOG Tsb deletion and mpddownloaderinstance release. It results in HTTP 404 error during fast channel change. This change immediately release the mpddownloaderinstance right after fog tsb deletion
Test Procedure: updated in ticket
Risks: Low