### PR TITLE
VPAAMP-83 l2 8015 test failures (regression)

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -1183,7 +1183,7 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 							// all fragments).  Blocking when placedDuration==0 stalls the FetcherLoop
 							// indefinitely — fragmentTime never advances, CheckForAdTerminate never fires —
 							// which delays seeks and causes test window violations on slow CI runners.
-							const uint32_t curPlacedDuration = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration;
+							const auto curPlacedDuration = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration;
 							const bool baselineSourcePeriodCheck = (curPlacedDuration == 0) ||
 								((pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset) < (curPlacedDuration / 1000.0));
 							const bool isCurrentAdCancelled = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).cancelled;
@@ -6883,6 +6883,10 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 	for (int i = 0; i < mMaxTracks; i++)
 	{
 		class MediaStreamContext *pMediaStreamContext = mMediaStreamContext[i];
+		if (!pMediaStreamContext)
+		{
+			continue;
+		}
 		size_t numAdaptationSets = period->GetAdaptationSets().size();
 		int  selAdaptationSetIndex = -1;
 		int selRepresentationIndex = -1;
@@ -7056,7 +7060,7 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 		}
 	}
 
-	if(1 == mNumberOfTracks && !mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled)
+	if(1 == mNumberOfTracks && mMediaStreamContext[eMEDIATYPE_VIDEO] && !mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled)
 	{ // what about audio+subtitles?
 		if(newTune)
 		{

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -1168,22 +1168,30 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 						}
 						bool liveEdgePeriodPlayback = mIsLiveManifest && (mCurrentPeriodIdx == mMPDParseHelper->mUpperBoundaryPeriod);
 						uint64_t fragmentNumberBackUp = pMediaStreamContext->fragmentDescriptor.Number;
-						if (mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING)
+						const bool curAdBoundaryCheck = (mCdaiObject &&
+														 mCdaiObject->mCurAds &&
+														 mCdaiObject->mCurAdIdx >= 0 &&
+														 mCdaiObject->mCurAdIdx < static_cast<int>(mCdaiObject->mCurAds->size()));
+						if (curAdBoundaryCheck && mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING)
 						{
 							// For live stream, ad break scheduling fragment should be within source period.
 							// Otherwise, it may be beyond control if ad break cancellation is requested by server.
-							const bool baselineSourcePeriodCheck = ((pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset) < (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration / 1000.0));
-
-							bool isCurrentAdCancelled = false;
-							if (mCdaiObject->mCurAds && mCdaiObject->mCurAdIdx >= 0 && mCdaiObject->mCurAdIdx < static_cast<int>(mCdaiObject->mCurAds->size()))
-							{
-								isCurrentAdCancelled = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).cancelled;
-							}
+							//
+							// placedDuration is set incrementally by PlaceAds() as manifest periods become
+							// available.  If PlaceAds() hasn't run yet for the current ad (placedDuration==0),
+							// treat the check as passing (allow all fragments) rather than as failing (block
+							// all fragments).  Blocking when placedDuration==0 stalls the FetcherLoop
+							// indefinitely — fragmentTime never advances, CheckForAdTerminate never fires —
+							// which delays seeks and causes test window violations on slow CI runners.
+							const uint32_t curPlacedDuration = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration;
+							const bool baselineSourcePeriodCheck = (curPlacedDuration == 0) ||
+								((pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset) < (curPlacedDuration / 1000.0));
+							const bool isCurrentAdCancelled = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).cancelled;
 							// Check if the ad fragment is within source period for live stream or cancelled ad break is within source period.
 							// If not, skip the fragment to avoid potential issues. CheckForAdTerminate() mark EOS for stream at boundaries.
 							if (((liveEdgePeriodPlayback || isCurrentAdCancelled) && !baselineSourcePeriodCheck))
 							{
-								AAMPLOG_INFO("Ad break fragment is not within source period. fragment offset:%lf, placedDuration: %lf", (pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset), (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).placedDuration / 1000.0));
+								AAMPLOG_INFO("Ad break fragment is not within source period. fragment offset:%lf, placedDuration: %lf", (pMediaStreamContext->fragmentTime - pMediaStreamContext->periodStartOffset), (curPlacedDuration / 1000.0));
 								return false;
 							}
 						}

--- a/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
+++ b/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
@@ -2001,9 +2001,10 @@ TEST_F(AdSelectionTests, PushNextFragment_DoesNotFetchWhenCurrentAdCancelled)
 	};
 	auto ads = cdaiObj->mAdBreaks[adPeriodId].ads;
 	ads->emplace_back(false /*invalid*/, true /*placed*/, true /*resolved*/,
-		"adId1" /*adId*/, adUrl /*url*/, 30000 /*duration*/, adPeriodId /*basePeriodId*/, 0 /*basePeriodOffset*/, nullptr /*mpd*/);
+		"adId1" /*adId*/, adUrl /*url*/, 30000 /*duration*/, adPeriodId /*basePeriodId*/, 0 /*basePeriodOffset*/,
+		nullptr /*mpd*/, true /*cancelled*/);
 	// Mark current ad as cancelled so PushNextFragment should not fetch
-	ads->at(0).cancelled = true;
+	ads->at(0).placedDuration = 10000; // Mark ad as partially placed
 	cdaiObj->mCurAds = ads;
 	cdaiObj->mCurAdIdx = 0;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);


### PR DESCRIPTION
Reason for Change: fix race condition causing frequent L2 test 8015 failures, epecially on ubuntu gitrunners

Test Guidance: L2 8015 passing reliably again

Risk: Low