### PR TITLE
VPAAMP-47 Add AAMP config to include the filename in log lines

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -374,6 +374,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{true, "utcSyncOnStartup", eAAMPConfig_UTCSyncOnStartup, true},
 	{false, "disableWebVTT", eAAMPConfig_DisableWebVTT, false},
 	{false, "enablePTSReStampLogging", eAAMPConfig_EnablePTSReStampLogging, false},
+	{false, "logFilename", eAAMPConfig_LogFilename, false},
 
 };
 
@@ -1834,6 +1835,8 @@ void AampConfig::ConfigureLogSettings()
 		AampLogManager::setLogLevel(eLOGLEVEL_INFO);
 		AampLogManager::lockLogLevel(true);
 	}
+
+	AampLogManager::logFilename = configValueBool[eAAMPConfig_LogFilename].value;
 }
 
 /**

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -229,6 +229,7 @@ typedef enum
 	eAAMPConfig_UTCSyncOnStartup,					/**< Perform sync at startup */
 	eAAMPConfig_DisableWebVTT,					/**< Config to disable/exclude WebVTT tracks (default: WebVTT enabled) */
 	eAAMPConfig_EnablePTSReStampLogging,		/**< Config to enable logging for PTS restamping in Mp4Demuxer */
+	eAAMPConfig_LogFilename,				/**< Config to include source filename in log output */
 	eAAMPConfig_BoolMaxValue				/**< Max value of bool config always last element */	
 
 } AAMPConfigSettingBool;

--- a/AampLogManager.h
+++ b/AampLogManager.h
@@ -51,7 +51,7 @@ extern const char* GetMediaTypeName( AampMediaType mediaType ); // from AampUtil
 do { \
 if( (LEVEL) >= AampLogManager::aampLoglevel ) \
 { \
-logprintf( LEVEL, __FUNCTION__, __LINE__, FORMAT, ##__VA_ARGS__); \
+logprintf( LEVEL, __FILE__, __FUNCTION__, __LINE__, FORMAT, ##__VA_ARGS__); \
 } \
 } while(0)
 
@@ -126,7 +126,7 @@ struct AAMPAbrInfo
  * @param[in] format - printf style string
  * @return void
  */
-extern void logprintf(AAMP_LogLevel level, const char* func, int line,const char *format, ...)  __attribute__ ((format (printf, 4, 5)));
+extern void logprintf(AAMP_LogLevel level, const char* file, const char* func, int line, const char *format, ...)  __attribute__ ((format (printf, 5, 6)));
 
 extern thread_local int gPlayerId;
 
@@ -156,6 +156,7 @@ public:
 	static AAMP_LogLevel aampLoglevel;
 	static bool locked;
 	static bool enableEthanLogRedirection;  /**<  Enables Ethan log redirection which uses Ethan lib for logging */
+	static bool logFilename;				/**<  Include source filename in log output */
 	
 	/**
 	 * @fn aampLogger
@@ -169,7 +170,7 @@ public:
 		/* loggerData is the playerId ... set it in case we are in a helper thread that the
 		** caller has spawned. */
 		UsingPlayerId playerId(loggerData);
-		logprintf(eLOGLEVEL_MIL, __FUNCTION__, __LINE__, "%s", tsbMessage.c_str());
+		logprintf(eLOGLEVEL_MIL, __FILE__, __FUNCTION__, __LINE__, "%s", tsbMessage.c_str());
 	}
 	
 	/**
@@ -186,7 +187,7 @@ public:
 		std::string location;
 		std::string symptom;
 		ParseContentUrl(url, location, symptom, type);
-		logprintf( eLOGLEVEL_WARN, __FUNCTION__, __LINE__, "AAMPLogNetworkLatency downloadTime=%d downloadThreshold=%d type='%s' location='%s' symptom='%s' url='%s'",
+		logprintf( eLOGLEVEL_WARN, __FILE__, __FUNCTION__, __LINE__, "AAMPLogNetworkLatency downloadTime=%d downloadThreshold=%d type='%s' location='%s' symptom='%s' url='%s'",
 				  downloadTime, downloadThresholdTimeoutMs, GetMediaTypeName(type), location.c_str(), symptom.c_str(), url);
 	}
 	
@@ -211,14 +212,14 @@ public:
 			{
 				if(errorCode >= 400)
 				{
-					logprintf( eLOGLEVEL_ERROR, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='http error %d' type='%s' location='%s' symptom='%s' url='%s'",
+					logprintf( eLOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='http error %d' type='%s' location='%s' symptom='%s' url='%s'",
 							  errorCode, GetMediaTypeName(type), location.c_str(), symptom.c_str(), url );
 				}
 			}
 				break; /*AAMPNetworkErrorHttp*/
 				
 			case AAMPNetworkErrorTimeout:
-				logprintf( eLOGLEVEL_ERROR, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='timeout %d' type='%s' location='%s' symptom='%s' url='%s'",
+				logprintf( eLOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='timeout %d' type='%s' location='%s' symptom='%s' url='%s'",
 							  errorCode, GetMediaTypeName(type), location.c_str(), symptom.c_str(), url );
 				break; /*AAMPNetworkErrorTimeout*/
 				
@@ -226,7 +227,7 @@ public:
 			{
 				if(errorCode > 0)
 				{
-					logprintf( eLOGLEVEL_ERROR, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='curl error %d' type='%s' location='%s' symptom='%s' url='%s'",
+					logprintf( eLOGLEVEL_ERROR, __FILE__, __FUNCTION__, __LINE__, "AAMPLogNetworkError error='curl error %d' type='%s' location='%s' symptom='%s' url='%s'",
 							  errorCode, GetMediaTypeName(type), location.c_str(), symptom.c_str(), url );
 				}
 			}
@@ -353,7 +354,7 @@ public:
 				symptom += " (or) freeze/buffering";
 			}
 			
-			logprintf( eLOGLEVEL_WARN, __FUNCTION__, __LINE__,
+			logprintf( eLOGLEVEL_WARN, __FILE__, __FUNCTION__, __LINE__,
 					  "AAMPLogABRInfo : switching to '%s' profile '%d -> %d' currentBandwidth[%" BITSPERSECOND_FORMAT "]->desiredBandwidth[%" BITSPERSECOND_FORMAT "] nwBandwidth[%" BITSPERSECOND_FORMAT "] reason='%s' symptom='%s'",
 					  profile.c_str(),
 					  pstAbrInfo->currentProfileIndex,

--- a/aamplogging.cpp
+++ b/aamplogging.cpp
@@ -78,6 +78,7 @@ bool AampLogManager::disableLogRedirection = false;
 bool AampLogManager::enableEthanLogRedirection = false;
 AAMP_LogLevel AampLogManager::aampLoglevel = eLOGLEVEL_WARN;
 bool AampLogManager::locked = false;
+bool AampLogManager::logFilename = false;
 
 thread_local int gPlayerId = -1;
 
@@ -87,11 +88,19 @@ static std::atomic<uint32_t> gLogCounter(0);
 /**
  * @brief Print logs to console / log file
  */
-void logprintf(AAMP_LogLevel logLevelIndex, const char* func, int line, const char *format, ...)
+void logprintf(AAMP_LogLevel logLevelIndex, const char* file, const char* func, int line, const char *format, ...)
 {
 	// Increment log counter for each log line
 	uint32_t logSeqNum = gLogCounter.fetch_add(1, std::memory_order_relaxed) % 1000;
-	
+
+	// Extract base filename if logging filename is enabled
+	const char *basename = "";
+	if( AampLogManager::logFilename && file )
+	{
+		basename = strrchr(file, '/');
+		basename = basename ? basename + 1 : file;
+	}
+
 	char timestamp[AAMPCLI_TIMESTAMP_PREFIX_MAX_CHARS];
 	timestamp[0] = 0x00;
 	if( AampLogManager::disableLogRedirection )
@@ -105,15 +114,31 @@ void logprintf(AAMP_LogLevel logLevelIndex, const char* func, int line, const ch
 	int format_bytes = 0;
 	for( int pass=0; pass<2; pass++ )
 	{ // two pass: measure required bytes then populate format string
-		format_bytes = snprintf(format_ptr, format_bytes,
-							   "%s[AAMP-PLAYER][%03u][%d][%s][%zx][%s][%d]%s\n",
-							   timestamp,
-							   logSeqNum,
-							   gPlayerId,
-							   mLogLevelStr[logLevelIndex],
-							   GetPrintableThreadID(),
-							   func, line,
-							   format );
+		if( AampLogManager::logFilename )
+		{
+			format_bytes = snprintf(format_ptr, format_bytes,
+								   "%s[AAMP-PLAYER][%03u][%d][%s][%zx][%s][%s][%d]%s\n",
+								   timestamp,
+								   logSeqNum,
+								   gPlayerId,
+								   mLogLevelStr[logLevelIndex],
+								   GetPrintableThreadID(),
+								   basename,
+								   func, line,
+								   format );
+		}
+		else
+		{
+			format_bytes = snprintf(format_ptr, format_bytes,
+								   "%s[AAMP-PLAYER][%03u][%d][%s][%zx][%s][%d]%s\n",
+								   timestamp,
+								   logSeqNum,
+								   gPlayerId,
+								   mLogLevelStr[logLevelIndex],
+								   GetPrintableThreadID(),
+								   func, line,
+								   format );
+		}
 		if( format_bytes<=0 )
 		{ // should never happen!
 			break;

--- a/abrsim/aamp_stubs.cpp
+++ b/abrsim/aamp_stubs.cpp
@@ -48,7 +48,7 @@ public:
 AAMP_LogLevel AampLogManager::aampLoglevel = eLOGLEVEL_WARN;
 
 // Stub logging function - must match AAMP's declaration exactly
-void logprintf(AAMP_LogLevel level, const char* file, int line, const char* format, ...) {
+void logprintf(AAMP_LogLevel level, const char* file, const char* func, int line, const char *format, ...) {
 	// Simple implementation for simulation - could be enhanced if needed
 	if (level < AampLogManager::aampLoglevel) {
 		return;

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -184,8 +184,9 @@ bool AampLogManager::disableLogRedirection = false;
 bool AampLogManager::enableEthanLogRedirection = false;
 AAMP_LogLevel AampLogManager::aampLoglevel = eLOGLEVEL_WARN;
 bool AampLogManager::locked = false;
+bool AampLogManager::logFilename = false;
 
-void logprintf(AAMP_LogLevel level, const char *func, int line, const char *format,
+void logprintf(AAMP_LogLevel level, const char *file, const char *func, int line, const char *format,
 			   ...)
 {
 	int playerId = -1;

--- a/test/utests/fakes/FakeAampLogManager.cpp
+++ b/test/utests/fakes/FakeAampLogManager.cpp
@@ -49,10 +49,11 @@ bool AampLogManager::disableLogRedirection = false;
 bool AampLogManager::enableEthanLogRedirection = false;
 AAMP_LogLevel AampLogManager::aampLoglevel = TEST_LOG_LEVEL;
 bool AampLogManager::locked = true;
+bool AampLogManager::logFilename = false;
 
 thread_local int gPlayerId = -1;
 
-void logprintf(AAMP_LogLevel level, const char* func, int line, const char *format, ...)
+void logprintf(AAMP_LogLevel level, const char* file, const char* func, int line, const char *format, ...)
 {
 	char timestamp[AAMPCLI_TIMESTAMP_PREFIX_MAX_CHARS];
 	timestamp[0] = 0x00;

--- a/test/utests/tests/AampLogManagerTests/AampLogManagerTests.cpp
+++ b/test/utests/tests/AampLogManagerTests/AampLogManagerTests.cpp
@@ -581,7 +581,6 @@ TEST_F(AampLogManagerTest, logprintf_Test1)
 	AAMP_LogLevel level = eLOGLEVEL_INFO;
 	std::string file("test.cpp");
 	std::string func("testFunction");
-	//const char* func = "testFunction";
 	int line = 2;
 	const char *format = "s3";
 	const char *format2 = "s4";

--- a/test/utests/tests/AampLogManagerTests/AampLogManagerTests.cpp
+++ b/test/utests/tests/AampLogManagerTests/AampLogManagerTests.cpp
@@ -579,13 +579,15 @@ TEST_F(AampLogManagerTest, logprintf_Test1)
 {
 	//Arrange: Creating the variables for passing to arguments
 	AAMP_LogLevel level = eLOGLEVEL_INFO;
-	const char* func = "testFunction";
+	std::string file("test.cpp");
+	std::string func("testFunction");
+	//const char* func = "testFunction";
 	int line = 2;
 	const char *format = "s3";
 	const char *format2 = "s4";
 
 	//Act: Calling the function for test
-	logprintf(level,func,line,format,format2);
+	logprintf(level, file.c_str(), func.c_str(), line, format, format2);
 }
 
 TEST_F(AampLogManagerTest, timestampStringify )
@@ -752,6 +754,7 @@ TEST_F(AampLogManagerTest, setLogLevelError_AAMPLOG_MIL)
 TEST_F(AampLogManagerTest, logprintf_TRACE)
 {
 	AAMP_LogLevel level = eLOGLEVEL_TRACE;
+	std::string file("test.cpp");
 	std::string func("testFunc");
 	int line = 2;
 	std::string message("message");
@@ -763,12 +766,13 @@ TEST_F(AampLogManagerTest, logprintf_TRACE)
 			HasSubstr("[TRACE]"),
 			HasSubstr("[" + func + "]"),
 			HasSubstr(message))));
-	logprintf(level, func.c_str(), line, "%s", message.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message.c_str());
 }
 
 TEST_F(AampLogManagerTest, logprintf_INFO)
 {
 	AAMP_LogLevel level = eLOGLEVEL_INFO;
+	std::string file("test.cpp");
 	std::string func("testFunc");
 	int line = 2;
 	std::string message("message");
@@ -780,7 +784,7 @@ TEST_F(AampLogManagerTest, logprintf_INFO)
 			HasSubstr("[INFO]"),
 			HasSubstr("[" + func + "]"),
 			HasSubstr(message))));
-	logprintf(level, func.c_str(), line, "%s", message.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message.c_str());
 }
 
 /*
@@ -792,6 +796,7 @@ const int MAX_DEBUG_LOG_BUFF_SIZE = 512;
 TEST_F(AampLogManagerTest, logprintf_LongFile)
 {
 	AAMP_LogLevel level = eLOGLEVEL_INFO;
+	std::string file("test.cpp");
 	std::string func("testFunc");
 	int line = 2;
 	std::string message("message");
@@ -801,7 +806,7 @@ TEST_F(AampLogManagerTest, logprintf_LongFile)
 			HasSubstr("[" + std::to_string(-1) + "]"),
 			HasSubstr("[INFO]"),
 			HasSubstr("[" + func + "]"))));
-	logprintf(level, func.c_str(), line, "%s", message.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message.c_str());
 }
 
 /*
@@ -811,6 +816,7 @@ TEST_F(AampLogManagerTest, logprintf_LongFile)
 TEST_F(AampLogManagerTest, logprintf_LongMessage)
 {
 	AAMP_LogLevel level = eLOGLEVEL_INFO;
+	std::string file("test.cpp");
 	std::string func("testFunc");
 	int line = 2;
 	std::string message(MAX_DEBUG_LOG_BUFF_SIZE, '*');
@@ -820,7 +826,7 @@ TEST_F(AampLogManagerTest, logprintf_LongMessage)
 			HasSubstr("[" + std::to_string(-1) + "]"),
 			HasSubstr("[INFO]"),
 			HasSubstr("[" + func + "]"))));
-	logprintf(level, func.c_str(), line, "%s", message.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message.c_str());
 }
 
 /*
@@ -830,6 +836,7 @@ TEST_F(AampLogManagerTest, logprintf_LongMessage)
 TEST_F(AampLogManagerTest, logprintf_MaxMessage)
 {
 	AAMP_LogLevel level = eLOGLEVEL_INFO;
+	std::string file("test.cpp");
 	std::string func("testFunc");
 	int line = 2;
 	std::ostringstream ossthread;
@@ -843,7 +850,7 @@ TEST_F(AampLogManagerTest, logprintf_MaxMessage)
 			HasSubstr("[INFO]"),
 			HasSubstr("[" + func + "]"),
 			HasSubstr(message))));
-	logprintf(level, func.c_str(), line, "%s", message.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message.c_str());
 }
 
 TEST_F(AampLogManagerTest, snprintf_tests)
@@ -912,7 +919,7 @@ TEST_F(AampLogManagerTest, logprintf_SequentialNumbers)
 			HasSubstr("[WARN]"),
 			HasSubstr(message1)
 		))).Times(1);
-	logprintf(level, func.c_str(), line, "%s", message1.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message1.c_str());
 	seqNum++;
 
 	EXPECT_CALL(*g_mockSdJournal, sd_journal_print_mock(LOG_NOTICE,
@@ -921,7 +928,7 @@ TEST_F(AampLogManagerTest, logprintf_SequentialNumbers)
 			HasSubstr("[WARN]"),
 			HasSubstr(message2)
 		))).Times(1);
-	logprintf(level, func.c_str(), line, "%s", message2.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message2.c_str());
 	seqNum++;
 
 	EXPECT_CALL(*g_mockSdJournal, sd_journal_print_mock(LOG_NOTICE,
@@ -930,5 +937,5 @@ TEST_F(AampLogManagerTest, logprintf_SequentialNumbers)
 			HasSubstr("[WARN]"),
 			HasSubstr(message3)
 		))).Times(1);
-	logprintf(level, func.c_str(), line, "%s", message3.c_str());
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message3.c_str());
 }

--- a/test/utests/tests/AampLogManagerTests/AampLogManagerTests.cpp
+++ b/test/utests/tests/AampLogManagerTests/AampLogManagerTests.cpp
@@ -939,3 +939,28 @@ TEST_F(AampLogManagerTest, logprintf_SequentialNumbers)
 		))).Times(1);
 	logprintf(level, file.c_str(), func.c_str(), line, "%s", message3.c_str());
 }
+
+/*
+	Test logprintf with logFilename enabled
+	When AampLogManager::logFilename is true, the base filename must appear in the log
+	output in square brackets immediately before the function name.
+*/
+TEST_F(AampLogManagerTest, logprintf_LogFilenameEnabled)
+{
+	AampLogManager::logFilename = true;
+
+	AAMP_LogLevel level = eLOGLEVEL_WARN;
+	std::string file("path/to/MySource.cpp");
+	std::string func("testFunc");
+	int line = 42;
+	std::string message("filename test message");
+
+	EXPECT_CALL(*g_mockSdJournal, sd_journal_print_mock(LOG_NOTICE,
+		AllOf(
+			HasSubstr("[MySource.cpp]"),
+			HasSubstr("[" + func + "]"),
+			HasSubstr(message))));
+	logprintf(level, file.c_str(), func.c_str(), line, "%s", message.c_str());
+
+	AampLogManager::logFilename = false;
+}


### PR DESCRIPTION
Reason for Change: Help filter logs and identify methods in the log.

Summary of Changes:
- Add new config logFilename, set to false by default
- Add the filename to every log line if logFilename is true
- Update the prototype of logprintf to include the filename

Test Procedure: Enable logFilename and confirm logs

Priority: P2

Risks: Low