### PR TITLE
VPLAY-12921 Remove AAMP Playlist downloader thread ERROR

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4265,12 +4265,6 @@ void MediaTrack::AbortWaitForPlaylistDownload()
 	{
 		plDownloadWait.notify_one();
 	}
-	else
-	{
-		// This is expected in some cases like playing DASH content, where the
-		// playlist downloader thread is not used.
-		AAMPLOG_TRACE("[%s] Playlist downloader thread not started", name);
-	}
 }
 
 /**

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4267,7 +4267,9 @@ void MediaTrack::AbortWaitForPlaylistDownload()
 	}
 	else
 	{
-		AAMPLOG_ERR("[%s] Playlist downloader thread not started", name);
+		// This is expected in some cases like playing DASH content, where the
+		// playlist downloader thread is not used.
+		AAMPLOG_TRACE("[%s] Playlist downloader thread not started", name);
 	}
 }
 


### PR DESCRIPTION
Reason for Change: Remove ERROR from log when AAMP playing DASH

Summary of Changes: Remove ERROR log line

Test Procedure: Verify that the following ERROR is not in the log
                "Playlist downloader thread not started"

Risk: Low