### PR TITLE
VPLAY-12820: [L2][2052]LLD playback was failing when mp4demux enabled

### DIFF
--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -168,6 +168,7 @@ Mp4Demux::Mp4Demux() :
 	duration(),
 	sampleOffset(), sencPresent(false),
 	handledEncryptedSamples(false),
+	mSampleInfo(),
 	codecInfo(GST_FORMAT_INVALID), parseError(MP4_PARSE_OK)
 {
 }
@@ -659,11 +660,11 @@ void Mp4Demux::ParseSampleEncryption()
 
 /**
  * @brief Parse track run box (TRUN)
- * Extracts sample information from the track run including:
- * - Sample data offsets and sizes
+ * Extracts sample metadata from the track run including:
  * - Sample durations and composition time offsets
  * - Sample flags and media timing information
- * Creates AampMediaSample objects with proper PTS/DTS timing.
+ * Actual sample data copy and boundary validation are deferred into mSampleInfo 
+ * This handles both normal and LLD streams where mdat follows moof.
  */
 void Mp4Demux::ParseTrackRun()
 {
@@ -675,10 +676,6 @@ void Mp4Demux::ParseTrackRun()
 		int32_t dataOffset = ReadI32();
 		dataPtr += dataOffset;
 	}
-	if( mdatStart && (dataPtr < mdatStart || dataPtr >= mdatEnd) )
-	{
-		throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "trun: dataPtr outside mdat");
-	}
 	uint32_t sampleFlags = 0;
 	if (flags & TRUN_FIRST_SAMPLE_FLAGS_PRESENT)
 	{
@@ -689,8 +686,6 @@ void Mp4Demux::ParseTrackRun()
 	for (auto i = 0u; i < sampleCount; i++)
 	{
 		samples.emplace_back();
-		// Get reference to newly added sample
-		AampMediaSample& newSample = samples.back();
 		uint32_t sampleLen = defaultSampleSize;
 		uint32_t sampleDuration = defaultSampleDuration;
 		if (flags & TRUN_SAMPLE_DURATION_PRESENT)
@@ -711,21 +706,57 @@ void Mp4Demux::ParseTrackRun()
 		{ // for samples where pts and dts differ (overriding 'trex')
 			sampleCompositionTimeOffset = ReadI32();
 		}
-		// Guard: sample buffer must not overrun endPtr (or mdat)
-		const uint8_t* hardEnd = mdatEnd ? mdatEnd : endPtr;
-		if ( dataPtr + sampleLen > hardEnd )
+		// mdat follows the moof in the bitstream
+		// so boundary checks and data copy must wait until mdatStart/mdatEnd are established.
+		PendingSamplePayload pendingSample;
+		pendingSample.dataPtr  = dataPtr;
+		pendingSample.sampleLen = sampleLen;
+		pendingSample.sampleIdx = samples.size() - 1;
+		pendingSample.mDts      = dts / (double)timeScale;
+		pendingSample.mPts      = (dts + sampleCompositionTimeOffset) / (double)timeScale;
+		pendingSample.mDuration = sampleDuration / (double)timeScale;
+		mSampleInfo.emplace_back(pendingSample);
+		dataPtr += sampleLen;
+		dts += sampleDuration;
+	}
+}
+
+/**
+ * @brief Assign sample payload data after mdat is parsed
+ *
+ * Called immediately after mdatStart/mdatEnd are set from an mdat box.
+ * Iterates over mSampleInfo, validates each sample's data
+ * pointer against the mdat extent, and copies the payload into the corresponding AampMediaSample.
+ * Clears mSampleInfo on exit.
+ */
+void Mp4Demux::ProcessSamples()
+{
+	if (!mdatStart || !mdatEnd)
+	{
+		throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "mdat: bounds not established");
+	}
+	for (const auto& pending : mSampleInfo)
+	{
+		const uint8_t* dataPtr = pending.dataPtr;
+		uint32_t sampleLen = pending.sampleLen;
+		// Validate data pointer is within current mdat bounds
+		if (dataPtr < mdatStart || dataPtr >= mdatEnd)
+		{
+			throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "trun: dataPtr outside mdat");
+		}
+		// Guard: sample payload must not overrun mdat
+		const uint8_t* hardEnd = mdatEnd;
+		if (dataPtr + sampleLen > hardEnd)
 		{
 			throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "trun: sample payload OOB");
 		}
-		newSample.mData.insert(newSample.mData.GetVector().end(),
-							   dataPtr,
-							   dataPtr + sampleLen);
-		dataPtr += sampleLen;
-		newSample.mDts = dts / (double)timeScale;
-		newSample.mPts = (dts + sampleCompositionTimeOffset) / (double)timeScale;
-		newSample.mDuration = sampleDuration / (double)timeScale;
-		dts += sampleDuration;
+		AampMediaSample& s = samples[pending.sampleIdx];
+		s.mData.insert(s.mData.GetVector().end(), dataPtr, dataPtr + sampleLen);
+		s.mDts      = pending.mDts;
+		s.mPts      = pending.mPts;
+		s.mDuration = pending.mDuration;
 	}
+	mSampleInfo.clear();
 }
 
 /**
@@ -1192,6 +1223,9 @@ void Mp4Demux::DemuxHelper(const uint8_t *fin)
 				gotAuxiliaryInformationOffset = false;
 				cencAuxInfoSizes.clear();
 				sencPresent = false;
+				// Clear any leftover pending payloads from a prior fragment so Left over should be treated as error
+				// they are not re-assigned when the next mdat is encountered.
+				mSampleInfo.clear();
 				DemuxHelper(next);
 				MP4_LOG_DEBUG("Completed parsing 'moof' box, sampleOffset: %" PRIu64 " total samples: %zu", sampleOffset, samples.size());
 				if (!sencPresent && gotAuxiliaryInformationOffset)
@@ -1240,6 +1274,8 @@ void Mp4Demux::DemuxHelper(const uint8_t *fin)
 				// Track mdat payload range for TRUN validation
 				mdatStart = ptr; // start of payload (after header bytes)
 				mdatEnd   = next; // end of payload
+				// Now that mdat bounds are known, copy sample payloads that were deferred by ParseTrackRun() (handles both normal and LLD order).
+				ProcessSamples();
 				ptr = next; // skip payload
 				break;
 			default:
@@ -1277,6 +1313,7 @@ bool Mp4Demux::Parse(const void *data, size_t len)
 	samples.clear();
 	cencAuxInfoSizes.clear();
 	protectionData.clear();
+	mSampleInfo.clear();
 	gotAuxiliaryInformationOffset = false;
 	moofPtr = nullptr;
 	endPtr = &((const uint8_t*)data)[len];

--- a/mp4demux/MP4Demux.h
+++ b/mp4demux/MP4Demux.h
@@ -174,6 +174,20 @@ private:
 	uint64_t sampleOffset; /**< Current sample offset */
 	bool sencPresent; /**< SENC box present flag */
 	bool handledEncryptedSamples; /**< Flag indicating encrypted samples have been handled */
+
+	/**
+	 * @brief Pending sample payload data.
+	 */
+	struct PendingSamplePayload
+	{
+		const uint8_t* dataPtr; /**< Pointer into the parse buffer where sample data starts */
+		uint32_t sampleLen;     /**< Byte length of this sample's payload */
+		size_t sampleIdx;       /**< Index into samples[] where data must be placed */
+		double mDts;            /**< Decode timestamp in seconds */
+		double mPts;            /**< Presentation timestamp in seconds */
+		double mDuration;       /**< Sample duration in seconds */
+	};
+	std::vector<PendingSamplePayload> mSampleInfo; /**< sample payloads awaiting mdat bounds */
 	MediaCodecInfo codecInfo; /**< Codec information */
 	Mp4ParseError parseError; /**< Current parse error state */
 
@@ -251,6 +265,10 @@ private:
 	void ParseSampleEncryption();
 	/** @brief Parse track run box (TRUN) */
 	void ParseTrackRun();
+	/**
+	 * @brief Assign deferred sample payload data after mdat is parsed
+	 */
+	void ProcessSamples();
 	/** @brief Parse track fragment header box (TFHD) */
 	void ParseTrackFragmentHeader();
 	/** @brief Parse track fragment decode time box (TFDT) */

--- a/test/utests/tests/Mp4BoxParsingTests/BoxParsingTests.cpp
+++ b/test/utests/tests/Mp4BoxParsingTests/BoxParsingTests.cpp
@@ -456,3 +456,228 @@ TEST(Mp4Demux_Gaps, TrunOverrunDetection) {
 	EXPECT_EQ(d.GetLastError(), MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH);
 }
 
+// F) Multiple moof+mdat pairs with correct trun data_offset handling (positive case)
+// Verifies that each sample's payload bytes are sourced from the correct mdat box in consecutive moof+mdat pairs.
+TEST(Mp4Demux_Gaps, TST2052_LLDMultipleMoofMdatPairs) {
+	std::vector<uint8_t> buf;
+
+	// ---- helper to patch a 4-byte big-endian int32 at a specific index ----
+	auto patchI32 = [&](size_t idx, int32_t v) {
+		buf[idx+0] = uint8_t((v>>24)&0xFF);
+		buf[idx+1] = uint8_t((v>>16)&0xFF);
+		buf[idx+2] = uint8_t((v>>8) &0xFF);
+		buf[idx+3] = uint8_t( v     &0xFF);
+	};
+
+	// ---- build moof1 ----
+	// default_sample_duration = 3000, default_sample_size = 10
+	// 2 samples → mdat1 payload = 20 bytes
+	size_t moof1Start;
+	size_t trun1DataOffsetPos;
+	{
+		Box moof(buf, "moof"); moof1Start = moof.start;
+		{ Box mfhd(buf, "mfhd"); writeFullBoxHeader(buf,0,0); write32be(buf,1); mfhd.close(); }
+		{ Box traf(buf, "traf");
+			{ Box tfhd(buf, "tfhd");
+				writeFullBoxHeader(buf, 0, 0x00008 | 0x00010); // default dur + default size
+				write32be(buf, 1);     // track_ID
+				write32be(buf, 3000);  // default_sample_duration (0.1 s @ 30000 Hz)
+				write32be(buf, 10);    // default_sample_size
+				tfhd.close();
+			}
+			{ Box tfdt(buf, "tfdt"); writeFullBoxHeader(buf,0,0); write32be(buf,0); tfdt.close(); }
+			{ Box trun(buf, "trun");
+				writeFullBoxHeader(buf, 0, 0x0001); // TRUN_DATA_OFFSET_PRESENT
+				write32be(buf, 2);  // sample_count = 2
+				trun1DataOffsetPos = buf.size();
+				write32be(buf, 0);  // data_offset placeholder
+				trun.close();
+			}
+			traf.close();
+		}
+		moof.close();
+	}
+	// patch trun1 data_offset: distance from moof1 start to mdat1 payload
+	// mdat1 header is 8 bytes, so payload starts at buf.size() + 8
+	patchI32(trun1DataOffsetPos, int32_t((buf.size() + 8) - moof1Start));
+
+	// ---- mdat1: 20 bytes (2 samples × 10 bytes) ----
+	write32be(buf, 28); write4cc(buf, "mdat"); // 8 header + 20 payload
+	for (int i = 0; i < 20; ++i) buf.push_back(uint8_t(0xAA + i));
+
+	// ---- build moof2 ----
+	// default_sample_duration = 3000, default_sample_size = 15
+	// 1 sample → mdat2 payload = 15 bytes
+	size_t moof2Start;
+	size_t trun2DataOffsetPos;
+	{
+		Box moof(buf, "moof"); moof2Start = moof.start;
+		{ Box mfhd(buf, "mfhd"); writeFullBoxHeader(buf,0,0); write32be(buf,2); mfhd.close(); }
+		{ Box traf(buf, "traf");
+			{ Box tfhd(buf, "tfhd");
+				writeFullBoxHeader(buf, 0, 0x00008 | 0x00010);
+				write32be(buf, 1);     // track_ID
+				write32be(buf, 3000);  // default_sample_duration
+				write32be(buf, 15);    // default_sample_size
+				tfhd.close();
+			}
+			// baseMediaDecodeTime = 6000 (2 samples × 3000)
+			{ Box tfdt(buf, "tfdt"); writeFullBoxHeader(buf,0,0); write32be(buf,6000); tfdt.close(); }
+			{ Box trun(buf, "trun");
+				writeFullBoxHeader(buf, 0, 0x0001); // TRUN_DATA_OFFSET_PRESENT
+				write32be(buf, 1);  // sample_count = 1
+				trun2DataOffsetPos = buf.size();
+				write32be(buf, 0);  // data_offset placeholder
+				trun.close();
+			}
+			traf.close();
+		}
+		moof.close();
+	}
+	// patch trun2 data_offset: distance from moof2 start to mdat2 payload
+	patchI32(trun2DataOffsetPos, int32_t((buf.size() + 8) - moof2Start));
+
+	// ---- mdat2: 15 bytes (1 sample × 15 bytes) ----
+	write32be(buf, 23); write4cc(buf, "mdat"); // 8 header + 15 payload
+	for (int i = 0; i < 15; ++i) buf.push_back(uint8_t(0xBB + i));
+
+	// ---- parse ----
+	Mp4Demux d;
+	ASSERT_TRUE(d.Parse(buf.data(), buf.size()))
+		<< "LLD [moof][mdat][moof][mdat] must parse without error";
+	EXPECT_EQ(d.GetLastError(), MP4_PARSE_OK);
+
+	auto samples = d.GetSamples();
+	ASSERT_EQ(samples.size(), 3u) << "Expected 3 samples total (2 from moof1 + 1 from moof2)";
+
+	// ---- validate moof1 samples (data from mdat1) ----
+	ASSERT_EQ(samples[0].mData.size(), 10u) << "Sample 0: 10 bytes from mdat1";
+	EXPECT_EQ(samples[0].mData.GetVector()[0], uint8_t(0xAA))
+		<< "Sample 0 first byte should match first byte of mdat1 payload";
+
+	ASSERT_EQ(samples[1].mData.size(), 10u) << "Sample 1: 10 bytes from mdat1";
+	EXPECT_EQ(samples[1].mData.GetVector()[0], uint8_t(0xAA + 10))
+		<< "Sample 1 first byte should match second chunk of mdat1 payload";
+
+	// ---- validate moof2 sample (data from mdat2, NOT mdat1) ----
+	ASSERT_EQ(samples[2].mData.size(), 15u) << "Sample 2: 15 bytes from mdat2";
+	EXPECT_EQ(samples[2].mData.GetVector()[0], uint8_t(0xBB))
+		<< "Sample 2 first byte must come from mdat2, not mdat1";
+}
+
+// G) LL-DASH regression: two consecutive moof+mdat pairs in one Parse() call must not produce DATA_BOUNDARY_MISMATCH.
+// each fragment's pending payloads are only resolved against the mdat that belongs to that specific moof.
+TEST(Mp4Demux_Gaps, MultiMoofMdatNoBoundaryError)
+{
+	std::vector<uint8_t> buf;
+
+	size_t moof1StartIdx = 0, moof2StartIdx = 0;
+	size_t trun1DataOffsetPos = 0, trun2DataOffsetPos = 0;
+	size_t mdat1PayloadStart = 0, mdat2PayloadStart = 0;
+
+	// --- moof1 + mdat1 ---
+	{
+		Box moof(buf, "moof"); moof1StartIdx = moof.start;
+		{
+			Box traf(buf, "traf");
+			{
+				// tfhd: default-sample-duration-present (0x8) | default-sample-size-present (0x10)
+				Box tfhd(buf, "tfhd"); writeFullBoxHeader(buf, 0, 0x00008 | 0x00010);
+				write32be(buf, 1);      // track_ID
+				write32be(buf, 3000);   // default_sample_duration
+				write32be(buf, 8);      // default_sample_size (8 bytes per sample)
+				tfhd.close();
+			}
+			{
+				Box tfdt(buf, "tfdt"); writeFullBoxHeader(buf, 0, 0);
+				write32be(buf, 0);      // baseMediaDecodeTime = 0
+				tfdt.close();
+			}
+			{
+				// trun: flags = 0x0001 (data-offset-present only; sizes from tfhd default)
+				Box trun(buf, "trun"); writeFullBoxHeader(buf, 0, 0x0001);
+				write32be(buf, 1);      // sample_count = 1
+				trun1DataOffsetPos = buf.size();
+				write32be(buf, 0);      // placeholder: data_offset (patched below)
+				trun.close();
+			}
+			traf.close();
+		}
+		moof.close();
+	}
+	// mdat1: 8-byte header + 8-byte payload
+	write32be(buf, 8 + 8); write4cc(buf, "mdat");
+	mdat1PayloadStart = buf.size();
+	for (int i = 0; i < 8; ++i) buf.push_back(uint8_t(0xA0 + i));
+
+	// --- moof2 + mdat2 ---
+	{
+		Box moof(buf, "moof"); moof2StartIdx = moof.start;
+		{
+			Box traf(buf, "traf");
+			{
+				Box tfhd(buf, "tfhd"); writeFullBoxHeader(buf, 0, 0x00008 | 0x00010);
+				write32be(buf, 1);      // track_ID
+				write32be(buf, 3000);   // default_sample_duration
+				write32be(buf, 8);      // default_sample_size
+				tfhd.close();
+			}
+			{
+				Box tfdt(buf, "tfdt"); writeFullBoxHeader(buf, 0, 0);
+				write32be(buf, 3000);   // baseMediaDecodeTime = 3000 (one chunk later)
+				tfdt.close();
+			}
+			{
+				Box trun(buf, "trun"); writeFullBoxHeader(buf, 0, 0x0001);
+				write32be(buf, 1);      // sample_count = 1
+				trun2DataOffsetPos = buf.size();
+				write32be(buf, 0);      // placeholder: data_offset (patched below)
+				trun.close();
+			}
+			traf.close();
+		}
+		moof.close();
+	}
+	// mdat2: 8-byte header + 8-byte payload
+	write32be(buf, 8 + 8); write4cc(buf, "mdat");
+	mdat2PayloadStart = buf.size();
+	for (int i = 0; i < 8; ++i) buf.push_back(uint8_t(0xB0 + i));
+
+	// Patch trun data_offset fields: offset is relative to the start of the owning moof box
+	auto patch32 = [&](size_t pos, int32_t v) {
+		buf[pos+0] = uint8_t((v >> 24) & 0xFF);
+		buf[pos+1] = uint8_t((v >> 16) & 0xFF);
+		buf[pos+2] = uint8_t((v >>  8) & 0xFF);
+		buf[pos+3] = uint8_t((v >>  0) & 0xFF);
+	};
+	patch32(trun1DataOffsetPos, int32_t(mdat1PayloadStart - moof1StartIdx));
+	patch32(trun2DataOffsetPos, int32_t(mdat2PayloadStart - moof2StartIdx));
+
+	Mp4Demux d;
+	bool ok = d.Parse(buf.data(), buf.size());
+	EXPECT_TRUE(ok) << "Multi-moof+mdat segment (LL-DASH) should parse without errors";
+	EXPECT_EQ(d.GetLastError(), MP4_PARSE_OK) << "Should not raise DATA_BOUNDARY_MISMATCH";
+
+	auto samples = d.GetSamples();
+	ASSERT_EQ(samples.size(), 2u) << "Should extract one sample per moof+mdat pair";
+
+	// Validate sample 0 is bound to mdat1 payload (0xA0–0xA7)
+	EXPECT_EQ(samples[0].mData.size(), 8u) << "Sample 0 should be 8 bytes (mdat1 payload)";
+	const auto& s0 = samples[0].mData.GetVector();
+	for (int i = 0; i < 8; ++i)
+	{
+		EXPECT_EQ(s0[i], uint8_t(0xA0 + i))
+			<< "Sample 0 byte[" << i << "] should be mdat1 payload (0x"
+			<< std::hex << (0xA0 + i) << ")";
+	}
+
+	// Validate sample 1 is bound to mdat2 payload (0xB0–0xB7)
+	EXPECT_EQ(samples[1].mData.size(), 8u) << "Sample 1 should be 8 bytes (mdat2 payload)";
+	const auto& s1 = samples[1].mData.GetVector();
+	for (int i = 0; i < 8; ++i)
+	{
+		EXPECT_EQ(s1[i], uint8_t(0xB0 + i))
+			<< "Sample 1 byte[" << i << "] should be mdat2 payload (0x"
+			<< std::hex << (0xB0 + i) << ")";
+	}
+}


### PR DESCRIPTION
Reason for change: Fixed LLD playback with Mp4Demux enabled,as LL-DASH segment contains multiple moof+mdat pairs
Risks: Low
Test Procedure: Refer jira ticket VPLAY-12820
Priority: P1