### PR TITLE
VPLAY-11838 Linear- Progress Bar Point jumping to the End/beginning While performing Trick Play/Seek (#1265) (#1271)

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -2441,7 +2441,7 @@ void InterfacePlayerPriv::SendGstEvents(int mediaType, GstClockTime pts, int ena
 
 	if(stream->pendingSeek)
 	{
-		if(gstPrivateContext->seekPosition > 0)
+		if(gstPrivateContext->seekPosition >= 0)
 		{
 			MW_LOG_MIL("gst_element_seek_simple! mediaType:%d pts:%" GST_TIME_FORMAT " seekPosition:%" GST_TIME_FORMAT,
 				mediaType, GST_TIME_ARGS(pts), GST_TIME_ARGS(gstPrivateContext->seekPosition * GST_SECOND));


### PR DESCRIPTION


Reason for change: Progress Bar Point jumping to the End/beginning
 While performing Trick Play/Seek in Linear channels.
 In the problematic scenario, aamp is getting a wrong position from rialto.
 So modifying aamp to perform seek even when the seek position is 0.

Test Procedure: Refer JIRA ticket

Risks: low
(cherry picked from commit 2624fb306d26c062758dcaace039509db1e54747)