### PR TITLE
VPLAY-12989 : Linear channel Play/Pause UI state is not synchronized …

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -825,7 +825,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					// Otherwise unpause the pipeline
 					if(aamp->IsLocalAAMPTsb() && !aamp->IsLocalAAMPTsbInjection())
 					{
-						retValue = false;
+						retValue = false; // Skip common notification to prevent premature state change
 						aamp->SetState(eSTATE_SEEKING);
 						aamp->seek_pos_seconds = aamp->GetPositionSeconds();
 						aamp->rate = AAMP_NORMAL_PLAY_RATE;
@@ -833,6 +833,9 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 						aamp->AcquireStreamLock();
 						aamp->TuneHelper(eTUNETYPE_SEEK, false);
 						aamp->ReleaseStreamLock();
+						// Notify speed change without state transition (keeps eSTATE_SEEKING)
+						// State will naturally transition to PLAYING when NotifyFirstBufferProcessed() is called after fragments arrive
+						aamp->NotifySpeedChanged(aamp->rate, false);
 					}
 					else
 					{

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2743,6 +2743,7 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_ResumeFromLive) {
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetPositionMilliseconds()).WillRepeatedly(Return(seek_pos_seconds));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, false)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifySpeedChanged(1.0, false)).Times(1);
 
 	mPlayerInstance->SetRate(1.0);
 


### PR DESCRIPTION
…with actual playback when toggling using the DPAD OK button.

Reason for change:
In paused playback with local TSB, resume using setSpeed(1) can enter the seek-into-TSB path where retValue is forced false, which skips the common post-rate NotifySpeedChanged As a result, the app may receive PlayStateChanged=seeking but miss PlaybackSpeedChanged=1, leaving speed stuck at 0. This change adds an explicit speed-change notification in that local-TSB so playback speed state  remains consistent with actual resume behavior and status reporting

Test Procedure: Refer JIRA ticket
Priority: P2
Risks: low