### PR TITLE
VPAAMP-42: Fix ad break fragment scheduling for live stream

### DIFF
--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -352,6 +352,7 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 								// Mark the ad as placed to stop further placement
 								abObj.ads->at(mPlacementObj.curAdIdx).placed = true;
 								abObj.ads->at(mPlacementObj.curAdIdx).cancelled = true;
+								abObj.ads->at(mPlacementObj.curAdIdx).placedDuration = mPlacementObj.adNextOffset;
 								mPlacementObj.adNextOffset = 0;
 
 								// Invalidate all remaining ads in the break so playback state machine skips them
@@ -456,6 +457,7 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 						if(periodDelta < (curAd.duration - mPlacementObj.adNextOffset))
 						{
 							mPlacementObj.adNextOffset += periodDelta;
+							curAd.placedDuration = mPlacementObj.adNextOffset;
 							if(isSrcdurnotequalstoaddur)
 							{
 								IPeriod* nextPeriod = periods.at(nextPeriodIter);
@@ -511,6 +513,7 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 							{
 								// Adjust the params for the current ad
 								mPlacementObj.adNextOffset += remainingAdDuration;
+								curAd.placedDuration = mPlacementObj.adNextOffset;
 								periodDelta -= remainingAdDuration;
 							}
 							else

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -127,6 +127,7 @@ struct AdNode {
 	std::string  adId;             /**< Ad's identifier */
 	std::string  url;              /**< Ad's manifest URL */
 	uint64_t     duration;         /**< Duration of the Ad in milliseconds*/
+	uint32_t     placedDuration;   /**< Duration of the Ad placed so far in milliseconds */
 	std::string  basePeriodId;     /**< Id of the base period at the beginning of the Ad */
 	int          basePeriodOffset; /**< Offset of the base period at the beginning of the Ad in milliseconds */
 	MPD*         mpd;              /**< Pointer to the MPD object */
@@ -134,7 +135,7 @@ struct AdNode {
 	/**
 	* @brief AdNode default constructor
 	*/
-	AdNode() : invalid(false), placed(false), resolved(false), cancelled(false), adId(), url(), duration(0), basePeriodId(), basePeriodOffset(0), mpd(nullptr)
+	AdNode() : invalid(false), placed(false), resolved(false), cancelled(false), adId(), url(), duration(0), placedDuration(0), basePeriodId(), basePeriodOffset(0), mpd(nullptr)
 	{
 
 	}
@@ -155,7 +156,7 @@ struct AdNode {
 	*/
 	AdNode(bool invalid, bool placed, bool resolved, std::string adId, std::string url, uint64_t duration,
 		std::string basePeriodId, int basePeriodOffset, MPD* mpd, bool cancelled = false)
-		: invalid(invalid), placed(placed), resolved(resolved), cancelled(cancelled), adId(std::move(adId)), url(std::move(url)), duration(duration), basePeriodId(std::move(basePeriodId)),
+		: invalid(invalid), placed(placed), resolved(resolved), cancelled(cancelled), adId(std::move(adId)), url(std::move(url)), duration(duration), placedDuration(0), basePeriodId(std::move(basePeriodId)),
 		basePeriodOffset(basePeriodOffset), mpd(mpd)
 	{
 
@@ -168,7 +169,7 @@ struct AdNode {
 	*/
 	AdNode(const AdNode& adNode)
 		: invalid(adNode.invalid), placed(adNode.placed), resolved(adNode.resolved), cancelled(adNode.cancelled), adId(adNode.adId),
-		url(adNode.url), duration(adNode.duration), basePeriodId(adNode.basePeriodId),
+		url(adNode.url), duration(adNode.duration), placedDuration(adNode.placedDuration), basePeriodId(adNode.basePeriodId),
 		basePeriodOffset(adNode.basePeriodOffset), mpd(adNode.mpd)
 	{
 	}

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -1468,7 +1468,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 						{
 							// For live stream, ad break scheduling fragment should be within source period.
 							// Otherwise, it may be beyond control if ad break cancellation is requested by server.
-							const bool baselineSourcePeriodCheck = (pMediaStreamContext->fragmentTime < (mPeriodStartTime + (mPeriodDuration / 1000)));
+							const bool baselineSourcePeriodCheck = ((pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset) < (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration / 1000.0));
 
 							bool isCurrentAdCancelled = false;
 							if (mCdaiObject->mCurAds && mCdaiObject->mCurAdIdx >= 0 && mCdaiObject->mCurAdIdx < static_cast<int>(mCdaiObject->mCurAds->size()))
@@ -1479,7 +1479,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 							// If not, skip the fragment to avoid potential issues. CheckForAdTerminate() mark EOS for stream at boundaries.
 							if (((liveEdgePeriodPlayback || isCurrentAdCancelled) && !baselineSourcePeriodCheck))
 							{
-								AAMPLOG_INFO("Ad break playing fragment is not within source period. fragmentTime: %f, mPeriodEndTime: %f", pMediaStreamContext->fragmentTime, (mPeriodStartTime + (mPeriodDuration / 1000)));
+								AAMPLOG_INFO("Ad break fragment is not within source period. fragment offset:%lf, placedDuration: %lf", (pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset), (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration / 1000.0));
 								return false;
 							}
 						}


### PR DESCRIPTION
Reason for change: Fix ad break fragment scheduling for live stream if split period ad is placed and in progress.
Risks: Low
Test Procedure: Test with Early return stream
Priority: P1