### PR TITLE
VPLAY-12490 Use CPP 17 to build AAMP (#917)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ function(xcode_define_schema new_schema)
 endfunction()
 
 project (AAMP)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format -Wno-multichar -Wno-non-virtual-dtor -Wno-psabi")

--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -95,7 +95,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     execute_process (
         COMMAND bash -c "xcrun --show-sdk-path" OUTPUT_VARIABLE osxSdkPath OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    set(OS_CXX_FLAGS "${OS_CXX_FLAGS}  -std=c++14 -g -x objective-c++ -Wno-inconsistent-missing-override -F${osxSdkPath}/System/Library/Frameworks")
+	set(OS_CXX_FLAGS "${OS_CXX_FLAGS}  -std=c++17 -g -x objective-c++ -Wno-inconsistent-missing-override -F${osxSdkPath}/System/Library/Frameworks")
     set(OS_LD_FLAGS "${OS_LD_FLAGS} -F${osxSdkPath}/System/Library/Frameworks -framework Cocoa -L${osxSdkPath}/../MacOSX.sdk/usr/lib -L.libs/lib -L/usr/local/lib/")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -isysroot ${osxSdkPath}/../MacOSX.sdk -I/usr/local/include")
     string(STRIP ${OS_LD_FLAGS} OS_LD_FLAGS)

--- a/middleware/baseConversion/CMakeLists.txt
+++ b/middleware/baseConversion/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(baseconversion)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include_directories(..)

--- a/middleware/gst-plugins/CMakeLists.txt
+++ b/middleware/gst-plugins/CMakeLists.txt
@@ -53,7 +53,7 @@ include_directories(${MW_ROOT}/)
 
 set(GST_COMMON_DEPENDENCIES ${OS_LD_FLAGS} ${GSTREAMERBASE_LIBRARIES} ${GSTREAMER_LIBRARIES} ${CURL_LIBRARIES} ${CLI_LD_FLAGS} -ldl -luuid ${SEC_CLIENT_LIB})
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-multichar -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-multichar")
 
 if(CMAKE_IARM_MGR)
 	message("CMAKE_IARM_MGR set")

--- a/middleware/gst-plugins/gst_subtec/CMakeLists.txt
+++ b/middleware/gst-plugins/gst_subtec/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required (VERSION 3.5)
 project (gst_subtec)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(PkgConfig REQUIRED)
 

--- a/middleware/playerJsonObject/CMakeLists.txt
+++ b/middleware/playerJsonObject/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(playerjsonobject)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FindPkgConfig)

--- a/middleware/playerLogManager/CMakeLists.txt
+++ b/middleware/playerLogManager/CMakeLists.txt
@@ -18,7 +18,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(playerlogmanager)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include_directories(..)

--- a/middleware/test/utests/CMakeLists.txt
+++ b/middleware/test/utests/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_GST1 -ggdb")
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Linux")
   add_compile_options(-fsanitize=address)

--- a/support/aampabr/CMakeLists.txt
+++ b/support/aampabr/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 cmake_minimum_required (VERSION 3.5)
 project (ABRManager)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(abr SHARED ABRManager.cpp HybridABRManager.cpp)

--- a/support/aampmetrics/CMakeLists.txt
+++ b/support/aampmetrics/CMakeLists.txt
@@ -16,7 +16,7 @@
 # limitations under the License.
 cmake_minimum_required (VERSION 3.5)
 project (Metrics)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(PkgConfig REQUIRED)

--- a/support/aampmetrics/test/CMakeLists.txt
+++ b/support/aampmetrics/test/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(GTEST REQUIRED gtest)
 pkg_check_modules(GMOCK REQUIRED gmock)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_GST1 -ggdb")
 

--- a/test/utests/tests/AampDRMLicPreFetcherTests/CMakeLists.txt
+++ b/test/utests/tests/AampDRMLicPreFetcherTests/CMakeLists.txt
@@ -25,8 +25,6 @@ include(${CMAKE_CURRENT_LIST_DIR}/../CommonTestIncludes.cmake)
 include_directories(${DRM_ROOT})
 include_directories(${DRM_ROOT}/mocks)
 
-set(CMAKE_CXX_STANDARD 14)
-
 set(TEST_SOURCES
 	AampDRMLicPreFetcherTestCases.cpp
 	AampDRMLicPreFetcherTests.cpp

--- a/test/utests/tests/CachedFragmentTests/CMakeLists.txt
+++ b/test/utests/tests/CachedFragmentTests/CMakeLists.txt
@@ -20,8 +20,6 @@ cmake_minimum_required(VERSION 3.10.3)
 # Project name
 project(CachedFragmentTests)
 
-# Set C++ standard
-set(CMAKE_CXX_STANDARD 11)
 
 # Include GoogleTest module
 include(GoogleTest)

--- a/test/utests/tests/tsb/CMakeLists.txt
+++ b/test/utests/tests/tsb/CMakeLists.txt
@@ -15,8 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(TSB_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../tsb)


### PR DESCRIPTION
VPLAY-12490 Use CPP 17 to build AAMP
Reason for Change: globally migrate AAMP code based from C++11 and C++14 to C++17 Test Guidance: general regression
Risk: Low
---------