### PR TITLE
Add measurement of prompt quality to instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,26 @@ They apply to all code suggestions, documentation, tests, diagrams, and refactor
 ---
 
 # ==============================
+#  PROMPT FEEDBACK GUIDELINES
+# ==============================
+
+## Prompt Feedback (Compact)
+- Provide prompt-quality feedback for every prompt using the following format:
+- Format: `Scores: Completeness X/10, Assumptions X/10, Clarity X/10 | Critique: <brief> | Improve: <specific edit>`.
+- Scoring: Completeness and Clarity are higher-is-better; Assumptions is lower-is-better.
+- Strict rubric for underspecified prompts:
+  - If the prompt is extremely vague (for example: "build something"), score it harshly.
+  - For these prompts, use: Completeness 0-3/10, Clarity 0-3/10, Assumptions 7-10/10.
+  - Never assign high scores to prompts that omit target, scope, constraints, or success criteria.
+- Keep it short and specific; avoid generic advice.
+- Suppress feedback when Completeness >= 8, Assumptions <= 2, and Clarity >= 8,
+  unless the user explicitly asks to apply feedback to the current prompt.
+- Prefer high-compliance guidance: suggest exact wording that reduces
+  ambiguity and improves instruction precision.
+
+---
+
+# ==============================
 #  COPILOT MASTER INSTRUCTIONS
 # ==============================
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,15 +39,18 @@ They apply to all code suggestions, documentation, tests, diagrams, and refactor
 # ==============================
 
 ## Prompt Feedback (Compact)
-- Provide prompt-quality feedback for every prompt using the following format:
+- Assess prompt quality for every prompt.
+- When feedback is not suppressed, use the following format:
 - Format: `Scores: Completeness X/10, Assumptions X/10, Clarity X/10 | Critique: <brief> | Improve: <specific edit>`.
 - Scoring: Completeness and Clarity are higher-is-better; Assumptions is lower-is-better.
 - Strict rubric for underspecified prompts:
   - If the prompt is extremely vague (for example: "build something"), score it harshly.
   - For these prompts, use: Completeness 0-3/10, Clarity 0-3/10, Assumptions 7-10/10.
-  - Never assign high scores to prompts that omit target, scope, constraints, or success criteria.
+  - If target, scope, constraints, or success criteria are omitted,
+    cap Completeness and Clarity at 7/10 and set Assumptions to at least 3/10.
 - Keep it short and specific; avoid generic advice.
-- Suppress feedback when Completeness >= 8, Assumptions <= 2, and Clarity >= 8,
+- Suppress displayed feedback when Completeness >= 8, Assumptions <= 2,
+  and Clarity >= 8,
   unless the user explicitly asks to apply feedback to the current prompt.
 - Prefer high-compliance guidance: suggest exact wording that reduces
   ambiguity and improves instruction precision.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,6 +52,7 @@ They apply to all code suggestions, documentation, tests, diagrams, and refactor
 - Suppress displayed feedback when Completeness >= 8, Assumptions <= 2,
   and Clarity >= 8,
   unless the user explicitly asks to apply feedback to the current prompt.
+- Determine suppression from the current user prompt only; retrospective analysis of earlier prompts should be provided only when explicitly requested.
 - Prefer high-compliance guidance: suggest exact wording that reduces
   ambiguity and improves instruction precision.
 


### PR DESCRIPTION
Prompt is checked by Copilot for completeness, assumptions and clarity.  
If the prompt metrics are below threshold, display the score and suggest improvements at the end of the prompt.
If the prompt metrics are at or above threshold, do not display anything additional.

This is to assist engineers in writing more effective prompts if they are not already doing so - nudge conditioning.
If the prompts are already effective, there's no nudge needed.