### PR TITLE
VPLAY-13012: Strict adherence to manifest refresh interval for LLD

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -504,16 +504,25 @@ void AampMPDDownloader::downloadMPDThread1()
 		//Wait for duration before refresh
 		if(mMPDData->mIsLiveManifest && !mReleaseCalled)
 		{
-			refreshNeeded = waitForRefreshInterval();
+			// Subtract the time already spent downloading, parsing, and
+			// post-processing from the target refresh interval so the total
+			// cycle time matches the manifest's minimumUpdatePeriod.
+			long long elapsed = NOW_STEADY_TS_MS - tStartTime;
+			uint32_t waitMs = (elapsed < (long long)mRefreshInterval)
+							  ? (uint32_t)((long long)mRefreshInterval - elapsed)
+							  : 0;
+			AAMPLOG_DEBUG("Manifest refresh: interval=%u elapsed=%lldms waitMs=%u",
+						 mRefreshInterval, elapsed, waitMs);
+			refreshNeeded = waitForRefreshInterval(waitMs);
 		}
 
 		//Timeout case during live refresh
 		if(!firstDownload && (IsCurlTimeoutFailure(mMPDData->mMPDDownloadResponse->iHttpRetValue) || CURLE_COULDNT_CONNECT == mMPDData->mMPDDownloadResponse->iHttpRetValue))
 		{
-			AAMPLOG_WARN("Refresh every 500ms to handle a manifest timeout error.");
-			//Forcefully go with 500 ms refresh
+			AAMPLOG_WARN("Refresh after 500ms to handle a manifest timeout error.");
+			//Forcefully go with 500 ms refresh after a download failure
 			mRefreshInterval = MIN_DELAY_BETWEEN_PLAYLIST_UPDATE_MS;
-			refreshNeeded = waitForRefreshInterval();
+			refreshNeeded = waitForRefreshInterval(mRefreshInterval);
 		}
 
 	}while(refreshNeeded && !mReleaseCalled);
@@ -764,15 +773,24 @@ ManifestDownloadResponsePtr AampMPDDownloader::GetManifest(bool bWait, int iWait
 
 
 /**
-*   @fn waitForRefreshInterval
-*   @brief Wait function for the duration of Refresh interval before next download
-*/
-bool AampMPDDownloader::waitForRefreshInterval()
+ * @fn waitForRefreshInterval
+ * @brief Wait function for the duration of refresh interval before next download.
+ * The caller passes the already elapsed-adjusted wait duration so that
+ * the full download + wait cycle equals the target update period.
+ */
+bool AampMPDDownloader::waitForRefreshInterval(uint32_t waitMs)
 {
 	bool refreshNeeded = false;
 
+	if (waitMs == 0)
+	{
+		// Elapsed time already consumed the entire interval; refresh immediately.
+		return true;
+	}
+
 	std::unique_lock<std::mutex> lck(mRefreshMtx);
-	if(mRefreshCondVar.wait_for(lck,std::chrono::milliseconds(mRefreshInterval))==std::cv_status::timeout) {
+	if (mRefreshCondVar.wait_for(lck, std::chrono::milliseconds(waitMs)) == std::cv_status::timeout)
+	{
 		refreshNeeded = true;
 	}
 	else
@@ -801,7 +819,7 @@ bool AampMPDDownloader::readMPDData(ManifestDownloadResponsePtr dnldManifest)
 	}
 	if(!publishTimeStr.empty())
 	{
-		publishTimeMSec = (uint64_t)ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str()) * 1000;
+		publishTimeMSec = static_cast<uint64_t>(ISO8601DateTimeToUTCSeconds(publishTimeStr.c_str()) * 1000.0);
 	}
 	AAMPLOG_TRACE("Publish Time of Updated manifest %" PRIu64 ", Previous manifest update time %" PRIu64, publishTimeMSec, mPublishTime);
 

--- a/AampMPDDownloader.h
+++ b/AampMPDDownloader.h
@@ -353,10 +353,14 @@ private:
 	*/
 	bool readMPDData(ManifestDownloadResponsePtr mMPD);
 	/**
-	*	@fn waitForRefreshInterval
-	*	@brief Function to wait for refresh interval before next download
-	*/
-	bool waitForRefreshInterval();
+	 *	@fn waitForRefreshInterval
+	 *	@brief Function to wait for refresh interval before next download
+	 *
+	 *	@param waitMs Actual duration to sleep in milliseconds. The caller
+	 *	should subtract already-elapsed time from mRefreshInterval
+	 *	so the total download + wait cycle matches the intended update period.
+	 */
+	bool waitForRefreshInterval(uint32_t waitMs);
 	/**
 	*	@fn pushDownloadDataToQueue
 	*	@brief Function to push the download MPD to Queue for collector to read it


### PR DESCRIPTION
Reason for change: Move the MPD Downloader thread into a timer mode to perform manifest refresh every minUpdateDuration value retrieved from manifest. This will allows us to accomodate for download delay, parsing and post-processing delay and schedule manifest refreshes in a timely manner.
Test Procedure: Regression testing on LLD, CDVR and Linear contents
Risks: Medium