### PR TITLE
VPLAY-12972 Fixing failure in L2 test 5016

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10501,9 +10501,7 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 	{
 		AAMPLOG_INFO("Abort TsbReader");
 		abortTsbReader = true;
-		// Unblock TsbReader if it is waiting for new video TSB content (e.g. during FF
-		// on local AAMP TSB where DisableDownloads is not called and therefore
-		// NotifyVideoTsbWaiters is not triggered via the downloads-disabled path).
+		// Unblock TsbReader if it is waiting for new video TSB content
 		if (AampTSBSessionManager *tsbMgr = aamp->GetTSBSessionManager())
 		{
 			tsbMgr->NotifyVideoTsbWaiters();

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10501,6 +10501,13 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 	{
 		AAMPLOG_INFO("Abort TsbReader");
 		abortTsbReader = true;
+		// Unblock TsbReader if it is waiting for new video TSB content (e.g. during FF
+		// on local AAMP TSB where DisableDownloads is not called and therefore
+		// NotifyVideoTsbWaiters is not triggered via the downloads-disabled path).
+		if (AampTSBSessionManager *tsbMgr = aamp->GetTSBSessionManager())
+		{
+			tsbMgr->NotifyVideoTsbWaiters();
+		}
 		// Signal TsbReader thread to exit wait for manifest update if waiting
 		AbortWaitForManifestUpdate();
 		tsbReaderThreadID.join();

--- a/test/utests/fakes/FakeTSBSessionManager.cpp
+++ b/test/utests/fakes/FakeTSBSessionManager.cpp
@@ -253,4 +253,8 @@ void AampTSBSessionManager::WaitForVideoTsbContentOrAbort()
 
 void AampTSBSessionManager::NotifyVideoTsbWaiters()
 {
+	if (g_mockTSBSessionManager)
+	{
+		g_mockTSBSessionManager->NotifyVideoTsbWaiters();
+	}
 }

--- a/test/utests/mocks/MockTSBSessionManager.h
+++ b/test/utests/mocks/MockTSBSessionManager.h
@@ -38,6 +38,7 @@ public:
 	MOCK_METHOD(bool, PushNextTsbFragment, (MediaStreamContext*, uint32_t));
 	MOCK_METHOD(AAMPStatusType, InvokeTsbReaders, (double &, float, TuneType));
 	MOCK_METHOD(double, GetTotalStoreDuration, (AampMediaType));
+	MOCK_METHOD(void, NotifyVideoTsbWaiters, ());
 };
 
 extern MockTSBSessionManager *g_mockTSBSessionManager;

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -3583,6 +3583,41 @@ TEST_F(StreamAbstractionAAMP_MPDTest, InitTsbReaderTest)
 	EXPECT_FLOAT_EQ(mStreamAbstractionAAMP_MPD->GetStreamPosition(), livePlayPosition);
 }
 
+/*
+ * @brief Test to verify Stop() calls NotifyVideoTsbWaiters() when TSB reader thread is active
+*/
+TEST_F(StreamAbstractionAAMP_MPDTest, Stop_NotifiesVideoTsbWaiters)
+{
+	double livePlayPosition = 123.456;
+	AampTSBSessionManager *tsbSessionManager = new AampTSBSessionManager(mPrivateInstanceAAMP);
+	std::shared_ptr<AampTsbDataManager> dataMgr;
+	std::shared_ptr<AampTsbReader> tsbReader = std::make_shared<AampTsbReader>(mPrivateInstanceAAMP, dataMgr, eMEDIATYPE_VIDEO, "sessionId");
+
+	// Setup InitTsbReader to start the TSB reader thread
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLivePlayPosition()).WillOnce(Return(livePlayPosition));
+	// For InitTsbReader, Stop and other calls
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(tsbSessionManager)); 
+	EXPECT_CALL(*g_mockTSBSessionManager, InvokeTsbReaders(livePlayPosition, AAMP_NORMAL_PLAY_RATE, eTUNETYPE_SEEKTOLIVE))
+		.WillOnce(Return(eAAMPSTATUS_OK));
+	// Handle GetTsbReader for all media types - return nullptr by default, then override for VIDEO
+	EXPECT_CALL(*g_mockTSBSessionManager, GetTsbReader(_)).WillRepeatedly(Return(nullptr));
+	EXPECT_CALL(*g_mockTSBSessionManager, GetTsbReader(eMEDIATYPE_VIDEO)).WillRepeatedly(Return(tsbReader));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifyOnEnteringLive()).Times(1);
+
+	mStreamAbstractionAAMP_MPD->InitTsbReader(eTUNETYPE_SEEKTOLIVE);
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillOnce(Return(true));
+	// Start the TSB reader thread	
+	mStreamAbstractionAAMP_MPD->Start();
+	EXPECT_CALL(*g_mockTSBSessionManager, NotifyVideoTsbWaiters()).Times(1);
+
+	// Execute Stop() - this should trigger NotifyVideoTsbWaiters for the TSB reader thread
+	mStreamAbstractionAAMP_MPD->Stop(false);
+
+	delete tsbSessionManager;
+}
+
 TEST_F(StreamAbstractionAAMP_MPDTest, SendAdReservationEvent_NoTSB)
 {
 	// Set up test parameters for start event

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -3589,16 +3589,16 @@ TEST_F(StreamAbstractionAAMP_MPDTest, InitTsbReaderTest)
 TEST_F(StreamAbstractionAAMP_MPDTest, Stop_NotifiesVideoTsbWaiters)
 {
 	double livePlayPosition = 123.456;
-	AampTSBSessionManager *tsbSessionManager = new AampTSBSessionManager(mPrivateInstanceAAMP);
+	std::unique_ptr<AampTSBSessionManager> tsbSessionManager = std::make_unique<AampTSBSessionManager>(mPrivateInstanceAAMP);
 	std::shared_ptr<AampTsbDataManager> dataMgr;
 	std::shared_ptr<AampTsbReader> tsbReader = std::make_shared<AampTsbReader>(mPrivateInstanceAAMP, dataMgr, eMEDIATYPE_VIDEO, "sessionId");
 
 	// Setup InitTsbReader to start the TSB reader thread
-	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mPrivateInstanceAAMP->rate = 2;
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLivePlayPosition()).WillOnce(Return(livePlayPosition));
 	// For InitTsbReader, Stop and other calls
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(tsbSessionManager)); 
-	EXPECT_CALL(*g_mockTSBSessionManager, InvokeTsbReaders(livePlayPosition, AAMP_NORMAL_PLAY_RATE, eTUNETYPE_SEEKTOLIVE))
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(tsbSessionManager.get()));
+	EXPECT_CALL(*g_mockTSBSessionManager, InvokeTsbReaders(livePlayPosition, 2, eTUNETYPE_SEEKTOLIVE))
 		.WillOnce(Return(eAAMPSTATUS_OK));
 	// Handle GetTsbReader for all media types - return nullptr by default, then override for VIDEO
 	EXPECT_CALL(*g_mockTSBSessionManager, GetTsbReader(_)).WillRepeatedly(Return(nullptr));
@@ -3614,8 +3614,6 @@ TEST_F(StreamAbstractionAAMP_MPDTest, Stop_NotifiesVideoTsbWaiters)
 
 	// Execute Stop() - this should trigger NotifyVideoTsbWaiters for the TSB reader thread
 	mStreamAbstractionAAMP_MPD->Stop(false);
-
-	delete tsbSessionManager;
 }
 
 TEST_F(StreamAbstractionAAMP_MPDTest, SendAdReservationEvent_NoTSB)


### PR DESCRIPTION
Reason for change: Unblocks the Tsb Reader when aborted from stop method. 
Test Procedure: Mentioned in the ticket
Risk:low