### PR TITLE
VPLAY-13162 Redundant ClearAndRelease after std::move

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -2334,7 +2334,6 @@ void TrackState::ProcessPlaylist(std::vector<uint8_t>& newPlaylist, int http_err
 
 		AcquirePlaylistLock();
 		playlist = std::move(newPlaylist);
-		aamp_utils::ClearAndRelease(newPlaylist);
 
 		AampTime culled{};
 		IndexPlaylist(true, culled);


### PR DESCRIPTION
VPLAY-13162 Redundant ClearAndRelease after std::move

Reason for Change: ClearAndRelease is unnecessarily called on an already-emptied playlist after std::move
Risk: Low
Test Guidance: regression only