### PR TITLE
VPLAY-13161 various build script fixes while debugging l2 tests with clean build

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -399,7 +399,6 @@ void AampMPDDownloader::downloadMPDThread1()
 				mDownloader1.Download(tuneUrl, mMPDData->mMPDDownloadResponse);
 			}
 		}
-		
 		if( IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) )
 		{
 			if(!mMPDData->mMPDDownloadResponse->getString().empty())

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -399,6 +399,7 @@ void AampMPDDownloader::downloadMPDThread1()
 				mDownloader1.Download(tuneUrl, mMPDData->mMPDDownloadResponse);
 			}
 		}
+		long long tEndTime = NOW_STEADY_TS_MS;
 
 		if( IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) )
 		{
@@ -483,7 +484,6 @@ void AampMPDDownloader::downloadMPDThread1()
 				mMPDData->mMPDDownloadResponse->show();
 			}
 		}
-		long long tEndTime = NOW_STEADY_TS_MS;
 		showDownloadMetrics(mMPDData->mMPDDownloadResponse, (int)(tEndTime - tStartTime));
 		if(doPush)
 		{

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -399,8 +399,7 @@ void AampMPDDownloader::downloadMPDThread1()
 				mDownloader1.Download(tuneUrl, mMPDData->mMPDDownloadResponse);
 			}
 		}
-		long long tEndTime = NOW_STEADY_TS_MS;
-
+		
 		if( IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) )
 		{
 			if(!mMPDData->mMPDDownloadResponse->getString().empty())

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -484,6 +484,7 @@ void AampMPDDownloader::downloadMPDThread1()
 				mMPDData->mMPDDownloadResponse->show();
 			}
 		}
+		long long tEndTime = NOW_STEADY_TS_MS;
 		showDownloadMetrics(mMPDData->mMPDDownloadResponse, (int)(tEndTime - tStartTime));
 		if(doPush)
 		{

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -399,6 +399,7 @@ void AampMPDDownloader::downloadMPDThread1()
 				mDownloader1.Download(tuneUrl, mMPDData->mMPDDownloadResponse);
 			}
 		}
+
 		if( IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) )
 		{
 			if(!mMPDData->mMPDDownloadResponse->getString().empty())

--- a/OSX/patches/websocket-ipplayer2-boost-system.patch
+++ b/OSX/patches/websocket-ipplayer2-boost-system.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/Ipp2UtilsConfig.cmake.in b/cmake/Ipp2UtilsConfig.cmake.in
+index e3adb51..09e848f 100644
+--- a/cmake/Ipp2UtilsConfig.cmake.in
++++ b/cmake/Ipp2UtilsConfig.cmake.in
+@@ -25,6 +25,6 @@
+ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(Boost REQUIRED system)
++find_dependency(Boost REQUIRED)
+ 
+ check_required_components("@PROJECT_NAME@")

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -214,6 +214,14 @@ function install_asio_fn()
         sudo make install
         popd
         INSTALL_STATUS_ARR+=("asio was successfully installed.")
+    elif [ ! -f /usr/local/include/asio.hpp ]; then
+        # Source directory exists but headers were never installed (e.g. interrupted build).
+        # Run make install from the existing build directory.
+        echo "asio source found but headers not installed. Running make install..."
+        pushd asio-1.18.2/build
+        sudo make install
+        popd
+        INSTALL_STATUS_ARR+=("asio headers were installed from existing build.")
     else
         echo "asio is already installed."
         INSTALL_STATUS_ARR+=("asio was already installed.")

--- a/scripts/install_subtec.sh
+++ b/scripts/install_subtec.sh
@@ -94,6 +94,12 @@ function subtec_install_fn() {
         return 1
     }
     
+    git apply -p1 "${1}/OSX/patches/websocket-ipplayer2-boost-system.patch" --directory websocket-ipplayer2-utils || {
+        echo "ERROR: Failed to apply websocket-ipplayer2-boost-system.patch"
+        popd
+        return 1
+    }
+    
     git apply -p1 "${1}/OSX/patches/websocket-ipplayer2-typescpp.patch" --directory websocket-ipplayer2-utils || {
         echo "ERROR: Failed to apply websocket-ipplayer2-typescpp.patch"
         popd


### PR DESCRIPTION
VPLAY-13161 various build script fixes while debugging l2 tests with clean build

Reason for Change: while doing clean built to get ASAN fixes, ran into multiple issues, fixed below:
Python 3.12 fix (l2framework_testenv.sh) — tests can now run
libdash ASAN rebuild (install_libdash.sh) — libdash.dylib now compiled with -fsanitize=address, eliminating the container-overflow crash in ValidateAdManifest → IsContentType that was killing the CDAI ad fulfillment thread
Asio install guard (install_dependencies.sh) — checks for asio.hpp on disk, not just the source directory
Boost system patch (install_subtec.sh + new patch file) — drops the boost_system component requirement that doesn't ship a cmake config in modern Boost

Test Guidance: able to build and pass l2 8004 test on Mac
Risk: Low
