### PR TITLE
VPLAY-13121 LLONG_MAX -> DBL_MAX

### DIFF
--- a/test/utests/tests/TsProcessorTests/sendSegmentTests.cpp
+++ b/test/utests/tests/TsProcessorTests/sendSegmentTests.cpp
@@ -302,7 +302,7 @@ TEST_F(sendSegmentTests, CallsetBasePTSTest5)
 
 TEST_F(sendSegmentTests, CallsetBasePTSTest6)
 {
-    double position = LLONG_MAX;
+    double position = DBL_MAX;
     long long pts = LLONG_MIN;
     mTSProcessor->CallsetBasePTS(position, pts);
 }


### PR DESCRIPTION
Reason for Change: address compilation warning in sendSegmentTests.cpp
Avoids implicit conversion from 'long long' to 'double'  warning while building l1 tests

Test Guidance:  build l1 tests and ensure no warnings
Risk: none