### PR TITLE
VPLAY-12920: [AAMP]- aamp tune version is displaying as 7.11 instead of 8.03

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -30,7 +30,7 @@
 #define AAMP_CFG_PATH "/opt/aamp.cfg"
 #define AAMP_JSON_PATH "/opt/aampcfg.json"
 
-#define AAMP_VERSION "7.11"
+#define AAMP_VERSION "8.03"
 #define AAMP_TUNETIME_VERSION 8
 
 //Stringification of Macro : use two levels of macros


### PR DESCRIPTION
Reason for change: Changed AAMP version to 8.03
Test Procedure: Refer Jira
Risks: No