### PR TITLE
VPLAY-13104 l2 fixes for tip of dev_sprint_25_2

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -152,7 +152,7 @@
 #define DEFAULT_UNDERFLOW_MEDIUM_BUFFER_POLL_MS 1000	/**< Polling interval when buffer is medium in milliseconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_POLL_MS 2000		/**< Polling interval when buffer is high in milliseconds */
 
-#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.0		/**< Threshold to detect underflow in seconds */
+#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.1		/**< Threshold to detect underflow in seconds */
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1297,7 +1297,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 			std::string temp = fragmentURI.tostring();
 			aamp_ResolveURL(fragmentUrl, mEffectiveUrl, temp.c_str(), ISCONFIGSET(eAAMPConfig_PropagateURIParam));
 			ReleasePlaylistLock();
-			AAMPLOG_TRACE("Got next fragment url %s fragmentEncrypted %d discontinuity %d mDrmMethod %d", fragmentUrl.c_str(), fragmentEncrypted, (int)discontinuity, mDrmMethod);
+			AAMPLOG_INFO("Got next fragment url %s fragmentEncrypted %d discontinuity %d mDrmMethod %d", fragmentUrl.c_str(), fragmentEncrypted, (int)discontinuity, mDrmMethod);
 
 			aamp->profiler.ProfileBegin(mediaTrackBucketTypes[type]);
 			const char *range;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6680,9 +6680,14 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	double offsetFromStart;
 
 	class MediaStreamContext *pMediaStreamContext = mMediaStreamContext[eMEDIATYPE_AUDIO];
-	if ((!pMediaStreamContext) || (!pMediaStreamContext->enabled))
+	if (!pMediaStreamContext)
 	{
-		AAMPLOG_WARN("pMediaStreamContext  is null");
+		AAMPLOG_WARN("pMediaStreamContext is null");
+		return;
+	}
+	if (!pMediaStreamContext->enabled)
+	{
+		AAMPLOG_WARN("pMediaStreamContext is not enabled");
 		pMediaStreamContext->NotifyCachedAudioFragmentAvailable();
 		return;
 	}


### PR DESCRIPTION
VPLAY-13104 l2 fixes for tip of dev_sprint_25_2

Reason for Change: Several L2 tests have begun consistently failing in recent days, including 1019, 2032, and 6002.
2032 failure is caused by change in log level (info vs. trace)
6002 is failing because a configuration value that controls underflow detection was set to 0, effectively disabling it
1019 - there was a recent change in how the test framework handles simulated server responses

Test Guidance: L2 1019, 2032, 6002 passing again

Risk: Medium