### PR TITLE
VPLAY-13215: Sometimes buffer underflows doesn't trigger buffering

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -152,7 +152,7 @@
 #define DEFAULT_UNDERFLOW_MEDIUM_BUFFER_POLL_MS 1000	/**< Polling interval when buffer is medium in milliseconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_POLL_MS 2000		/**< Polling interval when buffer is high in milliseconds */
 
-#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.0		/**< Threshold to detect underflow in seconds */
+#define DEFAULT_UNDERFLOW_DETECT_THRESHOLD_SEC 0.2		/**< Threshold to detect underflow in seconds */
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -155,9 +155,11 @@ BufferHealthStatus MediaTrack::GetBufferStatus()
 
 	if ( CachedFragmentsOrChunks <= 0  && (bufferedTime <= thresholdBuffer) && pContext)
 	{
-		AAMPLOG_MIL("[%s] bufferedTime %f totalInjectedDuration %f elapsed time %f",
-					 name, bufferedTime, injectedDuration, pContext->GetElapsedTime());
-		if (bufferedTime <= 0)
+		double underflowDetectThreshold = GETCONFIGVALUE(eAAMPConfig_UnderflowDetectThresholdSec);
+		AAMPLOG_MIL("[%s] bufferedTime %f totalInjectedDuration %f elapsed time %f threshold %f",
+					name, bufferedTime, injectedDuration,
+					pContext->GetElapsedTime(), underflowDetectThreshold);
+		if (bufferedTime <= underflowDetectThreshold)
 		{
 			bStatus = BUFFER_STATUS_RED;
 		}

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -94,7 +94,14 @@ double StreamAbstractionAAMP_MPD::GetStartTimeOfFirstPTS() { return 0; }
 
 MediaTrack* StreamAbstractionAAMP_MPD::GetMediaTrack(TrackType type) { return nullptr; }
 
-double StreamAbstractionAAMP_MPD::GetBufferedDuration (void) { return 0; }
+double StreamAbstractionAAMP_MPD::GetBufferedDuration (void)
+{
+	if (g_mockStreamAbstractionAAMP_MPD)
+	{
+		return g_mockStreamAbstractionAAMP_MPD->GetBufferedDuration();
+	}
+	return 0;
+}
 
 int StreamAbstractionAAMP_MPD::GetBWIndex( BitsPerSecond bandwidth) { return 0; }
 

--- a/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
@@ -41,6 +41,7 @@ public:
 	MOCK_METHOD(Accessibility, getAccessibilityNode, (AampJsonObject &accessNode));
 	MOCK_METHOD(std::vector<AudioTrackInfo>&, GetAvailableAudioTracks, (bool allTrack), (override));
 	MOCK_METHOD(double, GetFirstPTS, (), (override));
+	MOCK_METHOD(double, GetBufferedDuration, (), (override));
 
   };
 

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -34,6 +34,7 @@
 #include "MockIsoBmffBuffer.h"
 #include "MockAampConfig.h"
 #include "MockPrivateInstanceAAMP.h"
+#include "MockStreamAbstractionAAMP_MPD.h"
 
 using namespace testing;
 using ::testing::Values;
@@ -120,6 +121,7 @@ protected:
 		g_mockPrivateInstanceAAMP = new NiceMock<MockPrivateInstanceAAMP>();
 		g_mockIsoBmffHelper = new NiceMock<MockIsoBmffHelper>();
 		g_mockIsoBmffBuffer = new NiceMock<MockIsoBmffBuffer>();
+		g_mockStreamAbstractionAAMP_MPD = new NiceMock<MockStreamAbstractionAAMP_MPD>(mPrivateInstanceAAMP, 0, 0);
 
 		// A fake StreamAbstractionAAMP_MPD that derives from a *real* StreamAbstractionAAMP.
 		// The tests can't use a fake/mock StreamAbstractionAAMP base class because
@@ -130,6 +132,9 @@ protected:
 
 	void TearDown() override
 	{
+		delete g_mockStreamAbstractionAAMP_MPD;
+		g_mockStreamAbstractionAAMP_MPD = nullptr;
+
 		delete mStreamAbstractionAAMP_MPD;
 		mStreamAbstractionAAMP_MPD = nullptr;
 
@@ -1019,4 +1024,55 @@ TEST_F(MediaTrackTests, WaitForManifestUpdateSnapshotRacePreventionTest)
 	EXPECT_EQ(future.wait_for(std::chrono::milliseconds(500)), std::future_status::ready)
 		<< "WaitForManifestUpdate(snapshotCounter) blocked even though the counter was "
 		   "already incremented — lost-wakeup race prevention is broken";
+}
+
+/**
+ * @brief Test that GetBufferStatus() returns BUFFER_STATUS_GREEN when the buffer is sufficient
+ * in low latency mode.
+ */
+TEST_F(MediaTrackTests, GetBufferStatus_ReturnsGreen_WhenBufferIsSufficient)
+{
+	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
+	// Low Latency mode enabled, which doesn't check for cached fragments
+	SetLowLatencyMode(true);
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_UnderflowDetectThresholdSec))
+		.WillRepeatedly(Return(1.0)); // Set underflow threshold to 1 second
+	// Simulate sufficient buffered duration above the green threshold
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, GetBufferedDuration())
+		.WillOnce(Return(AAMP_BUFFER_MONITOR_GREEN_THRESHOLD_LLD + 2.0));
+	EXPECT_EQ(videoTrack.GetBufferStatus(), BUFFER_STATUS_GREEN);
+}
+
+/**
+ * @brief Test that GetBufferStatus() returns BUFFER_STATUS_YELLOW
+ * when the buffer is below threshold and above underflow threshold in low latency mode.
+ */
+TEST_F(MediaTrackTests, GetBufferStatus_ReturnsYellow_WhenBufferIsBelowThreshold)
+{
+	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
+	// Low Latency mode enabled, which doesn't check for cached fragments
+	SetLowLatencyMode(true);
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_UnderflowDetectThresholdSec))
+		.WillRepeatedly(Return(0.5)); // Set underflow threshold to 0.5 second
+	// Simulate buffered duration just below the threshold and above underflow threshold
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, GetBufferedDuration())
+		.WillOnce(Return(AAMP_BUFFER_MONITOR_GREEN_THRESHOLD_LLD - 0.1));
+	EXPECT_EQ(videoTrack.GetBufferStatus(), BUFFER_STATUS_YELLOW);
+}
+
+/**
+ * @brief Test that GetBufferStatus() returns BUFFER_STATUS_RED
+ * when the buffer is below underflow threshold in low latency mode.
+ */
+TEST_F(MediaTrackTests, GetBufferStatus_ReturnsRed_WhenBufferIsBelowUnderflowThreshold)
+{
+	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
+	// Low Latency mode enabled, which doesn't check for cached fragments
+	SetLowLatencyMode(true);
+	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_UnderflowDetectThresholdSec))
+		.WillRepeatedly(Return(0.5)); // Set underflow threshold to 0.5 second
+	// Simulate buffered duration just below the underflow threshold
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, GetBufferedDuration())
+		.WillOnce(Return(0.1));
+	EXPECT_EQ(videoTrack.GetBufferStatus(), BUFFER_STATUS_RED);
 }


### PR DESCRIPTION
Reason for change: Use init config underflowDetectThresholdSec to determine if its a true buffer underflow or false alarm when an underflow signal is received from sink
Test Procedure: Delay manifest download to cause a buffer underflow and ensure buffering is started
Risks: Low