### PR TITLE
Reason for Change: added new file to cmakelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,7 @@ set(LIBAAMP_SOURCES
 	iso639map.cpp iso639map.h
 	AampCacheHandler.cpp AampCacheHandler.h
 	AampGrowableBuffer.cpp AampGrowableBuffer.h
+	AampBoxReader.h
 	CachedFragment.cpp CachedFragment.h
 	AampScheduler.cpp AampScheduler.h
 	AampUtils.cpp AampUtils.h


### PR DESCRIPTION
VPLAY-12834 AampBoxReader

Reason for Change: add missing new AampBoxReader.h to cmakelist; ensures this module listed and searchable in Xcode's navigator

Risk: None
