### PR TITLE
VPLAY-13061: Build libdash with AddressSanitizer to fix ASAN

### DIFF
--- a/scripts/install_libdash.sh
+++ b/scripts/install_libdash.sh
@@ -70,8 +70,9 @@ function install_build_libdash_fn()
         cd build || { echo "ERROR: Failed to change to build directory"; return 1; }
         
         # Propagate sanitizer flags to libdash so it matches the ASAN
-        # instrumentation level of libaamp. On macOS, Xcode schemes always
-        # enable ASAN; on Ubuntu it is opt-in via the -u flag.
+        # instrumentation level of libaamp. ASAN is enabled by the build
+        # configuration (for example, on macOS builds or on Ubuntu via the
+        # -u flag).
         local SANITIZER_FLAGS=""
         if [[ "${PLATFORM}" == "darwin" || "${OPTION_UBUNTU_SANITIZER}" == "true" ]]; then
             SANITIZER_FLAGS="-fsanitize=address"

--- a/scripts/install_libdash.sh
+++ b/scripts/install_libdash.sh
@@ -69,7 +69,24 @@ function install_build_libdash_fn()
         mkdir -p build
         cd build || { echo "ERROR: Failed to change to build directory"; return 1; }
         
-        cmake .. -DCMAKE_INSTALL_PREFIX="${LOCAL_DEPS_BUILD_DIR}" -DCMAKE_MACOSX_RPATH=TRUE || {
+        # Propagate sanitizer flags to libdash so it matches the ASAN
+        # instrumentation level of libaamp. On macOS, Xcode schemes always
+        # enable ASAN; on Ubuntu it is opt-in via the -u flag.
+        local SANITIZER_FLAGS=""
+        if [[ "${PLATFORM}" == "darwin" || "${OPTION_UBUNTU_SANITIZER}" == "true" ]]; then
+            SANITIZER_FLAGS="-fsanitize=address"
+        fi
+
+        local EXTRA_C_FLAGS="${SANITIZER_FLAGS}"
+        local EXTRA_CXX_FLAGS="${SANITIZER_FLAGS}"
+        local EXTRA_LINK_FLAGS="${SANITIZER_FLAGS}"
+
+        cmake .. \
+            -DCMAKE_INSTALL_PREFIX="${LOCAL_DEPS_BUILD_DIR}" \
+            -DCMAKE_MACOSX_RPATH=TRUE \
+            -DCMAKE_C_FLAGS="${EXTRA_C_FLAGS}" \
+            -DCMAKE_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${EXTRA_LINK_FLAGS}" || {
             echo "ERROR: CMake configuration failed"
             return 1
         }


### PR DESCRIPTION
Reason for change: To fix ASAN issues in libdash, we need to build it with AddressSanitizer enabled. This will help us identify and resolve memory-related bugs in the library, improving its stability and performance.
Priority: P1
Signed-off-by: Nandakishor U M <nu641001@gmail.com>