### PR TITLE
VPLAY-12936: Permanent audio loss after repeated audio track switches on Multiview channel.

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6810,13 +6810,19 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	pMediaStreamContext->lastSegmentNumber = pMediaStreamContext->fragmentDescriptor.Number - 1;
 
 	/*Calculating the difference in Fetched duration, injected duration and diff in Media Sequence number */
+
+	//Finding the fragment duration in seconds, for calculating the diff in injected duration.
+	double fragmentDurationSec = static_cast<double>(fragmentDuration) / pMediaStreamContext->fragmentDescriptor.TimeScale;
+
 	diffInFetchedDuration = oldPlaylistPosition - pMediaStreamContext->fragmentTime;
 	diffInInjectedDuration = ( pMediaStreamContext->GetLastInjectedPosition() - pMediaStreamContext->fragmentTime );
+	diffInInjectedDuration += fragmentDurationSec;
+
 	diffFragmentsDownloaded = static_cast<int>(oldMediaSequenceNumber - pMediaStreamContext->fragmentDescriptor.Number);
 
-	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d]",
+	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d],fragmentDurationSec[%lf]",
 			oldPlaylistPosition,pMediaStreamContext->fragmentTime,diffInFetchedDuration, pMediaStreamContext->GetLastInjectedPosition(),
-			fragmentDuration, diffInInjectedDuration,oldMediaSequenceNumber, pMediaStreamContext->fragmentDescriptor.Number,diffFragmentsDownloaded);
+			fragmentDuration, diffInInjectedDuration,oldMediaSequenceNumber, pMediaStreamContext->fragmentDescriptor.Number,diffFragmentsDownloaded, fragmentDurationSec);
 
 	pMediaStreamContext->resetAbort(false);
 	pMediaStreamContext->OffsetTrackParams(diffInFetchedDuration, diffInInjectedDuration, diffFragmentsDownloaded);

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6815,7 +6815,7 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	double fragmentDurationSec = 0.0;
 	if (pMediaStreamContext->fragmentDescriptor.TimeScale == 0)
 	{
-		AAMPLOG_INFO("TimeScale is 0 while calculating fragmentDurationSec, treating fragmentDurationSec as 0");
+		AAMPLOG_WARN("TimeScale is 0 while calculating fragmentDurationSec, treating fragmentDurationSec as 0");
 	}
 	else
 	{
@@ -6826,7 +6826,7 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	// Add fragment duration offset to reduce from injected position for next fragment calculation
 	diffInInjectedDuration += fragmentDurationSec;
 
-	diffFragmentsDownloaded = static_cast<int>(oldMediaSequenceNumber - pMediaStreamContext->fragmentDescriptor.Number);
+	diffFragmentsDownloaded = static_cast<int>(static_cast<int64_t>(oldMediaSequenceNumber) - static_cast<int64_t>(pMediaStreamContext->fragmentDescriptor.Number));
 
 	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d],fragmentDurationSec[%lf]",
 			oldPlaylistPosition,pMediaStreamContext->fragmentTime,diffInFetchedDuration, pMediaStreamContext->GetLastInjectedPosition(),

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6812,10 +6812,18 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	/*Calculating the difference in Fetched duration, injected duration and diff in Media Sequence number */
 
 	//Finding the fragment duration in seconds, for calculating the diff in injected duration.
-	double fragmentDurationSec = static_cast<double>(fragmentDuration) / pMediaStreamContext->fragmentDescriptor.TimeScale;
-
+	double fragmentDurationSec = 0.0;
+	if (pMediaStreamContext->fragmentDescriptor.TimeScale == 0)
+	{
+		AAMPLOG_INFO("TimeScale is 0 while calculating fragmentDurationSec, treating fragmentDurationSec as 0");
+	}
+	else
+	{
+		fragmentDurationSec = static_cast<double>(fragmentDuration) / pMediaStreamContext->fragmentDescriptor.TimeScale;
+	}
 	diffInFetchedDuration = oldPlaylistPosition - pMediaStreamContext->fragmentTime;
 	diffInInjectedDuration = ( pMediaStreamContext->GetLastInjectedPosition() - pMediaStreamContext->fragmentTime );
+	// Add fragment duration offset to reduce from injected position for next fragment calculation
 	diffInInjectedDuration += fragmentDurationSec;
 
 	diffFragmentsDownloaded = static_cast<int>(oldMediaSequenceNumber - pMediaStreamContext->fragmentDescriptor.Number);


### PR DESCRIPTION
Adjust injected position calculation by subtracting fragment duration from injected duration. This ensures correct alignment when switching audio tracks seamlessly.

Previously, each track change introduced ~2s delay in audio injection relative to video. Over multiple switches, this accumulated drift led to significant desynchronization and eventual audio drops.

This fix prevents incremental lag and maintains A/V sync across track transitions.