### PR TITLE
VPLAY-13166 L2 6002 fails on OSX because DEFAULT_UNDERFLOW_DETECT_THESHOLD not reached

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -152,7 +152,13 @@
 #define DEFAULT_UNDERFLOW_MEDIUM_BUFFER_POLL_MS 1000	/**< Polling interval when buffer is medium in milliseconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_POLL_MS 2000		/**< Polling interval when buffer is high in milliseconds */
 
-#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.0		/**< Threshold to detect underflow in seconds */
+#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.5		/**< Threshold to detect underflow in seconds. Must be < RESUME threshold.
+                                                             * 0.0 is technically correct but unreachable in practice with fragment-based
+                                                             * caching: lastDownloadedPosition-currentPosition floors at ~segment-boundary
+                                                             * epsilon (~40ms), so the GStreamer IsSinkCacheEmpty path is the only Linux
+                                                             * trigger at 0.0  On macOS that path also does not fire (PTS keeps ticking).
+                                                             * 0.5s gives a safe detection margin above the floor while remaining well
+                                                             * below the 1.0s resume threshold. */
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */


### PR DESCRIPTION
Reason for Change:
DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC = 0.0 means the monitor only fires when bufferedTimeSec <= 0.0. On macOS, GetBufferedVideoDurationSec() = lastDownloadedPosition - currentPosition, which reaches a minimum of ~0.04s at segment boundaries — never quite reaching 0. On Linux, IsSinkCacheEmpty fires via the GStreamer appsrc/PTS path when the queue actually drains, but on macOS the PTS keeps ticking so that path also doesn't trigger.

The fix is to raise DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC to 0.5s — safely above the 0.04s floor, below the resume threshold of 1.0s so there's a proper hysteresis gap:

Risk: Medium

Test Guidance: L2 Test 6002 passing