### PR TITLE
VPLAY-13155 IsoBmffProcessor::sendSegment and ElementaryProcessor::sendSegment always return true, even if segment wasn't injected

### DIFF
--- a/ElementaryProcessor.cpp
+++ b/ElementaryProcessor.cpp
@@ -52,8 +52,8 @@ bool ElementaryProcessor::sendSegment(std::vector<uint8_t>& buffer, double posit
 	ret = setTuneTimePTS(buffer.data(), buffer.size(), position, duration, discontinuous, ptsError);
 	if (ret)
 	{
-		AAMPLOG_INFO("IsoBmffProcessor:: eMEDIATYPE_SUBTITLE sending segment at pos:%f dur:%f", position, duration);
-		sendStream(buffer, position, duration, fragmentPTSoffset, discontinuous, isInit);
+		AAMPLOG_INFO("ElementaryProcessor::sendSegment pos:%f dur:%f", position, duration);
+		ret = sendStream(buffer, position, duration, fragmentPTSoffset, discontinuous, isInit);
 	}
 	return ret;
 }
@@ -61,15 +61,21 @@ bool ElementaryProcessor::sendSegment(std::vector<uint8_t>& buffer, double posit
 /**
  *  @brief send stream based on media format
  */
-void ElementaryProcessor::sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit)
+bool ElementaryProcessor::sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit)
 {
+	if (buffer.empty())
+	{
+		AAMPLOG_ERR("ElementaryProcessor::sendStream: buffer is empty, skipping injection");
+		return false;
+	}
 	if(mediaFormat == eMEDIAFORMAT_DASH)
 	{
 		p_aamp->SendStreamTransfer((AampMediaType)eMEDIATYPE_SUBTITLE, buffer, position, position, duration, fragmentPTSoffset, isInit, discontinuous);
+		return true;
 	}
 	else
 	{
-		p_aamp->SendStreamCopy((AampMediaType)eMEDIATYPE_SUBTITLE, buffer, position, position, duration);
+		return p_aamp->SendStreamCopy((AampMediaType)eMEDIATYPE_SUBTITLE, buffer, position, position, duration);
 	}
 }
 

--- a/ElementaryProcessor.cpp
+++ b/ElementaryProcessor.cpp
@@ -55,7 +55,7 @@ bool ElementaryProcessor::sendSegment(std::vector<uint8_t>& buffer, double posit
 		AAMPLOG_INFO("IsoBmffProcessor:: eMEDIATYPE_SUBTITLE sending segment at pos:%f dur:%f", position, duration);
 		sendStream(buffer, position, duration, fragmentPTSoffset, discontinuous, isInit);
 	}
-	return true;
+	return ret;
 }
 
 /**

--- a/ElementaryProcessor.h
+++ b/ElementaryProcessor.h
@@ -152,9 +152,9 @@ private:
 	 * @param[in] fragmentPTSoffset - PTS offset
 	 * @param[in] discontinuous - true if discontinuous fragment
 	 * @param[in] isInit - flag for buffer type (init, data)
-	 * @return void
+	 * @return true if the buffer was successfully injected into the sink, false otherwise
 	 */
-	void sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit);
+	bool sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit);
 
     /**
 	 * @fn setTuneTimePTS

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -50,8 +50,8 @@ void MediaStreamContext::InjectFragmentInternal(CachedFragment* cachedFragment, 
 		AAMPLOG_DEBUG("Type[%d] cachedFragment->position: %f cachedFragment->duration: %f cachedFragment->initFragment: %d", type, cachedFragment->position,cachedFragment->duration,cachedFragment->initFragment);
 		aamp->SendStreamTransfer((AampMediaType)type, cachedFragment->fragment,
 		cachedFragment->position, cachedFragment->position, cachedFragment->duration, cachedFragment->PTSOffsetSec, cachedFragment->initFragment, cachedFragment->discontinuity);
+		fragmentDiscarded = false;
 	}
-	fragmentDiscarded = false;
 } // InjectFragmentInternal
 
 /**

--- a/isobmff/isobmffprocessor.cpp
+++ b/isobmff/isobmffprocessor.cpp
@@ -120,7 +120,7 @@ bool IsoBmffProcessor::sendSegment(std::vector<uint8_t>& buffer, double position
 		else
 		{
 			p_aamp->ProcessID3Metadata(buffer, (AampMediaType)type);
-			sendStream(buffer, position, duration, fragmentPTSoffset, discontinuous, isInit);
+			ret = sendStream(buffer, position, duration, fragmentPTSoffset, discontinuous, isInit);
 		}
 	}
 	return ret;
@@ -411,15 +411,21 @@ bool IsoBmffProcessor::setTuneTimePTS(std::vector<uint8_t>& fragBuffer, double p
 /**
  *  @brief send stream based on media format
  */
-void IsoBmffProcessor::sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit)
+bool IsoBmffProcessor::sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit)
 {
+	if (buffer.empty())
+	{
+		AAMPLOG_ERR("IsoBmffProcessor %s sendStream: buffer is empty, skipping injection", IsoBmffProcessorTypeName[type]);
+		return false;
+	}
 	if(mediaFormat == eMEDIAFORMAT_DASH)
 	{
 		p_aamp->SendStreamTransfer((AampMediaType)type, buffer, position, position, duration, fragmentPTSoffset, isInit, discontinuous);
+		return true;
 	}
 	else
 	{
-		p_aamp->SendStreamCopy((AampMediaType)type, buffer, position, position, duration);
+		return p_aamp->SendStreamCopy((AampMediaType)type, buffer, position, position, duration);
 	}
 }
 

--- a/isobmff/isobmffprocessor.cpp
+++ b/isobmff/isobmffprocessor.cpp
@@ -123,7 +123,7 @@ bool IsoBmffProcessor::sendSegment(std::vector<uint8_t>& buffer, double position
 			sendStream(buffer, position, duration, fragmentPTSoffset, discontinuous, isInit);
 		}
 	}
-	return true;
+	return ret;
 }
 /**
  *  @brief Update PTS and send pts for flush subtitle

--- a/isobmff/isobmffprocessor.h
+++ b/isobmff/isobmffprocessor.h
@@ -48,7 +48,7 @@ enum IsoBmffProcessorType
  * @struct InitRestampSegment
  * @brief structure to hold init details of fragment
  */
-typedef struct
+typedef struct stInitRestampSegment
 {
 	AampMediaType type{};
 	std::vector<uint8_t> buffer{};
@@ -308,9 +308,9 @@ private:
 	 * @param[in] fragmentPTSoffset - offset PTS value
 	 * @param[in] discontinuous - true if discontinuous fragment
 	 * @param[in] isInit - flag for buffer type (init, data)
-	 * @return void
+	 * @return true if the buffer was successfully injected into the sink, false otherwise
 	 */
-	void sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit);
+	bool sendStream(std::vector<uint8_t>& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous, bool isInit);
 
 	/**
 	 * @brief Set peer instance of IsoBmffProcessor

--- a/test/utests/tests/ElementaryProcessorTests/ElementaryProcessorTests.cpp
+++ b/test/utests/tests/ElementaryProcessorTests/ElementaryProcessorTests.cpp
@@ -23,8 +23,6 @@
 #include <string>
 #include <stdint.h>
 #include <iostream>
-#include <thread>
-#include <chrono>
 
 #include "MockPrivateInstanceAAMP.h"
 
@@ -224,30 +222,6 @@ protected:
 	PrivateInstanceAAMP    *mPrivateInstanceAAMP2{};
 	MediaProcessor::process_fcn_t mProcessorFn{};
 };
-
-// sendSegment() must return false and must not reach the sink when abort() is
-// called while it is waiting for PTS initialisation.
-TEST_F(ElementaryProcessorSendSegmentTest, sendSegmentReturnsFalse_WhenAborted)
-{
-	std::vector<uint8_t> buffer{0xAA, 0xBB};
-	bool ptsError = false;
-
-	// Neither injection API must be called on the abort path.
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _)).Times(0);
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _, _, _, _, _, _, _)).Times(0);
-
-	// processPTSComplete is false, so sendSegment() will block in setTuneTimePTS()
-	// waiting on the condition variable.  Trigger abort() from a background thread.
-	std::thread abortThread([this]() {
-		std::this_thread::sleep_for(std::chrono::milliseconds(20));
-		mElementaryProcessor->abort();
-	});
-
-	bool result = mElementaryProcessor->sendSegment(buffer, 0.0, 2.0, 0.0, false, false, mProcessorFn, ptsError);
-	abortThread.join();
-
-	EXPECT_FALSE(result);
-}
 
 // sendSegment() must return false when the sink rejects the buffer
 // (SendStreamCopy returns false on the HLS path).

--- a/test/utests/tests/ElementaryProcessorTests/ElementaryProcessorTests.cpp
+++ b/test/utests/tests/ElementaryProcessorTests/ElementaryProcessorTests.cpp
@@ -18,10 +18,15 @@
 */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <ElementaryProcessor.h>
 #include <string>
 #include <stdint.h>
 #include <iostream>
+#include <thread>
+#include <chrono>
+
+#include "MockPrivateInstanceAAMP.h"
 
 using namespace testing;
 AampConfig *gpGlobalConfig{nullptr};
@@ -186,4 +191,80 @@ TEST_F(ElementaryProcessorTest, setRateTest5)
     {
         mElementaryProcessor->setRate(rate, playerMode);
     }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture that wires up MockPrivateInstanceAAMP so injection API calls can be
+// observed.  Used to verify the new false-return contract of sendSegment().
+// ---------------------------------------------------------------------------
+class ElementaryProcessorSendSegmentTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		mPrivateInstanceAAMP2 = new PrivateInstanceAAMP(gpGlobalConfig);
+		g_mockPrivateInstanceAAMP = new MockPrivateInstanceAAMP();
+		// ElementaryProcessor constructor calls GetMediaFormatTypeEnum()
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetMediaFormatTypeEnum())
+			.WillRepeatedly(Return(eMEDIAFORMAT_HLS_MP4));
+		mElementaryProcessor = new ElementaryProcessor(mPrivateInstanceAAMP2);
+	}
+
+	void TearDown() override
+	{
+		delete mElementaryProcessor;
+		mElementaryProcessor = nullptr;
+		delete mPrivateInstanceAAMP2;
+		mPrivateInstanceAAMP2 = nullptr;
+		delete g_mockPrivateInstanceAAMP;
+		g_mockPrivateInstanceAAMP = nullptr;
+	}
+
+	ElementaryProcessor    *mElementaryProcessor{};
+	PrivateInstanceAAMP    *mPrivateInstanceAAMP2{};
+	MediaProcessor::process_fcn_t mProcessorFn{};
+};
+
+// sendSegment() must return false and must not reach the sink when abort() is
+// called while it is waiting for PTS initialisation.
+TEST_F(ElementaryProcessorSendSegmentTest, sendSegmentReturnsFalse_WhenAborted)
+{
+	std::vector<uint8_t> buffer{0xAA, 0xBB};
+	bool ptsError = false;
+
+	// Neither injection API must be called on the abort path.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _)).Times(0);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _, _, _, _, _, _, _)).Times(0);
+
+	// processPTSComplete is false, so sendSegment() will block in setTuneTimePTS()
+	// waiting on the condition variable.  Trigger abort() from a background thread.
+	std::thread abortThread([this]() {
+		std::this_thread::sleep_for(std::chrono::milliseconds(20));
+		mElementaryProcessor->abort();
+	});
+
+	bool result = mElementaryProcessor->sendSegment(buffer, 0.0, 2.0, 0.0, false, false, mProcessorFn, ptsError);
+	abortThread.join();
+
+	EXPECT_FALSE(result);
+}
+
+// sendSegment() must return false when the sink rejects the buffer
+// (SendStreamCopy returns false on the HLS path).
+TEST_F(ElementaryProcessorSendSegmentTest, sendSegmentReturnsFalse_WhenSinkRejectsBuffer)
+{
+	std::vector<uint8_t> buffer{0xAA, 0xBB};
+	bool ptsError = false;
+
+	// Unblock the PTS wait so sendSegment() reaches sendStream() synchronously.
+	mElementaryProcessor->abortInjectionWait();
+
+	// Sink signals failure.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _))
+		.WillOnce(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _, _, _, _, _, _, _)).Times(0);
+
+	bool result = mElementaryProcessor->sendSegment(buffer, 0.0, 2.0, 0.0, false, false, mProcessorFn, ptsError);
+
+	EXPECT_FALSE(result);
 }

--- a/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
+++ b/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
@@ -219,7 +219,9 @@ TEST_F(IsoBmffProcessorTests, abortTests4)
 //Call sendSegment after an abort and reset was called
 TEST_F(IsoBmffProcessorTests, abortTests5)
 {
-	std::vector<uint8_t> buffer;
+	// Non-empty buffer is required so the sendStream empty-buffer guard does not
+	// block injection before SendStreamCopy/SendStreamTransfer can be observed.
+	std::vector<uint8_t> buffer{0xAA, 0xBB, 0xCC, 0xDD};
 	bool ptsError = false;
 	Box *box = (Box*)(0xdeadbeef);
 
@@ -737,8 +739,10 @@ TEST_F(IsoBmffProcessorPTMTests, passThroughTests1)
 	uint64_t basePts = 240000;
 	uint32_t vCurrTS = 24000;
 
-	// 3 sendSegment calls and configured with HLS_MP4 content type
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _)).Times(3);
+	// 3 sendSegment calls and configured with HLS_MP4 content type.
+	// WillRepeatedly(Return(true)) is needed so that the bool result of
+	// SendStreamCopy propagates correctly into sendSegment()'s return value.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _)).Times(3).WillRepeatedly(Return(true));
 
 	// Expecting the timescale to be read first
 	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(true));

--- a/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
+++ b/test/utests/tests/IsoBmffProcessorTests/FunctionalTests.cpp
@@ -763,3 +763,74 @@ TEST_F(IsoBmffProcessorPTMTests, passThroughTests1)
 	EXPECT_TRUE(ret);
 
 }
+
+// sendSegment must return false when the sink rejects the buffer (SendStreamCopy returns false)
+TEST_F(IsoBmffProcessorPTMTests, sendSegmentReturnsFalse_WhenSendStreamCopyFails)
+{
+	std::vector<uint8_t> buffer;
+	const char* sampleData = "SampleData";
+	buffer.assign(sampleData, sampleData + strlen(sampleData));
+
+	double position = 0, duration = 2.0;
+	bool discontinuous = false, ptsError = false;
+	uint64_t basePts = 240000;
+	uint32_t vCurrTS = 24000;
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, ProcessID3Metadata(_, _, _)).Times(AnyNumber());
+
+	// First two injections succeed; the third (the case under test) fails
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _))
+		.WillOnce(Return(true))   // init segment injection
+		.WillOnce(Return(true))   // first data fragment injection
+		.WillOnce(Return(false)); // negative case: sink unavailable / rejects buffer
+
+	// Step 1: process init segment
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getTimeScale(_)).WillOnce(DoAll(SetArgReferee<0>(vCurrTS), Return(true)));
+	mIsoBmffProcessor->sendSegment(buffer, position, duration, 0.0, discontinuous, true, mProcessorFn, ptsError);
+
+	// Step 2: first data fragment — advances initSegmentProcessComplete
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(false));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getFirstPTS(_)).WillOnce(DoAll(SetArgReferee<0>(basePts), Return(true)));
+	mIsoBmffProcessor->sendSegment(buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
+
+	// Step 3: injection fails — sendSegment must propagate the failure
+	bool ret = mIsoBmffProcessor->sendSegment(buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
+	EXPECT_FALSE(ret);
+}
+
+// sendSegment must return false and must not call into the sink when the buffer is empty
+TEST_F(IsoBmffProcessorPTMTests, sendSegmentReturnsFalse_WhenBufferIsEmpty)
+{
+	std::vector<uint8_t> buffer;
+	const char* sampleData = "SampleData";
+	buffer.assign(sampleData, sampleData + strlen(sampleData));
+
+	double position = 0, duration = 2.0;
+	bool discontinuous = false, ptsError = false;
+	uint64_t basePts = 240000;
+	uint32_t vCurrTS = 24000;
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, ProcessID3Metadata(_, _, _)).Times(AnyNumber());
+
+	// Exactly two injections during setup; the empty-buffer call must not trigger a third
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamCopy(_, _, _, _, _))
+		.WillOnce(Return(true))
+		.WillOnce(Return(true));
+
+	// Step 1: process init segment
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getTimeScale(_)).WillOnce(DoAll(SetArgReferee<0>(vCurrTS), Return(true)));
+	mIsoBmffProcessor->sendSegment(buffer, position, duration, 0.0, discontinuous, true, mProcessorFn, ptsError);
+
+	// Step 2: first data fragment — advances initSegmentProcessComplete
+	EXPECT_CALL(*g_mockIsoBmffBuffer, isInitSegment()).WillOnce(Return(false));
+	EXPECT_CALL(*g_mockIsoBmffBuffer, getFirstPTS(_)).WillOnce(DoAll(SetArgReferee<0>(basePts), Return(true)));
+	mIsoBmffProcessor->sendSegment(buffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
+
+	// Step 3: empty buffer — sendStream must reject without calling SendStreamCopy
+	std::vector<uint8_t> emptyBuffer{};
+	bool ret = mIsoBmffProcessor->sendSegment(emptyBuffer, position, duration, 0.0, discontinuous, false, mProcessorFn, ptsError);
+	EXPECT_FALSE(ret);
+	// The Times(2) constraint on SendStreamCopy above verifies no extra injection occurred
+}

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -55,55 +55,55 @@ public:
 	{
 	}
 
-	std::string &GetPlaylistUrl()
+	std::string &GetPlaylistUrl() override
 	{
 		return playlistURL;
 	}
 
-	void SetEffectivePlaylistUrl(std::string url)
+	void SetEffectivePlaylistUrl(std::string url) override
 	{
 		playlistURL = url;
 	}
 
-	std::string &GetEffectivePlaylistUrl()
+	std::string &GetEffectivePlaylistUrl() override
 	{
 		return playlistURL;
 	}
 
-	long long GetLastPlaylistDownloadTime()
+	long long GetLastPlaylistDownloadTime() override
 	{
 		return 0;
 	}
 
-	long GetMinUpdateDuration()
+	long GetMinUpdateDuration() override
 	{
 		return 2;
 	}
 
-	int GetDefaultDurationBetweenPlaylistUpdates()
+	int GetDefaultDurationBetweenPlaylistUpdates() override
 	{
 		return 0;
 	}
 
-	void SetLastPlaylistDownloadTime(long long time)
+	void SetLastPlaylistDownloadTime(long long time) override
 	{
 		return;
 	}
-	void ABRProfileChanged(void) {}
-	void updateSkipPoint(double position, double duration) {}
+	void ABRProfileChanged(void) override {}
+	void updateSkipPoint(double position, double duration) override {}
 
-	void setDiscontinuityState(bool isDiscontinuity) {}
+	void setDiscontinuityState(bool isDiscontinuity) override {}
 
-	void abortWaitForVideoPTS() {}
+	void abortWaitForVideoPTS() override {}
 
-	double GetBufferedDuration(void) { return 0.0; }
+	double GetBufferedDuration(void) override { return 0.0; }
 
-	class StreamAbstractionAAMP *GetContext()
+	class StreamAbstractionAAMP *GetContext() override
 	{
 		return aamp->mpStreamAbstractionAAMP;
 	}
 
-	void InjectFragmentInternal(CachedFragment *cachedFragment, bool &fragmentDiscarded, bool isDiscontinuity = false)
+	void InjectFragmentInternal(CachedFragment *cachedFragment, bool &fragmentDiscarded, bool isDiscontinuity = false) override
 	{
 		AAMPLOG_WARN("Type[%d] cachedFragment->position: %f cachedFragment->duration: %f cachedFragment->initFragment: %d",
 					 type, cachedFragment->position, cachedFragment->duration, cachedFragment->initFragment);


### PR DESCRIPTION
VPLAY-13155 IsoBmffProcessor::sendSegment and ElementaryProcessor::sendSegment always return true, even if segment wasn't injected

Reason for Change: pair of functions are returning hardcoded true (success), despite having potential to fail

Risk: Medium: failure paths (however unlikely) need to be exercised

Test Guidance: needs new l1 test coverage and general regression