### PR TITLE
VPLAY-13156 autotriage visualization of manifest download times isn't reflecting 6s induced delay

### DIFF
--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -177,7 +177,9 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				CURL_EASY_SETOPT_STRING(mCurl, CURLOPT_URL, urlStr.c_str());
 			}
 			bool loopAgain = false;
-			long long loopStartTime = NOW_STEADY_TS_MS;  // capture before retries begin
+			// High-resolution start time captured before any retry so that total in
+			// downloadCompleteMetrics reflects the full wall-clock span including retries.
+			auto loopStartTimeHR = std::chrono::steady_clock::now();
 			do{
 				mDownloadStartTime = mDownloadUpdatedTime = NOW_STEADY_TS_MS;
 				if( mDnldCfg && mDnldCfg->bCurlThroughput )
@@ -265,10 +267,12 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 			if (mDnldCfg && mDnldCfg->bNeedDownloadMetrics)
 			{
 				std::lock_guard<std::mutex> lock(mCurlMutex);
-				double cumulativeTotal = (NOW_STEADY_TS_MS - loopStartTime) / 1000.0;
+				double cumulativeTotal = std::chrono::duration<double>(
+					std::chrono::steady_clock::now() - loopStartTimeHR).count();
+				// Always override total: CURLINFO_TOTAL_TIME only covers the last attempt.
+				mDownloadResponse->downloadCompleteMetrics.total = cumulativeTotal;
 				if (cumulativeTotal > 0)
 				{
-					mDownloadResponse->downloadCompleteMetrics.total = cumulativeTotal;
 					mDownloadResponse->downloadCompleteMetrics.downloadbps =
 						(long)(mDownloadResponse->downloadCompleteMetrics.dlSize * 8 / cumulativeTotal);
 				}

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -177,6 +177,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				CURL_EASY_SETOPT_STRING(mCurl, CURLOPT_URL, urlStr.c_str());
 			}
 			bool loopAgain = false;
+			long long loopStartTime = NOW_STEADY_TS_MS;  // capture before retries begin
 			do{
 				mDownloadStartTime = mDownloadUpdatedTime = NOW_STEADY_TS_MS;
 				if( mDnldCfg && mDnldCfg->bCurlThroughput )
@@ -258,6 +259,20 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 			// update the download response metrics for success and failure case 
 			// and for last attempt only (if retries enabled)
 			updateResponseParams();
+			// Override total/downloadbps with cumulative wall time across all retry attempts.
+			// CURLINFO_TOTAL_TIME (set by updateResponseParams) only reflects the last attempt,
+			// which causes autotriage timeline tools to see a long idle gap instead of a long bar.
+			if (mDnldCfg && mDnldCfg->bNeedDownloadMetrics)
+			{
+				std::lock_guard<std::mutex> lock(mCurlMutex);
+				double cumulativeTotal = (NOW_STEADY_TS_MS - loopStartTime) / 1000.0;
+				if (cumulativeTotal > 0)
+				{
+					mDownloadResponse->downloadCompleteMetrics.total = cumulativeTotal;
+					mDownloadResponse->downloadCompleteMetrics.downloadbps =
+						(long)(mDownloadResponse->downloadCompleteMetrics.dlSize * 8 / cumulativeTotal);
+				}
+			}
 			mDownloadActive = false;
 			mDownloadResponse->iHttpRetValue = httpRetVal;		
 			if( mDnldCfg && mDnldCfg->bCurlThroughput )

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4556,6 +4556,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 	if (mDownloadsEnabled)
 	{
 		int downloadTimeMS = 0;
+		int totalDownloadTimeMS = 0;  // cumulative wall time across all retry attempts
 		bool isDownloadStalled = false;
 		CurlAbortReason abortReason = eCURL_ABORT_REASON_NONE;
 		double connectTime = 0;
@@ -4837,6 +4838,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				downloadAttempt++;
 
 				downloadTimeMS = (int)(tEndTime - tStartTime);
+				totalDownloadTimeMS += downloadTimeMS;  // accumulate wall time across all retry attempts
 				bool loopAgain = false;
 				if (res == CURLE_OK)
 				{ // all data collected
@@ -5151,7 +5153,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				}
 				if (AampLogManager::isLogLevelAllowed(reqEndLogLevel))
 				{
-					double totalPerformRequest = (double)(downloadTimeMS)/1000;
+					double totalPerformRequest = (double)(totalDownloadTimeMS)/1000;  // total wall time including retries
 #if LIBCURL_VERSION_NUM >= 0x073700 // CURL version >= 7.55.0
 					dlSize = aamp_CurlEasyGetinfoOffset(curl, CURLINFO_SIZE_DOWNLOAD_T);
 #else

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4556,7 +4556,6 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 	if (mDownloadsEnabled)
 	{
 		int downloadTimeMS = 0;
-		int totalDownloadTimeMS = 0;  // cumulative wall time across all retry attempts
 		bool isDownloadStalled = false;
 		CurlAbortReason abortReason = eCURL_ABORT_REASON_NONE;
 		double connectTime = 0;
@@ -4760,6 +4759,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				CURL_EASY_SETOPT_LIST(curl, CURLOPT_HTTPHEADER, httpHeaders);
 			}
 			long curlDownloadTimeoutMS = curlDLTimeout[curlInstance]; // curlDLTimeout is in msec
+			auto getFileStartTimeHR = std::chrono::steady_clock::now(); // captured before retries; used to compute totalPerformRequest including backoff sleeps
 			long long maxInitDownloadRetryUntil = maxInitDownloadTimeMS + NOW_STEADY_TS_MS;
 			AAMPLOG_INFO("[%s] steady ms %lld, maxInitDownloadRetryUntil %lld, maxInitDownloadTimeMS %d maxDownloadAttempt %d",
 				GetMediaTypeName(mediaType), (long long int)NOW_STEADY_TS_MS, maxInitDownloadRetryUntil, maxInitDownloadTimeMS, maxDownloadAttempt);
@@ -4838,7 +4838,6 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				downloadAttempt++;
 
 				downloadTimeMS = (int)(tEndTime - tStartTime);
-				totalDownloadTimeMS += downloadTimeMS;  // accumulate wall time across all retry attempts
 				bool loopAgain = false;
 				if (res == CURLE_OK)
 				{ // all data collected
@@ -5153,7 +5152,9 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				}
 				if (AampLogManager::isLogLevelAllowed(reqEndLogLevel))
 				{
-					double totalPerformRequest = (double)(totalDownloadTimeMS)/1000;  // total wall time including retries
+					// Wall-clock time from before first attempt through any backoff sleeps to now, in seconds.
+					double totalPerformRequest = std::chrono::duration<double>(
+						std::chrono::steady_clock::now() - getFileStartTimeHR).count();
 #if LIBCURL_VERSION_NUM >= 0x073700 // CURL version >= 7.55.0
 					dlSize = aamp_CurlEasyGetinfoOffset(curl, CURLINFO_SIZE_DOWNLOAD_T);
 #else

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5117,6 +5117,10 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				{
 					downloadbps = ((long)(buffer.size() / downloadTimeMS)*8000);
 				}
+				// NOTE: 'total' and all CURLINFO_* values below reflect the final curl attempt only.
+				// For a retried download, earlier attempts' timing is not captured here.
+				// The full end-to-end duration (including backoff waits) is in totalPerformRequest
+				// (logged as the first timing field of HttpRequestEnd).
 				total = aamp_CurlEasyGetinfoDouble(curl, CURLINFO_TOTAL_TIME);
 				connect = aamp_CurlEasyGetinfoDouble(curl, CURLINFO_CONNECT_TIME);
 				resolve = aamp_CurlEasyGetinfoDouble(curl, CURLINFO_NAMELOOKUP_TIME);
@@ -5124,6 +5128,10 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				connectTime = connect;
 				if(res != CURLE_OK || http_code == 0 || http_code >= 400 || total > 2.0 /*seconds*/)
 				{
+					// Note: 'total' is CURLINFO_TOTAL_TIME of the last attempt; for multi-retry
+					// requests the totalPerformRequest field in HttpRequestEnd is a better
+					// indicator of overall slowness, but is not evaluated here to avoid
+					// promoting every retried download to WARN regardless of outcome.
 					reqEndLogLevel = eLOGLEVEL_WARN;
 				}
 				if (mAampLLDashServiceData.lowLatencyMode && http_code == 206 && mediaType == eMEDIATYPE_VIDEO)
@@ -5132,7 +5140,8 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 					// But log at warning level to indicate partial download
 					reqEndLogLevel = eLOGLEVEL_WARN;
 				}
-				// Store the CMCD data irrespective of logging level
+				// CMCD metrics use last-attempt CURLINFO_* values; this is intentional as CMCD
+				// reports per-request connection quality rather than aggregate retry duration.
 				mCMCDCollector->CMCDSetNetworkMetrics(mediaType , (int)(startTransfer*1000),(int)(total*1000),(int)(resolve*1000));
 				// IsTuneTypeNew set to false in streamabstraction.cpp once top profile has been reached
 				if(IsTuneTypeNew)
@@ -5152,6 +5161,14 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				}
 				if (AampLogManager::isLogLevelAllowed(reqEndLogLevel))
 				{
+					// HttpRequestEnd field layout (comma-separated):
+					//   [appName,] telemetryType, mediaType, httpCode[timeoutClass],
+					//   totalPerformRequest  ← wall-clock across ALL attempts + backoff (this is what
+					//                           autotriage timeline tools use for bar width)
+					//   total               ← CURLINFO_TOTAL_TIME of the LAST attempt only
+					//   connect, startTransfer, resolve, appConnect, preTransfer, redirect
+					//                       ← all CURLINFO_* of last attempt only
+					//   dlSize, reqSize, downloadbps, bitrate, url[, range]
 					// Wall-clock time from before first attempt through any backoff sleeps to now, in seconds.
 					double totalPerformRequest = std::chrono::duration<double>(
 						std::chrono::steady_clock::now() - getFileStartTimeHR).count();

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -543,3 +543,108 @@ TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCond
 	// Verify no crash occurred and state is clean
 	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
 }
+
+/**
+ * @brief Verify that downloadCompleteMetrics.total uses cumulative wall-clock time, not CURLINFO_TOTAL_TIME.
+ *
+ * CURLINFO_TOTAL_TIME is obtained after the retry loop ends (last attempt only).
+ * Without the fix, total == 0.0 here because the fake mock returns 0.0 for any
+ * curl_easy_getinfo call that is not CURLINFO_RESPONSE_CODE.
+ * After the fix, total is overridden with the wall-clock elapsed time across all
+ * attempts, so total > 0 even for a single-attempt download.
+ */
+TEST_F(FunctionalTests, DownloadTest_Metrics_TotalIsWallClockNotCurlInfoTotal)
+{
+	DownloadResponsePtr respData = std::make_shared<DownloadResponse>();
+	DownloadConfigPtr inpData = std::make_shared<DownloadConfig>();
+	inpData->bNeedDownloadMetrics = true;
+	inpData->bIgnoreResponseHeader = true;
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+	mAampCurlDownloader->Initialize(inpData);
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_str(mCurlEasyHandle, CURLOPT_URL, mUrl.c_str()))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_perform(mCurlEasyHandle))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_getinfo_int(mCurlEasyHandle, CURLINFO_RESPONSE_CODE, NotNull()))
+		.WillOnce(DoAll(SetArgPointee<2>(200), Return(CURLE_OK)));
+
+	mAampCurlDownloader->Download(mUrl, respData);
+
+	EXPECT_EQ(200, respData->iHttpRetValue);
+	// FakeCurl returns 0.0 for CURLINFO_TOTAL_TIME (only RESPONSE_CODE is mocked).
+	// Without the fix, total would remain 0.0. With the fix, total = wall-clock elapsed > 0.
+	EXPECT_GT(respData->downloadCompleteMetrics.total, 0.0);
+}
+
+/**
+ * @brief Verify that downloadCompleteMetrics.total accumulates across retry attempts.
+ *
+ * Simulates a throttled network: first curl attempt takes 50 ms (HTTP 503, retried),
+ * second attempt succeeds instantly (HTTP 200). The autotriage timeline tool reads
+ * the 'total' field to draw the download bar width; it must span both attempts.
+ *
+ * Without the fix:
+ *   total = CURLINFO_TOTAL_TIME of last attempt = 0.0 (mock returns 0 for non-RESPONSE_CODE)
+ *   → autotriage shows a 50 ms idle gap then an instant bar.
+ *
+ * After the fix:
+ *   total = wall-clock elapsed from before first attempt to after last attempt >= 0.050 s
+ *   → autotriage shows a single 50 ms wide bar.
+ */
+TEST_F(FunctionalTests, DownloadTest_Metrics_TotalCumulatesAcrossRetries)
+{
+	DownloadResponsePtr respData = std::make_shared<DownloadResponse>();
+	DownloadConfigPtr inpData = std::make_shared<DownloadConfig>();
+	inpData->bNeedDownloadMetrics = true;
+	inpData->bIgnoreResponseHeader = true;
+	inpData->iDownloadRetryCount = 1;
+	inpData->iDownloadRetryWaitMs = 0;  // no inter-retry sleep; all timing is from the slow first attempt
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+	mAampCurlDownloader->Initialize(inpData);
+
+	constexpr int kSlowAttemptMs = 50;
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_str(mCurlEasyHandle, CURLOPT_URL, mUrl.c_str()))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_perform(mCurlEasyHandle))
+		// First attempt: slow (50 ms), HTTP 503 → triggers a retry
+		.WillOnce(DoAll(
+			InvokeWithoutArgs([&]() {
+				std::this_thread::sleep_for(std::chrono::milliseconds(kSlowAttemptMs));
+			}),
+			Return(CURLE_OK)))
+		// Retry: instant, HTTP 200
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_getinfo_int(mCurlEasyHandle, CURLINFO_RESPONSE_CODE, NotNull()))
+		.WillOnce(DoAll(SetArgPointee<2>(503), Return(CURLE_OK)))
+		.WillOnce(DoAll(SetArgPointee<2>(200), Return(CURLE_OK)));
+
+	mAampCurlDownloader->Download(mUrl, respData);
+
+	EXPECT_EQ(200, respData->iHttpRetValue);
+	// Wall-clock total must include the 50 ms slow first attempt.
+	// Before fix: total = CURLINFO_TOTAL_TIME of the instant retry = 0.0 (mock default).
+	// After fix:  total = cumulative wall-clock elapsed >= 0.050 s.
+	EXPECT_GE(respData->downloadCompleteMetrics.total, kSlowAttemptMs / 1000.0);
+}


### PR DESCRIPTION
Reason for Change: fix httpRequestEnd logging to measure from true incoming request time to end, rather than only recording the "final attempt" (in case of internal retries)

Test Guidance: check autotriage after throttling network

Risk: Low