### PR TITLE
VPAAMP-46 OSX build brittleness fixes, continued

### DIFF
--- a/OSX/patches/subttxrend-app-homebrew-paths.patch
+++ b/OSX/patches/subttxrend-app-homebrew-paths.patch
@@ -1,0 +1,31 @@
+diff --git a/subttxrend-app/x86_builder/build.sh b/subttxrend-app/x86_builder/build.sh
+index 3faa7f0..a6f4b95 100755
+--- a/subttxrend-app/x86_builder/build.sh
++++ b/subttxrend-app/x86_builder/build.sh
+@@ -42,6 +42,16 @@ get_abs_filename() {
+ function build_project_cmake {
+     echo "Building project: $2"
+ 
++    # On macOS, add Homebrew prefix so cmake finds brew-installed packages
++    local FIND_ROOT="$3"
++    local EXTRA_PREFIX_PATH=""
++    if [[ "$OSTYPE" == "darwin"* ]]; then
++        local BREW_PREFIX
++        BREW_PREFIX=$(brew --prefix)
++        FIND_ROOT="$3;${BREW_PREFIX}"
++        EXTRA_PREFIX_PATH="-DCMAKE_PREFIX_PATH=${BREW_PREFIX}"
++    fi
++
+     mkdir -p $2
+     pushd $2
+ 
+@@ -49,7 +59,8 @@ function build_project_cmake {
+         -DCMAKE_INSTALL_PREFIX=$3/usr/local \
+         -DCMAKE_MODULE_PATH=$3/usr/local/share/cmake/Modules \
+         -DCMAKE_BUILD_TYPE=Debug \
+-        -DCMAKE_FIND_ROOT_PATH=$3 \
++        -DCMAKE_FIND_ROOT_PATH="$FIND_ROOT" \
++        ${EXTRA_PREFIX_PATH} \
+         -DCMAKE_INSTALL_NAME_DIR=$3/usr/local/lib \
+         -DCMAKE_CXX_FLAGS="-DPC_BUILD" \
+         $4 \

--- a/OSX/patches/websocket-ipplayer2-homebrew-includes.patch
+++ b/OSX/patches/websocket-ipplayer2-homebrew-includes.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ipp2/CMakeLists.txt b/src/ipp2/CMakeLists.txt
+index 9931cc0..ca5df41 100644
+--- a/src/ipp2/CMakeLists.txt
++++ b/src/ipp2/CMakeLists.txt
+@@ -174,6 +174,8 @@ if(ENABLE_DS_CLIENT)
+ endif(ENABLE_DS_CLIENT)
+ include_directories(${Boost_INCLUDE_DIRS})
+ include_directories(${JSONCPP_INCLUDE_DIRS})
++include_directories(${LIBWEBSOCKETPP_INCLUDE_DIRS})
++include_directories(${TINYXML2_INCLUDE_DIR})
+ 
+ find_path(ASIO_PATH asio.hpp)
+ if(ASIO_PATH)

--- a/README.md
+++ b/README.md
@@ -511,6 +511,8 @@ note: the branch changes over time - dev_sprint_YY_Q
 currently dev_sprint_25_2
 ```
 cd aamp
+brew update
+brew upgrade
 bash install-aamp.sh
 ```
 select aamp-cli as default project

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -55,7 +55,7 @@ function install_pkgs_darwin_fn()
             OPENSSL_PATH=$(brew --prefix ${DEFAULT_OPENSSL_VERSION})
             # link may not exist so don't fail
             OPENSSL_CUR_PATH=`readlink /usr/local/ssl` || true
-            if [ "$OPENSSL_CUR_PATH" != "{$OPENSSL_PATH}" ] ; then
+            if [ "$OPENSSL_CUR_PATH" != "${OPENSSL_PATH}" ] ; then
                 sudo rm -f /usr/local/ssl || true
                 sudo ln -s $OPENSSL_PATH /usr/local/ssl
             fi 
@@ -205,8 +205,8 @@ function install_asio_fn()
     cd ${LOCAL_DEPS_BUILD_DIR}
     if [ ! -d asio-1.18.2 ]; then
         echo "Installing asio"
-        curl -o asio-1.18.2.tar.gz "https://excellmedia.dl.sourceforge.net/project/asio/asio/1.18.2%20%28Stable%29/asio-1.18.2.tar.bz2?viasf=1"
-        tar -xf asio-1.18.2.tar.gz
+        curl -L -o asio-1.18.2.tar.bz2 "https://downloads.sourceforge.net/project/asio/asio/1.18.2%20%28Stable%29/asio-1.18.2.tar.bz2?viasf=1" --ssl-no-revoke
+        tar -xf asio-1.18.2.tar.bz2
         pushd asio-1.18.2
         mkdir build && cd build
         ../configure

--- a/scripts/install_libdash.sh
+++ b/scripts/install_libdash.sh
@@ -84,6 +84,7 @@ function install_build_libdash_fn()
         cmake .. \
             -DCMAKE_INSTALL_PREFIX="${LOCAL_DEPS_BUILD_DIR}" \
             -DCMAKE_MACOSX_RPATH=TRUE \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_C_FLAGS="${EXTRA_C_FLAGS}" \
             -DCMAKE_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
             -DCMAKE_SHARED_LINKER_FLAGS="${EXTRA_LINK_FLAGS}" || {

--- a/scripts/install_subtec.sh
+++ b/scripts/install_subtec.sh
@@ -123,7 +123,19 @@ function subtec_install_fn() {
         popd
         return 1
     }
- 
+
+    git apply -p1 "${1}/OSX/patches/subttxrend-app-homebrew-paths.patch" || {
+        echo "ERROR: Failed to apply subttxrend-app-homebrew-paths.patch"
+        popd
+        return 1
+    }
+
+    git apply -p1 "${1}/OSX/patches/websocket-ipplayer2-homebrew-includes.patch" --directory websocket-ipplayer2-utils || {
+        echo "ERROR: Failed to apply websocket-ipplayer2-homebrew-includes.patch"
+        popd
+        return 1
+    }
+
     echo "subtec-app source prepared"
     popd
 }
@@ -211,7 +223,14 @@ function subtec_install_build_fn() {
     cd subtec-app/subttxrend-app/x86_builder/ || { echo "Failed to change to subtec build directory"; return 1; }
 
     if [ ! -d build/install ] ; then
-        PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig:/usr/local/ssl/lib/pkgconfig:/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH ./build.sh fast
+        if [ "$(uname)" = "Darwin" ] ; then
+            BOOST_ROOT="$(brew --prefix boost@1.85)" \
+            CMAKE_PREFIX_PATH="$(brew --prefix tinyxml2);$(brew --prefix websocketpp);$(brew --prefix boost@1.85)" \
+            PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig:/usr/local/ssl/lib/pkgconfig:/opt/homebrew/lib/pkgconfig:$PKG_CONFIG_PATH \
+            ./build.sh fast
+        else
+            ./build.sh fast
+        fi
 
         if [ -f ./build/install/usr/local/bin/subttxrend-app ]; then
             echo "subtec-app has been built."


### PR DESCRIPTION
Reason for Change: These changes allow for the AAMP simulator to be built on the latest version of MacOS (Tahoe) and the latest Homebrew packages for MacOS.

Risk: Low

Test Guidance: no impact to existing builds, no issues building aamp simualtor on latest Tahoe Mac OS