### PR TITLE
VPLAY-12682:SoC-independent underflow detection - follow-up improvements

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3239,20 +3239,22 @@ void PrivateInstanceAAMP::UpdateRefreshPlaylistInterval(float maxIntervalSecs)
 
 /**
  * @brief Sends UnderFlow Event messages
+ * @param[in] bufferingStarted True if buffering started, false if buffering ended.
  */
-void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStopped)
+void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStarted)
 {
 	// Buffer Change event indicate buffer availability
-	// Buffering stop notification need to be inverted to indicate if buffer available or not
+	// bufferingStarted need to be inverted to indicate if buffer available or not
 	// BufferChangeEvent with False = Underflow / non-availability of buffer to play
 	// BufferChangeEvent with True  = Availability of buffer to play
-	BufferingChangedEventPtr e = std::make_shared<BufferingChangedEvent>(!bufferingStopped, GetSessionId());
+	bool bufferAvailable = !bufferingStarted;
+	BufferingChangedEventPtr e = std::make_shared<BufferingChangedEvent>(bufferAvailable, GetSessionId());
 
-	SetBufUnderFlowStatus(bufferingStopped);
+	SetBufUnderFlowStatus(bufferingStarted);
 	// Calculating the duration for which buffering was happening and sending it as part of telemetry.
 	// This will help in understanding the buffering duration for each buffering event and also help in calculating the total buffering duration for a session.
 	long long bufferingDurationMs = 0;
-	if (bufferingStopped)
+	if (bufferingStarted)
 	{
 		// Atomically set the start time only if no episode is already being tracked (-1).
 		// compare_exchange_strong ensures that concurrent SendBufferChangeEvent(true) calls
@@ -3281,7 +3283,7 @@ void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStopped)
 	AAMPLOG_INFO("PrivateInstanceAAMP: Sending Buffer Change event status (Buffering): %s durationMs: %lld", (e->buffering() ? "End": "Start"), bufferingDurationMs);
 #ifdef AAMP_TELEMETRY_SUPPORT
 	AAMPTelemetry2 at2(mAppName);
-	std::string telemetryName = bufferingStopped?"VideoBufferingStart":"VideoBufferingEnd";
+	std::string telemetryName = bufferingStarted?"VideoBufferingStart":"VideoBufferingEnd";
 	std::map<std::string,int> intData;
 	intData["dur"] = static_cast<int>(bufferingDurationMs);
 	at2.send(telemetryName, intData, {/*string data*/}, {/*float data*/});
@@ -3289,7 +3291,7 @@ void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStopped)
 	SendEvent(e,AAMP_EVENT_ASYNC_MODE);
 
 	// If rebuffering started, notify latency monitor to relax the latency band
-	if (bufferingStopped)
+	if (bufferingStarted)
 	{
 		mLatencyMonitor->OnRebufferingStart();
 	}

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1570,10 +1570,9 @@ public:
 	/**
 	 * @fn SendBufferChangeEvent
 	 *
-	 * @param[in] bufferingStopped- Flag to indicate buffering stopped.Underflow = True
-	 * @return void
+	 * @param[in] bufferingStarted True if buffering started, false if buffering ended.
 	 */
-	void SendBufferChangeEvent(bool bufferingStopped=false);
+	void SendBufferChangeEvent(bool bufferingStart=false);
 
 	/**
 	 * @fn SendTuneMetricsEvent

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -1309,7 +1309,7 @@ bool PrivateInstanceAAMP::PausePipeline(bool pause, bool forceStopGstreamerPreBu
 	return false;
 }
 
-void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStopped)
+void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStarted)
 {
 }
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1606,7 +1606,7 @@ bool PrivateInstanceAAMP::PausePipeline(bool pause, bool forceStopGstreamerPreBu
 	return false;
 }
 
-void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStopped)
+void PrivateInstanceAAMP::SendBufferChangeEvent(bool bufferingStarted)
 {
 }
 


### PR DESCRIPTION
Reason for change:SendBufferChangeEvent bufferingStop bool is changed to bufferingStart 
Risks: Medium
Signed-off-by: varshnie <varshniblue14@gmail.com>
