### PR TITLE
VPAAMP-48 EWMA algorithm (new default) over RMO

### DIFF
--- a/AampConfig.h
+++ b/AampConfig.h
@@ -324,10 +324,7 @@ typedef enum
 	eAAMPConfig_ProgressLoggingDivisor,				/**<  Divisor to avoid printing the progress report too frequently in the log */
 	eAAMPConfig_MonitorAVReportingInterval,			/**< Timeout in milliseconds for reporting MonitorAV events */
 	eAAMPConfig_UTCSyncMinIntervalSec,				/**< Minimum interval between sync attempts */
-	eAAMPConfig_ABRBandwidthEstimator,				/**< Select ABR bandwidth estimator:
-													 ROLLING_MEDIAN_OUTLIER = 0
-													 HARMONIC_EWMA = 1
-													 */
+	eAAMPConfig_ABRBandwidthEstimator,				/**< Select ABR bandwidth estimator: 0=ROLLING_MEDIAN_OUTLIER, 1=HARMONIC_EWMA */
 	eAAMPConfig_EarlyAbortProfileBandwidthPercent,	/**< Early abort threshold as percentage of profile bandwidth */
 	eAAMPConfig_UnderflowLowBufferPollMs,			/**< Underflow monitor polling interval for low buffer condition in milliseconds */
 	eAAMPConfig_UnderflowMediumBufferPollMs,		/**< Underflow monitor polling interval for medium buffer condition in milliseconds */

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -324,7 +324,10 @@ typedef enum
 	eAAMPConfig_ProgressLoggingDivisor,				/**<  Divisor to avoid printing the progress report too frequently in the log */
 	eAAMPConfig_MonitorAVReportingInterval,			/**< Timeout in milliseconds for reporting MonitorAV events */
 	eAAMPConfig_UTCSyncMinIntervalSec,				/**< Minimum interval between sync attempts */
-	eAAMPConfig_ABRBandwidthEstimator,				/**< Select ABR bandwidth estimator */
+	eAAMPConfig_ABRBandwidthEstimator,				/**< Select ABR bandwidth estimator:
+													 ROLLING_MEDIAN_OUTLIER = 0
+													 HARMONIC_EWMA = 1
+													 */
 	eAAMPConfig_EarlyAbortProfileBandwidthPercent,	/**< Early abort threshold as percentage of profile bandwidth */
 	eAAMPConfig_UnderflowLowBufferPollMs,			/**< Underflow monitor polling interval for low buffer condition in milliseconds */
 	eAAMPConfig_UnderflowMediumBufferPollMs,		/**< Underflow monitor polling interval for medium buffer condition in milliseconds */

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -60,7 +60,7 @@
 #define DEFAULT_BUFFER_HEALTH_MONITOR_INTERVAL 5
 #define DEFAULT_ABR_CACHE_LENGTH 3                  		/**< Default ABR cache length */
 #define DEFAULT_ABR_BUFFER_COUNTER 4				/**< Default ABR Buffer Counter */
-#define DEFAULT_ABR_BANDWIDTH_ESTIMATION_ALGORITHM 0			/**< Default ABR Bandwidth Estimation Algorithm */
+#define DEFAULT_ABR_BANDWIDTH_ESTIMATION_ALGORITHM 1			/**< Default ABR Bandwidth Estimation Algorithm */
 #define DEFAULT_REPORT_PROGRESS_INTERVAL 1     			/**< Progress event reporting interval: 1sec */
 #define DEFAULT_PROGRESS_LOGGING_DIVISOR 4			/**< Divisor of progress logging frequency to print logging */
 #define DEFAULT_LICENSE_REQ_RETRY_WAIT_TIME 500			/**< Wait time in milliseconds before retrying for DRM license */

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -60,7 +60,7 @@
 #define DEFAULT_BUFFER_HEALTH_MONITOR_INTERVAL 5
 #define DEFAULT_ABR_CACHE_LENGTH 3                  		/**< Default ABR cache length */
 #define DEFAULT_ABR_BUFFER_COUNTER 4				/**< Default ABR Buffer Counter */
-#define DEFAULT_ABR_BANDWIDTH_ESTIMATION_ALGORITHM 1			/**< Default ABR Bandwidth Estimation Algorithm */
+#define DEFAULT_ABR_BANDWIDTH_ESTIMATION_ALGORITHM 1			/**< Default ABR bandwidth estimation algorithm; value must stay in sync with BandwidthEstimationAlgorithm ordinal 1 in abr/abr.h */
 #define DEFAULT_REPORT_PROGRESS_INTERVAL 1     			/**< Progress event reporting interval: 1sec */
 #define DEFAULT_PROGRESS_LOGGING_DIVISOR 4			/**< Divisor of progress logging frequency to print logging */
 #define DEFAULT_LICENSE_REQ_RETRY_WAIT_TIME 500			/**< Wait time in milliseconds before retrying for DRM license */


### PR DESCRIPTION
Reason for Change: flip network bandwith estimation algorithm to modern EWMA for testing in sprint

Test Guidance: monitor for any improvement or regression with ABR behavior

Risk: Medium - this has been dev tested, and believed to give better results