### PR TITLE
VPLAY-12936: Permanent audio loss after repeated audio track switches…

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7149,13 +7149,27 @@ void StreamAbstractionAAMP_MPD::SwitchAudioTrack()
 	pMediaStreamContext->lastSegmentNumber = pMediaStreamContext->fragmentDescriptor.Number - 1;
 
 	/*Calculating the difference in Fetched duration, injected duration and diff in Media Sequence number */
+
+	//Finding the fragment duration in seconds, for calculating the diff in injected duration.
+	double fragmentDurationSec = 0.0;
+	if (pMediaStreamContext->fragmentDescriptor.TimeScale == 0)
+	{
+		AAMPLOG_WARN("TimeScale is 0 while calculating fragmentDurationSec, treating fragmentDurationSec as 0");
+	}
+	else
+	{
+		fragmentDurationSec = static_cast<double>(fragmentDuration) / pMediaStreamContext->fragmentDescriptor.TimeScale;
+	}
 	diffInFetchedDuration = oldPlaylistPosition - pMediaStreamContext->fragmentTime;
 	diffInInjectedDuration = ( pMediaStreamContext->GetLastInjectedPosition() - pMediaStreamContext->fragmentTime );
-	diffFragmentsDownloaded = static_cast<int>(oldMediaSequenceNumber - pMediaStreamContext->fragmentDescriptor.Number);
+	// Add fragment duration offset to reduce from injected position for next fragment calculation
+	diffInInjectedDuration += fragmentDurationSec;
 
-	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d]",
+	diffFragmentsDownloaded = static_cast<int>(static_cast<int64_t>(oldMediaSequenceNumber) - static_cast<int64_t>(pMediaStreamContext->fragmentDescriptor.Number));
+
+	AAMPLOG_INFO("Calculated oldPlaylistPosition[%lf] newPlaylistPosition[%lf] diffInFetchedDuration[%lf] LastInjectedDuration[%lf] Duration[%u], diffInInjectedDuration[%lf] oldMediaSequenceNumber[%" PRIu64 "] newMediaSequenceNumber[%" PRIu64 "] diffFragmentsDownloaded[%d],fragmentDurationSec[%lf]",
 			oldPlaylistPosition,pMediaStreamContext->fragmentTime,diffInFetchedDuration, pMediaStreamContext->GetLastInjectedPosition(),
-			fragmentDuration, diffInInjectedDuration,oldMediaSequenceNumber, pMediaStreamContext->fragmentDescriptor.Number,diffFragmentsDownloaded);
+			fragmentDuration, diffInInjectedDuration,oldMediaSequenceNumber, pMediaStreamContext->fragmentDescriptor.Number,diffFragmentsDownloaded, fragmentDurationSec);
 
 	pMediaStreamContext->resetAbort(false);
 	pMediaStreamContext->OffsetTrackParams(diffInFetchedDuration, diffInInjectedDuration, diffFragmentsDownloaded);


### PR DESCRIPTION
… on Multiview channel. (#1250)

* VPLAY-12936: Fix audio injection drift during seamless track change

Adjust injected position calculation by subtracting fragment duration from injected duration. This ensures correct alignment when switching audio tracks seamlessly.

Previously, each track change introduced ~2s delay in audio injection relative to video. Over multiple switches, this accumulated drift led to significant desynchronization and eventual audio drops.

This fix prevents incremental lag and maintains A/V sync across track transitions.

* Added a zero-check to safely fall back to 0 in case the time scale is 0.

* Update fragmentcollector_mpd.cpp

---------



(cherry picked from commit 737783a67972c1d3165cefafe7fd1782414ed17c)