### PR TITLE
VPLAY-13199: LLD hardening - default configuration updates

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -170,9 +170,9 @@ Configuration options are passed to AAMP using the UVE `initConfig()` method. Th
 | licenseRetryWaitTime | Number | 500 | License retry wait interval (milliseconds). |
 | licenseServerUrl | String | - | URL to be used for license requests for encrypted(PR/WV) assets. |
 | linearTrickPlayFps | Number | 8 | Specify the framerate for Linear trickplay. |
-| lowLatencyMinValue | Number | 3 | Minimum acceptable latency (seconds). Avoids getting too close to live edge, preventing buffering. If latency drops below this, playback slows down to increase delay and avoid buffer underrun. |
+| lowLatencyMinValue | Number | 5 | Minimum acceptable latency (seconds). Avoids getting too close to live edge, preventing buffering. If latency drops below this, playback slows down to increase delay and avoid buffer underrun. |
 | lowLatencyTargetValue | Number | 6 | Target latency for playback (seconds). If reduced, playback will be closer to live edge, but with increased chance of buffering. |
-| lowLatencyMaxValue | Number | 9 | Maximum acceptable latency (seconds). Ensures playback does not fall too far behind live stream. If latency exceeds this, playback speeds up to catch up with live edge. |
+| lowLatencyMaxValue | Number | 7 | Maximum acceptable latency (seconds). Ensures playback does not fall too far behind live stream. If latency exceeds this, playback speeds up to catch up with live edge. |
 | lowLatencyMinBuffer | Float | 2 | Minimum buffer level the player should maintain for low latency buffering (seconds). |
 | lowLatencyTargetBuffer | Float | 4 | Target buffer size for low latency mode (seconds). Balances latency and stability by keeping a healthy buffer. |
 | maxABRBufferRampup | Number | 15 | Maximum ABR Buffer for Rampup in secs. |

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -311,7 +311,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{true,"webVttNative",eAAMPConfig_WebVTTNative,false},
 	{false,"asyncTune",eAAMPConfig_AsyncTune,true},
 	{false,"disableUnderflow",eAAMPConfig_DisableUnderflow,false},
-	{false,"enableAampUnderflowMonitor",eAAMPConfig_EnableAampUnderflowMonitor,true},
+	{true,"enableAampUnderflowMonitor",eAAMPConfig_EnableAampUnderflowMonitor,true},
 	{false,"limitResolution",eAAMPConfig_LimitResolution,false},
 	{false,"useAbsoluteTimeline",eAAMPConfig_UseAbsoluteTimeline,false},
 	{true,"enableAccessAttributes",eAAMPConfig_EnableAccessAttributes,false},
@@ -430,9 +430,6 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{DEFAULT_LATENCY_MONITOR_INTERVAL_MS,"latencyMonitorIntervalMs",eAAMPConfig_LatencyMonitorIntervalMs,false},
 	{DEFAULT_CACHED_FRAGMENT_CHUNKS_PER_TRACK,"downloadBufferChunks",eAAMPConfig_MaxFragmentChunkCached,false},
 	{DEFAULT_AAMP_ABR_CHUNK_THRESHOLD_SIZE,"abrChunkThresholdSize",eAAMPConfig_ABRChunkThresholdSize,false},
-	{DEFAULT_MIN_LOW_LATENCY,"lowLatencyMinValue",eAAMPConfig_LLMinLatency,true},
-	{DEFAULT_TARGET_LOW_LATENCY,"lowLatencyTargetValue",eAAMPConfig_LLTargetLatency,true},
-	{DEFAULT_MAX_LOW_LATENCY,"lowLatencyMaxValue",eAAMPConfig_LLMaxLatency,true},
 	{MAX_SEG_DOWNLOAD_FAIL_COUNT,"fragmentDownloadFailThreshold",eAAMPConfig_FragmentDownloadFailThreshold,false,eCONFIG_RANGE_DOWNLOAD_ERROR_THRESHOLD },
 	{MAX_INIT_FRAGMENT_CACHE_PER_TRACK,"maxInitFragCachePerTrack",eAAMPConfig_MaxInitFragCachePerTrack,true, eCONFIG_RANGE_INIT_FRAGMENT_CACHE },
 	{FOG_MAX_CONCURRENT_DOWNLOADS,"fogMaxConcurrentDownloads",eAAMPConfig_FogMaxConcurrentDownloads, false },
@@ -518,7 +515,10 @@ static const ConfigLookupEntryFloat mConfigLookupTableFloat[AAMPCONFIG_FLOAT_COU
 	{DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC, "underflowHighBufferSec", eAAMPConfig_UnderflowHighBufferSec, true},
 	{DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC, "bufferLevelToEnableLatencySec", eAAMPConfig_BufferLevelToEnableCorrectionSec, false},
 	{DEFAULT_REBUFFER_LATENCY_STEP_SEC, "rebufferLatencyStepSec", eAAMPConfig_RebufferLatencyStepSec, false},
-	{DEFAULT_REBUFFER_LATENCY_MAX_INCREMENT_SEC, "rebufferLatencyMaxIncrementSec", eAAMPConfig_RebufferLatencyMaxIncrementSec, false}
+	{DEFAULT_REBUFFER_LATENCY_MAX_INCREMENT_SEC, "rebufferLatencyMaxIncrementSec", eAAMPConfig_RebufferLatencyMaxIncrementSec, false},
+	{DEFAULT_MIN_LOW_LATENCY, "lowLatencyMinValue", eAAMPConfig_LLMinLatency, true},
+	{DEFAULT_TARGET_LOW_LATENCY, "lowLatencyTargetValue", eAAMPConfig_LLTargetLatency, true},
+	{DEFAULT_MAX_LOW_LATENCY, "lowLatencyMaxValue", eAAMPConfig_LLMaxLatency, true}
 };
 
 /**

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -282,9 +282,6 @@ typedef enum
 	eAAMPConfig_LatencyMonitorIntervalMs,           				/**< Latency Monitor Interval */
 	eAAMPConfig_MaxFragmentChunkCached,           				/**< fragment chunk cache length*/
 	eAAMPConfig_ABRChunkThresholdSize,                			/**< AAMP ABR Chunk threshold size*/
-	eAAMPConfig_LLMinLatency,						/**< Low Latency Min Latency Offset */
-	eAAMPConfig_LLTargetLatency,						/**< Low Latency Target Latency */
-	eAAMPConfig_LLMaxLatency,						/**< Low Latency Max Latency */
 	eAAMPConfig_FragmentDownloadFailThreshold, 				/**< Retry attempts for non-init fragment curl timeout failures*/
 	eAAMPConfig_MaxInitFragCachePerTrack,					/**< Max no of Init fragment cache per track */
 	eAAMPConfig_FogMaxConcurrentDownloads,                                  /**< Concurrent download posted to fog from player*/
@@ -362,6 +359,9 @@ typedef enum
 	eAAMPConfig_BufferLevelToEnableCorrectionSec,   /**< Buffer level to enable latency correction in seconds */
 	eAAMPConfig_RebufferLatencyStepSec,				/**< Step value for latency increase when rebuffering occurs */
 	eAAMPConfig_RebufferLatencyMaxIncrementSec,		/**< Max latency increment allowed due to rebuffering */
+	eAAMPConfig_LLMinLatency,						/**< Low Latency Min Latency Offset */
+	eAAMPConfig_LLTargetLatency,					/**< Low Latency Target Latency */
+	eAAMPConfig_LLMaxLatency,						/**< Low Latency Max Latency */
 	eAAMPConfig_FloatMaxValue						/**< Max value for float config always last element*/
 } AAMPConfigSettingFloat;
 #define AAMPCONFIG_FLOAT_COUNT (eAAMPConfig_FloatMaxValue)

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -152,14 +152,14 @@
 #define DEFAULT_UNDERFLOW_MEDIUM_BUFFER_POLL_MS 1000	/**< Polling interval when buffer is medium in milliseconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_POLL_MS 2000		/**< Polling interval when buffer is high in milliseconds */
 
-#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.0		/**< Threshold to detect underflow in seconds */
+#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.2		/**< Threshold to detect underflow in seconds */
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */
 
 #define DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC 0.0  /*< Default is 0.0 means latency correction is enabled at all buffer values */
-#define DEFAULT_REBUFFER_LATENCY_STEP_SEC 1.0		/*< Step value for latency increase when rebuffering occurs in seconds */
-#define DEFAULT_REBUFFER_LATENCY_MAX_INCREMENT_SEC 6	/*< LiveOffset(15s) - MaxLatency(9s) */
+#define DEFAULT_REBUFFER_LATENCY_STEP_SEC 1.0			/*< Step value for latency increase when rebuffering occurs in seconds */
+#define DEFAULT_REBUFFER_LATENCY_MAX_INCREMENT_SEC 8.0	/*< LiveOffset(15s) - MaxLatency(7s) */
 
 // We can enable the following once we have a thread monitoring video PTS progress and triggering subtec clock fast update when we detect video freeze. Disabled it for now for brute force fast refresh..
 //#define SUBTEC_VARIABLE_CLOCK_UPDATE_RATE   /* enable this to make the clock update rate dynamic*/
@@ -193,9 +193,9 @@
 
 #define DEFAULT_LATENCY_MONITOR_DELAY_MS		5000		/**< Latency Monitor Delay */
 #define DEFAULT_LATENCY_MONITOR_INTERVAL_MS		1000		/**< Latency monitor interval */
-#define DEFAULT_MIN_LOW_LATENCY					3			/**< min Default Latency */
-#define DEFAULT_MAX_LOW_LATENCY					9			/**< max Default Latency */
-#define DEFAULT_TARGET_LOW_LATENCY				6			/**< Target Default Latency */
+#define DEFAULT_MIN_LOW_LATENCY					5.0			/**< min Default Latency */
+#define DEFAULT_MAX_LOW_LATENCY					7.0			/**< max Default Latency */
+#define DEFAULT_TARGET_LOW_LATENCY				6.0			/**< Target Default Latency */
 #define DEFAULT_MIN_RATE_CORRECTION_SPEED		0.97f		/**< min Rate correction speed */
 #define DEFAULT_MAX_RATE_CORRECTION_SPEED		1.03f		/**< max Rate correction speed */
 #define DEFAULT_NORMAL_RATE_CORRECTION_SPEED	1.00f		/**< Live Catchup Normal play rate */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -3549,12 +3549,12 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 
 				if (mLowLatencyMode && !liveAdjust)
 				{
-					int maxLatency = GETCONFIGVALUE(eAAMPConfig_LLMaxLatency);
+					float maxLatency = GETCONFIGVALUE(eAAMPConfig_LLMaxLatency);
 					//Chunk mode is applied when the seek position is between the live edge and the maximum allowed latency from it
 					if (seekPosition > (duration - maxLatency))
 					{
 						aamp->SetLLDashChunkMode(true);
-						AAMPLOG_MIL("Chunk mode set: seekPosition (%f) not exceeded maxLatency (%d) threshold, enabling LLDashChunkMode", seekPosition, maxLatency);
+						AAMPLOG_MIL("Chunk mode set: seekPosition (%f) not exceeded maxLatency (%f) threshold, enabling LLDashChunkMode", seekPosition, maxLatency);
 					}
 				}
 			}
@@ -12983,7 +12983,7 @@ AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayba
 	{
 		AampLLDashServiceData stLLServiceData;
 		double currentOffset = 0;
-		int maxLatency=0,minLatency=0,TargetLatency=0;
+		float maxLatency = 0, minLatency = 0, targetLatency = 0;
 		AampMPDDownloader *dnldInstance = aamp->GetMPDDownloader();
 		if((dnldInstance->IsMPDLowLatency(stLLServiceData))
 			&&	(stLLServiceData.availabilityTimeComplete == false ))
@@ -13026,7 +13026,7 @@ AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayba
 			}
 
 			minLatency = GETCONFIGVALUE(eAAMPConfig_LLMinLatency);
-			TargetLatency = GETCONFIGVALUE(eAAMPConfig_LLTargetLatency);
+			targetLatency = GETCONFIGVALUE(eAAMPConfig_LLTargetLatency);
 			maxLatency = GETCONFIGVALUE(eAAMPConfig_LLMaxLatency);
 			if (aamp->mIsStream4K)
 			{
@@ -13041,7 +13041,7 @@ AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayba
 
 			if(	stLLServiceData.minLatency <= 0)
 			{
-				if(minLatency <= 0 || minLatency > TargetLatency )
+				if(minLatency <= 0 || minLatency > targetLatency )
 				{
 					stLLServiceData.minLatency = DEFAULT_MIN_LOW_LATENCY*1000;
 				}
@@ -13068,7 +13068,7 @@ AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayba
 				stLLServiceData.targetLatency > stLLServiceData.maxLatency )
 
 			{
-				if(TargetLatency <=0 || TargetLatency < minLatency || TargetLatency > maxLatency )
+				if(targetLatency <=0 || targetLatency < minLatency || targetLatency > maxLatency )
 				{
 					stLLServiceData.targetLatency = DEFAULT_TARGET_LOW_LATENCY*1000;
 					stLLServiceData.maxLatency = DEFAULT_MAX_LOW_LATENCY*1000;
@@ -13076,12 +13076,12 @@ AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayba
 				}
 				else
 				{
-					stLLServiceData.targetLatency = TargetLatency*1000;
+					stLLServiceData.targetLatency = targetLatency*1000;
 				}
 			}
 			double latencyOffsetMin = stLLServiceData.minLatency/(double)1000;
 			double latencyOffsetMax = stLLServiceData.maxLatency/(double)1000;
-			AAMPLOG_MIL("StreamAbstractionAAMP_MPD:[LL-Dash] Min Latency: %ld Max Latency: %ld Target Latency: %ld",(long)latencyOffsetMin,(long)latencyOffsetMax,(long)TargetLatency);
+			AAMPLOG_MIL("StreamAbstractionAAMP_MPD:[LL-Dash] Min Latency: %ld Max Latency: %ld Target Latency: %ld",(long)latencyOffsetMin,(long)latencyOffsetMax,(long)targetLatency);
 			SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_IgnoreAppLiveOffset, true);
 			//Ignore Low latency setting
 			if(!ISCONFIGSET(eAAMPConfig_ForceLLDFlow) && !ISCONFIGSET(eAAMPConfig_IgnoreAppLiveOffset) && (((AAMP_DEFAULT_SETTING != GETCONFIGOWNER(eAAMPConfig_LiveOffset4K)) && (currentOffset > latencyOffsetMax) && aamp->mIsStream4K) ||

--- a/test/utests/tests/AampLatencyMonitorTests/AampLatencyMonitorTestCases.cpp
+++ b/test/utests/tests/AampLatencyMonitorTests/AampLatencyMonitorTestCases.cpp
@@ -57,6 +57,12 @@ AampConfig *gpGlobalConfig{nullptr};
 #define DEFAULT_TARGET_LATENCY_MS (DEFAULT_TARGET_LOW_LATENCY * 1000.0)
 #define DEFAULT_MAX_LATENCY_MS    (DEFAULT_MAX_LOW_LATENCY    * 1000.0)
 
+// Integer (ms) equivalents — use in Return() stubs and atomic initialisers to
+// avoid implicit double→long narrowing conversions.
+static constexpr long kMinLatencyMs    = static_cast<long>(DEFAULT_MIN_LATENCY_MS);
+static constexpr long kTargetLatencyMs = static_cast<long>(DEFAULT_TARGET_LATENCY_MS);
+static constexpr long kMaxLatencyMs    = static_cast<long>(DEFAULT_MAX_LATENCY_MS);
+
 // ---------------------------------------------------------------------------
 // Helper: build a LatencyConfig with very short poll intervals so worker
 // tests complete quickly in CI.
@@ -105,7 +111,7 @@ protected:
 		// Default safe stubs — overridden per test as required.
 		ON_CALL(*mMockAamp, GetState()).WillByDefault(Return(eSTATE_PLAYING));
 		ON_CALL(*mMockAamp, IsAdPlaying()).WillByDefault(Return(false));
-		ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(static_cast<long>(DEFAULT_TARGET_LATENCY_MS)));
+		ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kTargetLatencyMs));
 		ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 		ON_CALL(*mMockAamp, UpdateVideoEndMetrics(_)).WillByDefault(Return());
 		ON_CALL(*mMockSinkMgr, GetStreamSink(_)).WillByDefault(Return(mMockSink));
@@ -266,7 +272,7 @@ TEST_F(AampLatencyMonitorTest, State_StartSetsRateFromConfig)
 TEST_F(AampLatencyMonitorTest, Reset_StopResetsRateToNormal)
 {
 	// Use latency > maxLatencyMs so the worker drives rate to maxRate.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(15000L)); // > 9000 ms max
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 6000L)); // > 7000 ms max
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	ON_CALL(*mMockSink, SetPlayBackRate(_)).WillByDefault(Return(true));
 
@@ -295,7 +301,7 @@ TEST_F(AampLatencyMonitorTest, Reset_StopResetsRateToNormal)
 TEST_F(AampLatencyMonitorTest, Reset_EnableRateCorrectionFalse_ResetsToNormal)
 {
 	// Drive the monitor to maxRate first.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(15000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 6000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
     EXPECT_CALL(*mMockSinkMgr, GetStreamSink(_))
 		.WillRepeatedly(Return(mMockSink));
@@ -325,7 +331,7 @@ TEST_F(AampLatencyMonitorTest, Reset_EnableRateCorrectionFalse_ResetsToNormal)
 TEST_F(AampLatencyMonitorTest, Reset_EnableRateCorrectionFalse_ThenTrue_Resumes)
 {
 	// Latency in-band so rate stays normal once correction re-enabled.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(static_cast<long>(DEFAULT_TARGET_LATENCY_MS)));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kTargetLatencyMs));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 
 	mMonitor->Start(MakeFastConfig());
@@ -367,8 +373,8 @@ TEST_F(AampLatencyMonitorTest, Reset_EnableRateCorrectionSameState_IsNoOp)
  */
 TEST_F(AampLatencyMonitorTest, RateCorrection_HighLatency_SpeedsUp)
 {
-	// Latency = 12 000 ms > 9 000 ms max; buffer = 5 s >= 4 s target.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	// Latency = 10 000 ms > 7 000 ms max; buffer = 5 s >= 4 s target.
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 
 	EXPECT_CALL(*mMockSink, SetPlayBackRate(DEFAULT_MAX_RATE_CORRECTION_SPEED)).Times(AtLeast(1)).WillRepeatedly(Return(true));
@@ -390,7 +396,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_BufferBelowThreshold_SkipsPoll)
 {
 	// Latency is out-of-band-high, but buffer (1.5 s) is below the configured
 	// correction-enable threshold (2000ms) — the poll must be skipped.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(1.5));
 
 	mMonitor->Start(MakeFastConfig(
@@ -411,8 +417,8 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_BufferBelowThreshold_SkipsPoll)
  */
 TEST_F(AampLatencyMonitorTest, RateCorrection_LowLatency_SlowsDown)
 {
-	// Latency = 1 000 ms < 3 000 ms min; buffer healthy.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(1000L));
+	// Latency = 3 000 ms < 5 000 ms min; buffer healthy.
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMinLatencyMs - 2000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 
 	EXPECT_CALL(*mMockSink, SetPlayBackRate(DEFAULT_MIN_RATE_CORRECTION_SPEED)).Times(AtLeast(1)).WillRepeatedly(Return(true));
@@ -432,7 +438,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_LowLatency_SlowsDown)
 TEST_F(AampLatencyMonitorTest, RateCorrection_InBandLatency_StaysNormal)
 {
 	// Latency at target — squarely in the dead-band [min, max].
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(static_cast<long>(DEFAULT_TARGET_LATENCY_MS)));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kTargetLatencyMs));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 
 	mMonitor->Start(MakeFastConfig());
@@ -449,7 +455,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_InBandLatency_StaysNormal)
 TEST_F(AampLatencyMonitorTest, RateCorrection_ReturnToNormal_AfterSpeedUp)
 {
 	// Phase 1: high latency — drive to maxRate.
-	std::atomic<long> latency{12000L};
+	std::atomic<long> latency{kMaxLatencyMs + 3000L};
 	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault([&latency]() { return latency.load(); });
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	ON_CALL(*mMockSink, SetPlayBackRate(_)).WillByDefault(Return(true));
@@ -459,7 +465,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_ReturnToNormal_AfterSpeedUp)
 	ASSERT_TRUE(WaitForRate(DEFAULT_MAX_RATE_CORRECTION_SPEED, 500));
 
 	// Phase 2: latency caught up to target — expect return to normal.
-	latency.store(5000L); // <= DEFAULT_TARGET_LATENCY_MS, while at maxRate
+	latency.store(kTargetLatencyMs - 100L); // <= kTargetLatencyMs, while at maxRate
 	EXPECT_TRUE(WaitForRate(DEFAULT_NORMAL_RATE_CORRECTION_SPEED, 500));
 }
 
@@ -471,7 +477,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_ReturnToNormal_AfterSpeedUp)
 TEST_F(AampLatencyMonitorTest, RateCorrection_ReturnToNormal_AfterSlowDown)
 {
 	// Phase 1: low latency — drive to minRate.
-	std::atomic<long> latency{1000L};
+	std::atomic<long> latency{kMinLatencyMs - 2000L};
 	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault([&latency]() { return latency.load(); });
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	ON_CALL(*mMockSink, SetPlayBackRate(_)).WillByDefault(Return(true));
@@ -481,7 +487,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_ReturnToNormal_AfterSlowDown)
 	ASSERT_TRUE(WaitForRate(DEFAULT_MIN_RATE_CORRECTION_SPEED, 500));
 
 	// Phase 2: latency rose back to target — should return to normal.
-	latency.store(7000L); // >= DEFAULT_TARGET_LATENCY_MS, while at minRate
+	latency.store(kTargetLatencyMs + 100L); // >= kTargetLatencyMs, while at minRate
 	EXPECT_TRUE(WaitForRate(DEFAULT_NORMAL_RATE_CORRECTION_SPEED, 500));
 }
 
@@ -493,7 +499,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_ReturnToNormal_AfterSlowDown)
 TEST_F(AampLatencyMonitorTest, RateCorrection_AdPlaying_SkipsCorrection)
 {
 	// Latency would normally trigger speed-up, but ad is playing.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	ON_CALL(*mMockAamp, IsAdPlaying()).WillByDefault(Return(true));
 
@@ -512,7 +518,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_AdPlaying_SkipsCorrection)
 TEST_F(AampLatencyMonitorTest, RateCorrection_NotPlaying_SkipsCorrection)
 {
 	ON_CALL(*mMockAamp, GetState()).WillByDefault(Return(eSTATE_BUFFERING));
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 
     EXPECT_CALL(*mMockSink, SetPlayBackRate(_)).Times(0); // no rate changes when state != eSTATE_PLAYING
@@ -529,7 +535,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_NotPlaying_SkipsCorrection)
  */
 TEST_F(AampLatencyMonitorTest, RateCorrection_SinkReturnsFailure_RateUnchanged)
 {
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	// Sink rejects rate change.
 	ON_CALL(*mMockSink, SetPlayBackRate(_)).WillByDefault(Return(false));
@@ -548,7 +554,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_SinkReturnsFailure_RateUnchanged)
  */
 TEST_F(AampLatencyMonitorTest, RateCorrection_NoSink_RateUnchanged)
 {
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	ON_CALL(*mMockSinkMgr, GetStreamSink(_)).WillByDefault(Return(nullptr));
 
@@ -566,7 +572,7 @@ TEST_F(AampLatencyMonitorTest, RateCorrection_NoSink_RateUnchanged)
  */
 TEST_F(AampLatencyMonitorTest, RateCorrection_NegativeBuffer_SkipsPoll)
 {
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(12000L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMaxLatencyMs + 3000L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(-1.0));
 
 	mMonitor->Start(MakeFastConfig()); // default correctionActivationThresholdSec = 0.0
@@ -736,7 +742,7 @@ TEST_F(AampLatencyMonitorTest,
 	AdaptiveThreshold_ShiftedThreshold_ChangesRateCorrectionBehavior)
 {
 	// Latency just above the default min — initially in-band.
-	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(3200L));
+	ON_CALL(*mMockAamp, GetCurrentLatencyMs()).WillByDefault(Return(kMinLatencyMs + 200L));
 	ON_CALL(*mMockAamp, GetBufferedDurationSecs()).WillByDefault(Return(5.0));
 	ON_CALL(*mMockSink, SetPlayBackRate(_)).WillByDefault(Return(true));
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -2820,16 +2820,16 @@ TEST_F(FunctionalTests, ChunkMode_LLD_ForMaxLatency_Case)
 	EXPECT_CALL(*g_mockAampMPDDownloader, IsMPDLowLatency (_))
 		.WillRepeatedly(Return(true));
 
-	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(testing::Matcher<AAMPConfigSettingInt>(_)))
-	.WillRepeatedly([](AAMPConfigSettingInt config) {
-	// Check if the config is maxLatencyConfig, return 9(default value); otherwise, return 0
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(testing::Matcher<AAMPConfigSettingFloat>(_)))
+	.WillRepeatedly([](AAMPConfigSettingFloat config) {
+	// Check if the config is maxLatencyConfig, return 9 for the test usecase; otherwise, return 0
 	if (config == eAAMPConfig_LLMaxLatency) {
-		return 9;
+		return 9.0;
 	}
-	return 0;
+	return 0.0;
 	});
 
-	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(testing::Matcher<AAMPConfigSettingFloat>(_))).WillRepeatedly(Return(0.0));
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(testing::Matcher<AAMPConfigSettingInt>(_))).WillRepeatedly(Return(0));
 	//For this test case we need EnableLowLatencyDash as true
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_))
 		.WillRepeatedly(Return(false));


### PR DESCRIPTION
Reason for change:
Update the default configurations for LLD as part of LLD and ABR hardening changes.
Migrate latency to float to get millisecond precision.
Enable AAMP underflow monitor by default and set 0.2s as the underflow threshold.
Test Procedure: Sanity testing LLD playback
Risks: Medium