### PR TITLE
Revert "Feature/vplay 13040 growable buffer to vector idx drm aamp media sample fragment cache descriptor"

### DIFF
--- a/AampDemuxDataTypes.h
+++ b/AampDemuxDataTypes.h
@@ -22,25 +22,33 @@
 
 #include <string>
 #include <vector>
-#include <cstdint>
+#include <cstring> // for std::memset
+#include "AampGrowableBuffer.h" // for AampGrowableBuffer
 #include "DemuxDataTypes.h" // for MediaDrmMetadata
 
-/**
+/*
  * @struct AampMediaSample
- * @brief Media sample structure.
- *
+ * @brief Media sample structure
  * In future, we can consider unifying this with MediaSample in DemuxDataTypes.h
  */
 struct AampMediaSample
 {
-	std::vector<uint8_t> mData{};  /**< Sample data buffer */
-	double mPts{0.0};
-	double mDts{0.0};
-	double mDuration{0.0};
-	MediaDrmMetadata mDrmMetadata{}; /**< DRM metadata for encrypted samples */
+	// For lifetime management of sample data, we are using AampGrowableBuffer
+	AampGrowableBuffer mData;
+	double mPts;
+	double mDts;
+	double mDuration;
+
+    MediaDrmMetadata mDrmMetadata; // DRM metadata for encrypted samples
+
+	/**
+	 * @brief Constructor for AampMediaSample
+	 */
+	AampMediaSample() : mData("AampMediaSample"), mPts(0), mDts(0), mDuration(0), mDrmMetadata()
+	{
+	}
 
 	// Move constructor and move assignment (allow efficient transfers)
-	AampMediaSample() = default;
 	AampMediaSample(AampMediaSample&&) = default;
 	AampMediaSample& operator=(AampMediaSample&&) = default;
 

--- a/FragmentCacheDescriptor.h
+++ b/FragmentCacheDescriptor.h
@@ -25,10 +25,10 @@
 #ifndef FRAGMENT_CACHE_DESCRIPTOR_H
 #define FRAGMENT_CACHE_DESCRIPTOR_H
 
+#include "AampGrowableBuffer.h"
 #include "AampMediaType.h"
 #include <cstdint>
 #include <string>
-#include <vector>
 
 /**
  * @struct FragmentCacheDescriptor
@@ -45,13 +45,13 @@ struct FragmentCacheDescriptor
 	 * @brief Chunk mode payload pointer (ephemeral CURL callback buffer)
 	 *        COPY REQUIRED - buffer is temporary and owned by CURL
 	 */
-	const uint8_t* chunkPayload;
+	const char* chunkPayload;
 	
 	/**
-	 * @brief Fragment mode buffer holding downloaded fragment data
-	 *        May be copied by the caching layer depending on API semantics
+	 * @brief Fragment mode buffer (for ZERO-COPY move)
+	 *        Ownership transferred via std::move() to CachedFragment
 	 */
-	std::vector<uint8_t> downloadBuffer;
+	AampGrowableBuffer* downloadBuffer;
 	
 	/**
 	 * @brief Size of payload in bytes
@@ -162,6 +162,7 @@ struct FragmentCacheDescriptor
 	 */
 	FragmentCacheDescriptor()
 		: chunkPayload(nullptr)
+		, downloadBuffer(nullptr)
 		, payloadSize(0)
 		, url()
 		, position(0.0)

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -121,7 +121,7 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 					maxInitDownloadTimeMS, initSegment, aamp->mTsbDepthMs, (unsigned long long)dnldInstance->GetPublishTime(), fragmentTime);
 			}
 
-			ret = aamp->GetFile(fragmentUrl, actualType, mTempFragment, effectiveUrl, httpErrorCode, &downloadTimeS, range, curlInstance, true/*resetBuffer*/,  &bitrate, &iFogError, fragmentDurationS, bucketType, maxInitDownloadTimeMS);
+			ret = aamp->GetFile(fragmentUrl, actualType, mTempFragment, effectiveUrl, &httpErrorCode, &downloadTimeS, range, curlInstance, true/*resetBuffer*/,  &bitrate, &iFogError, fragmentDurationS, bucketType, maxInitDownloadTimeMS);
 			if (initSegment && ret)
 			{
 				aamp->getAampCacheHandler()->InsertToInitFragCache(fragmentUrl, mTempFragment, effectiveUrl, actualType);
@@ -610,11 +610,11 @@ bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment> fragme
 	// FN_TRACE_F_MPD( __FUNCTION__ );
 	std::lock_guard<std::mutex> lock(fetchChunkBufferMutex);
 	bool ret = false;
-	if(!fragment->fragment.empty() && WaitForCachedFragmentChunkInjected())
+	if(fragment->fragment.capacity() != 0 && WaitForCachedFragmentChunkInjected())
 	{
 		AAMPLOG_TRACE("Type[%s] fragmentTime %f discontinuity %d duration %f initFragment:%d", name, fragment->position, fragment->discontinuity, fragment->duration, fragment->initFragment);
 		CachedFragment* cachedFragment = GetFetchChunkBuffer(true);
-		if(!cachedFragment->fragment.empty())
+		if(cachedFragment->fragment.capacity() != 0)
 		{
 			// If following log is coming, possible memory leak. Need to clear the data first before slot reuse.
 			AAMPLOG_WARN("Fetch buffer has junk data, Need to free this up");
@@ -971,49 +971,58 @@ bool MediaStreamContext::DownloadFragment(DownloadInfoPtr dlInfo)
 	}
 
 	// Handle change in bandwidth for segmentBase streams, so need to load new range
-	if((dlInfo->bandwidth != fragmentDescriptor.Bandwidth) && !IDX.empty() && uriInfo.range.empty())
+	if((dlInfo->bandwidth != fragmentDescriptor.Bandwidth) && IDX.capacity() != 0 && uriInfo.range.empty())
 	{
 		// If the bandwidth is different, then set the range
 		if (dlInfo->bandwidth > 0)
 		{
 			dlInfo->fragmentOffset = 0;
 			dlInfo->fragmentOffset++; // first byte following packed index
-			unsigned int firstOffset = 0;
-			if (ParseSegmentIndexBox(IDX.data(),
-									 IDX.size(),
-									 0,
-									 NULL,
-									 NULL,
-									 &firstOffset))
+			if (IDX.capacity() != 0)
 			{
+				unsigned int firstOffset;
+				ParseSegmentIndexBox(
+										IDX.data(),
+										IDX.size(),
+										0,
+										NULL,
+										NULL,
+										&firstOffset);
 				dlInfo->fragmentOffset += firstOffset;
 			}
-			unsigned int referenced_size = 0;
-			float fragmentDuration = 0.0f;
-			AAMPLOG_DEBUG("current fragmentIndex = %d", dlInfo->fragmentIndex);
-			// Find the offset of previous fragment in new representation
-			for (int i = 0; i < dlInfo->fragmentIndex; i++)
+			if (dlInfo->fragmentOffset != 0 && IDX.capacity() != 0)
 			{
-				if (ParseSegmentIndexBox(IDX.data(),
-										 IDX.size(),
-										 i,
-										 &referenced_size,
-										 &fragmentDuration,
-										 NULL))
+				unsigned int referenced_size;
+				float fragmentDuration;
+				AAMPLOG_DEBUG("current fragmentIndex = %d", dlInfo->fragmentIndex);
+				//Find the offset of previous fragment in new representation
+				for (int i = 0; i < dlInfo->fragmentIndex; i++)
 				{
-					dlInfo->fragmentOffset += referenced_size;
+					if (ParseSegmentIndexBox(
+												IDX.data(),
+												IDX.size(),
+												i,
+												&referenced_size,
+												&fragmentDuration,
+												NULL))
+					{
+						dlInfo->fragmentOffset += referenced_size;
+					}
 				}
 			}
-			if (ParseSegmentIndexBox(IDX.data(),
-									 IDX.size(),
-									 dlInfo->fragmentIndex,
-									 &referenced_size,
-									 &fragmentDuration,
-									 NULL))
+			unsigned int referenced_size;
+			float fragmentDuration;
+			if (ParseSegmentIndexBox(
+										IDX.data(),
+										IDX.size(),
+										dlInfo->fragmentIndex,
+										&referenced_size,
+										&fragmentDuration,
+										NULL) )
 			{
 				char range[MAX_RANGE_STRING_CHARS];
 				snprintf(range, sizeof(range), "%" PRIu64 "-%" PRIu64 "", dlInfo->fragmentOffset, dlInfo->fragmentOffset + referenced_size - 1);
-				AAMPLOG_INFO("%s [%s]", GetMediaTypeName(dlInfo->mediaType), range);
+				AAMPLOG_INFO("%s [%s]",GetMediaTypeName(dlInfo->mediaType), range);
 				uriInfo.range = range;
 				dlInfo->fragmentDurationSec = fragmentDuration;
 			}

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -46,40 +46,20 @@ public:
 	MediaStreamContext(TrackType type, StreamAbstractionAAMP_MPD* ctx,
 			PrivateInstanceAAMP* aamp, const char* name) :
 			MediaTrack(type, aamp, name),
-			mediaType((AampMediaType)type),
-			adaptationSet(NULL),
-			representation(NULL),
-			fragmentIndex(0),
-			timeLineIndex(0),
-			fragmentRepeatCount(0),
-			fragmentOffset(0),
-			eos(false),
-			fragmentTime(0),
-			periodStartOffset(0),
-			timeStampOffset(0),
-			lastSegmentTime(0),
-			lastSegmentNumber(0),
-			lastSegmentDuration(0),
-			adaptationSetIdx(0),
-			representationIndex(0),
-			profileChanged(true),
-			adaptationSetId(0),
-			fragmentDescriptor(),
-			context(ctx),
-			initialization(""),
-			discontinuity(false),
-			mSkipSegmentOnError(true),
+			mediaType((AampMediaType)type), adaptationSet(NULL),
+			representation(NULL), fragmentIndex(0), timeLineIndex(0),
+			fragmentRepeatCount(0), fragmentOffset(0), eos(false),
+			fragmentTime(0), periodStartOffset(0), timeStampOffset(0),
+			IDX("fragment-IDX"), lastSegmentTime(0), lastSegmentNumber(0),
+			lastSegmentDuration(0), adaptationSetIdx(0),
+			representationIndex(0), profileChanged(true), adaptationSetId(0),
+			fragmentDescriptor(), context(ctx), initialization(""),
+			discontinuity(false), mSkipSegmentOnError(true),
 			lastDownloadedPosition(0), // ,mCMCDNetworkMetrics{-1,-1,-1}
-			scaledPTO(0),
-			failAdjacentSegment(false),
-			httpErrorCode(0),
-			mPlaylistUrl(""),
-			mEffectiveUrl(""),
-			freshManifest(false),
-			nextfragmentIndex(-1),
-			mReachedFirstFragOnRewind(false),
-			fetchChunkBufferMutex(),
-			mActiveDownloadInfo(nullptr),
+			scaledPTO(0), failAdjacentSegment(false), httpErrorCode(0),
+			mPlaylistUrl(""), mEffectiveUrl(""), freshManifest(false),
+			nextfragmentIndex(-1), mReachedFirstFragOnRewind(false),
+			fetchChunkBufferMutex(), mActiveDownloadInfo(nullptr),
 			mMediaStreamContextMutex()
 	{
 		AAMPLOG_INFO("[%s] Create new MediaStreamContext",
@@ -346,14 +326,14 @@ bool CacheFragmentData(const FragmentCacheDescriptor& desc);
 	bool eos;
 	bool profileChanged;
 	bool discontinuity;
-	std::vector<uint8_t> mDownloadedFragment{};	/**< Fragment stored across ABR profile changes */
-	std::vector<uint8_t> mTempFragment{};		/**< Scratch buffer for init/download fragments */
+	std::vector<uint8_t> mDownloadedFragment;	/**< Fragment stored across ABR profile changes */
+	std::vector<uint8_t> mTempFragment;			/**< Scratch buffer for init/download fragments */
 
 	double fragmentTime; // Absolute Fragment time from Availability start
 	std::atomic<double> lastDownloadedPosition;
 	double periodStartOffset;
 	uint64_t timeStampOffset;
-	std::vector<uint8_t> IDX{};		/**< Index data buffer for DASH byte-range segments */
+	AampGrowableBuffer IDX;
 	uint64_t lastSegmentTime;       // zeroed at start of period and also 0 when first segment of an ad has been sent otherwise fragmentDescriptor.Time
 	uint64_t lastSegmentNumber;
 	uint64_t lastSegmentDuration;   //lastSegmentTime+ duration of that segment

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1353,7 +1353,7 @@ void AAMPGstPlayer::SetStreamCaps(AampMediaType type, MediaCodecInfo&& codecInfo
  */
 bool AAMPGstPlayer::SendSample(AampMediaType mediaType, AampMediaSample& sample)
 {
-	MediaSample gstSample(std::move(sample.mData), sample.mPts, sample.mDts, sample.mDuration, 0.0);
+	MediaSample gstSample(sample.mData.ExtractVector(), sample.mPts, sample.mDts, sample.mDuration, 0.0);
 	gstSample.mDrmMetadata = std::move(sample.mDrmMetadata);
 
 	return SendHelper(mediaType, std::move(gstSample));

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -964,7 +964,7 @@ MPD* PrivateCDAIObjectMPD::GetAdMPD(std::string &manifestUrl, bool &finalManifes
 	AampGrowableBuffer manifest("adMPD_CDN");
 	bool gotManifest = false;
 	std::string effectiveUrl;
-	gotManifest = mAamp->GetFile(manifestUrl, eMEDIATYPE_MANIFEST, manifest.GetVector(), effectiveUrl, http_error, &downloadTime, NULL, eCURLINSTANCE_DAI);
+	gotManifest = mAamp->GetFile(manifestUrl, eMEDIATYPE_MANIFEST, manifest.GetVector(), effectiveUrl, &http_error, &downloadTime, NULL, eCURLINSTANCE_DAI);
 	if (gotManifest)
 	{
 		AAMPLOG_TRACE("PrivateCDAIObjectMPD:: manifest download success");
@@ -1010,7 +1010,7 @@ MPD* PrivateCDAIObjectMPD::GetAdMPD(std::string &manifestUrl, bool &finalManifes
 
 			AampGrowableBuffer fogManifest("adMPD_FOG");
 			http_error = 0;
-			mAamp->GetFile(effectiveUrl, eMEDIATYPE_MANIFEST, fogManifest.GetVector(), effectiveUrl, http_error, &downloadTime, NULL, eCURLINSTANCE_DAI);
+			mAamp->GetFile(effectiveUrl, eMEDIATYPE_MANIFEST, fogManifest.GetVector(), effectiveUrl, &http_error, &downloadTime, NULL, eCURLINSTANCE_DAI);
 			if(200 == http_error || 204 == http_error)
 			{
 				manifestUrl = std::move(effectiveUrl);
@@ -1897,7 +1897,7 @@ bool PrivateCDAIObjectMPD::FetchAndCacheInitHeaders(std::string& manifestStr, st
 						bool gotInit = mAamp->getAampCacheHandler()->RetrieveFromInitFragmentCache(fragmentUrl, adInit->GetVector(), fragmentUrl);
 						if(!gotInit)
 						{
-							gotInit = mAamp->GetFile(fragmentUrl, actualMediaType, adInit->GetVector(), fragmentUrl, segment_http_error, &segment_downloadTime, nullptr, eCURLINSTANCE_DAI);
+							gotInit = mAamp->GetFile(fragmentUrl, actualMediaType, adInit->GetVector(), fragmentUrl, &segment_http_error, &segment_downloadTime, nullptr, eCURLINSTANCE_DAI);
 							mAamp->UpdateVideoEndMetrics(actualMediaType, fragmentDescriptor->Bandwidth, segment_http_error, fragmentUrl, 0, segment_downloadTime);
 						}
 						if (gotInit)

--- a/drm/DrmInterface.cpp
+++ b/drm/DrmInterface.cpp
@@ -19,6 +19,7 @@
 #include "DrmInterface.h"
 #include "Aes.h"
 #include "HlsOcdmBridgeInterface.h"
+#include "AampGrowableBuffer.h"
 #include "HlsDrmSessionManager.h"
 #include "AampDRMLicManager.h"
 #define AES_128_KEY_LEN_BYTES 16
@@ -85,9 +86,10 @@ void registerCallbackForHls(DrmInterface* _this, PlayerHlsDrmSessionInterface* i
 /*
  * @brief DrmInterface constructor 
  * */
-DrmInterface::DrmInterface(PrivateInstanceAAMP* aamp)
-	: mpAamp(aamp)
+DrmInterface::DrmInterface(PrivateInstanceAAMP* aamp):mAesKeyBuf("aesKeyBuf")
 {
+	
+	mpAamp = aamp;
 }
 
 /*
@@ -163,7 +165,8 @@ void DrmInterface::ProfileUpdateDrmDecrypt(bool type, int bucketType)
  */
 void DrmInterface::GetAccessKey(std::string &keyURI,  std::string& tempEffectiveUrl, int& http_error, double& downloadTime,unsigned int curlInstance, bool &keyAcquisitionStatus, int &failureReason,  char** ptr)
 {
-	bool fetched = mpAamp->GetFile(keyURI, (AampMediaType)eMEDIATYPE_LICENCE, mAesKeyBuf, tempEffectiveUrl, http_error, &downloadTime, NULL, curlInstance, true);
+	bool fetched = mpAamp->GetFile(keyURI, (AampMediaType)eMEDIATYPE_LICENCE, mAesKeyBuf.GetVector(), tempEffectiveUrl, &http_error, &downloadTime, NULL, curlInstance, true);
+	*ptr = reinterpret_cast<char*>(mAesKeyBuf.data());
 	
 	if (fetched)
 	{
@@ -171,13 +174,11 @@ void DrmInterface::GetAccessKey(std::string &keyURI,  std::string& tempEffective
 		{
 			AAMPLOG_WARN("Key fetch success len = %d",  (int)mAesKeyBuf.size());
 			keyAcquisitionStatus = true;
-			*ptr = reinterpret_cast<char*>(mAesKeyBuf.data());
 		}
 		else
 		{
 			AAMPLOG_ERR("Error Key fetch - size %d",  (int)mAesKeyBuf.size() );
 			failureReason = AAMP_TUNE_INVALID_DRM_KEY;
-			*ptr = nullptr;
 		}
 	}
 	else
@@ -191,7 +192,6 @@ void DrmInterface::GetAccessKey(std::string &keyURI,  std::string& tempEffective
 		{
 			failureReason = AAMP_TUNE_LICENCE_REQUEST_FAILED;
 		}
-		*ptr = nullptr;
 	}
 }
 

--- a/drm/DrmInterface.h
+++ b/drm/DrmInterface.h
@@ -27,7 +27,6 @@
 
 #include <stddef.h>
 #include <memory>
-#include <vector>
 #include <condition_variable>
 #include <priv_aamp.h>
 #include <AampCurlDefine.h>
@@ -97,8 +96,8 @@ public:
 	/**
 	 * Storing aamp instance */
 	PrivateInstanceAAMP* mpAamp;
-	/** AES key buffer for HLS AES-128 decryption */
-	std::vector<uint8_t> mAesKeyBuf{};
+	/**Storing AampGrowableBuffer */
+	AampGrowableBuffer mAesKeyBuf;
 
 	/** 
 	 * @fn GetAccessKey 

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1349,7 +1349,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 			}
 
 			bool fetched = aamp->GetFile(fragmentUrl, (AampMediaType)(type), cachedFragment->fragment,
-		 tempEffectiveUrl, http_error, &downloadTime, range, type, false, NULL, NULL, fragmentDurationSeconds);
+			 tempEffectiveUrl, &http_error, &downloadTime, range, type, false, NULL, NULL, fragmentDurationSeconds);
 			//Workaround for 404 of subtitle fragments
 			//TODO: This needs to be handled at server side and this workaround has to be removed
 			if (!fetched && http_error == 404 && type == eTRACK_SUBTITLE)
@@ -3254,7 +3254,7 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 		// take the original url before its gets changed in GetFile
 		std::string mainManifestOrigUrl = aamp->GetManifestUrl();
 		aamp->SetCurlTimeout(aamp->mManifestTimeoutMs, eCURLINSTANCE_MANIFEST_MAIN);
-		(void) aamp->GetFile(aamp->GetManifestUrl(), eMEDIATYPE_MANIFEST, this->mainManifest.GetVector(), aamp->GetManifestUrl(), http_error, &mainManifestdownloadTime, NULL, eCURLINSTANCE_MANIFEST_MAIN, true,NULL,NULL,0);//CID:82578 - checked return
+		(void) aamp->GetFile(aamp->GetManifestUrl(), eMEDIATYPE_MANIFEST, this->mainManifest.GetVector(), aamp->GetManifestUrl(), &http_error, &mainManifestdownloadTime, NULL, eCURLINSTANCE_MANIFEST_MAIN, true,NULL,NULL,0);//CID:82578 - checked return
 		// Set playlist curl timeouts.
 		for (int i = eCURLINSTANCE_MANIFEST_PLAYLIST_VIDEO; i < (eCURLINSTANCE_MANIFEST_PLAYLIST_VIDEO + AAMP_TRACK_COUNT); i++)
 		{
@@ -4329,7 +4329,7 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 				if( !aamp->getAampCacheHandler()->RetrieveFromPlaylistCache(defaultIframePlaylistUrl, defaultIframePlaylist.GetVector(), defaultIframePlaylistEffectiveUrl, eMEDIATYPE_PLAYLIST_IFRAME) )
 				{
 					double tempDownloadTime{0.0};
-					bFiledownloaded = aamp->GetFile(defaultIframePlaylistUrl, eMEDIATYPE_PLAYLIST_IFRAME, defaultIframePlaylist.GetVector(), defaultIframePlaylistEffectiveUrl, http_error, &tempDownloadTime, NULL,eCURLINSTANCE_MANIFEST_MAIN);
+					bFiledownloaded = aamp->GetFile(defaultIframePlaylistUrl, eMEDIATYPE_PLAYLIST_IFRAME, defaultIframePlaylist.GetVector(), defaultIframePlaylistEffectiveUrl, &http_error, &tempDownloadTime, NULL,eCURLINSTANCE_MANIFEST_MAIN);
 					AampTime downloadTime{tempDownloadTime};
 					//update videoend info
 					ManifestData manifestData(downloadTime.milliseconds(), defaultIframePlaylist.size());
@@ -5290,7 +5290,7 @@ bool StreamAbstractionAAMP_HLS::SetThumbnailTrack( int thumbIndex )
 				AampTime downloadTime{};
 				std::string tempEffectiveUrl;
 				double tempDownloadTime;
-				if( aamp->GetFile(std::move(url), eMEDIATYPE_PLAYLIST_IFRAME, thumbnailManifest.GetVector(), tempEffectiveUrl, http_error, &tempDownloadTime, NULL, eCURLINSTANCE_MANIFEST_MAIN,true) )
+				if( aamp->GetFile(std::move(url), eMEDIATYPE_PLAYLIST_IFRAME, thumbnailManifest.GetVector(), tempEffectiveUrl, &http_error, &tempDownloadTime, NULL, eCURLINSTANCE_MANIFEST_MAIN,true) )
 				{
 					downloadTime = tempDownloadTime;
 					AAMPLOG_WARN("In StreamAbstractionAAMP_HLS: Configured Thumbnail");
@@ -5754,7 +5754,7 @@ void TrackState::FetchPlaylist()
 	aamp->profiler.ProfileBegin(bucketId);
 
 	double tempDownloadTime{};
-	(void) aamp->GetFile(mPlaylistUrl, mType, playlist.GetVector(), mEffectiveUrl, http_error, &tempDownloadTime, NULL, (unsigned int)dnldCurlInstance, true );
+	(void) aamp->GetFile(mPlaylistUrl, mType, playlist.GetVector(), mEffectiveUrl, &http_error, &tempDownloadTime, NULL, (unsigned int)dnldCurlInstance, true );
 	downloadTime = tempDownloadTime;
 	// update videoend info
 	main_error = context->getOriginalCurlError(http_error);
@@ -6271,7 +6271,7 @@ bool TrackState::FetchInitFragmentHelper(int &http_code, bool forcePushEncrypted
 			if ( !fetched )
 			{
 				double tempDownloadTime{0.0};
-				fetched = aamp->GetFile(fragmentUrl, actualType, cachedFragment->fragment, tempEffectiveUrl, http_code, &tempDownloadTime, range,
+				fetched = aamp->GetFile(fragmentUrl, actualType, cachedFragment->fragment, tempEffectiveUrl, &http_code, &tempDownloadTime, range,
 										type, false);
 				AampTime downloadTime{tempDownloadTime};
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -1610,7 +1610,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 		{ // single-segment
 			std::string fragmentUrl;
 			ConstructFragmentURL(fragmentUrl, &pMediaStreamContext->fragmentDescriptor, "", aamp->mConfig);
-			if (pMediaStreamContext->IDX.empty())
+			if (pMediaStreamContext->IDX.capacity() == 0)
 			{ // lazily load index
 				std::string range = segmentBase->GetIndexRange();
 				uint64_t start;
@@ -1625,7 +1625,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 				int iCurrentRate = aamp->rate; //  Store it as back up, As sometimes by the time File is downloaded, rate might have changed due to user initiated Trick-Play
 				AampCurlInstance curlInst = aamp->GetPlaylistCurlInstance(actualType, false);
 				aamp->CurlInit(curlInst, 1, aamp->GetNetworkProxy());
-				aamp->LoadIDX(bucketType, fragmentUrl, effectiveUrl, pMediaStreamContext->IDX, curlInst, range.c_str(), http_code, &downloadTime, actualType, &iFogError);
+				aamp->LoadIDX(bucketType, fragmentUrl, effectiveUrl,&pMediaStreamContext->IDX, curlInst, range.c_str(),&http_code, &downloadTime, actualType,&iFogError);
 				aamp->CurlTerm(curlInst);
 
 
@@ -1648,40 +1648,40 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 										(iFogError > 0 ? iFogError : http_code),effectiveUrl,pMediaStreamContext->fragmentDescriptor.Time, downloadTime);
 
 				pMediaStreamContext->fragmentOffset++; // first byte following packed index
-				if (!pMediaStreamContext->IDX.empty())
+				if (pMediaStreamContext->IDX.capacity() != 0)
 				{
-					unsigned int firstOffset = 0;
-					if (ParseSegmentIndexBox(pMediaStreamContext->IDX.data(),
-											 pMediaStreamContext->IDX.size(),
-											 0,
-											 NULL,
-											 NULL,
-											 &firstOffset))
+					unsigned int firstOffset;
+					ParseSegmentIndexBox(
+										 pMediaStreamContext->IDX.data(),
+										 pMediaStreamContext->IDX.size(),
+										 0,
+										 NULL,
+										 NULL,
+										 &firstOffset);
+					pMediaStreamContext->fragmentOffset += firstOffset;
+				}
+				if (pMediaStreamContext->fragmentIndex != 0 && pMediaStreamContext->IDX.capacity() != 0)
+				{
+					unsigned int referenced_size;
+					float fragmentDuration;
+					AAMPLOG_INFO("current fragmentIndex = %d", pMediaStreamContext->fragmentIndex);
+					//Find the offset of previous fragment in new representation
+					for (int i = 0; i < pMediaStreamContext->fragmentIndex; i++)
 					{
-						pMediaStreamContext->fragmentOffset += firstOffset;
-					}
-					if (pMediaStreamContext->fragmentIndex != 0)
-					{
-						unsigned int referenced_size;
-						float fragmentDuration;
-						AAMPLOG_INFO("current fragmentIndex = %d", pMediaStreamContext->fragmentIndex);
-						// Find the offset of previous fragment in new representation
-						for (int i = 0; i < pMediaStreamContext->fragmentIndex; i++)
+						if (ParseSegmentIndexBox(
+												 pMediaStreamContext->IDX.data(),
+												 pMediaStreamContext->IDX.size(),
+												 i,
+												 &referenced_size,
+												 &fragmentDuration,
+												 NULL))
 						{
-							if (ParseSegmentIndexBox(pMediaStreamContext->IDX.data(),
-													 pMediaStreamContext->IDX.size(),
-													 i,
-													 &referenced_size,
-													 &fragmentDuration,
-													 NULL))
-							{
-								pMediaStreamContext->fragmentOffset += referenced_size;
-							}
+							pMediaStreamContext->fragmentOffset += referenced_size;
 						}
 					}
 				}
 			}
-			if (!pMediaStreamContext->IDX.empty())
+			if (pMediaStreamContext->IDX.capacity() != 0)
 			{
 				unsigned int referenced_size;
 				float fragmentDuration;
@@ -1722,7 +1722,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 				}
 				else
 				{ // done with index
-					aamp_utils::ClearAndRelease(pMediaStreamContext->IDX);
+					pMediaStreamContext->IDX.Free();
 					pMediaStreamContext->eos = true;
 				}
 			}
@@ -2442,7 +2442,7 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 			// Disable parallel fragment download for segment base streams as there is a sidx box dependency for live contents
 			SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_DashParallelFragDownload, false);
 			std::string range = segmentBase->GetIndexRange();
-			if (pMediaStreamContext->IDX.empty())
+			if (pMediaStreamContext->IDX.capacity() == 0)
 			{ // lazily load index
 				std::string fragmentUrl;
 				ConstructFragmentURL(fragmentUrl, &pMediaStreamContext->fragmentDescriptor, "", aamp->mConfig);
@@ -2457,10 +2457,10 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 				int iFogError = -1;
 				AampCurlInstance curlInstance = aamp->GetPlaylistCurlInstance(actualType, false);
 				aamp->CurlInit(curlInstance, 1, aamp->GetNetworkProxy());
-				aamp->LoadIDX(bucketType, std::move(fragmentUrl), effectiveUrl, pMediaStreamContext->IDX, curlInstance, range.c_str(), http_code, &downloadTime, actualType, &iFogError);
+				aamp->LoadIDX(bucketType, std::move(fragmentUrl), effectiveUrl, &pMediaStreamContext->IDX, curlInstance, range.c_str(),&http_code, &downloadTime, actualType,&iFogError);
 				aamp->CurlTerm(curlInstance);
 			}
-			if (!pMediaStreamContext->IDX.empty())
+			if (pMediaStreamContext->IDX.capacity() != 0)
 			{
 				unsigned int referenced_size = 0;
 				float fragmentDuration = 0.00;
@@ -2505,7 +2505,7 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 					else
 					{
 						// done with index
-						aamp_utils::ClearAndRelease(pMediaStreamContext->IDX);
+						pMediaStreamContext->IDX.Free();
 						pMediaStreamContext->eos = true;
 						break;
 					}
@@ -8282,7 +8282,7 @@ void StreamAbstractionAAMP_MPD::FetchAndInjectInitialization(int trackIdx, bool 
 					if (segmentBase)
 					{
 						pMediaStreamContext->fragmentOffset = 0;
-						aamp_utils::ClearAndRelease(pMediaStreamContext->IDX);
+						pMediaStreamContext->IDX.Free();
 						std::string range;
 						std::string nextrange; //CMCD get the next range
 						const IURLType *urlType = segmentBase->GetInitialization();
@@ -8299,6 +8299,23 @@ void StreamAbstractionAAMP_MPD::FetchAndInjectInitialization(int trackIdx, bool 
 							char temp[MAX_RANGE_STRING_CHARS];
 							snprintf( temp, sizeof(temp), "0-%" PRIu64 , s1-1 );
 							range = temp;
+							if (pMediaStreamContext->IDX.capacity() != 0)
+							{
+								unsigned int referenced_size;
+								float fragmentDuration;
+								if (ParseSegmentIndexBox(
+										pMediaStreamContext->IDX.data(),
+										pMediaStreamContext->IDX.size(),
+										pMediaStreamContext->fragmentIndex,
+										&referenced_size,
+										&fragmentDuration,
+										NULL))
+								{
+									char temprange[MAX_RANGE_STRING_CHARS];
+									snprintf(temprange, sizeof(temprange), "%" PRIu64 "-%" PRIu64 "", pMediaStreamContext->fragmentOffset, pMediaStreamContext->fragmentOffset + referenced_size - 1);
+									nextrange = temprange;
+								}
+							}
 						}
 						std::string fragmentUrl;
 						ConstructFragmentURL(fragmentUrl, &pMediaStreamContext->fragmentDescriptor, "", aamp->mConfig);
@@ -10559,7 +10576,7 @@ void StreamAbstractionAAMP_MPD::Stop(bool clearChannelData)
 			{
 				track->SetLocalTSBInjection(false);
 			}
-			aamp_utils::ClearAndRelease(track->IDX);
+			track->IDX.Free();
 		}
 	}
 
@@ -11399,7 +11416,7 @@ void StreamAbstractionAAMP_MPD::SendMediaHeaders()
 				std::vector<uint8_t> initSegment;
 				std::string effectiveUrl;
 				int http_error{};
-				if (aamp->GetFile(header->url, (AampMediaType) iTrack, initSegment, effectiveUrl, http_error, NULL, NULL, eCURLINSTANCE_VIDEO + iTrack))
+				if (aamp->GetFile(header->url, (AampMediaType) iTrack, initSegment, effectiveUrl, &http_error, NULL, NULL, eCURLINSTANCE_VIDEO + iTrack))
 				{
 					aamp->SendStreamTransfer((AampMediaType) iTrack, initSegment, 0, 0, 0, 0, true, false);
 				}

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -787,7 +787,7 @@ void Mp4Demux::ProcessSamples()
 			throw Mp4ParseException(MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH, "trun: sample payload OOB");
 		}
 		AampMediaSample& s = samples[pending.sampleIdx];
-		s.mData.insert(s.mData.end(), dataPtr, dataPtr + sampleLen);
+		s.mData.insert(s.mData.GetVector().end(), dataPtr, dataPtr + sampleLen);
 		s.mDts      = pending.mDts;
 		s.mPts      = pending.mPts;
 		s.mDuration = pending.mDuration;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4474,7 +4474,7 @@ static inline bool HasDownloadTimedOutWithData(CURLcode curlCode, CurlAbortReaso
 /**
  * @brief Download a file from the CDN
  */
-bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaType, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int& http_error, double *downloadTimeS, const char *range, unsigned int curlInstance, bool resetBuffer, BitsPerSecond *bitrate, int * fogError, double fragmentDurationS, ProfilerBucketType bucketType, int maxInitDownloadTimeMS)
+bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaType, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int * http_error, double *downloadTimeS, const char *range, unsigned int curlInstance, bool resetBuffer, BitsPerSecond *bitrate, int * fogError, double fragmentDurationS, ProfilerBucketType bucketType, int maxInitDownloadTimeMS)
 {
 	if( ISCONFIGSET_PRIV(eAAMPConfig_CurlThroughput) )
 	{
@@ -5382,10 +5382,13 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 		AAMPLOG_WARN("downloads disabled");
 	}
 
-	http_error = http_code;
-	if (downloadTimeS)
+	if (http_error)
 	{
-		*downloadTimeS = total;
+		*http_error = http_code;
+		if(downloadTimeS)
+		{
+			*downloadTimeS = total;
+		}
 	}
 	if (httpHeaders != NULL)
 	{
@@ -5433,7 +5436,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 	{
 		if( !ret )
 		{
-			profiler.ProfileError(bucketType, http_error);
+			profiler.ProfileError(bucketType, *http_error);
 		}
 		profiler.ProfileEnd(bucketType);
 	}
@@ -7106,20 +7109,20 @@ MediaFormat PrivateInstanceAAMP::GetMediaFormatType(const char *url)
 		CurlInit(eCURLINSTANCE_MANIFEST_MAIN, 1, GetNetworkProxy());
 		EnableMediaDownloads(eMEDIATYPE_MANIFEST);
 		bool gotManifest = GetFile(url,
-								   eMEDIATYPE_MANIFEST,
-								   sniffedBytes.GetVector(),
-								   effectiveUrl,
-								   http_error,
-								   &downloadTime,
-								   "0-150", // download first few bytes only
-								   // TODO: ideally could use "0-6" for range but write_callback sometimes not called before curl returns http 206
-								   eCURLINSTANCE_MANIFEST_MAIN,
-								   false,
-								   &bitrate,
-								   &fogError,
-								   0.0);
+							eMEDIATYPE_MANIFEST,
+							sniffedBytes.GetVector(),
+							effectiveUrl,
+							&http_error,
+							&downloadTime,
+							"0-150", // download first few bytes only
+							// TODO: ideally could use "0-6" for range but write_callback sometimes not called before curl returns http 206
+							eCURLINSTANCE_MANIFEST_MAIN,
+							false,
+							&bitrate,
+							&fogError,
+							0.0 );
 
-		if (gotManifest)
+		if(gotManifest)
 		{
 			if(sniffedBytes.size() >= 7 && memcmp(sniffedBytes.data(), "#EXTM3U8", 7) == 0)
 			{
@@ -7553,12 +7556,12 @@ BitsPerSecond PrivateInstanceAAMP::GetIframeBitrate4K()
 /**
  * @brief Fetch a file from CDN and update profiler
  */
-void PrivateInstanceAAMP::LoadIDX(ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, std::vector<uint8_t>& fragment, unsigned int curlInstance, const char *range, int& http_code, double *downloadTime, AampMediaType mediaType, int *fogError)
+void PrivateInstanceAAMP::LoadIDX(ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, AampGrowableBuffer *fragment, unsigned int curlInstance, const char *range, int * http_code, double *downloadTime, AampMediaType mediaType,int * fogError)
 {
 	profiler.ProfileBegin(bucketType);
-	if (!GetFile(std::move(fragmentUrl), mediaType, fragment, effectiveUrl, http_code, downloadTime, range, curlInstance, true, NULL, fogError))
+	if (!GetFile(std::move(fragmentUrl), mediaType, fragment->GetVector(), effectiveUrl, http_code, downloadTime, range, curlInstance, true, NULL,fogError))
 	{
-		profiler.ProfileError(bucketType, http_code);
+		profiler.ProfileError(bucketType, *http_code);
 		profiler.ProfileEnd(bucketType);
 	}
 	else
@@ -10764,7 +10767,7 @@ void PrivateInstanceAAMP::PreCachePlaylistDownloadTask()
 						// Using StreamLock to avoid StreamAbstractionAAMP deletion when external player commands or stop call received
 						{
 							std::lock_guard<std::recursive_mutex> lock(mStreamLock);
-						  ret = GetFile(newelem.url, newelem.type, playlistStore.GetVector(), playlistEffectiveUrl, http_code, &downloadTime, NULL, eCURLINSTANCE_PLAYLISTPRECACHE, true );
+						  ret = GetFile(newelem.url, newelem.type, playlistStore.GetVector(), playlistEffectiveUrl, &http_code, &downloadTime, NULL, eCURLINSTANCE_PLAYLISTPRECACHE, true );
 						  if(ret != false)
 						  {
 							  // If successful download , then insert into Cache

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1371,37 +1371,25 @@ public:
 	/**
 	 * @fn GetFile
 	 *
-	 * @brief Download a file from the CDN and store it in memory.
-	 *
-	 * @param[in]  remoteUrl           URL of the media resource to download.
-	 * @param[in]  mediaType           Media type being downloaded.
-	 * @param[out] buffer              Buffer that receives the downloaded bytes
-	 *                                 on success.
-	 * @param[out] effectiveUrl        Final URL after any HTTP redirects.
-	 * @param[out] http_error          Reference that receives the HTTP response
-	 *                                 code on return.
-	 * @param[out] downloadTime        Optional pointer that receives the total
-	 *                                 download time in seconds; may be NULL.
-	 * @param[in]  range               Optional HTTP byte-range string; pass
-	 *                                 NULL to request the full object.
-	 * @param[in]  curlInstance        Curl instance index to use.
-	 * @param[in]  resetBuffer         When true the output buffer is cleared
-	 *                                 before the download begins.
-	 * @param[in]  bitrate             Optional pointer that receives the
-	 *                                 measured download bitrate; may be NULL.
-	 * @param[out] fogError            Optional pointer that receives any FOG
-	 *                                 error code; may be NULL.
-	 * @param[in]  fragmentDurationS   Duration of the fragment in seconds
-	 *                                 (0 if not applicable).
-	 * @param[in]  bucketType          Profiling bucket type.
-	 * @param[in]  maxInitDownloadTimeMS Max time (ms) to retry init-segment
-	 *                                 downloads when AAMP TSB is enabled;
-	 *                                 pass 0 otherwise.
-	 * @return true on success, false on failure.
+	 * @param [in] bucketType profiling bucket
+	 * @param[in] remoteUrl media file to download
+	 * @param[in] mediaType
+	 * @param[out] buffer receives downloaded bytes on success
+	 * @param[out] effectiveUrl - Final URL after HTTP redirection
+	 * @param[out] http_error - HTTP error code
+	 * @param[out] downloadTime
+	 * @param[in] range - Byte range
+	 * @param[in] curlInstance - Curl instance to be used
+	 * @param[in] resetBuffer - Flag to reset the out buffer
+	 * @param[in] bitrate
+	 * @param[out] fogError
+	 * @param[in] fragmentDurationS
+	 * @param[in] maxInitDownloadTimeMS - Max time to retry init segment downloads if AAMP TSB is enabled, 0 otherwise
+	 * @return true iff successful
 	 */
 	bool GetFile( std::string remoteUrl, AampMediaType mediaType,
 				std::vector<uint8_t> &buffer, std::string& effectiveUrl,
-				int& http_error, double *downloadTime = NULL,
+				int *http_error = NULL, double *downloadTime = NULL,
 				const char *range = NULL, unsigned int curlInstance = 0,
 				bool resetBuffer = true, BitsPerSecond *bitrate = NULL,
 				int *fogError = NULL, double fragmentDurationS = 0,
@@ -1445,26 +1433,17 @@ public:
 	/**
 	 * @fn LoadIDX
 	 *
- 	 * @brief Download an IDX resource and store it in memory.
- 	 *
- 	 * @param[in]  bucketType   Bucket type used for profiling the download.
- 	 * @param[in]  fragmentUrl  URL of the IDX resource to download.
- 	 * @param[out] effectiveUrl Final URL after redirects, if any.
- 	 * @param[out] idx          Reference to the buffer that receives the
- 	 *                          downloaded IDX bytes.
- 	 * @param[in]  curlInstance Curl instance index to use for the download.
- 	 * @param[in]  range        Optional HTTP byte range to request; pass NULL
- 	 *                          to request the full object.
- 	 * @param[out] http_code    Reference that receives the HTTP response code.
- 	 * @param[out] downloadTime Optional pointer that receives the total
- 	 *                          download time in seconds; may be NULL.
- 	 * @param[in]  mediaType    Media type associated with the IDX resource.
- 	 * @param[out] fogError     Optional pointer that receives any FOG error
- 	 *                          code; may be NULL when FOG is not used.
- 	 *
+	 * @param[in] bucketType - Bucket type of the profiler
+	 * @param[in] fragmentUrl - Fragment URL
+	 * @param[out] buffer - Pointer to the output buffer
+	 * @param[out] len - Content length
+	 * @param[in] curlInstance - Curl instance to be used
+	 * @param[in] range - Byte range
+	 * @param[in] mediaType - File type
+	 * @param[out] fogError - Error from FOG
 	 * @return void
 	 */
-	void LoadIDX( ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, std::vector<uint8_t>& idx, unsigned int curlInstance, const char *range, int& http_code, double *downloadTime = NULL, AampMediaType mediaType = eMEDIATYPE_MANIFEST, int *fogError = NULL);
+	void LoadIDX( ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl,  AampGrowableBuffer *idx, unsigned int curlInstance = 0, const char *range = NULL,int * http_code = NULL, double *downloadTime = NULL, AampMediaType mediaType = eMEDIATYPE_MANIFEST,int * fogError = NULL);
 
 	/**
 	 * @fn EndOfStreamReached

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4525,7 +4525,7 @@ void MediaTrack::PlaylistDownloader()
 					AAMPLOG_INFO("[%s] Re-enabling media download", trackName.c_str());
 					aamp->EnableMediaDownloads(mediaType);
 				}
-				gotManifest = aamp->GetFile(manifestUrl, mediaType, manifest.GetVector(), effectiveUrl, http_error, &downloadTime, NULL, curlInstance, true );
+				gotManifest = aamp->GetFile(manifestUrl, mediaType, manifest.GetVector(), effectiveUrl, &http_error, &downloadTime, NULL, curlInstance, true );
 				if(seamlessAudioSwitchInProgress && (manifestUrl != GetPlaylistUrl()))
 				{
 					//new Playlist updated in mid.

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -1096,23 +1096,10 @@ void PrivateInstanceAAMP::SendHTTPHeaderResponse()
 }
 
 void PrivateInstanceAAMP::LoadIDX(ProfilerBucketType bucketType, std::string fragmentUrl,
-								  std::string &effectiveUrl, std::vector<uint8_t>& fragment,
-								  unsigned int curlInstance, const char *range, int& http_code,
+								  std::string &effectiveUrl, AampGrowableBuffer *fragment,
+								  unsigned int curlInstance, const char *range, int *http_code,
 								  double *downloadTime, AampMediaType fileType, int *fogError)
 {
-	// Deterministic defaults for mock implementation
-	effectiveUrl = fragmentUrl;
-	http_code = 0;
-	if (downloadTime != nullptr)
-	{
-		*downloadTime = 0.0;
-	}
-	if (fogError != nullptr)
-	{
-		*fogError = 0;
-	}
-	// Ensure output fragment buffer is in a known, empty state
-	fragment.clear();
 	return;
 }
 

--- a/test/utests/fakes/FakeDrmInterface.cpp
+++ b/test/utests/fakes/FakeDrmInterface.cpp
@@ -24,9 +24,9 @@
  * @brief HLS Drm Interface */
 /* Constructor for dmrInterfce()
  * */
-DrmInterface::DrmInterface(PrivateInstanceAAMP* aamp)
-	: mpAamp(aamp)
+DrmInterface::DrmInterface(PrivateInstanceAAMP* aamp):mAesKeyBuf("aesKeyBuf")
 {
+
 }
 /*Destructor for DrmInterfcae()
  */

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -747,11 +747,11 @@ void PrivateInstanceAAMP::CurlInit(AampCurlInstance startIdx, unsigned int insta
 }
 
 bool PrivateInstanceAAMP::GetFile(std::string remoteUrl, AampMediaType mediaType, std::vector<uint8_t> &buffer, std::string& effectiveUrl,
-                int& http_error, double *downloadTime, const char *range, unsigned int curlInstance,
+                int * http_error, double *downloadTime, const char *range, unsigned int curlInstance,
                 bool resetBuffer, BitsPerSecond *bitrate, int * fogError,
                 double fragmentDurationSeconds, ProfilerBucketType bucketType, int maxInitDownloadTimeMS)
 {
-	bool rv = false;
+	bool rv = true;
 
 	if (g_mockPrivateInstanceAAMP != nullptr)
 	{
@@ -759,31 +759,6 @@ bool PrivateInstanceAAMP::GetFile(std::string remoteUrl, AampMediaType mediaType
 				 								http_error, downloadTime, range, curlInstance,
 												resetBuffer, bitrate, fogError,
 												fragmentDurationSeconds, bucketType, maxInitDownloadTimeMS);
-	}
-	else
-	{
-		// In the absence of a mock, ensure output parameters are initialized.
-		// Use a failure sentinel for http_error to match the false return value.
-		http_error = -1;
-		effectiveUrl = remoteUrl;
-		if (downloadTime != nullptr)
-		{
-			*downloadTime = 0.0;
-		}
-		if (bitrate != nullptr)
-		{
-			*bitrate = 0;
-		}
-		if (fogError != nullptr)
-		{
-			*fogError = 0;
-		}
-
-		// Apply resetBuffer contract to keep fake semantics aligned with GetFile expectations
-		if (resetBuffer)
-		{
-			buffer.clear();
-		}
 	}
 
 	return rv;
@@ -1325,27 +1300,12 @@ void PrivateInstanceAAMP::SendHTTPHeaderResponse()
 {
 }
 
-void PrivateInstanceAAMP::LoadIDX(ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, std::vector<uint8_t>& fragment, unsigned int curlInstance, const char *range, int& http_code, double *downloadTime, AampMediaType mediaType, int *fogError)
+void PrivateInstanceAAMP::LoadIDX(ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, AampGrowableBuffer *fragment, unsigned int curlInstance, const char *range, int * http_code, double *downloadTime, AampMediaType mediaType,int * fogError)
 {
-	// Ensure deterministic default values when no mock is installed
-	http_code = 0;
-	if (g_mockPrivateInstanceAAMP != nullptr)
-	{
+	if (g_mockPrivateInstanceAAMP != nullptr){
 		g_mockPrivateInstanceAAMP->LoadIDX(bucketType, fragmentUrl, effectiveUrl, fragment, curlInstance, range, http_code, downloadTime, mediaType, fogError);
-		return;
 	}
-
-	// No mock installed: initialize all outputs to stable defaults
-	effectiveUrl = fragmentUrl;
-	fragment.clear();
-	if (downloadTime != nullptr)
-	{
-		*downloadTime = 0.0;
-	}
-	if (fogError != nullptr)
-	{
-		*fogError = 0;
-	}
+	return;
 }
 
 bool PrivateInstanceAAMP::IsAudioLanguageSupported (const char *checkLanguage)

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -39,7 +39,7 @@ public:
 	MOCK_METHOD(void, SetState, (AAMPPlayerState state, bool sendStateChangeEvent));
 
 	MOCK_METHOD(bool, GetFile, (std::string remoteUrl, AampMediaType mediaType, std::vector<uint8_t> &buffer, std::string& effectiveUrl,
-				int& http_error, double *downloadTime, const char *range, unsigned int curlInstance,
+				int * http_error, double *downloadTime, const char *range, unsigned int curlInstance,
 				bool resetBuffer, BitsPerSecond *bitrate, int * fogError,
 				double fragmentDurationSeconds, ProfilerBucketType bucketType, int maxInitDownloadTimeMS));
 	MOCK_METHOD(void, SetStreamFormat, (StreamOutputFormat videoFormat, StreamOutputFormat audioFormat));
@@ -99,7 +99,7 @@ public:
 	MOCK_METHOD(bool, IsAdPlaying, ());
 	MOCK_METHOD(void, UpdateVideoEndMetrics, (double adjustedRate));
 	MOCK_METHOD(void, NotifyReservationComplete, (const std::string& reservationId));
-	MOCK_METHOD(void, LoadIDX, (ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, std::vector<uint8_t>& fragment, unsigned int curlInstance, const char *range, int& http_code, double *downloadTime, AampMediaType mediaType, int *fogError));
+	MOCK_METHOD(void, LoadIDX, (ProfilerBucketType bucketType, std::string fragmentUrl, std::string& effectiveUrl, AampGrowableBuffer *fragment, unsigned int curlInstance, const char *range, int * http_code, double *downloadTime, AampMediaType mediaType,int * fogError));
 	MOCK_METHOD(void, UpdateUseSinglePipeline, ());
 };
 

--- a/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
@@ -264,13 +264,13 @@ class AdFallbackTests : public ::testing::Test
 			return mStreamAbstractionAAMP_MPD->Init(tuneType);
 		}
 
-		bool GetManifest(std::string remoteUrl, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int& httpError)
+		bool GetManifest(std::string remoteUrl, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int *httpError)
 		{
 			/* Setup fake buffer contents. */
 			buffer.clear();
 			buffer.assign(mAdManifest, mAdManifest + strlen(mAdManifest));
 			effectiveUrl = remoteUrl;
-			httpError = 200;
+			*httpError = 200;
 
 			return true;
 		}

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -121,13 +121,13 @@ protected:
   }
 
 public:
-  bool GetManifest(std::string remoteUrl, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int& httpError)
+  bool GetManifest(std::string remoteUrl, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int *httpError)
   {
     /* Setup fake buffer contents. */
     buffer.clear();
     buffer.assign(mManifest, mManifest + strlen(mManifest));
     effectiveUrl = remoteUrl;
-    httpError = 200;
+    *httpError = 200;
 
     return true;
   }
@@ -164,8 +164,8 @@ public:
     else
     {
       EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile (adManifestUrl, _, _, _, _, _, _, _, _, _, _, _, _, _))
-              .WillOnce(WithArgs<4>(Invoke([httpError](int& err){
-                err = httpError;
+              .WillOnce(WithArgs<4>(Invoke([httpError](int* err){
+                *err = httpError;
                 return false;
               })));
     }
@@ -981,11 +981,11 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_13)
       .WillOnce(Return(true));
     // Set up the mock for GetFile before any SetAlternateContents calls
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(url, _, _, _, _, _, _, _, _, _, _, _, _, _))
-      .WillOnce(WithArgs<0,2,3,4>(Invoke([this, periodId, manifest](std::string remoteUrl, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int& httpError)
+      .WillOnce(WithArgs<0,2,3,4>(Invoke([this, periodId, manifest](std::string remoteUrl, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int *httpError)
         {
             buffer.clear();
             buffer.assign(manifest, manifest + strlen(manifest));
-            httpError = 200;
+            *httpError = 200;
             effectiveUrl = remoteUrl;
             if (!this->mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->empty())
             {

--- a/test/utests/tests/Mp4BoxParsingTests/BoxParsingTests.cpp
+++ b/test/utests/tests/Mp4BoxParsingTests/BoxParsingTests.cpp
@@ -552,16 +552,16 @@ TEST(Mp4Demux_Gaps, TST2052_LLDMultipleMoofMdatPairs) {
 	
 	// ---- validate moof1 samples (data from mdat1) ----
 	ASSERT_EQ(samples[0].mData.size(), 10u) << "Sample 0: 10 bytes from mdat1";
-	EXPECT_EQ(samples[0].mData[0], uint8_t(0xAA))
+	EXPECT_EQ(samples[0].mData.GetVector()[0], uint8_t(0xAA))
 	<< "Sample 0 first byte should match first byte of mdat1 payload";
 	
 	ASSERT_EQ(samples[1].mData.size(), 10u) << "Sample 1: 10 bytes from mdat1";
-	EXPECT_EQ(samples[1].mData[0], uint8_t(0xAA + 10))
+	EXPECT_EQ(samples[1].mData.GetVector()[0], uint8_t(0xAA + 10))
 	<< "Sample 1 first byte should match second chunk of mdat1 payload";
 	
 	// ---- validate moof2 sample (data from mdat2, NOT mdat1) ----
 	ASSERT_EQ(samples[2].mData.size(), 15u) << "Sample 2: 15 bytes from mdat2";
-	EXPECT_EQ(samples[2].mData[0], uint8_t(0xBB))
+	EXPECT_EQ(samples[2].mData.GetVector()[0], uint8_t(0xBB))
 	<< "Sample 2 first byte must come from mdat2, not mdat1";
 }
 
@@ -663,7 +663,7 @@ TEST(Mp4Demux_Gaps, MultiMoofMdatNoBoundaryError)
 	
 	// Validate sample 0 is bound to mdat1 payload (0xA0–0xA7)
 	EXPECT_EQ(samples[0].mData.size(), 8u) << "Sample 0 should be 8 bytes (mdat1 payload)";
-	const auto& s0 = samples[0].mData;
+	const auto& s0 = samples[0].mData.GetVector();
 	for (int i = 0; i < 8; ++i)
 	{
 		EXPECT_EQ(s0[i], uint8_t(0xA0 + i))
@@ -673,7 +673,7 @@ TEST(Mp4Demux_Gaps, MultiMoofMdatNoBoundaryError)
 	
 	// Validate sample 1 is bound to mdat2 payload (0xB0–0xB7)
 	EXPECT_EQ(samples[1].mData.size(), 8u) << "Sample 1 should be 8 bytes (mdat2 payload)";
-	const auto& s1 = samples[1].mData;
+	const auto& s1 = samples[1].mData.GetVector();
 	for (int i = 0; i < 8; ++i)
 	{
 		EXPECT_EQ(s1[i], uint8_t(0xB0 + i))

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -2239,8 +2239,8 @@ TEST_F(PrivAampTests,GetFileTest)
 	AampGrowableBuffer gBuff("GrowableBuffer");
 	double downloadTime;BitsPerSecond bitrate;
 	int fogError;
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", eMEDIATYPE_VIDEO, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150", eCURLINSTANCE_MANIFEST_MAIN, false,
-								 &bitrate, &fogError, 0.0));
+EXPECT_FALSE(p_aamp->GetFile("remoteurl", eMEDIATYPE_VIDEO, gBuff.GetVector(),effectiveUrl,&http_error,&downloadTime,"0-150",eCURLINSTANCE_MANIFEST_MAIN,false,
+									&bitrate,&fogError,0.0));
 }
 
 TEST_F(PrivAampTests,GetFileTest_1)
@@ -2253,8 +2253,8 @@ TEST_F(PrivAampTests,GetFileTest_1)
 	AampMediaType mType = eMEDIATYPE_VIDEO;
 	BitsPerSecond bitrate;
 	int fogError;
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150", eCURLINSTANCE_MANIFEST_MAIN, false,
-								 &bitrate, &fogError, 0.0));
+EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(),effectiveUrl,&http_error,&downloadTime,"0-150",eCURLINSTANCE_MANIFEST_MAIN,false,
+									&bitrate,&fogError,0.0));
 }
 
 TEST_F(PrivAampTests,GetFileTest_2)
@@ -2268,10 +2268,10 @@ TEST_F(PrivAampTests,GetFileTest_2)
 	AampMediaType mType = eMEDIATYPE_VIDEO;
 	BitsPerSecond bitrate;
 	int fogError;
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150", eCURLINSTANCE_MANIFEST_MAIN, resetBuffer,
-								 &bitrate, &fogError, 0.0));
+EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(),effectiveUrl,&http_error,&downloadTime,"0-150",eCURLINSTANCE_MANIFEST_MAIN,resetBuffer,
+									&bitrate,&fogError,0.0));
 }
-TEST_F(PrivAampTests, GetFileTest_3)
+TEST_F(PrivAampTests,GetFileTest_3)
 {
 	const char *url;
 	std::string effectiveUrl;
@@ -2285,11 +2285,11 @@ TEST_F(PrivAampTests, GetFileTest_3)
 
 	p_aamp->EnableDownloads();
 
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150", eCURLINSTANCE_MANIFEST_MAIN, resetBuffer,
-								 &bitrate, &fogError, 0.0));
+	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(),effectiveUrl,&http_error,&downloadTime,"0-150",eCURLINSTANCE_MANIFEST_MAIN,resetBuffer,
+									&bitrate,&fogError,0.0));
 }
 
-TEST_F(PrivAampTests, GetFileTest_4)
+TEST_F(PrivAampTests,GetFileTest_4)
 {
 	const char *url;
 	std::string effectiveUrl;
@@ -2303,8 +2303,8 @@ TEST_F(PrivAampTests, GetFileTest_4)
 
 	p_aamp->EnableDownloads();
 
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150", eCURLINSTANCE_MANIFEST_MAIN, resetBuffer,
-								 &bitrate, &fogError, 0.0));
+	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(),effectiveUrl,&http_error,&downloadTime,"0-150",eCURLINSTANCE_MANIFEST_MAIN,resetBuffer,
+									&bitrate,&fogError,0.0));
 }
 
 class PrivAampInitMediaTypeTest : public PrivAampTests,
@@ -2352,7 +2352,7 @@ TEST_P(PrivAampInitMediaTypeTest, GetFileTest_RetryInitWhilstBufferDepthTest)
 		.WillOnce(Return(2.0))
 		.WillRepeatedly(Return(0.0));
 
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150",
+	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, &http_error, &downloadTime, "0-150",
 								eCURLINSTANCE_MANIFEST_MAIN, resetBuffer, &bitrate, &fogError, 0.0));
 }
 
@@ -2422,7 +2422,7 @@ TEST_F(PrivAampTests, GetFileTest_RetryInitWhilstBufferDepthTsbTest)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetBufferedDuration())
 		.WillRepeatedly(Return(3000.0));
 
-	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150",
+	EXPECT_FALSE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, &http_error, &downloadTime, "0-150",
 								 eCURLINSTANCE_MANIFEST_MAIN, resetBuffer, &bitrate, &fogError, 0.0, PROFILE_BUCKET_TYPE_COUNT,
 								 maxInitTimeoutDuration));
 }
@@ -2474,7 +2474,7 @@ TEST_F(PrivAampTests,GetFileTest_RetryInitWhilstBufferDepthBeforeSuccessTest)
 		.WillOnce(Return(10.0))
 		.WillOnce(Return(8.0));
 
-	EXPECT_TRUE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error, &downloadTime, "0-150",
+	EXPECT_TRUE(p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, &http_error, &downloadTime, "0-150",
 								eCURLINSTANCE_MANIFEST_MAIN, resetBuffer, &bitrate, &fogError, 0.0));
 }
 
@@ -5471,8 +5471,7 @@ TEST_F(PrivAampTests, GetFileTest_EnableLowBWTimeoutOnNotLowestProfile)
 			return CURLE_OK;
 		}));
 
-	int http_error{-1};
-	p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error);
+	p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl);
 }
 
 // Validates that low bandwidth timeout is disabled if the video is at the lowest profile
@@ -5507,8 +5506,7 @@ TEST_F(PrivAampTests, GetFileTest_DisableLowBWTimeoutOnLowestProfile)
 			return CURLE_OK;
 		}));
 
-	int http_error{-1};
-	p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl, http_error);
+	p_aamp->GetFile("remoteurl", mType, gBuff.GetVector(), effectiveUrl);
 }
 
 // Pass null pointer as CurlCallbackContext and abort should be false

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -20,7 +20,6 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <chrono>
-#include <iterator>
 #include "priv_aamp.h"
 #include "AampConfig.h"
 #include "AampScheduler.h"
@@ -2535,9 +2534,9 @@ TEST_P(AdvancedFetcherLoopTests, FetcherLoopTestsWithDifferentMPD)
 	if (mockIDXDownload)
 	{
 		EXPECT_CALL(*g_mockPrivateInstanceAAMP, LoadIDX(_, _, _, _, _, _, _, _, _, _))
-			.WillRepeatedly(WithArg<3>(Invoke([](std::vector<uint8_t>& idxBuffer)
+			.WillRepeatedly(WithArg<3>(Invoke([](AampGrowableBuffer *idxBuffer)
 			{
-				idxBuffer.insert(idxBuffer.end(), std::cbegin(sidxBox), std::cend(sidxBox));
+				idxBuffer->AppendBytes((const uint8_t *)sidxBox, sizeof(sidxBox));
 			})));
 	}
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(videoFragmentUrl, _, _, _, _, true, _, _, _)).Times(1).WillOnce(Return(true));


### PR DESCRIPTION
Reverts rdkcentral/aamp#1190
For isolating failed l2 tests