### PR TITLE
VPAAMP-135 abrsim impacting fix - aamp abr

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -204,7 +204,10 @@ bool ABRManager::HasBandwidthEstimator() const
 double ABRManager::GetPredictedDownloadTimeSeconds(std::size_t segmentSizeBytes) const
 {
 	std::lock_guard<std::mutex> lock(mBandwidthEstimatorLock);
-	if (!mBandwidthEstimator) return 0.0;
+	if (!mBandwidthEstimator)
+	{
+		return 0.0;
+	}
 	return mBandwidthEstimator->GetPredictedDownloadTimeSeconds(segmentSizeBytes);
 }
 

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -201,6 +201,13 @@ bool ABRManager::HasBandwidthEstimator() const
 	return (mBandwidthEstimator != nullptr);
 }
 
+double ABRManager::GetPredictedDownloadTimeSeconds(std::size_t segmentSizeBytes) const
+{
+	std::lock_guard<std::mutex> lock(mBandwidthEstimatorLock);
+	if (!mBandwidthEstimator) return 0.0;
+	return mBandwidthEstimator->GetPredictedDownloadTimeSeconds(segmentSizeBytes);
+}
+
 /**
  * @brief Get initial profile index, choose the medium profile or
  * the profile whose bitrate >= the default bitrate.

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -21,6 +21,7 @@
 #ifndef ABR_H
 #define ABR_H
 
+#include <cstddef>
 #include <iostream>
 #include <vector>
 #include <map>

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -62,6 +62,7 @@ public:
 	BitsPerSecond GetCurrentlyAvailableBandwidth();
 	BitsPerSecond GetNetworkBandwidth();
 	bool HasBandwidthEstimator() const;
+	double GetPredictedDownloadTimeSeconds(std::size_t segmentSizeBytes) const;
 	
 	struct ProfileInfo {
 		/**


### PR DESCRIPTION
Reason for Change: Exposes ABRManager::GetPredictedDownloadTimeSeconds() — a thin, mutex-safe passthrough to the bandwidth estimator's existing prediction method — making segment download time prediction accessible to callers of ABRManager without bypassing encapsulation.

Enables the in-flight download bail heuristic (abort a stalling high-profile download and retry the same segment at a lower profile) to be implemented at the ABRManager boundary in both production AAMP and simulation tooling.