### PR TITLE
VPLAY-12919 [VIPA] Black screen after rewinding VOD asset through ads…

### DIFF
--- a/AampStreamSinkInactive.h
+++ b/AampStreamSinkInactive.h
@@ -30,7 +30,7 @@ class AampStreamSinkInactive : public StreamSink
 {
 
 public:
-	AampStreamSinkInactive(id3_callback_t id3HandlerCallback) : mId3HandlerCallback(std::move(id3HandlerCallback))
+	AampStreamSinkInactive(id3_callback_t id3HandlerCallback) : mId3HandlerCallback(std::move(id3HandlerCallback)), mTuned(false)
 	{
 	}
 
@@ -346,8 +346,25 @@ public:
 	{
 		return mId3HandlerCallback;
 	}
+	/**
+	 *   @fn SetTuned
+	 *   @brief Sets the tuned flag indicating this instance has been tuned
+	 */
+	void SetTuned(bool tuned)
+	{
+		mTuned = tuned;
+	}
+	/**
+	 *   @fn IsTuned
+	 *   @brief Returns the tuned status of this instance
+	 */
+	bool IsTuned() const
+	{
+		return mTuned;
+	}
 
 private:
 	id3_callback_t mId3HandlerCallback;		/**< Returns the id3 callback handle associated with this instance */
+	bool mTuned;							/**< Indicates if this instance has been tuned */
 };
 #endif /* AAMPSTREAMSINKINACTIVE_H */

--- a/AampStreamSinkManager.cpp
+++ b/AampStreamSinkManager.cpp
@@ -592,8 +592,34 @@ StreamSink *AampStreamSinkManager::GetStoppingStreamSink(PrivateInstanceAAMP *aa
 
 	if ((mPipelineMode == ePIPELINEMODE_SINGLE) && mActiveGstPlayersMap.empty())
 	{
-		AAMPLOG_WARN("AampStreamSinkManager(%p) No active player, returning single-pipeline sink for PLAYER[%d]", this, aamp->mPlayerId);
-		sink_ptr = mGstPlayer;
+		// Check if there is any inactive player that has been tuned (excluding the calling aamp)
+		bool hasTunedInactivePlayer = false;
+		for (const auto& inactivePlayer : mInactiveGstPlayersMap)
+		{
+			if (inactivePlayer.first != aamp)
+			{
+				AAMPLOG_INFO("AampStreamSinkManager(%p) Inactive PLAYER[%d], tuned=%s",
+						this, inactivePlayer.first->mPlayerId, inactivePlayer.second->IsTuned() ? "true" : "false");
+				if (inactivePlayer.second->IsTuned())
+				{
+					hasTunedInactivePlayer = true;
+					break;
+				}
+			}
+		}
+
+		if (!hasTunedInactivePlayer)
+		{
+			AAMPLOG_INFO("AampStreamSinkManager(%p) No active player and no tuned inactive players, returning single-pipeline sink for PLAYER[%d]",
+					this, aamp->mPlayerId);
+			sink_ptr = mGstPlayer;
+		}
+		else
+		{
+			AAMPLOG_INFO("AampStreamSinkManager(%p) Has tuned inactive players, getting stream sink for PLAYER[%d]",
+					this, aamp->mPlayerId);
+			sink_ptr = GetStreamSinkNoLock(aamp);
+		}
 	}
 	else
 	{
@@ -602,6 +628,22 @@ StreamSink *AampStreamSinkManager::GetStoppingStreamSink(PrivateInstanceAAMP *aa
 	}
 
 	return sink_ptr;
+}
+
+void AampStreamSinkManager::SetTuned(PrivateInstanceAAMP *aamp)
+{
+	std::lock_guard<std::mutex> lock(mStreamSinkMutex);
+
+	auto it = mInactiveGstPlayersMap.find(aamp);
+	if (it != mInactiveGstPlayersMap.end())
+	{
+		it->second->SetTuned(true);
+		AAMPLOG_INFO("AampStreamSinkManager(%p) Set tuned flag for PLAYER[%d]", this, aamp->mPlayerId);
+	}
+	else
+	{
+		AAMPLOG_WARN("AampStreamSinkManager(%p) Could not find inactive stream sink for PLAYER[%d]", this, aamp->mPlayerId);
+	}
 }
 
 void AampStreamSinkManager::UpdateTuningPlayer(PrivateInstanceAAMP *aamp)

--- a/AampStreamSinkManager.h
+++ b/AampStreamSinkManager.h
@@ -142,13 +142,25 @@ public:
 	virtual StreamSink* GetStreamSink(PrivateInstanceAAMP *aamp);
 	/**
 	 *  @fn GetStoppingStreamSink
-	 *  @brief Gets the stream sink to stop for the given PrivateInstanceAAMP. In single-pipeline mode,
-	 * 		   if there are no active stream sinks, then the single pipeline stream sink will be returned.
-	 *  @param[in] aamp - the PrivateInstanceAAMP that represents the player being stopped
-	 *  @param[out] - return the stream sink to stop - either the single pipeline stream sink,
-	 * 				  or the stream sink associated with the given player (may be nullptr if couldn't be found)
+ 	 *  @brief Gets the stream sink to stop for the given PrivateInstanceAAMP.
+ 	 *         In single-pipeline mode, if there are no active stream sinks, the
+ 	 *         stream sink to stop is selected conditionally: when another tuned
+ 	 *         inactive player exists the stream sink associated with the calling
+ 	 *         player is returned, otherwise the single pipeline stream sink is
+ 	 *         returned.
+ 	 *  @param[in] aamp - the PrivateInstanceAAMP that represents the player
+ 	 *                    being stopped
+ 	 *  @param[out] - return the stream sink to stop - either the single
+ 	 *                pipeline stream sink or the stream sink associated with
+ 	 *                the given player (may be nullptr if it could not be found)
 	 */
 	virtual StreamSink* GetStoppingStreamSink(PrivateInstanceAAMP *aamp);
+	/**
+	 *  @fn SetTuned
+	 *  @brief Sets a flag indicating that there has been a tune on the PrivateInstanceAAMP passed
+	 *  @param[in] aamp - the PrivateInstanceAAMP that has been tuned
+	 */
+	virtual void SetTuned(PrivateInstanceAAMP *aamp);
 	/**
 	 *  @fn UpdateTuningPlayer
 	 *  @brief Updates the player associated with the single pipeline stream sink, if there are

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -310,7 +310,12 @@ void PlayerInstanceAAMP::Tune(const char *mainManifestUrl,
 								const char *manifestData
 								)
 {
+	UsingPlayerId(aamp->mPlayerId);
 	ManageAsyncTuneConfig(mainManifestUrl);
+	
+	// Set tuned flag before scheduling the tune task
+	AampStreamSinkManager::GetInstance().SetTuned(aamp);
+
 	if(mAsyncTuneEnabled)
 	{
 		const std::string manifest {mainManifestUrl};

--- a/test/utests/drm/mocks/FakeAampStreamSinkManager.cpp
+++ b/test/utests/drm/mocks/FakeAampStreamSinkManager.cpp
@@ -110,4 +110,7 @@ std::shared_ptr<AampStreamSinkManager::MediaHeader> AampStreamSinkManager::GetMe
 	return {};
 }
 
+void AampStreamSinkManager::SetTuned(PrivateInstanceAAMP *aamp)
+{
+}
 

--- a/test/utests/fakes/FakeAampStreamSinkManager.cpp
+++ b/test/utests/fakes/FakeAampStreamSinkManager.cpp
@@ -128,3 +128,7 @@ std::shared_ptr<AampStreamSinkManager::MediaHeader> AampStreamSinkManager::GetMe
 	return {};
 }
 
+void AampStreamSinkManager::SetTuned(PrivateInstanceAAMP *aamp)
+{
+}
+

--- a/test/utests/mocks/MockAampStreamSinkManager.h
+++ b/test/utests/mocks/MockAampStreamSinkManager.h
@@ -41,6 +41,7 @@ public:
 	MOCK_METHOD(void, GetEncryptedHeaders, ((std::map<int, std::string>)&));
 	MOCK_METHOD(void, SetActive, (PrivateInstanceAAMP *));
 	MOCK_METHOD(void, UpdateTuningPlayer, (PrivateInstanceAAMP *));
+	MOCK_METHOD(void, SetTuned, (PrivateInstanceAAMP *));
 	MOCK_METHOD(void, AddMediaHeader, (int , std::shared_ptr<AampStreamSinkManager::MediaHeader> ));
 	MOCK_METHOD(void, RemoveMediaHeader, (int));
 	MOCK_METHOD(std::shared_ptr<AampStreamSinkManager::AampStreamSinkManager::MediaHeader>, GetMediaHeader, (int));

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -94,6 +94,7 @@ public:
 	MOCK_METHOD(bool, IsAtLivePoint, ());
 	MOCK_METHOD(bool, IsLiveStream, ());
 	MOCK_METHOD(void, Individualization, (const std::string &payload));
+	MOCK_METHOD(void, UpdateUseSinglePipeline, ());
 };
 
 extern MockPrivateInstanceAAMP *g_mockPrivateInstanceAAMP;

--- a/test/utests/tests/AampStreamSinkManagerTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampStreamSinkManagerTests/FunctionalTests.cpp
@@ -349,6 +349,125 @@ TEST_F(AampStreamSinkManagerTests, ChangeAampTests)
 }
 
 /*
+    @brief: - Tests SetTuned sets the tuned flag for an inactive player
+    Test Procedure: -
+    Create a stream sink and deactivate it (making it inactive).
+    Call SetTuned to mark it as tuned.
+    Verify the tuned flag can be read back via GetStreamSink and checking IsTuned.
+*/
+TEST_F(AampStreamSinkManagerTests, SetTuned_MarksInactivePlayerAsTuned)
+{
+    AampStreamSinkManager::GetInstance().CreateStreamSink(mPrivateInstanceAAMP1, mId3HandlerCallback1);
+    AampStreamSinkManager::GetInstance().SetSinglePipelineMode(mPrivateInstanceAAMP1);
+    AampStreamSinkManager::GetInstance().DeactivatePlayer(mPrivateInstanceAAMP1, false);
+
+    // Set the tuned flag
+    AampStreamSinkManager::GetInstance().SetTuned(mPrivateInstanceAAMP1);
+
+    // Get the inactive sink and verify it's tuned
+    StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(mPrivateInstanceAAMP1);
+    ASSERT_NE(sink, nullptr);
+
+    AampStreamSinkInactive *inactiveSink = dynamic_cast<AampStreamSinkInactive*>(sink);
+    ASSERT_NE(inactiveSink, nullptr);
+    EXPECT_TRUE(inactiveSink->IsTuned());
+}
+
+/*
+    @brief: - Tests that IsTuned returns false by default for a newly created inactive sink
+    Test Procedure: -
+    Create a stream sink and deactivate it.
+    Without calling SetTuned, verify IsTuned returns false.
+*/
+TEST_F(AampStreamSinkManagerTests, IsTuned_DefaultsToFalse)
+{
+    AampStreamSinkManager::GetInstance().CreateStreamSink(mPrivateInstanceAAMP1, mId3HandlerCallback1);
+    AampStreamSinkManager::GetInstance().SetSinglePipelineMode(mPrivateInstanceAAMP1);
+    AampStreamSinkManager::GetInstance().DeactivatePlayer(mPrivateInstanceAAMP1, false);
+
+    // Get the inactive sink and verify it's not tuned by default
+    StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(mPrivateInstanceAAMP1);
+    ASSERT_NE(sink, nullptr);
+
+    AampStreamSinkInactive *inactiveSink = dynamic_cast<AampStreamSinkInactive*>(sink);
+    ASSERT_NE(inactiveSink, nullptr);
+    EXPECT_FALSE(inactiveSink->IsTuned());
+}
+
+/*
+    @brief: - Tests GetStoppingStreamSink returns single pipeline sink when no tuned inactive players exist
+    Test Procedure: -
+    In single pipeline mode with no active players and no tuned inactive players,
+    GetStoppingStreamSink should return the single pipeline sink (mGstPlayer).
+*/
+TEST_F(AampStreamSinkManagerTests, GetStoppingStreamSink_NoTunedInactivePlayers_ReturnsSinglePipeline)
+{
+    AampStreamSinkManager::GetInstance().CreateStreamSink(mPrivateInstanceAAMP1, mId3HandlerCallback1);
+    AampStreamSinkManager::GetInstance().SetSinglePipelineMode(mPrivateInstanceAAMP1);
+    StreamSink *singlePipelineSink = AampStreamSinkManager::GetInstance().GetStreamSink(mPrivateInstanceAAMP1);
+
+    // Deactivate player but don't tune it
+    AampStreamSinkManager::GetInstance().DeactivatePlayer(mPrivateInstanceAAMP1, false);
+
+    // GetStoppingStreamSink should return the single pipeline sink
+    StreamSink *stoppingSink = AampStreamSinkManager::GetInstance().GetStoppingStreamSink(mPrivateInstanceAAMP1);
+    EXPECT_EQ(singlePipelineSink, stoppingSink);
+}
+
+/*
+    @brief: - Tests GetStoppingStreamSink returns inactive sink when tuned inactive players exist
+    Test Procedure: -
+    In single pipeline mode with no active players but a tuned inactive player exists,
+    GetStoppingStreamSink should NOT return the single pipeline sink but the specific player's sink.
+*/
+TEST_F(AampStreamSinkManagerTests, GetStoppingStreamSink_WithTunedInactivePlayers_ReturnsSpecificSink)
+{
+    // Create two players
+    AampStreamSinkManager::GetInstance().CreateStreamSink(mPrivateInstanceAAMP1, mId3HandlerCallback1);
+    AampStreamSinkManager::GetInstance().SetSinglePipelineMode(mPrivateInstanceAAMP1);
+    AampStreamSinkManager::GetInstance().CreateStreamSink(mPrivateInstanceAAMP2, mId3HandlerCallback2);
+
+    StreamSink *singlePipelineSink = AampStreamSinkManager::GetInstance().GetStreamSink(mPrivateInstanceAAMP1);
+
+    // Deactivate both players
+    AampStreamSinkManager::GetInstance().DeactivatePlayer(mPrivateInstanceAAMP1, false);
+    AampStreamSinkManager::GetInstance().DeactivatePlayer(mPrivateInstanceAAMP2, false);
+
+    // Mark player2 as tuned
+    AampStreamSinkManager::GetInstance().SetTuned(mPrivateInstanceAAMP2);
+
+    // GetStoppingStreamSink for player1 should NOT return the single pipeline sink
+    // because player2 is tuned
+    StreamSink *stoppingSink = AampStreamSinkManager::GetInstance().GetStoppingStreamSink(mPrivateInstanceAAMP1);
+    StreamSink *player1Sink = AampStreamSinkManager::GetInstance().GetStreamSink(mPrivateInstanceAAMP1);
+
+    EXPECT_EQ(player1Sink, stoppingSink);
+    EXPECT_NE(singlePipelineSink, stoppingSink);
+}
+
+/*
+    @brief: - Tests GetStoppingStreamSink ignores the calling aamp when checking for tuned players
+    Test Procedure: -
+    In single pipeline mode with no active players, if only the calling player is tuned,
+    GetStoppingStreamSink should still return the single pipeline sink.
+*/
+TEST_F(AampStreamSinkManagerTests, GetStoppingStreamSink_IgnoresCallingPlayerTunedStatus)
+{
+    AampStreamSinkManager::GetInstance().CreateStreamSink(mPrivateInstanceAAMP1, mId3HandlerCallback1);
+    AampStreamSinkManager::GetInstance().SetSinglePipelineMode(mPrivateInstanceAAMP1);
+    StreamSink *singlePipelineSink = AampStreamSinkManager::GetInstance().GetStreamSink(mPrivateInstanceAAMP1);
+
+    // Deactivate and tune player1
+    AampStreamSinkManager::GetInstance().DeactivatePlayer(mPrivateInstanceAAMP1, false);
+    AampStreamSinkManager::GetInstance().SetTuned(mPrivateInstanceAAMP1);
+
+    // GetStoppingStreamSink for player1 should return the single pipeline sink
+    // because the calling player (player1) itself should be ignored
+    StreamSink *stoppingSink = AampStreamSinkManager::GetInstance().GetStoppingStreamSink(mPrivateInstanceAAMP1);
+    EXPECT_EQ(singlePipelineSink, stoppingSink);
+}
+
+/*
     @brief: - verifies that progressive ActivatePlayer() uses stream position
     Test Procedure
     Initialize AampStreamSinkManager into single pipeline mode.

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2800,3 +2800,27 @@ TEST_F(PlayerInstanceAAMPTests, SetRateTest_LocalTSB_TrickPlayWhenPausedFromTSB)
 	EXPECT_EQ(mPrivateInstanceAAMP->rate, 2.0);
 
 }
+
+/*
+    @brief: - Tests that PlayerInstanceAAMP::Tune calls AampStreamSinkManager::SetTuned
+    Test Procedure: -
+    Call Tune on PlayerInstanceAAMP and verify SetTuned is called on the stream sink manager.
+*/
+TEST_F(PlayerInstanceAAMPTests, Tune_CallsSetTuned)
+{
+	const char *testUrl = "http://example.com/test.mpd";
+	const char *contentType = "video/mpd";
+
+	mPlayerInstance->aamp = mPrivateInstanceAAMP;
+
+	// Mock the necessary calls for Tune
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState()).WillRepeatedly(Return(eSTATE_IDLE));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, StopPausePositionMonitoring(_)).Times(1);
+
+	// Expect SetTuned to be called with the PrivateInstanceAAMP
+	EXPECT_CALL(*g_mockAampStreamSinkManager, SetTuned(mPrivateInstanceAAMP)).Times(1);
+
+	// Call Tune - this should trigger SetTuned
+	mPlayerInstance->Tune(testUrl, contentType, true, false, nullptr, true);
+}
+


### PR DESCRIPTION
… (#1169)

* VPLAY-12919 [VIPA] Black screen after rewinding VOD asset through ads

Reason for change: Rewinding from main content to ad and in the middle of
 rewinding in ad, got a black screen.
 The issue of the black screen appears to be because the calls to
 StopInternal and SetRateInternal get swapped in order,
 due to SetRateInternal being put on the scheduler whereas Stop doesn't.

Changes:
* Add an additional check to only allow the StreamSink to be stopped if there are no inactive aamp players that have a tune performed on them.

Test Procedure: Refer JIRA ticket

Risks: low

---------