### PR TITLE
VPLAY-12917: missing closed caption after seek to advert

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -6982,7 +6982,7 @@ void StreamAbstractionAAMP_HLS::ConfigureTextTrack()
 	{
 		aamp->mIsInbandCC = mediaInfoStore[currentTextTrackProfileIndex].isCC;
 	}
-	AAMPLOG_WARN("TextTrack Selected :%d", currentTextTrackProfileIndex);
+	AAMPLOG_WARN("TextTrack Selected :%d inBandCC:%d", currentTextTrackProfileIndex, aamp->mIsInbandCC);
 }
 /**
  * @brief Stops the Track Injection,Restarts once the track has been changed
@@ -7145,7 +7145,17 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 				std::string index = std::to_string(i);
 				std::string language = (!media.language.empty()) ? GetLanguageCode(i) : std::string();
 				AAMPLOG_INFO("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, media.group_id.c_str(), media.name.c_str(), media.instreamID.c_str(), media.characteristics.c_str());
-				mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
+				if( ISCONFIGSET(eAAMPConfig_DisableWebVTT)  && media.isCC )
+				{
+					AAMPLOG_WARN("pushing only isCC:%d tracks", media.isCC);
+					mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
+				}
+				else if ( !ISCONFIGSET(eAAMPConfig_DisableWebVTT))
+				{
+					AAMPLOG_WARN("pushing all isCC:%d tracks", media.isCC);
+					mTextTracks.push_back(TextTrackInfo(std::move(index), std::move(language), media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
+				}
+				
 			}
 			i++;
 		}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -11143,10 +11143,13 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 		std::vector<CCTrackInfo> updatedTextTracks;
 		UpdateCCTrackInfo(textTracksCopy,updatedTextTracks);
 		PlayerCCManager::GetInstance()->updateLastTextTracks(updatedTextTracks);
-		if( ISCONFIGSET_PRIV(eAAMPConfig_DisableWebVTT) )
+		for (auto iter = trackInfo.begin(); iter != trackInfo.end(); iter++)
 		{
-			trackInfo.swap(textTracksCopy);
-			AAMPLOG_DEBUG("Filtered track list to include only in-band CC tracks");
+			AAMPLOG_WARN("textTracksCopy name:%s isCC:%d",iter->name.c_str(),iter->isCC);
+		}
+		for (auto iter = textTracksCopy.begin(); iter != textTracksCopy.end(); iter++)
+		{
+			AAMPLOG_WARN("textTracksCopy name:%s isCC:%d",iter->name.c_str(),iter->isCC);
 		}
 		if (!trackInfo.empty())
 		{
@@ -11558,7 +11561,7 @@ std::string PrivateInstanceAAMP::GetAudioTrackInfo()
 }
 
 /**
- * @brief Get current audio track index
+ * @brief Get current text track index
  */
 std::string PrivateInstanceAAMP::GetTextTrackInfo()
 {


### PR DESCRIPTION
VPLAY-12917: missing closed caption after seek to advert
Reason for Change: filter webVTT while parsing

Test Guidance: updated in ticket

Risk: Low