### PR TITLE
VPLAY-13012: Strict adherence to manifest refresh interval for LLD

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -833,7 +833,7 @@ uint32_t AampMPDDownloader::getNextLLDManifestRefreshInterval(ManifestDownloadRe
 	// so that devices watching the same stream do not all request the CDN simultaneously.
 	// A function-local mt19937 seeded once from std::random_device gives each
 	// device/process a unique sequence without relying on a global srand() call.
-	static std::mt19937 sJitterRng(std::random_device{}());
+	static thread_local std::mt19937 sJitterRng(std::random_device{}());
 	std::uniform_int_distribution<uint32_t> jitterDist(0, MAX_LLD_MANIFEST_REFRESH_JITTER_MS);
 	refreshIntervalMs += jitterDist(sJitterRng);
 

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -28,10 +28,15 @@
 #include "AampUtils.h"
 #include "AampLogManager.h"
 #include <inttypes.h>
+#include <random>
 
 
 
 #define DEFAULT_INTERVAL_BETWEEN_MPD_UPDATES_MS 3000
+
+/// Maximum random jitter added to LLD manifest refresh intervals.
+/// Spreads CDN request load across all devices watching the same stream.
+static constexpr uint32_t MAX_LLD_MANIFEST_REFRESH_JITTER_MS = 500;
 
 void _manifestDownloadResponse::show()
 {
@@ -772,7 +777,7 @@ bool AampMPDDownloader::waitForRefreshInterval()
 	bool refreshNeeded = false;
 
 	std::unique_lock<std::mutex> lck(mRefreshMtx);
-	if(mRefreshCondVar.wait_for(lck,std::chrono::milliseconds(mRefreshInterval))==std::cv_status::timeout) {
+	if (mRefreshCondVar.wait_for(lck,std::chrono::milliseconds(mRefreshInterval))==std::cv_status::timeout) {
 		refreshNeeded = true;
 	}
 	else
@@ -783,6 +788,66 @@ bool AampMPDDownloader::waitForRefreshInterval()
 	return refreshNeeded;
 }
 
+
+/**
+*   @fn getNextLLDManifestRefreshInterval
+*   @brief Calculates the next manifest refresh interval for Low-Latency DASH streams.
+*
+*   Anchors the next fetch to the wall-clock time at which the server is
+*   expected to publish a new manifest (publishTime + minimumUpdatePeriod),
+*   then adds a small random jitter to spread CDN load across the device field.
+*
+*   @param dnldManifest   The most recently downloaded manifest response.
+*   @return Refresh interval in milliseconds.
+*/
+uint32_t AampMPDDownloader::getNextLLDManifestRefreshInterval(ManifestDownloadResponsePtr dnldManifest)
+{
+	// Read minimumUpdatePeriod from the manifest.
+	uint32_t minUpdateDurationMs = DEFAULT_INTERVAL_BETWEEN_MPD_UPDATES_MS;
+	std::string tempStr = dnldManifest->mMPDInstance->GetMinimumUpdatePeriod();
+	if (!tempStr.empty())
+	{
+		minUpdateDurationMs = ParseISO8601Duration(tempStr.c_str());
+	}
+
+	// Schedule the next fetch at: publishTime + minimumUpdatePeriod - now.
+	// This aligns each device with when the CDN will have a new manifest ready,
+	// instead of counting from the moment the download completed.
+	uint32_t refreshIntervalMs = minUpdateDurationMs;
+	if (mPublishTime > 0 && minUpdateDurationMs > 0)
+	{
+		uint64_t nextPublishTimeMs = mPublishTime + (uint64_t)minUpdateDurationMs;
+		uint64_t nowMs = (uint64_t)aamp_GetCurrentTimeMS();
+		if (nextPublishTimeMs > nowMs)
+		{
+			refreshIntervalMs = (uint32_t)(nextPublishTimeMs - nowMs);
+		}
+		else
+		{
+			// Next manifest is already overdue; refresh as soon as the jitter expires.
+			refreshIntervalMs = 0;
+		}
+	}
+
+	// Add a uniformly distributed random jitter in [0, MAX_LLD_MANIFEST_REFRESH_JITTER_MS]
+	// so that devices watching the same stream do not all request the CDN simultaneously.
+	// A function-local mt19937 seeded once from std::random_device gives each
+	// device/process a unique sequence without relying on a global srand() call.
+	static std::mt19937 sJitterRng(std::random_device{}());
+	std::uniform_int_distribution<uint32_t> jitterDist(0, MAX_LLD_MANIFEST_REFRESH_JITTER_MS);
+	refreshIntervalMs += jitterDist(sJitterRng);
+
+	// Clamp to the platform minimum to avoid excessive thrashing if publishTime
+	// or the wall-clock source is unavailable / unreliable.
+	if (refreshIntervalMs < (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS)
+	{
+		refreshIntervalMs = (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS;
+	}
+
+	AAMPLOG_INFO("[LLD] Manifest refresh: publishTime=%" PRIu64 "ms minUpdateMs=%u nextFetchMs=%u",
+				 mPublishTime, minUpdateDurationMs, refreshIntervalMs);
+	return refreshIntervalMs;
+}
 
 /**
 *   @fn readMPDData
@@ -801,27 +866,48 @@ bool AampMPDDownloader::readMPDData(ManifestDownloadResponsePtr dnldManifest)
 	}
 	if(!publishTimeStr.empty())
 	{
-		publishTimeMSec = (uint64_t)ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str()) * 1000;
+		publishTimeMSec = static_cast<uint64_t>(ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str()) * 1000.0);
 	}
 	AAMPLOG_TRACE("Publish Time of Updated manifest %" PRIu64 ", Previous manifest update time %" PRIu64, publishTimeMSec, mPublishTime);
 
-	/* If there is no update in the manifest and publish time is not zero, Set the refresh interval to a minimal value (500ms). This is done for a maximum of two times to avoid frequent manifest refresh.*/
-	if (publishTimeMSec == mPublishTime && publishTimeMSec != 0) 
+	if (mIsLowLatency)
 	{
-		if (mMinimalRefreshRetryCount < 2) 
+		// For LLD streams the publish-time-anchored API schedules each fetch
+		// precisely at publishTime + minimumUpdatePeriod, so the stale-manifest
+		// retry counter is not needed.  Suppress the queue push when the
+		// manifest has not been updated (same guarantee as the non-LLD path).
+		if (publishTimeMSec != 0 && publishTimeMSec == mPublishTime)
+		{
+			AAMPLOG_INFO("[LLD] No update detected in manifest (publishTime==%" PRIu64 ").", mPublishTime);
+			retVal = false;
+		}
+		else
+		{
+			mPublishTime = publishTimeMSec;
+		}
+		mRefreshInterval = getNextLLDManifestRefreshInterval(dnldManifest);
+		mMinimalRefreshRetryCount = 0;
+	}
+	else if (publishTimeMSec == mPublishTime && publishTimeMSec != 0)
+	{
+		/* If there is no update in the manifest and publish time is not zero,
+		 * set the refresh interval to a minimal value (500ms) for up to two
+		 * consecutive checks to avoid excessive refresh. */
+		if (mMinimalRefreshRetryCount < 2)
 		{
 			mRefreshInterval = (uint32_t)(MIN_DELAY_BETWEEN_MPD_UPDATE_MS);
 			AAMPLOG_INFO("No update detected in manifest. Setting refresh interval to minimal refresh interval %u", mRefreshInterval);
 			mMinimalRefreshRetryCount++;
-			/* To avoid race condition when GetNetworkTime is executed ,meanwhile manifest refresh is done for next attempt */
+			/* To avoid race condition when GetNetworkTime is executed,
+			 * meanwhile manifest refresh is done for next attempt */
 			retVal = false;
-		} 
+		}
 		else
 		{
 			mRefreshInterval = getMeNextManifestDownloadWaitTime(std::move(dnldManifest));
 		}
-	} 
-	else 
+	}
+	else
 	{
 		mPublishTime = publishTimeMSec;
 		mRefreshInterval = getMeNextManifestDownloadWaitTime(std::move(dnldManifest));
@@ -958,14 +1044,15 @@ uint32_t AampMPDDownloader::getMeNextManifestDownloadWaitTime(ManifestDownloadRe
 				break;
 			}
 		}
-		AAMPLOG_INFO("Min Update Period from Manifest %u Latency Value %d lowLatencyMode %d",minUpdateDuration,mLatencyValue,mIsLowLatency);
+		AAMPLOG_INFO("Min Update Period from Manifest %u Latency Value %d lowLatencyMode %d",
+					 minUpdateDuration, mLatencyValue, mIsLowLatency);
 
 		// playTarget value will vary if TSB is full and trickplay is attempted. Cant use for buffer calculation
 		// So using the endposition in playlist - Current playing position to get the buffer availability
 		int bufferAvailable = mLatencyValue;
 
 		// when target duration is high value(>Max delay)  but buffer is available just above the max update interval,then go with max delay between playlist refresh.
-		if(bufferAvailable != -1 && !mIsLowLatency)
+		if(bufferAvailable != -1)
 		{
 			if(bufferAvailable < (2* MAX_DELAY_BETWEEN_MPD_UPDATE_MS))
 			{
@@ -973,15 +1060,7 @@ uint32_t AampMPDDownloader::getMeNextManifestDownloadWaitTime(ManifestDownloadRe
 				{
 					//1.If buffer Available is > 2*minUpdateDuration , may be 1.0 times also can be set ???
 					//2.If buffer is between 2*target & mMinUpdateDurationMs
-					float mFactor=0.0f;
-					if (mIsLowLatency)
-					{
-						mFactor = (bufferAvailable  > (minUpdateDuration * 2)) ? 1.0 : 0.5;
-					}
-					else
-					{
-						mFactor = (bufferAvailable  > (minUpdateDuration * 2)) ? 1.5 : 0.5;
-					}
+					float mFactor = (bufferAvailable  > (minUpdateDuration * 2)) ? 1.5 : 0.5;
 					minDelayBetweenPlaylistUpdates = (int)(mFactor * minUpdateDuration);
 				}
 				// if buffer < targetDuration && buffer < MaxDelayInterval
@@ -1009,7 +1088,7 @@ uint32_t AampMPDDownloader::getMeNextManifestDownloadWaitTime(ManifestDownloadRe
 
 		// If any CDAI entries present in playlist, then refresh with update duration specified in playlist
 		// For lld ,honour min  update duration specified in manifest
-		if ((eventStreamFound || mIsLowLatency) && minUpdateDuration >0 && minUpdateDuration < minDelayBetweenPlaylistUpdates)
+		if ((eventStreamFound) && minUpdateDuration >0 && minUpdateDuration < minDelayBetweenPlaylistUpdates)
 		{
 			minDelayBetweenPlaylistUpdates = (int)minUpdateDuration;
 		}
@@ -1022,50 +1101,8 @@ uint32_t AampMPDDownloader::getMeNextManifestDownloadWaitTime(ManifestDownloadRe
 
 		if(minDelayBetweenPlaylistUpdates < MIN_DELAY_BETWEEN_MPD_UPDATE_MS)
 		{
-			if (mIsLowLatency)
-			{
-				long availTimeOffMs = (long)((mLLDashData.availabilityTimeOffset)*1000);
-				long maxSegDuration = (long)((mLLDashData.fragmentDuration)*1000);
-				if(minUpdateDuration > 0 && minUpdateDuration < maxSegDuration)
-				{
-					minDelayBetweenPlaylistUpdates = (uint32_t)minUpdateDuration;
-				}
-				else if(minUpdateDuration > 0 && minUpdateDuration > availTimeOffMs)
-				{
-					minDelayBetweenPlaylistUpdates = (uint32_t)(minUpdateDuration-availTimeOffMs);
-				}
-				else if (maxSegDuration > 0 && maxSegDuration > availTimeOffMs)
-				{
-					minDelayBetweenPlaylistUpdates = (uint32_t)(maxSegDuration-availTimeOffMs);
-				}
-				else
-				{
-					// minimum of 500 mSec needed to avoid too frequent download.
-					minDelayBetweenPlaylistUpdates = (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS;
-				}
-				if(minDelayBetweenPlaylistUpdates < MIN_DELAY_BETWEEN_MPD_UPDATE_MS)
-				{
-						// minimum of 500 mSec needed to avoid too frequent download.
-					minDelayBetweenPlaylistUpdates = (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS;
-				}
-			}
-			else
-			{
-				// minimum of 500 mSec needed to avoid too frequent download.
-				minDelayBetweenPlaylistUpdates = (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS;
-			}
-		}
-
-		//When you have content to download in manifest ,no need to do frequent 500msec refresh
-		if (mIsLowLatency && minDelayBetweenPlaylistUpdates <= (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS && mCurrentposDeltaToManifestEnd > (long)((mLLDashData.fragmentDuration)*1000)*2)
-		{
-			minDelayBetweenPlaylistUpdates = (uint32_t)minUpdateDuration;
-		}
-		// When the buffer hits zero, it is worth refreshing frequently in order to rebuild the buffer
-		if (bufferAvailable <= 0.5 && mIsLowLatency) 
-		{
-			// Set the minimum delay between playlist updates 
-			minDelayBetweenPlaylistUpdates = (uint32_t)(MIN_DELAY_BETWEEN_MPD_UPDATE_MS);
+			// minimum of 500 mSec needed to avoid too frequent download.
+			minDelayBetweenPlaylistUpdates = (uint32_t)MIN_DELAY_BETWEEN_MPD_UPDATE_MS;
 		}
 
 		AAMPLOG_INFO("aamp playlist end refresh bufferMs(%d) delay(%u)", bufferAvailable,minDelayBetweenPlaylistUpdates);

--- a/AampMPDDownloader.h
+++ b/AampMPDDownloader.h
@@ -195,7 +195,10 @@ typedef std::shared_ptr<ManifestDownloadResponse> ManifestDownloadResponsePtr;
 
 typedef std::shared_ptr<ManifestDownloadConfig> ManifestDownloadConfigPtr;
 
-
+/**
+ * @class AampMPDDownloader
+ * @brief Class responsible for downloading and managing MPD files for Aamp.
+ */
 class AampMPDDownloader
 {
 public:
@@ -310,7 +313,7 @@ public:
 	 * @brief function to get the manifest publish time
 	 * @return publish time in milliseconds
 	 */
-	uint64_t GetPublishTime() { return mPublishTime;}
+	uint64_t GetPublishTime() { return mPublishTime; }
 
 private:
 
@@ -354,7 +357,7 @@ private:
 	bool readMPDData(ManifestDownloadResponsePtr mMPD);
 	/**
 	*	@fn waitForRefreshInterval
-	*	@brief Function to wait for refresh interval before next download
+	*	@brief Function to wait for refresh interval before next download.
 	*/
 	bool waitForRefreshInterval();
 	/**
@@ -382,6 +385,7 @@ private:
 	*	@brief Function to calculate the download refresh interval
 	*/
 	uint32_t getMeNextManifestDownloadWaitTime(ManifestDownloadResponsePtr mMPD);
+
 	/**
 	*	@fn GetCMCDHeader
 	*	@brief Function to get CMCD Headers to pack during download
@@ -392,6 +396,22 @@ private:
 	*	@brief Function to harvest the downloaded manifest
 	*/
 	void harvestManifest();
+
+protected:
+
+	/**
+	 *	@fn getNextLLDManifestRefreshInterval
+	 *	@brief Calculate the next manifest refresh interval for Low-Latency DASH
+	 *	streams based on the manifest's publishTime and minimumUpdatePeriod,
+	 *	with a random jitter to spread CDN load across devices in the field.
+	 *
+	 *	@param dnldManifest  The most recently downloaded manifest response.
+	 *	@return Refresh interval in milliseconds.
+	 */
+	uint32_t getNextLLDManifestRefreshInterval(ManifestDownloadResponsePtr dnldManifest);
+
+	uint64_t mPublishTime;			/**< Publish time of updated manifest */
+
 private:
 
 	std::queue<ManifestDownloadResponsePtr> mMPDBufferQ;
@@ -404,8 +424,8 @@ private:
 	// Download data
 	ManifestDownloadResponsePtr mMPDData;
 	ManifestDownloadResponsePtr mCachedMPDData;
+	uint32_t mRefreshInterval;		/**< Refresh interval in milliseconds */
 
-	uint32_t mRefreshInterval ; 		// refresh interval in mSec
 	int mLatencyValue;			// buffer value to be considered for manifest refresh
 
 	std::thread mDownloaderThread_t1;
@@ -435,7 +455,6 @@ private:
 	bool mIsLowLatency;  /**< Flag indicating whether it is a low latency stream or not.*/
 	AampLLDashServiceData mLLDashData; /**< Parsed LLDash Data*/
 	int mCurrentposDeltaToManifestEnd; /* Delta between current pos and ManifestEnd */
-	uint64_t mPublishTime; 		   /* Publish time of updated manifest*/
 	int mMinimalRefreshRetryCount;  /* A counter to checks if the publication time remains the same for 2 consecutive refresh*/
 	std::atomic_bool mMPDNotifyPending ; /*To allow wait for downloadNotifier based on NotifyPending Status */
 	std::function<std::string()> mMpdPreProcessFuncptr; /* function invoked to read the available preprocessed manifest data or to send event if manifest data is not available */

--- a/test/utests/fakes/FakeAampMPDDownloader.cpp
+++ b/test/utests/fakes/FakeAampMPDDownloader.cpp
@@ -194,3 +194,8 @@ void AampMPDDownloader::UnRegisterCallback()
 void AampMPDDownloader::GetLastDownloadedManifest(std::string& manifestBuffer)
 {
 }
+
+uint32_t AampMPDDownloader::getNextLLDManifestRefreshInterval(ManifestDownloadResponsePtr dnldManifest)
+{
+	return 0;
+}

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -25,6 +25,7 @@
 #include "AampDefine.h"
 #include "AampConfig.h"
 #include "AampLogManager.h"
+#include "AampUtils.h"
 #include "priv_aamp.h"
 #include <thread>
 #include <unistd.h>
@@ -45,6 +46,33 @@ std::string url1 = "https://example.com/VideoTestStream/xyz.mpd";
 std::string url2 = "http://example.com/Content/CMAF_S2-CTR-4s-v2/Live/channel(exampleChannel)/60_master_2hr.m3u8?c3.ri=example-ri&audio=all&subtitle=all&forcedNarrative=true";
 std::string url3 = "https://example-livesim.org/livesim/Manifest.mpd";
 std::string url4 = "https://example.com/GOLFD_HD_NAT_16403_0_example.mpd";
+
+/**
+ * @class TestableAampMPDDownloader
+ * @brief Test subclass exposing protected members of AampMPDDownloader
+ *        for white-box unit testing.
+ */
+class TestableAampMPDDownloader : public AampMPDDownloader
+{
+public:
+	/**
+	 * @brief Public wrapper for the protected
+	 *        getNextLLDManifestRefreshInterval() method.
+	 */
+	uint32_t CallGetNextLLDManifestRefreshInterval(
+		ManifestDownloadResponsePtr manifest)
+	{
+		return getNextLLDManifestRefreshInterval(manifest);
+	}
+
+	/**
+	 * @brief Directly set mPublishTime for test control.
+	 */
+	void SetPublishTime(uint64_t publishTimeMs)
+	{
+		mPublishTime = publishTimeMs;
+	}
+};
 
 class FunctionalTests : public ::testing::Test
 {
@@ -102,7 +130,7 @@ TEST_F(FunctionalTests, AampMPDDownloader_PreInitTest_3)
     EXPECT_NO_THROW(mAampMPDDownloader->Start());
     EXPECT_NO_THROW(mAampMPDDownloader->Release());
 }
-// Commented below tests to avoid more wait duaration
+// Commented below tests to avoid more wait duration
 #if 0
 TEST_F(FunctionalTests, AampMPDDownloader_PreInitTest_4)
 {
@@ -396,4 +424,121 @@ TEST_F(FunctionalTests,
 		thirdManifest->mMPDDownloadResponse->iHttpRetValue));
 
 	mAampMPDDownloader->Release();
+}
+
+// Confirms that the next manifest refresh interval will be approximately equal
+// to (minimumUpdatePeriod - elapsedSincePublish) plus a jitter in
+// [0, MAX_LLD_MANIFEST_REFRESH_JITTER_MS].
+//
+// Setup:
+//   minimumUpdatePeriod = PT2.00S  (2 000 ms)
+//   mPublishTime        = nowMs - 1 000 ms
+//
+// Expected base interval:
+//   nextPublishTimeMs - nowMs = (nowMs - 1000 + 2000) - nowMs = ~1 000 ms
+//
+// After jitter [0, 500 ms] the result must be in [~1 000, ~1 500] ms.
+// A lower bound of 500 ms is used to absorb any CI timing variance.
+TEST_F(FunctionalTests, AampMPDDownloader_LLDManifestRefreshIntervalTest1)
+{
+	static const char *kMpdWithMinUpdatePeriod =
+	R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="dynamic"
+     minimumUpdatePeriod="PT2.00S"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011"
+     availabilityStartTime="1977-05-25T18:00:00Z">
+  <Period id="1" start="PT0S">
+    <AdaptationSet id="1" mimeType="video/mp4">
+      <Representation id="r1" bandwidth="500000" codecs="avc1.640028"/>
+    </AdaptationSet>
+  </Period>
+</MPD>)xml";
+
+	// Build a ManifestDownloadResponse with the MPD above and parse it so
+	// mMPDInstance is populated (required by getNextLLDManifestRefreshInterval).
+	ManifestDownloadResponsePtr respData =
+		std::make_shared<_manifestDownloadResponse>();
+	std::string mpdStr(kMpdWithMinUpdatePeriod);
+	respData->mMPDDownloadResponse->mDownloadData.assign(
+		mpdStr.begin(), mpdStr.end());
+	respData->parseMPD();
+	ASSERT_NE(respData->mMPDInstance, nullptr)
+		<< "MPD failed to parse – check the test XML";
+
+	// Set mPublishTime to 1 second in the past so the expected base interval
+	// is approximately 1 000 ms (2 000 ms period minus 1 000 ms elapsed).
+	TestableAampMPDDownloader testableDownloader;
+	uint64_t publishTimeMs =
+		static_cast<uint64_t>(aamp_GetCurrentTimeMS()) - 1000ULL;
+	testableDownloader.SetPublishTime(publishTimeMs);
+
+	uint32_t refreshIntervalMs =
+		testableDownloader.CallGetNextLLDManifestRefreshInterval(respData);
+
+	// Base ≈ 1 000 ms; jitter adds up to 500 ms → expected range [1 000, 1 500].
+	// Lower bound is relaxed to 500 ms to tolerate CI scheduling latency.
+	EXPECT_GE(refreshIntervalMs, 500u)
+		<< "Refresh interval too short: " << refreshIntervalMs << " ms";
+	EXPECT_LE(refreshIntervalMs, 1500u)
+		<< "Refresh interval too long: " << refreshIntervalMs << " ms";
+}
+
+// Confirms that when (mPublishTime + minimumUpdatePeriod) has already elapsed
+// the refresh interval is clamped to MIN_DELAY_BETWEEN_MPD_UPDATE_MS (500 ms).
+//
+// Setup:
+//   minimumUpdatePeriod = PT2.00S  (2 000 ms)
+//   mPublishTime        = nowMs - 5 000 ms  (deadline was 3 000 ms ago)
+//
+// Expected base interval:
+//   nextPublishTimeMs - nowMs < 0  → base = 0
+//
+// After jitter [0, 500 ms] the value is in [0, 500]; the clamp to
+// MIN_DELAY_BETWEEN_MPD_UPDATE_MS (500 ms) brings it to exactly [500, 1000].
+TEST_F(FunctionalTests, AampMPDDownloader_LLDManifestRefreshIntervalTest2_ElapsedDeadline)
+{
+	static const char *kMpdWithMinUpdatePeriod =
+	R"xml(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"
+     type="dynamic"
+     minimumUpdatePeriod="PT2.00S"
+     profiles="urn:mpeg:dash:profile:isoff-live:2011"
+     availabilityStartTime="1977-05-25T18:00:00Z">
+  <Period id="1" start="PT0S">
+    <AdaptationSet id="1" mimeType="video/mp4">
+      <Representation id="r1" bandwidth="500000" codecs="avc1.640028"/>
+    </AdaptationSet>
+  </Period>
+</MPD>)xml";
+
+	// Build and parse the response so mMPDInstance is populated.
+	ManifestDownloadResponsePtr respData =
+		std::make_shared<_manifestDownloadResponse>();
+	std::string mpdStr(kMpdWithMinUpdatePeriod);
+	respData->mMPDDownloadResponse->mDownloadData.assign(
+		mpdStr.begin(), mpdStr.end());
+	respData->parseMPD();
+	ASSERT_NE(respData->mMPDInstance, nullptr)
+		<< "MPD failed to parse – check the test XML";
+
+	// Set mPublishTime 5 000 ms in the past.
+	// nextPublishTimeMs = (now - 5000) + 2000 = now - 3000, which is already
+	// overdue, so the implementation sets base = 0 before applying jitter.
+	TestableAampMPDDownloader testableDownloader;
+	uint64_t publishTimeMs =
+		static_cast<uint64_t>(aamp_GetCurrentTimeMS()) - 5000ULL;
+	testableDownloader.SetPublishTime(publishTimeMs);
+
+	uint32_t refreshIntervalMs =
+		testableDownloader.CallGetNextLLDManifestRefreshInterval(respData);
+
+	// base=0, jitter∈[0,500] → pre-clamp value∈[0,500].
+	// MIN_DELAY_BETWEEN_MPD_UPDATE_MS clamp raises any value below 500 to 500.
+	// Upper bound is 500 (base) + 500 (max jitter) = 1000 ms.
+	EXPECT_GE(refreshIntervalMs, static_cast<uint32_t>(MIN_DELAY_BETWEEN_MPD_UPDATE_MS))
+		<< "Refresh interval below minimum: " << refreshIntervalMs << " ms";
+	EXPECT_LE(refreshIntervalMs, 1000u)
+		<< "Refresh interval too long for overdue deadline: "
+		<< refreshIntervalMs << " ms";
 }


### PR DESCRIPTION
Reason for change: Use publishTime + minUpdateDuration + some jitter to decide the next manifest download time. This is a much cleaner way. If this window has elapsed, AAMP will refresh in 500ms ensuring the manifest is downloaded quickly.
Test Procedure: Ensure manifest refreshes are happening in a timely manner
Risks: Low