### PR TITLE
VPLAY-13101 bogus check in fragmentcollector_mpd leads to null pointer dereference

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6680,9 +6680,14 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	double offsetFromStart;
 
 	class MediaStreamContext *pMediaStreamContext = mMediaStreamContext[eMEDIATYPE_AUDIO];
-	if ((!pMediaStreamContext) || (!pMediaStreamContext->enabled))
+	if (!pMediaStreamContext)
 	{
-		AAMPLOG_WARN("pMediaStreamContext  is null");
+		AAMPLOG_WARN("pMediaStreamContext is null");
+		return;
+	}
+	if (!pMediaStreamContext->enabled)
+	{
+		AAMPLOG_WARN("pMediaStreamContext is not enabled");
 		pMediaStreamContext->NotifyCachedAudioFragmentAvailable();
 		return;
 	}


### PR DESCRIPTION
VPLAY-13101 bogus check in fragmentcollector_mpd leads to null pointer dereference

Reason for Change: fix for a broken sanity check

Test Guidance: see ticket

Risk: Low