### PR TITLE
VPLAY-11960: Crash(82066964-AAMP_JSEventListener::Event) observed while playing VOD assets

### DIFF
--- a/AampEventManager.cpp
+++ b/AampEventManager.cpp
@@ -366,8 +366,12 @@ void AampEventManager::SendEventSync(const AAMPEventPtr &eventData)
 #endif
 	// Check if already player in release state , then no need to send any events
 	// Its checked again here ,as async events can come to sync mode after playback is stopped 
-	if(mPlayerState == eSTATE_RELEASED)
+	// Added guard in SendEventSync() to skip event dispatch if player is in
+	// RELEASED state or  No listeners are registered for the specific event type (except AAMP_EVENT_ALL_EVENTS)
+	
+	if(mPlayerState == eSTATE_RELEASED || (mEventListeners[eventType] == NULL && eventType != AAMP_EVENT_ALL_EVENTS))
 	{
+		AAMPLOG_TRACE("No listeners for event %d or player released, not sending event", eventType);
 		return;
 	}
 	

--- a/test/utests/tests/AampEventManagerTests/AampEventManagerTests.cpp
+++ b/test/utests/tests/AampEventManagerTests/AampEventManagerTests.cpp
@@ -263,3 +263,22 @@ TEST_F(AampEventManagerTest, IsSpecificEventListenerAvailableTest_1)
     EXPECT_FALSE(val);
     }
 }
+
+TEST_F(AampEventManagerTest, SendEventSyncAfterListenerRemovedTest)
+{
+    // Arrange: Add and then remove listener for a specific event
+    AAMPEventType eventType = AAMP_EVENT_STATE_CHANGED;
+
+    handler->AddEventListener(eventType, eventListener);
+    handler->RemoveEventListener(eventType, eventListener);
+
+    // Ensure listener is removed
+    EXPECT_FALSE(handler->IsSpecificEventListenerAvailable(eventType));
+
+    // Create event and call SendEventSync
+    AAMPEventPtr eventData = std::make_shared<AAMPEventObject>(eventType, session_id);
+
+    handler->CallSendEventSync(eventData);
+
+    // Assert: No crash and no listener should be invoked.
+}


### PR DESCRIPTION
VPLAY-11960: Crash(82066964-AAMP_JSEventListener::Event) observed while playing VOD assets
Reason for change: Added additional guards in SendEventSync() to skip event dispatch 
when:

- Player is already in eSTATE_RELEASED state, or
- No listeners are registered for the specific event type
  (except AAMP_EVENT_ALL_EVENTS).

- Also added an L1 unit test to validate that SendEventSync() does not dispatch events after listener removal.

Test Procedure: Refer JIRA ticket

Risk : Low