### PR TITLE
VPLAY-12687 Detect EOS if pipeline is paused due to underflow

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -90,7 +90,8 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 	auto CheckEos = [this, &tsbSessionManager, &actualType]() {
 		return IsLocalTSBInjection() &&
 			AAMP_NORMAL_PLAY_RATE == aamp->rate &&
-			!aamp->pipeline_paused &&
+			// No EOS detection if the user paused the playback, but it can be if the playback was paused due to underflow
+			!(aamp->pipeline_paused && !aamp->GetBufUnderFlowStatus()) &&
 			eTUNETYPE_SEEKTOLIVE == context->mTuneType &&
 			tsbSessionManager &&
 			tsbSessionManager->GetTsbReader((AampMediaType)type) &&

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -22,6 +22,7 @@
 #include <memory>
 
 MockStreamAbstractionAAMP *g_mockStreamAbstractionAAMP = nullptr;
+MockMediaTrack *g_mockMediaTrack = nullptr;
 
 StreamAbstractionAAMP::StreamAbstractionAAMP(PrivateInstanceAAMP* aamp, id3_callback_t mID3Handler) : aamp(nullptr), mAudiostateChangeCount(0), mESChangeStatus(false)
 {
@@ -237,7 +238,7 @@ bool MediaTrack::isPlaylistDownloaderThreadStarted()
 	return true;
 }
 
-MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* name) : parsedBufferChunk("parsedBufferChunk"), unparsedBufferChunk("unparsedBufferChunk"), name(name), aamp(aamp), type(type)
+MediaTrack::MediaTrack(TrackType type, PrivateInstanceAAMP* aamp, const char* name) : parsedBufferChunk("parsedBufferChunk"), unparsedBufferChunk("unparsedBufferChunk"), name(name), aamp(aamp), type(type), abort(false), abortInject(false)
 {
 }
 
@@ -292,15 +293,24 @@ bool MediaTrack::SignalIfEOSReached()
 
 void MediaTrack::SetLocalTSBInjection(bool value)
 {
+	if (g_mockMediaTrack != nullptr)
+	{
+		g_mockMediaTrack->SetLocalTSBInjection(value);
+	}
 }
 
 bool MediaTrack::IsLocalTSBInjection()
 {
 	bool localTsbInjection = false;
 
-	// When using mock, delegate to mock implementation
-	if (auto* mock = dynamic_cast<MockMediaTrack*>(this)) {
-		localTsbInjection = mock->IsLocalTSBInjection();
+	if (auto* mockObj = dynamic_cast<MockMediaTrack*>(this))
+	{
+		localTsbInjection = mockObj->IsLocalTSBInjection();
+	}
+
+	if (g_mockMediaTrack != nullptr)
+	{
+		localTsbInjection = g_mockMediaTrack->IsLocalTSBInjection();
 	}
 
 	return localTsbInjection;

--- a/test/utests/mocks/MockStreamAbstractionAAMP.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP.h
@@ -28,6 +28,7 @@ class MockMediaTrack : public MediaTrack
 public:
 	MockMediaTrack(TrackType type, PrivateInstanceAAMP *aamp, const char *name)
 		: MediaTrack(type, aamp, name) {}
+	//MOCK_METHOD(void, SetLocalTSBInjection, (bool value));
 	MOCK_METHOD(bool, IsLocalTSBInjection, ());
 	MOCK_METHOD(bool, Enabled, ());
 	MOCK_METHOD(void, ProcessPlaylist, (AampGrowableBuffer& newPlaylist, int http_error),(override));
@@ -49,6 +50,8 @@ public:
 	MOCK_METHOD(double, GetTotalInjectedDuration, (), (override));
 	MOCK_METHOD(void, ResetTrickModePtsRestamping, (), (override));
 };
+
+extern MockMediaTrack *g_mockMediaTrack;
 
 class MockStreamAbstractionAAMP : public StreamAbstractionAAMP
 {

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -101,7 +101,7 @@ TestParams testCases[] =
 
 	// Test with pipeline paused and underflow
 	{.lowlatency = false, .chunk = false, .tsb = true, .eos = false, .paused = true, .underflow = true, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = true, .underflow = true, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = true, .eos = true, .paused = true, .underflow = true, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 
 	// Test with rate != AAMP_NORMAL_PLAY_RATE
 	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = true, .rate = (AAMP_NORMAL_PLAY_RATE*2), .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0}
@@ -310,7 +310,7 @@ class MediaStreamContextTest : public ::testing::TestWithParam<TestParams>
 				mStreamAbstractionAAMP_MPD->mTuneType = eTUNETYPE_SEEKTOLIVE;
 				EXPECT_CALL(*g_mockTSBSessionManager, GetTsbReader(_)).WillRepeatedly(Return(mTsbReader));
 				EXPECT_CALL(*g_mockTSBReader, IsEos()).WillRepeatedly(Return(true));
-				if (!paused)
+				if (!paused || underflow)
 				{
 					EXPECT_CALL(*g_mockPrivateInstanceAAMP, UpdateLocalAAMPTsbInjection());
 				}
@@ -348,9 +348,10 @@ TEST_P(MediaStreamContextTest, CacheFragment)
 	Initialize(testParam.lowlatency, testParam.chunk, testParam.tsb, testParam.eos, testParam.paused, testParam.underflow, testParam.init, testParam.rate);
 	bool retResult = mMediaStreamContext->CacheFragment("remoteUrl", 0, 10, 0, NULL, testParam.init, false, false, 0, 0, false);
 
-	if (testParam.eos && !testParam.paused)
+	if (testParam.eos && (!testParam.paused || testParam.underflow))
 	{
-		// Check that  TSB injection flag is cleared after TSB Reader EoS if the pipeline is not paused
+		// Check that TSB injection flag is cleared after TSB Reader EoS if the
+		// pipeline is not paused, or if paused due to underflow
 		EXPECT_EQ(mMediaStreamContext->IsLocalTSBInjection(), false);
 	}
 	else


### PR DESCRIPTION
Reason for Change: Fix Technical Fault when FF to live

Summary of Changes:
* In CacheFragment() detect EOS if pipeline is paused due to underflow

Test Procedure: FF to live in underflow conditions

Risk: Low