### PR TITLE
iVPLAY-12893: [VIPA][AAMP] Race condition in TsbReader

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9997,10 +9997,7 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 						break;
 					}
 					AAMPLOG_INFO("EOS from both tracks - Wait for next fragment");
-					// Snapshot counter before waiting. If AbortWaitForManifestUpdate()
-					// fired between EOS detection and here, the predicate fires
-					// immediately and we re-enter the loop to check for new segments.
-					WaitForManifestUpdate(GetManifestUpdateCounter());
+					aamp->interruptibleMsSleep(500);
 				}
 				if(cacheFullStatus[eMEDIATYPE_VIDEO] || (vEOS && !aEOS))
 				{

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9996,7 +9996,7 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 						exitLoop = true;
 						break;
 					}
-					AAMPLOG_INFO("EOS from both tracks - Wait for next fragment");
+					AAMPLOG_INFO("EOS detected (video=%d, audio=%d) - Wait for next fragment", vEOS, aEOS);
 					aamp->interruptibleMsSleep(500);
 				}
 				if(cacheFullStatus[eMEDIATYPE_VIDEO] || (vEOS && !aEOS))


### PR DESCRIPTION
Reason for change: Revert back to interruptible sleep when we either hit video or audio EOS in TSBReader. TSBReader has no dependency with manifest updates.
Test Procedure: As mentioned in the ticket
Risks: None