### PR TITLE
VPLAY-12738 :  "com.comcast.viper" crash on VIPA enabled devices cont…

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7162,6 +7162,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 			{
 				AAMPLOG_WARN("empty period");
 				pMediaStreamContext->adaptationSet = NULL;
+				pMediaStreamContext->representation = NULL;
 				continue;
 			}
 			if (pMediaStreamContext->adaptationSetIdx >= numAdaptationSets )

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3815,9 +3815,17 @@ void PrivateInstanceAAMP::PlayFromTsbStart()
 		AAMPLOG_INFO("Resetting trickStartUTCMS to %lld since no first frame on trick play rate %f", trickStartUTCMS, rate);
 	}
 	rate = AAMP_NORMAL_PLAY_RATE;
-	AcquireStreamLock();
-	TuneHelper(eTUNETYPE_SEEK);
-	ReleaseStreamLock();
+	// Try to acquire the lock with a timeout to avoid deadlock
+	// If we can't get the lock, another operation is in progress
+	if (!TryStreamLock())
+	{
+		AAMPLOG_WARN("Could not acquire stream lock for PlayFromTsbStart, operation already in progress");
+	}
+	else
+	{
+		TuneHelper(eTUNETYPE_SEEK);
+		ReleaseStreamLock();
+	}
 	NotifySpeedChanged(rate);
 }
 


### PR DESCRIPTION
…ributing BERR.  (#1033)

* Crash in GetCurrentMimeType() on empty period Reason for Change: Potential floating pointer with empty periods Test Procedure: Tune regression testing
Risk: Low



* LLAMA-18029 Release stream lock before calling Stop()

Reason for Change: Fix deadlock

Test Procedure: Stress test rewind to TSB start with increased progress
                frequency

Risk: Low



* VPLAY-12067 - [Linear] Crash occurred in PreFetchThread in channel change (#746)

* VPLAY-12067 - [Linear] Crash occurred in PreFetchThread while doing sequential channel change

Reason for change: In sequential channel change scenario, stop can be initiated
  when AampLicensePreFetcher::PreFetchThread is in the middle of processing the
  license request(ie in the middle of executing CreateDRMSession()). This
  operation internally uses StreamAbstractionAamp object(mFetchInstance)
  to call UpdateFailedDRMStatus. As PrivateInstanceAAMP::Stop progresses,
  it can destroy the StreamAbstractionAamp object, but this status will reflect
  in AampLicensePreFetcher at a later point when mDRMLicenseManager->Stop()
  is called. Meanwhile, PreFetchThread is calling UpdateFailedDRMStatus
  on the destroyed object and leading to crash.

Changes:
* Setting mFetchInstance in AampLicensePreFetcher to nullptr before destroying StreamAbstractionAamp object.

Test Procedure: Refer JIRA ticket

Risks: low


* Addit Fix for Unit Test compilation issue



* Implement a less intrusive protection against stream abstraction mutex deadlock

---------