### PR TITLE
VPLAY-13097 "User Agent:" dead code removal

### DIFF
--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -119,7 +119,6 @@ namespace aamp
 #define MANIFEST_TIMEOUT_FOR_LLD 3      /**< 3 sec timeout for manifest refresh in case of LLD*/
 #define ABR_BUFFER_COUNTER_FOR_LLD 3		/** Counter for steady state rampup/rampdown for lld */
 
-#define AAMP_USER_AGENT_MAX_CONFIG_LEN  512    /**< Max Chars allowed in aamp.cfg for user-agent */
 #define SERVER_UTCTIME_DIRECT "urn:mpeg:dash:utc:direct:2014"
 #define SERVER_UTCTIME_HTTP "urn:mpeg:dash:utc:http-xsdate:2014"
 // MSO-specific VSS Service Zone identifier in URL


### PR DESCRIPTION
VPLAY-13097 "User Agent:" dead code removal

Reason for Change: remove AAMP_USER_AGENT_MAX_CONFIG_LEN definition, unused anywhere in code

Test Guidance: no compilation issue

Risk: None