### PR TITLE
RDKEMW-15310: [l3test] TST_2002 failing on Realtek with Rialto

### DIFF
--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -28,7 +28,7 @@
 #include <gst/base/gstbasetransform.h>
 #include "PlayerLogManager.h"
 
-#define REQUIRED_QUEUED_FRAMES_DEFAULT (5+1)
+#define REQUIRED_QUEUED_FRAMES_DEFAULT (3+1)
 
 typedef gboolean (*AcceptCapsFunc)(GstBaseTransform *, GstPadDirection, GstCaps *);
 


### PR DESCRIPTION
Reason for change: Modified the default queued frame value to 4 instead of 6, as Rialto uses the SoC type as the default Soc.
Test Procedure: As mentioned in the ticket
Risks: None

Signed-off-by: Varatharajan_Narayanan <Varatharajan_Narayanan@comcast.com>