### PR TITLE
VPAAMP-11:AAMP TSB not working w/ adaptive latency test build

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2582,7 +2582,11 @@ bool PrivateInstanceAAMP::IsAtLivePoint()
 {
 	if (IsLiveStream())
 	{
-		std::lock_guard<std::recursive_mutex> guard(GetStreamLock());
+		// Avoid acquiring StreamLock here to prevent a circular deadlock.
+		// One of the scenarios is listed below:
+		// 1. SetRateInternal() holds StreamLock and then waits for a lock in decoder
+		// 2. The decoder first-frame callback holds the lock and then calls
+		// NotifyFirstBufferProcessed() -> IsAtLivePoint(), which waits for StreamLock.
 		if (mpStreamAbstractionAAMP)
 		{
 			return mpStreamAbstractionAAMP->mIsAtLivePoint;


### PR DESCRIPTION
Reason for change: Deadlock chain -
        1. SetRateInternal() holds StreamLock and then waits for the GStreamer lock inside gst_omx_video_dec_sink_event().
        2. The decoder first-frame callback holds the GStreamer lock and then calls PrivateInstanceAAMP::IsAtLivePoint(), which waits for StreamLock.
        This creates a circular wait
        Removing the streamlock from PrivateInstanceAAMP::IsAtLivePoint() breaks this circular dependency.
Test Procedure: updated in ticket
Risks: Low