### PR TITLE
DELIA-70176 : Player Failure observed with OSM on unplug/replug

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -554,6 +554,7 @@ static void HandleRedButtonCallback(const char *data, AAMPGstPlayer * _this)
 static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 {
 	UsingPlayerId playerId( _this->aamp->mPlayerId );
+	AAMPLOG_WARN("VRN IN - %s", busEvent.msg.c_str());
 	switch(busEvent.msgType)
 	{
 		case MESSAGE_ERROR:
@@ -576,7 +577,7 @@ static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 			{ // note: surfacing this intermittent error can cause freeze on partner apps.
 				AAMPLOG_WARN("%s", errorDesc.c_str());
 			}
-			else if (busEvent.msg.find("Rialto dropped a frame that failed to decrypt") != std::string::npos)
+			else if (busEvent.msg.find("failed to decrypt") != std::string::npos)
 			{
 				bool isDeviceConnected = pPlayerExternalsInterface?pPlayerExternalsInterface->GetDeviceConectedStatus():false;
 				if(isDeviceConnected)
@@ -596,6 +597,7 @@ static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 			}
 			else
 			{
+				AAMPLOG_ERR("%s", errorDesc.c_str());
 				_this->aamp->SendErrorEvent(AAMP_TUNE_GST_PIPELINE_ERROR, errorDesc.c_str());
 			}
 		}

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -554,7 +554,6 @@ static void HandleRedButtonCallback(const char *data, AAMPGstPlayer * _this)
 static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 {
 	UsingPlayerId playerId( _this->aamp->mPlayerId );
-	AAMPLOG_WARN("VRN IN - %s", busEvent.msg.c_str());
 	switch(busEvent.msgType)
 	{
 		case MESSAGE_ERROR:
@@ -577,7 +576,7 @@ static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 			{ // note: surfacing this intermittent error can cause freeze on partner apps.
 				AAMPLOG_WARN("%s", errorDesc.c_str());
 			}
-			else if (busEvent.msg.find("failed to decrypt") != std::string::npos)
+			else if (busEvent.msg.find("Rialto dropped a frame that failed to decrypt") != std::string::npos)
 			{
 				bool isDeviceConnected = pPlayerExternalsInterface?pPlayerExternalsInterface->GetDeviceConectedStatus():false;
 				if(isDeviceConnected)

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -41,6 +41,7 @@
 #include "AampSegmentInfo.hpp"
 #include "AampBufferControl.h"
 #include "AampDefine.h"
+#include "PlayerExternalsInterface.h"
 #include <functional>
 #include <inttypes.h>
 
@@ -48,6 +49,8 @@
 
 #define AAMP_MIN_DECODE_ERROR_INTERVAL 10000                     /**< Minimum time interval in milliseconds between two decoder error CB to send anomaly error */
 #define INVALID_RATE -9999
+
+extern PlayerExternalsInterface *pPlayerExternalsInterface;
 
 /**
  * @struct AAMPGstPlayerPriv
@@ -572,6 +575,19 @@ static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 			else if (busEvent.msg.find("Error parsing H.264 stream") != std::string::npos)
 			{ // note: surfacing this intermittent error can cause freeze on partner apps.
 				AAMPLOG_WARN("%s", errorDesc.c_str());
+			}
+			else if (busEvent.msg.find("Rialto dropped a frame that failed to decrypt") != std::string::npos)
+			{
+				bool isDeviceConnected = pPlayerExternalsInterface?pPlayerExternalsInterface->GetDeviceConectedStatus():false;
+				if(isDeviceConnected)
+				{
+					_this->aamp->SendErrorEvent(AAMP_TUNE_GST_PIPELINE_ERROR, errorDesc.c_str(), false);
+					AAMPLOG_WARN("%s", errorDesc.c_str());
+				}
+				else
+				{
+					AAMPLOG_WARN("Ignore Error[%s] as Device connected status is [%d]", errorDesc.c_str(),isDeviceConnected);
+				}
 			}
 			else if (busEvent.msg.find("This file is corrupt and cannot be played") != std::string::npos)
 			{ // fatal error; disable retry flag to avoid failure loop

--- a/middleware/externals/PlayerExternalsInterface.cpp
+++ b/middleware/externals/PlayerExternalsInterface.cpp
@@ -86,6 +86,11 @@ void PlayerExternalsInterface::GetDisplayResolution(int &width, int &height)
     m_pIarmInterface->GetDisplayResolution(width, height);
 }
 
+bool PlayerExternalsInterface::GetDeviceConectedStatus()
+{
+	return m_pIarmInterface->GetDeviceConectedStatus( );
+}
+
 /**
  * @brief Check if  PlayerExternalsInterfaceInstance active
  */

--- a/middleware/externals/PlayerExternalsInterface.h
+++ b/middleware/externals/PlayerExternalsInterface.h
@@ -60,6 +60,9 @@ class FakePlayerExternalsInterface : public PlayerExternalsInterfaceBase
          */
         void GetDisplayResolution(int &width, int &height) override{}
 
+		
+		bool GetDeviceConectedStatus() override{ return false;}
+
         /**
          * @fn SetHDMIStatus
          * @brief Checks Display Settings and sets HDMI parameters like video output resolution, HDCP protocol
@@ -177,6 +180,8 @@ public:
      * @param[out] height : Display height
      */
     void GetDisplayResolution(int &width, int &height);
+
+	bool GetDeviceConectedStatus();
 
     /**
      * @brief Set GstElement

--- a/middleware/externals/PlayerExternalsInterfaceBase.h
+++ b/middleware/externals/PlayerExternalsInterfaceBase.h
@@ -42,6 +42,7 @@ class PlayerExternalsInterfaceBase
 {
     protected:
         bool m_isHDCPEnabled;
+		bool m_isDisplayConnected;
         int m_displayWidth;
         int m_displayHeight;
 
@@ -105,6 +106,8 @@ class PlayerExternalsInterfaceBase
          * @param[out] height height of current resolution
          */
         virtual void GetDisplayResolution(int &width, int &height){}
+
+		virtual bool GetDeviceConectedStatus( ){return false;}		
 
         /**
          * @fn SetHDMIStatus

--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
@@ -211,6 +211,7 @@ void PlayerExternalsRdkInterface::GetDisplayResolution(int &width, int &height)
 
 bool PlayerExternalsRdkInterface::GetDeviceConectedStatus( )
 {
+    MW_LOG_WARN(" Device Connected Status : %d\n",m_isDisplayConnected);
     return m_isDisplayConnected;
 }
 
@@ -305,7 +306,8 @@ void PlayerExternalsRdkInterface::SetHDMIStatus()
     }
 
     m_isHDCPEnabled = isHDCPEnabled;
-	m_isDisplayConnected = isConnected;
+    m_isDisplayConnected = isConnected;
+    MW_LOG_WARN("status - Display connected[%d] HDCP[%d]\n", m_isDisplayConnected, m_isHDCPEnabled);
 
     if(m_isHDCPEnabled) {
         if(hdcpCurrentProtocol == dsHDCP_VERSION_2X) {

--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
@@ -209,6 +209,12 @@ void PlayerExternalsRdkInterface::GetDisplayResolution(int &width, int &height)
     height  = m_displayHeight;
 }
 
+bool PlayerExternalsRdkInterface::GetDeviceConectedStatus( )
+{
+    return m_isDisplayConnected;
+}
+
+
 void PlayerExternalsRdkInterface::SetResolution(int width, int height)
 {
     MW_LOG_WARN(" Resolution : width %d height:%d\n",width,height);
@@ -299,6 +305,7 @@ void PlayerExternalsRdkInterface::SetHDMIStatus()
     }
 
     m_isHDCPEnabled = isHDCPEnabled;
+	m_isDisplayConnected = isConnected;
 
     if(m_isHDCPEnabled) {
         if(hdcpCurrentProtocol == dsHDCP_VERSION_2X) {

--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.h
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.h
@@ -109,6 +109,9 @@ class PlayerExternalsRdkInterface : public PlayerExternalsInterfaceBase
          */
         void GetDisplayResolution(int &width, int &height) override;
 
+		
+		bool GetDeviceConectedStatus() override;
+
         /**
          * @fn SetHDMIStatus
          * @brief Checks Display Settings and sets HDMI parameters like video output resolution, HDCP protocol

--- a/middleware/test/utests/fakes/FakePlayerExternalsRdkInterface.cpp
+++ b/middleware/test/utests/fakes/FakePlayerExternalsRdkInterface.cpp
@@ -154,6 +154,12 @@ public:
 		height = m_displayHeight;
 	}
 
+	
+	bool GetDeviceConectedStatus()
+	{
+		return false;
+	}	
+
 	void SetResolution(int width, int height)
 	{
 		// Validate input: reject zero, negative, or out-of-range values

--- a/test/utests/fakes/FakePlayerExternalsInterface.cpp
+++ b/test/utests/fakes/FakePlayerExternalsInterface.cpp
@@ -59,6 +59,11 @@ void PlayerExternalsInterface::GetDisplayResolution(int &width, int &height)
 {
 }
 
+bool PlayerExternalsInterface::GetDeviceConectedStatus()
+{
+	return false;
+}
+
 /**
  * @brief Check if  PlayerExternalsInterfaceInstance active
  */


### PR DESCRIPTION
Reason for change: Handle HDMI unplug case where pipeline fails to transition from Ready to Paused by ignoring the error event when HDMI is not connected.
Test Procedure: Ensure decryption failure handling is consistent across both STB and TV
Risks: Low

Signed-off-by: Varatharajan_Narayanan <Varatharajan_Narayanan@comcast.com>