### PR TITLE
VPLAY-11152 crash during first playback after coming out of deepsleep

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -81,7 +81,8 @@ void getConfigs(DrmSessionManager *mDRMSessionManager , PrivateInstanceAAMP *aam
  *  @brief AampDRMLicenseManager constructor.
  */
 AampDRMLicenseManager::AampDRMLicenseManager(int maxDrmSessions, PrivateInstanceAAMP *aamp) : mMaxDRMSessions(maxDrmSessions),
-		aampInstance(aamp), mDRMSessionManager(NULL)
+		aampInstance(aamp), mDRMSessionManager(NULL),
+		accessToken(NULL), accessTokenLen(0)
 {
     aampInstance = aamp; 
     mDRMSessionManager = new DrmSessionManager(maxDrmSessions ,aampInstance);

--- a/externals/rdk/PlayerIarmRdkInterface.cpp
+++ b/externals/rdk/PlayerIarmRdkInterface.cpp
@@ -32,6 +32,10 @@
 #define DISPLAY_HEIGHT_UNKNOWN      -1  /**< Parsing failed for getResolution().getName(); */
 #define DISPLAY_RESOLUTION_NA        0  /**< Resolution not available yet or not connected to HDMI */
 
+#ifdef IARM_MGR
+static IARM_Bus_PWRMgr_PowerState_t prevState = IARM_BUS_PWRMGR_POWERSTATE_ON;
+#endif
+
 /**
  * @brief Enumeration for net_srv_mgr active interface event callback
  */
@@ -77,11 +81,13 @@ void powerModeChangeHandler(const char *owner, IARM_EventId_t eventId, void *dat
         IARM_Bus_PWRMgr_EventData_t *param = (IARM_Bus_PWRMgr_EventData_t *)data;
         printf("Event IARM_BUS_PWRMGR_EVENT_MODECHANGED: State Changed %d -- > %d\n",
                 param->data.state.curState, param->data.state.newState);
-        if(param->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP && param->data.state.newState != IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP )
+        bool isOnOrStandby = (param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY || param->data.state.newState == IARM_BUS_PWRMGR_POWERSTATE_ON);
+	if((param->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP && isOnOrStandby) || (prevState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_DEEP_SLEEP && param->data.state.curState == IARM_BUS_PWRMGR_POWERSTATE_STANDBY_LIGHT_SLEEP && isOnOrStandby))
         {
             printf(" DEEPSLEEP : calling triggerFakeTune  \n");
 	    triggerFakeTune();
         }
+	prevState = param->data.state.curState;
     }
 }
 #endif // IARM


### PR DESCRIPTION
Reason for change: Initialise AampDRMLicenseManager class members
Test Procedure: see ticket
Risks: Low


VPLAY-11854 Webprocess crash AampDRMLicenseManager::createDrmSession

Reason for change: trigger the fake tune only when the device transitions from DEEPSLEEP to ON/STANDBY, we can make sure that HDMI is in the expected state and the playback should work as expected.
Test Procedure: updated in ticket
Risks: Low