### PR TITLE
VPLAY-13157 CurlDownloader wrongly including manifest parse time in httpRequestEnd download profiling

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -399,6 +399,7 @@ void AampMPDDownloader::downloadMPDThread1()
 				mDownloader1.Download(tuneUrl, mMPDData->mMPDDownloadResponse);
 			}
 		}
+		long long tEndTime = NOW_STEADY_TS_MS;
 
 		if( IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) )
 		{
@@ -483,7 +484,6 @@ void AampMPDDownloader::downloadMPDThread1()
 				mMPDData->mMPDDownloadResponse->show();
 			}
 		}
-		long long tEndTime = NOW_STEADY_TS_MS;
 		showDownloadMetrics(mMPDData->mMPDDownloadResponse, (int)(tEndTime - tStartTime));
 		if(doPush)
 		{


### PR DESCRIPTION
VPLAY-13157 CurlDownloader wrongly including manifest parse time in httpRequestEnd download profiling

Reason for Change: exclude manifest parse time from the curl profiling for manifest downloads, to avoid muddying reporting

Test Guidance: review httpRequestEnd and autotriage before and after this change

Risk: Low