### PR TITLE
VPAAMP-147 Unify the two AAMP fragment cache buffers

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -809,39 +809,36 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 	}
 	else
 	{
-		// Move staging fragment into the cache slot for injection
-		CachedFragment *slot = GetFetchBuffer(false);
-		*slot = std::move(mStagingFragment);
-		cachedFragment = slot;
+		UpdateTSAfterFetchStats(&mStagingFragment, dlInfo->isInitSegment);
 
-		// Update buffer index after fetch for injection
-		UpdateTSAfterFetch(dlInfo->isInitSegment);
-
-		// For all DASH SLD content (with or without TSB), write the fragment into the chunk cache
-		// so the inject thread reads from mCachedFragmentChunks (unified cache path)
-		if(aamp->IsDashAsset() && !aamp->GetLLDashChunkMode())
+		if (!aamp->GetLLDashChunkMode())
 		{
+			// Non-LLD DASH (SLD, AAMP TSB write-phase): route directly into the
+			// chunk cache. The inject thread reads from mCachedFragmentChunks.
 			std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
-			fragmentToCache->Copy(*cachedFragment);
+			fragmentToCache->Copy(mStagingFragment);
 			CacheTsbFragment(std::move(fragmentToCache));
-		}
-
-		// If injection is from chunk buffer, remove the fragment for injection
-		if(IsInjectionFromCachedFragmentChunks())
-		{
-			UpdateTSAfterInject();
-			// For LLD and AAMP TSB the fragment is handed off here, so consume the
-			// buffer now. For plain SLD DASH (routed via IsDashAsset), the inject
-			// thread in ProcessAndInjectFragment calls ConsumeBuffer after injection.
-			if (aamp->GetLLDashChunkMode() || aamp->IsLocalAAMPTsb())
+			if (aamp->IsLocalAAMPTsb())
 			{
 				auto timeBasedBufferManager = GetTimeBasedBufferManager();
-				if(timeBasedBufferManager)
+				if (timeBasedBufferManager)
 				{
-					timeBasedBufferManager->ConsumeBuffer(cachedFragment->duration);
+					timeBasedBufferManager->ConsumeBuffer(mStagingFragment.duration);
 				}
 			}
 		}
+		else
+		{
+			// LLD DASH: media data already injected via CacheFragmentChunk callbacks.
+			// Consume the time-based buffer counter and discard the staging data.
+			auto timeBasedBufferManager = GetTimeBasedBufferManager();
+			if (timeBasedBufferManager)
+			{
+				timeBasedBufferManager->ConsumeBuffer(mStagingFragment.duration);
+			}
+		}
+		mStagingFragment.Clear();
+		cachedFragment = nullptr;
 	}
 
 	if (aamp->IsLive())

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -817,9 +817,9 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 		// Update buffer index after fetch for injection
 		UpdateTSAfterFetch(dlInfo->isInitSegment);
 
-		// With AAMP TSB enabled, the chunk cache is used for any content type (SLD or LLD)
-		// When playing live SLD content, the fragment is written to the regular cache and to the chunk cache
-		if(tsbSessionManager && !IsLocalTSBInjection() && !aamp->GetLLDashChunkMode())
+		// For all DASH SLD content (with or without TSB), write the fragment into the chunk cache
+		// so the inject thread reads from mCachedFragmentChunks (unified cache path)
+		if(aamp->IsDashAsset() && !aamp->GetLLDashChunkMode())
 		{
 			std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
 			fragmentToCache->Copy(*cachedFragment);
@@ -830,10 +830,16 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 		if(IsInjectionFromCachedFragmentChunks())
 		{
 			UpdateTSAfterInject();
-			auto timeBasedBufferManager = GetTimeBasedBufferManager();
-			if(timeBasedBufferManager)
+			// For LLD and AAMP TSB the fragment is handed off here, so consume the
+			// buffer now. For plain SLD DASH (routed via IsDashAsset), the inject
+			// thread in ProcessAndInjectFragment calls ConsumeBuffer after injection.
+			if (aamp->GetLLDashChunkMode() || aamp->IsLocalAAMPTsb())
 			{
-				timeBasedBufferManager->ConsumeBuffer(cachedFragment->duration);
+				auto timeBasedBufferManager = GetTimeBasedBufferManager();
+				if(timeBasedBufferManager)
+				{
+					timeBasedBufferManager->ConsumeBuffer(cachedFragment->duration);
+				}
 			}
 		}
 	}

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -1149,7 +1149,6 @@ bool MediaStreamContext::DownloadFragment(DownloadInfoPtr dlInfo)
 			// Assign the new download info to mActiveDownloadInfo
 			mActiveDownloadInfo = dlInfo;
 		}
-		int maxCachedFragmentsPerTrack = GETCONFIGVALUE(eAAMPConfig_MaxFragmentCached); // Max cached fragments per track
 		auto DownloadsEnabled = [this]()
 		{
 			return aamp->DownloadsAreEnabled() && !abort;
@@ -1164,8 +1163,10 @@ bool MediaStreamContext::DownloadFragment(DownloadInfoPtr dlInfo)
 				   aamp->GetLLDashServiceData()->lowLatencyMode &&
 				   !aamp->TrackDownloadsAreEnabled(mediaType);
 		};
-		// Wait for free fragment only if the number of fragments cached is equal to the max cached fragments per track
-		if (numberOfFragmentsCached == maxCachedFragmentsPerTrack)
+		// Wait for a free cache slot before starting the download.
+		// IsFragmentCacheFull() dispatches to the chunk cache for DASH and the
+		// ring buffer for HLS, so the wait always targets the right structure.
+		if (IsFragmentCacheFull())
 		{
 			while (DownloadsEnabled() && !WaitForFreeFragmentAvailable(MAX_WAIT_TIMEOUT_MS))
 			{

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -819,13 +819,19 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 			// giving the inject thread a systematic head-start.
 			std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
 			fragmentToCache->Copy(mStagingFragment);
-			// Populate stream info on the chunk slot before handing it to the inject
-			// thread.  UpdateTSAfterFetchStats runs after CacheTsbFragment so the copy
-			// that the inject thread picks up would otherwise have empty
+			// Populate profileIndex and cacheFragStreamInfo on the chunk slot BEFORE
+			// handing it to the inject thread.  UpdateTSAfterFetchStats runs after
+			// CacheTsbFragment on mStagingFragment (a separate object), so the chunk
+			// slot consumed by the inject thread would otherwise carry empty
 			// cacheFragStreamInfo (all zeros), causing NotifyBitRateUpdate to silently
 			// skip AAMP_EVENT_BITRATE_CHANGED (gated on bandwidthBitsPerSecond != 0).
-			// This mirrors what OnFragmentDownloadSuccess already does for the TSB path.
-			if (fragmentToCache->initFragment)
+			// Mirror UpdateTSAfterFetchStats exactly: read profileIdxForBandwidthNotification
+			// and call UpdateStreamInfoBitrateData for ALL fragments (init and media)
+			// so that (profileIndex, bps, resolution, framerate) are all consistent and
+			// sourced from the ABR stream info, avoiding any mismatch between profileIndex
+			// and bandwidthBitsPerSecond that would fire a spurious bitrate-change event
+			// with wrong data (which then persists the profile index, blocking the correct
+			// event from firing later).
 			{
 				class StreamAbstractionAAMP* pContext = GetContext();
 				if (pContext)
@@ -834,7 +840,6 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 					pContext->UpdateStreamInfoBitrateData(fragmentToCache->profileIndex, fragmentToCache->cacheFragStreamInfo);
 				}
 			}
-			fragmentToCache->cacheFragStreamInfo.bandwidthBitsPerSecond = fragmentDescriptor.Bandwidth;
 			CacheTsbFragment(std::move(fragmentToCache));
 			if (aamp->IsLocalAAMPTsb())
 			{

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -1184,8 +1184,8 @@ bool MediaStreamContext::DownloadFragment(DownloadInfoPtr dlInfo)
 				   !aamp->TrackDownloadsAreEnabled(mediaType);
 		};
 		// Wait for a free cache slot before starting the download.
-		// IsFragmentCacheFull() dispatches to the chunk cache for DASH and the
-		// ring buffer for HLS, so the wait always targets the right structure.
+		// IsFragmentCacheFull() checks the unified fragment chunk cache usage, so
+		// this wait throttles downloads until shared cache capacity is available.
 		if (IsFragmentCacheFull())
 		{
 			while (DownloadsEnabled() && !WaitForFreeFragmentAvailable(MAX_WAIT_TIMEOUT_MS))

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -819,6 +819,22 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 			// giving the inject thread a systematic head-start.
 			std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
 			fragmentToCache->Copy(mStagingFragment);
+			// Populate stream info on the chunk slot before handing it to the inject
+			// thread.  UpdateTSAfterFetchStats runs after CacheTsbFragment so the copy
+			// that the inject thread picks up would otherwise have empty
+			// cacheFragStreamInfo (all zeros), causing NotifyBitRateUpdate to silently
+			// skip AAMP_EVENT_BITRATE_CHANGED (gated on bandwidthBitsPerSecond != 0).
+			// This mirrors what OnFragmentDownloadSuccess already does for the TSB path.
+			if (fragmentToCache->initFragment)
+			{
+				class StreamAbstractionAAMP* pContext = GetContext();
+				if (pContext)
+				{
+					fragmentToCache->profileIndex = pContext->profileIdxForBandwidthNotification;
+					pContext->UpdateStreamInfoBitrateData(fragmentToCache->profileIndex, fragmentToCache->cacheFragStreamInfo);
+				}
+			}
+			fragmentToCache->cacheFragStreamInfo.bandwidthBitsPerSecond = fragmentDescriptor.Bandwidth;
 			CacheTsbFragment(std::move(fragmentToCache));
 			if (aamp->IsLocalAAMPTsb())
 			{

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -809,12 +809,14 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 	}
 	else
 	{
-		UpdateTSAfterFetchStats(&mStagingFragment, dlInfo->isInitSegment);
-
 		if (!aamp->GetLLDashChunkMode())
 		{
-			// Non-LLD DASH (SLD, AAMP TSB write-phase): route directly into the
-			// chunk cache. The inject thread reads from mCachedFragmentChunks.
+			// Non-LLD DASH (SLD, AAMP TSB write-phase): cache the fragment first
+			// so the inject thread is signalled (via fragmentChunkFetched.notify_one
+			// inside UpdateTSAfterChunkFetch) before UpdateTSAfterFetchStats runs.
+			// This mirrors the original ring-buffer ordering where
+			// fragmentFetched.notify_one() fired before NotifyFragmentCachingComplete,
+			// giving the inject thread a systematic head-start.
 			std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
 			fragmentToCache->Copy(mStagingFragment);
 			CacheTsbFragment(std::move(fragmentToCache));
@@ -837,6 +839,10 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 				timeBasedBufferManager->ConsumeBuffer(mStagingFragment.duration);
 			}
 		}
+		// Update fetch statistics after the inject thread has been signalled,
+		// so that any NotifyFragmentCachingComplete fired here arrives after
+		// the inject thread already has data to forward to GStreamer.
+		UpdateTSAfterFetchStats(&mStagingFragment, dlInfo->isInitSegment);
 		mStagingFragment.Clear();
 		cachedFragment = nullptr;
 	}

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -661,6 +661,30 @@ bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment>&& frag
 }
 
 /**
+ * @fn CacheStagingFragmentForInjection
+ * @brief Copy the staging fragment into a chunk-cache slot and signal the
+ *        inject thread (non-LLD DASH path only).
+ *
+ *  Pre-populates profileIndex and cacheFragStreamInfo on the slot before
+ *  handing it to the inject thread.  UpdateTSAfterFetchStats runs after this
+ *  call on the separate mStagingFragment object, so without this population
+ *  the chunk slot would carry zeroed cacheFragStreamInfo, causing
+ *  NotifyBitRateUpdate to skip AAMP_EVENT_BITRATE_CHANGED.
+ */
+void MediaStreamContext::CacheStagingFragmentForInjection()
+{
+	std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
+	fragmentToCache->Copy(mStagingFragment);
+	if (auto* pContext = GetContext())
+	{
+		fragmentToCache->profileIndex = pContext->profileIdxForBandwidthNotification;
+		pContext->UpdateStreamInfoBitrateData(fragmentToCache->profileIndex,
+											 fragmentToCache->cacheFragStreamInfo);
+	}
+	CacheTsbFragment(std::move(fragmentToCache));
+}
+
+/**
  * @fn OnFragmentDownloadSuccess
  * @brief Function called on fragment download success
  * @param[in] downloadInfo - download information
@@ -809,63 +833,38 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 	}
 	else
 	{
-		if (!aamp->GetLLDashChunkMode())
+		// Both SLD and LLD consume the time-based buffer counter.
+		// SLD also caches the fragment for the inject thread first (see below).
+		auto consumeBuffer = [this]()
 		{
-			// Non-LLD DASH (SLD, AAMP TSB write-phase): cache the fragment first
-			// so the inject thread is signalled (via fragmentChunkFetched.notify_one
-			// inside UpdateTSAfterChunkFetch) before UpdateTSAfterFetchStats runs.
-			// This mirrors the original ring-buffer ordering where
-			// fragmentFetched.notify_one() fired before NotifyFragmentCachingComplete,
-			// giving the inject thread a systematic head-start.
-			std::shared_ptr<CachedFragment> fragmentToCache = std::make_shared<CachedFragment>();
-			fragmentToCache->Copy(mStagingFragment);
-			// Populate profileIndex and cacheFragStreamInfo on the chunk slot BEFORE
-			// handing it to the inject thread.  UpdateTSAfterFetchStats runs after
-			// CacheTsbFragment on mStagingFragment (a separate object), so the chunk
-			// slot consumed by the inject thread would otherwise carry empty
-			// cacheFragStreamInfo (all zeros), causing NotifyBitRateUpdate to silently
-			// skip AAMP_EVENT_BITRATE_CHANGED (gated on bandwidthBitsPerSecond != 0).
-			// Mirror UpdateTSAfterFetchStats exactly: read profileIdxForBandwidthNotification
-			// and call UpdateStreamInfoBitrateData for ALL fragments (init and media)
-			// so that (profileIndex, bps, resolution, framerate) are all consistent and
-			// sourced from the ABR stream info, avoiding any mismatch between profileIndex
-			// and bandwidthBitsPerSecond that would fire a spurious bitrate-change event
-			// with wrong data (which then persists the profile index, blocking the correct
-			// event from firing later).
-			{
-				class StreamAbstractionAAMP* pContext = GetContext();
-				if (pContext)
-				{
-					fragmentToCache->profileIndex = pContext->profileIdxForBandwidthNotification;
-					pContext->UpdateStreamInfoBitrateData(fragmentToCache->profileIndex, fragmentToCache->cacheFragStreamInfo);
-				}
-			}
-			CacheTsbFragment(std::move(fragmentToCache));
-			if (aamp->IsLocalAAMPTsb())
-			{
-				auto timeBasedBufferManager = GetTimeBasedBufferManager();
-				if (timeBasedBufferManager)
-				{
-					timeBasedBufferManager->ConsumeBuffer(mStagingFragment.duration);
-				}
-			}
-		}
-		else
-		{
-			// LLD DASH: media data already injected via CacheFragmentChunk callbacks.
-			// Consume the time-based buffer counter and discard the staging data.
 			auto timeBasedBufferManager = GetTimeBasedBufferManager();
 			if (timeBasedBufferManager)
 			{
 				timeBasedBufferManager->ConsumeBuffer(mStagingFragment.duration);
 			}
+		};
+
+		if (!aamp->GetLLDashChunkMode())
+		{
+			// Non-LLD DASH (SLD, AAMP TSB write-phase): signal the inject thread
+			// before UpdateTSAfterFetchStats fires NotifyFragmentCachingComplete.
+			CacheStagingFragmentForInjection();
+			if (aamp->IsLocalAAMPTsb())
+			{
+				consumeBuffer();
+			}
+		}
+		else
+		{
+			// LLD DASH: media data already injected via CacheFragmentChunk callbacks.
+			// Only the buffer counter needs consuming; staging data is discarded.
+			consumeBuffer();
 		}
 		// Update fetch statistics after the inject thread has been signalled,
 		// so that any NotifyFragmentCachingComplete fired here arrives after
 		// the inject thread already has data to forward to GStreamer.
 		UpdateTSAfterFetchStats(&mStagingFragment, dlInfo->isInitSegment);
 		mStagingFragment.Clear();
-		cachedFragment = nullptr;
 	}
 
 	if (aamp->IsLive())

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -64,7 +64,8 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 
 	fragmentDurationSeconds = fragmentDurationS;
 	ProfilerBucketType bucketType = aamp->GetProfilerBucketForMedia(mediaType, initSegment);
-	CachedFragment *cachedFragment = GetFetchBuffer(true);
+	mStagingFragment.Clear();
+	CachedFragment *cachedFragment = &mStagingFragment;
 	BitsPerSecond bitrate = 0;
 	double downloadTimeS = 0;
 	AampMediaType actualType = (AampMediaType)(initSegment ? (eMEDIATYPE_INIT_VIDEO + mediaType) : mediaType); // Need to revisit the logic
@@ -672,8 +673,8 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 		return;
 	}
 
-	// Get active buffer
-	CachedFragment *cachedFragment = GetFetchBuffer(false);
+	// Get staging fragment populated by CacheFragment
+	CachedFragment *cachedFragment = &mStagingFragment;
 	mActiveDownloadInfo = nullptr;
 	AampTSBSessionManager *tsbSessionManager = aamp->GetTSBSessionManager();
 
@@ -808,6 +809,11 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 	}
 	else
 	{
+		// Move staging fragment into the cache slot for injection
+		CachedFragment *slot = GetFetchBuffer(false);
+		*slot = std::move(mStagingFragment);
+		cachedFragment = slot;
+
 		// Update buffer index after fetch for injection
 		UpdateTSAfterFetch(dlInfo->isInitSegment);
 
@@ -861,8 +867,8 @@ void MediaStreamContext::OnFragmentDownloadFailed(DownloadInfoPtr dlInfo)
 		return;
 	}
 
-	// Get active buffer
-	CachedFragment *cachedFragment = GetFetchBuffer(false);
+	// Get staging fragment populated by CacheFragment
+	CachedFragment *cachedFragment = &mStagingFragment;
 	mActiveDownloadInfo = nullptr;
 	AAMPLOG_INFO("fragment fetch failed - Free cachedFragment for %d", cachedFragment->type);
 	aamp_utils::ClearAndRelease(cachedFragment->fragment);

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -375,6 +375,14 @@ bool CacheFragmentData(const FragmentCacheDescriptor& desc);
 	std::mutex fetchChunkBufferMutex;
 	DownloadInfoPtr mActiveDownloadInfo;
 	std::recursive_mutex mMediaStreamContextMutex; /**< Recursive mutex to protect MediaStreamContext state during ABR profile changes and playlist updates */
+
+private:
+	/**
+	 * @fn CacheStagingFragmentForInjection
+	 * @brief Copy the staging fragment into a chunk-cache slot for the inject
+	 *        thread (non-LLD DASH path only).
+	 */
+	void CacheStagingFragmentForInjection();
 }; // MediaStreamContext
 
 #endif /* MEDIASTREAMCONTEXT_H */

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -348,6 +348,7 @@ bool CacheFragmentData(const FragmentCacheDescriptor& desc);
 	bool discontinuity;
 	std::vector<uint8_t> mDownloadedFragment{};	/**< Fragment stored across ABR profile changes */
 	std::vector<uint8_t> mTempFragment{};		/**< Scratch buffer for init/download fragments */
+	CachedFragment mStagingFragment{};		/**< Staging buffer for fragment download in progress */
 
 	double fragmentTime; // Absolute Fragment time from Availability start
 	std::atomic<double> lastDownloadedPosition;

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -348,7 +348,6 @@ bool CacheFragmentData(const FragmentCacheDescriptor& desc);
 	bool discontinuity;
 	std::vector<uint8_t> mDownloadedFragment{};	/**< Fragment stored across ABR profile changes */
 	std::vector<uint8_t> mTempFragment{};		/**< Scratch buffer for init/download fragments */
-	CachedFragment mStagingFragment{};		/**< Staging buffer for fragment download in progress */
 
 	double fragmentTime; // Absolute Fragment time from Availability start
 	std::atomic<double> lastDownloadedPosition;
@@ -375,6 +374,9 @@ bool CacheFragmentData(const FragmentCacheDescriptor& desc);
 	std::mutex fetchChunkBufferMutex;
 	DownloadInfoPtr mActiveDownloadInfo;
 	std::recursive_mutex mMediaStreamContextMutex; /**< Recursive mutex to protect MediaStreamContext state during ABR profile changes and playlist updates */
+
+protected:
+	CachedFragment mStagingFragment{};		/**< Staging buffer for fragment download in progress */
 
 private:
 	/**

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -368,6 +368,17 @@ public:
 	void UpdateTSAfterFetch(bool IsInitSegment);
 
 	/**
+	 * @fn UpdateTSAfterFetchStats
+	 * @brief Updates fetch statistics using a caller-supplied fragment without
+	 *        touching the mCachedFragment ring buffer. Use in place of
+	 *        UpdateTSAfterFetch() + UpdateTSAfterInject() when the fragment
+	 *        goes directly into mCachedFragmentChunks.
+	 * @param[in] cachedFragment - Fragment supplying duration and metadata
+	 * @param[in] isInitSegment  - true for initialization segments
+	 */
+	void UpdateTSAfterFetchStats(CachedFragment* cachedFragment, bool isInitSegment);
+
+	/**
 	 * @fn UpdateTSAfterChunkFetch
 	 *
 	 * @return void

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -685,15 +685,6 @@ public:
 	virtual void ResetTrickModePtsRestamping(void);
 
 	/**
-	 * @fn IsInjectionFromCachedFragmentChunks
-	 *
-	 * @brief Are fragments to inject coming from mCachedFragmentChunks
-	 *
-	 * @return True if fragments to inject are coming from mCachedFragmentChunks
-	 */
-	bool IsInjectionFromCachedFragmentChunks();
-
-	/**
 	 * @fn GetTimeBasedBufferManager 
 	 *
 	 * @brief Get the time based buffer manager for this track

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1734,8 +1734,12 @@ void TrackState::FetchFragment()
 			AAMPLOG_WARN("%s cachedFragment->fragment has no allocated data buffer", name);
 		}
 		mSkipAbr = false; //To enable ABR since we have cached fragment after init fragment
-		UpdateTSAfterFetchStats(cachedFragment, false);
+		// Order matters: UpdateTSAfterChunkFetch() increments numberOfFragmentChunksCached,
+		// which UpdateTSAfterFetchStats() then reads for its cache-full / caching-complete
+		// decision. Calling the stats function first would observe a stale (pre-increment)
+		// count and miss the "chunk cache is full" abort trigger on the slot-filling fragment.
 		UpdateTSAfterChunkFetch();
+		UpdateTSAfterFetchStats(cachedFragment, false);
 	}
 }
 
@@ -6103,8 +6107,11 @@ void TrackState::FetchInitFragment()
 			mSkipAbr = true;				  // Skip ABR, since last fragment cached is init fragment.
 			mCheckForInitialFragEnc = false;  // Push encrypted header is a one-time operation
 			mFirstEncInitFragmentInfo = NULL; // reset init fragment, since encrypted header already pushed
-			UpdateTSAfterFetchStats(cachedFragment, true);
+			// Order matters: UpdateTSAfterChunkFetch() increments numberOfFragmentChunksCached,
+			// which UpdateTSAfterFetchStats() reads for cache-full / caching-complete handling.
+			// Kept consistent with FetchFragment() to avoid divergent stale-count behaviour.
 			UpdateTSAfterChunkFetch();
+			UpdateTSAfterFetchStats(cachedFragment, true);
 		}
 		else if (type == eTRACK_VIDEO && aamp->CheckABREnabled() && !context->CheckForRampDownLimitReached())
 		{

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1293,7 +1293,13 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 		if (!mInjectInitFragment && !fragmentURI.empty() && !bSegmentRepeated)
 		{
 			std::string fragmentUrl;
-			CachedFragment* cachedFragment = GetFetchBuffer(true);
+			CachedFragment* cachedFragment = GetFetchChunkBuffer(true);
+			if (!cachedFragment)
+			{
+				AAMPLOG_WARN("[%s] GetFetchChunkBuffer returned null in FetchFragmentHelper", name);
+				ReleasePlaylistLock();
+				return false;
+			}
 			std::string temp = fragmentURI.tostring();
 			aamp_ResolveURL(fragmentUrl, mEffectiveUrl, temp.c_str(), ISCONFIGSET(eAAMPConfig_PropagateURIParam));
 			ReleasePlaylistLock();
@@ -1659,7 +1665,12 @@ void TrackState::FetchFragment()
 			context->mRampDownCount = 0;
 		}
 
-		CachedFragment* cachedFragment = GetFetchBuffer(false);
+		CachedFragment* cachedFragment = GetFetchChunkBuffer(false);
+		if (!cachedFragment)
+		{
+			AAMPLOG_WARN("[%s] GetFetchChunkBuffer returned null in FetchFragment", name);
+			return;
+		}
 		if (cachedFragment->fragment.capacity() != 0)
 		{
 			AampTime duration{fragmentDurationSeconds};
@@ -1723,7 +1734,8 @@ void TrackState::FetchFragment()
 			AAMPLOG_WARN("%s cachedFragment->fragment has no allocated data buffer", name);
 		}
 		mSkipAbr = false; //To enable ABR since we have cached fragment after init fragment
-		UpdateTSAfterFetch(false);
+		UpdateTSAfterFetchStats(cachedFragment, false);
+		UpdateTSAfterChunkFetch();
 	}
 }
 
@@ -6067,7 +6079,13 @@ void TrackState::FetchInitFragment()
 		{
 			aamp->profiler.ProfileEnd(bucketType);
 
-			CachedFragment *cachedFragment = GetFetchBuffer(false);
+			CachedFragment *cachedFragment = GetFetchChunkBuffer(false);
+			if (!cachedFragment)
+			{
+				AAMPLOG_WARN("[%s] GetFetchChunkBuffer returned null for init fragment in FetchFragment", name);
+				mInjectInitFragment = true; // mark for retry
+				return;
+			}
 			if (cachedFragment->fragment.capacity() != 0)
 			{
 				cachedFragment->duration = 0;
@@ -6085,7 +6103,8 @@ void TrackState::FetchInitFragment()
 			mSkipAbr = true;				  // Skip ABR, since last fragment cached is init fragment.
 			mCheckForInitialFragEnc = false;  // Push encrypted header is a one-time operation
 			mFirstEncInitFragmentInfo = NULL; // reset init fragment, since encrypted header already pushed
-			UpdateTSAfterFetch(true);
+			UpdateTSAfterFetchStats(cachedFragment, true);
+			UpdateTSAfterChunkFetch();
 		}
 		else if (type == eTRACK_VIDEO && aamp->CheckABREnabled() && !context->CheckForRampDownLimitReached())
 		{
@@ -6219,7 +6238,12 @@ bool TrackState::FetchInitFragmentHelper(int &http_code, bool forcePushEncrypted
 			std::string fragmentUrl;
 			aamp_ResolveURL(fragmentUrl, mEffectiveUrl, uri.c_str(), ISCONFIGSET(eAAMPConfig_PropagateURIParam));
 			std::string tempEffectiveUrl;
-			CachedFragment* cachedFragment = GetFetchBuffer(true);
+			CachedFragment* cachedFragment = GetFetchChunkBuffer(true);
+			if (!cachedFragment)
+			{
+				AAMPLOG_WARN("[%s] GetFetchChunkBuffer returned null in FetchInitFragmentHelper", name);
+				return false;
+			}
 			AAMPLOG_WARN("TrackState::[%s] init-fragment = %s", name, fragmentUrl.c_str());
 			int iCurrentRate = aamp->rate; //  Store it as back up, As sometimes by the time File is downloaded, rate might have changed due to user initiated Trick-Play
 

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1296,7 +1296,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 			CachedFragment* cachedFragment = GetFetchChunkBuffer(true);
 			if (!cachedFragment)
 			{
-				AAMPLOG_WARN("[%s] GetFetchChunkBuffer returned null in FetchFragmentHelper", name);
+				AAMPLOG_WARN("[%s] GetFetchChunkBuffer returned null", name);
 				ReleasePlaylistLock();
 				return false;
 			}

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -575,13 +575,7 @@ void MediaTrack::UpdateTSAfterFetch(bool IsInitSegment)
 }
 
 /**
- * @brief Updates fetch statistics using a caller-supplied fragment without
- *        touching the mCachedFragment ring buffer.
- *
- * Use in place of UpdateTSAfterFetch() + UpdateTSAfterInject() when the
- * fragment goes directly into mCachedFragmentChunks, so there is no need
- * to allocate a ring buffer slot via GetFetchBuffer() only to free it
- * immediately afterwards.
+ * @brief Updates fetch statistics using a caller-supplied fragment.
  *
  * @param[in] cachedFragment - Fragment supplying duration and metadata
  * @param[in] isInitSegment  - true for initialization segments
@@ -589,7 +583,7 @@ void MediaTrack::UpdateTSAfterFetch(bool IsInitSegment)
 void MediaTrack::UpdateTSAfterFetchStats(CachedFragment* cachedFragment, bool isInitSegment)
 {
 	bool notifyCacheCompleted = false;
-	class StreamAbstractionAAMP* pContext = GetContext();
+	auto* pContext = GetContext();
 	std::unique_lock<std::mutex> lock(mutex);
 
 	if (pContext)
@@ -782,7 +776,7 @@ bool MediaTrack::WaitForCachedFragmentChunkInjected(int timeoutMs)
 		else
 		{
 			AAMPLOG_DEBUG("[%s] waiting for fragmentChunkInjected condition", name);
-			fragmentChunkInjected.wait(lock, [this] { //DJH - testing add predicate to avoid spurious wake ups
+			fragmentChunkInjected.wait(lock, [this] { // Predicate to avoid spurious wake ups
 				return numberOfFragmentChunksCached < mCachedFragmentChunksSize || abort;
 			});
 			AAMPLOG_DEBUG("[%s] wait complete for fragmentChunkInjected", name);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4955,14 +4955,16 @@ void MediaTrack::HandleFragmentPositionJump(CachedFragment* cachedFragment)
 bool MediaTrack::IsInjectionFromCachedFragmentChunks()
 {
 	// CachedFragmentChunks is used for LL-DASH, for any content if AAMP TSB is enabled,
-	// and for all DASH content (to unify the fragment cache path)
+	// and for all DASH and HLS content (to unify the fragment cache path)
 	bool isLLDashChunkMode = aamp->GetLLDashChunkMode();
 	bool aampTsbEnabled = aamp->IsLocalAAMPTsb();
 	bool isDash = aamp->IsDashAsset();
-	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled || isDash;
+	bool isHls = (aamp->mMediaFormat == eMEDIAFORMAT_HLS ||
+				  aamp->mMediaFormat == eMEDIAFORMAT_HLS_MP4);
+	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled || isDash || isHls;
 
-	AAMPLOG_TRACE("[%s] isLLDashChunkMode %d aampTsbEnabled %d isDash %d ret %d",
-				  name, isLLDashChunkMode, aampTsbEnabled, isDash, isInjectionFromCachedFragmentChunks);
+	AAMPLOG_TRACE("[%s] isLLDashChunkMode %d aampTsbEnabled %d isDash %d isHls %d ret %d",
+				  name, isLLDashChunkMode, aampTsbEnabled, isDash, isHls, isInjectionFromCachedFragmentChunks);
 	return isInjectionFromCachedFragmentChunks;
 }
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -767,11 +767,10 @@ bool MediaTrack::WaitForCachedFragmentChunkInjected(int timeoutMs)
 	{
 		if (timeoutMs >= 0)
 		{
-			if (std::cv_status::timeout == fragmentChunkInjected.wait_for(lock,std::chrono::milliseconds(timeoutMs)))
-			{
-				AAMPLOG_DEBUG("[%s] pthread_cond_timedwait timed out", name);
-				ret = false;
-			}
+			AAMPLOG_DEBUG("[%s] waiting for fragmentChunkInjected condition (timeout %dms)", name, timeoutMs);
+			fragmentChunkInjected.wait_for(lock, std::chrono::milliseconds(timeoutMs), [this] { // Predicate to avoid spurious wake ups
+				return numberOfFragmentChunksCached < mCachedFragmentChunksSize || abort;
+			});
 		}
 		else
 		{
@@ -786,9 +785,9 @@ bool MediaTrack::WaitForCachedFragmentChunkInjected(int timeoutMs)
 			AAMPLOG_DEBUG("[%s] abort set, returning false", name);
 			ret = false;
 		}
-		else if (numberOfFragmentChunksCached == mCachedFragmentChunksSize)
+		if (numberOfFragmentChunksCached == mCachedFragmentChunksSize)
 		{
-			AAMPLOG_DEBUG("[%s] cache still full (%d/%zu), returning false", name, numberOfFragmentChunksCached, mCachedFragmentChunksSize);
+			AAMPLOG_DEBUG("[%s] fragmentChunkInjected timed out, buffer still full", name);
 			ret = false;
 		}
 	}

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -150,9 +150,7 @@ BufferHealthStatus MediaTrack::GetBufferStatus()
 	else if (pContext)
 	{
 		bufferedTime 	    = injectedDuration - pContext->GetElapsedTime();
-		CachedFragmentsOrChunks = IsInjectionFromCachedFragmentChunks()
-			? numberOfFragmentChunksCached
-			: numberOfFragmentsCached;
+		CachedFragmentsOrChunks = numberOfFragmentChunksCached;
 	}
 
 	if ( CachedFragmentsOrChunks <= 0  && (bufferedTime <= thresholdBuffer) && pContext)
@@ -738,33 +736,7 @@ bool MediaTrack::WaitForFreeFragmentAvailable( int timeoutMs)
 
 	if (ret)
 	{
-		if (IsInjectionFromCachedFragmentChunks())
-		{
-			ret = WaitForCachedFragmentChunkInjected(timeoutMs);
-		}
-		else
-		{
-			std::unique_lock<std::mutex> lock(mutex);
-			if ((maxCachedFragmentsPerTrack) && (numberOfFragmentsCached == maxCachedFragmentsPerTrack))
-			{
-				if (timeoutMs >= 0)
-				{
-					if (std::cv_status::timeout == fragmentInjected.wait_for(lock, std::chrono::milliseconds(timeoutMs)))
-					{
-						AAMPLOG_TRACE("Timed out waiting for fragmentInjected");
-						ret = false;
-					}
-				}
-				else
-				{
-					fragmentInjected.wait(lock);
-				}
-				if (abort)
-				{
-					ret = false;
-				}
-			}
-		}
+		ret = WaitForCachedFragmentChunkInjected(timeoutMs);
 	}
 	return ret;
 }
@@ -1573,23 +1545,11 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 		}
 
 		// Release the memory and Update the inject
-		if(IsInjectionFromCachedFragmentChunks())
+		UpdateTSAfterChunkInject();
+		// Plain SLD DASH (not LLD chunk mode, not AAMP TSB) routes through the chunk
+		// cache but still needs time-based buffer accounting, as it did before.
+		if (!aamp->GetLLDashChunkMode() && !aamp->IsLocalAAMPTsb())
 		{
-			UpdateTSAfterChunkInject();
-			// Plain SLD DASH (not LLD chunk mode, not AAMP TSB) routes through the chunk
-			// cache but still needs time-based buffer accounting, as it did before.
-			if (!aamp->GetLLDashChunkMode() && !aamp->IsLocalAAMPTsb())
-			{
-				auto timeBasedBufferManager = GetTimeBasedBufferManager();
-				if (timeBasedBufferManager)
-				{
-					timeBasedBufferManager->ConsumeBuffer(inFragmentDuration);
-				}
-			}
-		}
-		else
-		{
-			UpdateTSAfterInject();
 			auto timeBasedBufferManager = GetTimeBasedBufferManager();
 			if (timeBasedBufferManager)
 			{
@@ -1606,7 +1566,6 @@ bool MediaTrack::InjectFragment()
 {
 	bool ret = true;
 	bool isChunkMode = aamp->GetLLDashChunkMode() && (aamp->IsLocalAAMPTsbInjection() == false);
-	bool isChunkBuffer = IsInjectionFromCachedFragmentChunks();
 	bool lowLatency = aamp->GetLLDashServiceData()->lowLatencyMode;
 	StreamAbstractionAAMP* pContext = GetContext();
 
@@ -1614,27 +1573,16 @@ bool MediaTrack::InjectFragment()
 	{
 		aamp->BlockUntilGstreamerWantsData(NULL, 0, type);
 	}
-	bool notAborted = isChunkBuffer ? WaitForCachedFragmentChunkAvailable() : WaitForCachedFragmentAvailable();
+	bool notAborted = WaitForCachedFragmentChunkAvailable();
 	if (notAborted)
 	{
 		bool stopInjection = false;
 		bool fragmentDiscarded = false;
 		bool isDiscontinuity = false;
-		CachedFragment* cachedFragment = nullptr;
-		if(isChunkBuffer)
-		{
-			cachedFragment = &this->mCachedFragmentChunks[fragmentChunkIdxToInject];
-			AAMPLOG_TRACE("[%s] fragmentChunkIdxToInject : %d Discontinuity %d ", name, fragmentChunkIdxToInject, cachedFragment->discontinuity);
-
-		}
-		else
-		{
-			cachedFragment = &this->mCachedFragment[fragmentIdxToInject];
-			AAMPLOG_TRACE("[%s] fragmentIdxToInject : %d Discontinuity %d ", name, fragmentIdxToInject, cachedFragment->discontinuity);
-		}
-
-		AAMPLOG_TRACE("[%s] - fragmentIdxToInject %d cachedFragment %p ptr %p",
-					  name, fragmentIdxToInject, cachedFragment, cachedFragment->fragment.data());
+		CachedFragment* cachedFragment = &this->mCachedFragmentChunks[fragmentChunkIdxToInject];
+		AAMPLOG_TRACE("[%s] fragmentChunkIdxToInject : %d Discontinuity %d ", name, fragmentChunkIdxToInject, cachedFragment->discontinuity);
+		AAMPLOG_TRACE("[%s] - fragmentChunkIdxToInject %d cachedFragment %p ptr %p",
+					  name, fragmentChunkIdxToInject, cachedFragment, cachedFragment->fragment.data());
 		if (cachedFragment->fragment.capacity() != 0)
 		{
 			// This is currently supported for non-LL DASH streams only at normal play rate
@@ -1991,16 +1939,8 @@ bool MediaTrack::IsFragmentCacheFull()
 {
 	bool rc = false;
 	std::lock_guard<std::mutex> guard(mutex);
-	if(IsInjectionFromCachedFragmentChunks())
-	{
-		AAMPLOG_DEBUG("[%s] numberOfFragmentChunksCached %d mCachedFragmentChunksSize %zu", name, numberOfFragmentChunksCached, mCachedFragmentChunksSize);
-		rc = (numberOfFragmentChunksCached == mCachedFragmentChunksSize);
-	}
-	else
-	{
-		AAMPLOG_DEBUG("[%s] numberOfFragmentsCached %d maxCachedFragmentsPerTrack %d", name, numberOfFragmentsCached, maxCachedFragmentsPerTrack);
-		rc = numberOfFragmentsCached == maxCachedFragmentsPerTrack;
-	}
+	AAMPLOG_DEBUG("[%s] numberOfFragmentChunksCached %d mCachedFragmentChunksSize %zu", name, numberOfFragmentChunksCached, mCachedFragmentChunksSize);
+	rc = (numberOfFragmentChunksCached == mCachedFragmentChunksSize);
 	return rc;
 }
 
@@ -2036,38 +1976,19 @@ BitsPerSecond MediaTrack::GetCurrentBandWidth()
 void MediaTrack::FlushFetchedFragments()
 {
 	std::lock_guard<std::mutex> guard(mutex);
-	if (IsInjectionFromCachedFragmentChunks())
+	while (numberOfFragmentChunksCached)
 	{
-		while (numberOfFragmentChunksCached)
-		{
-			AAMPLOG_DEBUG("[%s] Free mCachedFragmentChunks[%d] numberOfFragmentChunksCached %d", name, fragmentChunkIdxToInject, numberOfFragmentChunksCached);
-			mCachedFragmentChunks[fragmentChunkIdxToInject].Clear();
+		AAMPLOG_DEBUG("[%s] Free mCachedFragmentChunks[%d] numberOfFragmentChunksCached %d", name, fragmentChunkIdxToInject, numberOfFragmentChunksCached);
+		mCachedFragmentChunks[fragmentChunkIdxToInject].Clear();
 
-			fragmentChunkIdxToInject++;
-			if (fragmentChunkIdxToInject == maxCachedFragmentChunksPerTrack)
-			{
-				fragmentChunkIdxToInject = 0;
-			}
-			numberOfFragmentChunksCached--;
-		}
-		fragmentChunkInjected.notify_one();
-	}
-	else
-	{
-		while (numberOfFragmentsCached)
+		fragmentChunkIdxToInject++;
+		if (fragmentChunkIdxToInject == maxCachedFragmentChunksPerTrack)
 		{
-			AAMPLOG_DEBUG("[%s] Free cachedFragment[%d] numberOfFragmentsCached %d", name, fragmentIdxToInject, numberOfFragmentsCached);
-			mCachedFragment[fragmentIdxToInject].Clear();
-
-			fragmentIdxToInject++;
-			if (fragmentIdxToInject == maxCachedFragmentsPerTrack)
-			{
-				fragmentIdxToInject = 0;
-			}
-			numberOfFragmentsCached--;
+			fragmentChunkIdxToInject = 0;
 		}
-		fragmentInjected.notify_one();
+		numberOfFragmentChunksCached--;
 	}
+	fragmentChunkInjected.notify_one();
 }
 
 /**
@@ -2078,40 +1999,19 @@ void MediaTrack::FlushFetchedFragments()
 void MediaTrack::FlushFragments()
 {
 	AAMPLOG_WARN("[%s]", name);
-	if(IsInjectionFromCachedFragmentChunks())
+	for (int i = 0; i < maxCachedFragmentChunksPerTrack; i++)
 	{
-		for (int i = 0; i < maxCachedFragmentChunksPerTrack; i++)
-		{
-			mCachedFragmentChunks[i].Clear();
-		}
-		aamp_utils::ClearAndRelease(unparsedBufferChunk);
-		aamp_utils::ClearAndRelease(parsedBufferChunk);
-		fragmentChunkIdxToInject = 0;
-		fragmentChunkIdxToFetch = 0;
-		std::lock_guard<std::mutex> guard(mutex);
-		numberOfFragmentChunksCached = 0;
-		totalFragmentChunksDownloaded = 0;
-		// We need to revisit if these variables should be also sync using mTrackParamsMutex
-		totalInjectedChunksDuration = 0;
+		mCachedFragmentChunks[i].Clear();
 	}
-	else
-	{
-		for (int i = 0; i < maxCachedFragmentsPerTrack; i++)
-		{
-			mCachedFragment[i].Clear();
-		}
-		fragmentIdxToInject = 0;
-		fragmentIdxToFetch = 0;
-		numberOfFragmentsCached = 0;
-		lastInjectedDuration = 0;
-		if( ( type == eTRACK_AUDIO && !loadNewAudio ) || ( type == eTRACK_SUBTITLE && !loadNewSubtitle ) )
-		{
-			std::lock_guard<std::mutex> lock(mTrackParamsMutex);
-			totalFetchedDuration = 0;
-			totalFragmentsDownloaded = 0;
-			totalInjectedDuration = 0;
-		}
-	}
+	aamp_utils::ClearAndRelease(unparsedBufferChunk);
+	aamp_utils::ClearAndRelease(parsedBufferChunk);
+	fragmentChunkIdxToInject = 0;
+	fragmentChunkIdxToFetch = 0;
+	std::lock_guard<std::mutex> guard(mutex);
+	numberOfFragmentChunksCached = 0;
+	totalFragmentChunksDownloaded = 0;
+	// We need to revisit if these variables should be also sync using mTrackParamsMutex
+	totalInjectedChunksDuration = 0;
 }
 
 
@@ -3046,13 +2946,9 @@ bool StreamAbstractionAAMP::CheckIfPlayerRunningDry()
 	{
 		return false;
 	}
-	bool videoBufferIsEmpty = (videoTrack->IsInjectionFromCachedFragmentChunks()
-		? videoTrack->numberOfFragmentChunksCached == 0
-		: videoTrack->numberOfFragmentsCached == 0) && aamp->IsSinkCacheEmpty(eMEDIATYPE_VIDEO);
+	bool videoBufferIsEmpty = (videoTrack->numberOfFragmentChunksCached == 0) && aamp->IsSinkCacheEmpty(eMEDIATYPE_VIDEO);
 	bool audioBufferIsEmpty = (audioTrack->Enabled()
-		? (audioTrack->IsInjectionFromCachedFragmentChunks()
-			? audioTrack->numberOfFragmentChunksCached == 0
-			: audioTrack->numberOfFragmentsCached == 0)
+		? audioTrack->numberOfFragmentChunksCached == 0
 		: true) && aamp->IsSinkCacheEmpty(eMEDIATYPE_AUDIO);
 	if (videoBufferIsEmpty || audioBufferIsEmpty) /* Changed the condition from '&&' to '||', because if video getting stalled it doesn't need to wait until audio become dry */
 	{
@@ -3265,9 +3161,7 @@ void StreamAbstractionAAMP::CheckForPlaybackStall(bool fragmentParsed)
 		if(mediatrack != NULL)
 		{
 			int stalltimeout = GETCONFIGVALUE(eAAMPConfig_StallTimeoutMS);
-			bool cacheEmpty = mediatrack->IsInjectionFromCachedFragmentChunks()
-				? mediatrack->numberOfFragmentChunksCached == 0
-				: mediatrack->numberOfFragmentsCached == 0;
+			bool cacheEmpty = mediatrack->numberOfFragmentChunksCached == 0;
 			if (!mNetworkDownDetected && (timeElapsedSinceLastFragment > stalltimeout) && cacheEmpty)
 			{
 				AAMPLOG_INFO("StreamAbstractionAAMP: Didn't download a new fragment for a long time(%f) and cache empty!", timeElapsedSinceLastFragment);
@@ -3631,20 +3525,10 @@ bool MediaTrack::CheckForFutureDiscontinuity(double &cachedDuration)
 
 	std::lock_guard<std::mutex> guard(mutex);
 
-	if (IsInjectionFromCachedFragmentChunks())
-	{
-		index = fragmentChunkIdxToInject;
-		count = numberOfFragmentChunksCached;
-		maxFrags = maxCachedFragmentChunksPerTrack;
-		pCachedFragment = mCachedFragmentChunks;
-	}
-	else
-	{
-		index = fragmentIdxToInject;
-		count = numberOfFragmentsCached;
-		maxFrags = maxCachedFragmentsPerTrack;
-		pCachedFragment = mCachedFragment;
-	}
+	index = fragmentChunkIdxToInject;
+	count = numberOfFragmentChunksCached;
+	maxFrags = maxCachedFragmentChunksPerTrack;
+	pCachedFragment = mCachedFragmentChunks;
 
 	while (count > 0)
 	{
@@ -3663,7 +3547,7 @@ bool MediaTrack::CheckForFutureDiscontinuity(double &cachedDuration)
 		}
 		count--;
 	}
-	AAMPLOG_WARN("track %s numberOfFragmentsCached - %d, cachedDuration - %f", name, IsInjectionFromCachedFragmentChunks() ? numberOfFragmentChunksCached : numberOfFragmentsCached, cachedDuration);
+	AAMPLOG_WARN("track %s numberOfFragmentChunksCached - %d, cachedDuration - %f", name, numberOfFragmentChunksCached, cachedDuration);
 
 	return ret;
 }
@@ -4950,22 +4834,6 @@ void MediaTrack::HandleFragmentPositionJump(CachedFragment* cachedFragment)
 			}
 		}
 	}
-}
-
-bool MediaTrack::IsInjectionFromCachedFragmentChunks()
-{
-	// CachedFragmentChunks is used for LL-DASH, for any content if AAMP TSB is enabled,
-	// and for all DASH and HLS content (to unify the fragment cache path)
-	bool isLLDashChunkMode = aamp->GetLLDashChunkMode();
-	bool aampTsbEnabled = aamp->IsLocalAAMPTsb();
-	bool isDash = aamp->IsDashAsset();
-	bool isHls = (aamp->mMediaFormat == eMEDIAFORMAT_HLS ||
-				  aamp->mMediaFormat == eMEDIAFORMAT_HLS_MP4);
-	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled || isDash || isHls;
-
-	AAMPLOG_TRACE("[%s] isLLDashChunkMode %d aampTsbEnabled %d isDash %d isHls %d ret %d",
-				  name, isLLDashChunkMode, aampTsbEnabled, isDash, isHls, isInjectionFromCachedFragmentChunks);
-	return isInjectionFromCachedFragmentChunks;
 }
 
 /**

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1478,6 +1478,16 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 		if(IsInjectionFromCachedFragmentChunks())
 		{
 			UpdateTSAfterChunkInject();
+			// Plain SLD DASH (not LLD chunk mode, not AAMP TSB) routes through the chunk
+			// cache but still needs time-based buffer accounting, as it did before.
+			if (!aamp->GetLLDashChunkMode() && !aamp->IsLocalAAMPTsb())
+			{
+				auto timeBasedBufferManager = GetTimeBasedBufferManager();
+				if (timeBasedBufferManager)
+				{
+					timeBasedBufferManager->ConsumeBuffer(inFragmentDuration);
+				}
+			}
 		}
 		else
 		{
@@ -4837,13 +4847,15 @@ void MediaTrack::HandleFragmentPositionJump(CachedFragment* cachedFragment)
 
 bool MediaTrack::IsInjectionFromCachedFragmentChunks()
 {
-	// CachedFragmentChunks is used for LL-DASH and for any content if AAMP TSB is enabled
+	// CachedFragmentChunks is used for LL-DASH, for any content if AAMP TSB is enabled,
+	// and for all DASH content (to unify the fragment cache path)
 	bool isLLDashChunkMode = aamp->GetLLDashChunkMode();
 	bool aampTsbEnabled = aamp->IsLocalAAMPTsb();
-	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled;
+	bool isDash = aamp->IsDashAsset();
+	bool isInjectionFromCachedFragmentChunks = isLLDashChunkMode || aampTsbEnabled || isDash;
 
-	AAMPLOG_TRACE("[%s] isLLDashChunkMode %d aampTsbEnabled %d ret %d",
-				  name, isLLDashChunkMode, aampTsbEnabled, isInjectionFromCachedFragmentChunks);
+	AAMPLOG_TRACE("[%s] isLLDashChunkMode %d aampTsbEnabled %d isDash %d ret %d",
+				  name, isLLDashChunkMode, aampTsbEnabled, isDash, isInjectionFromCachedFragmentChunks);
 	return isInjectionFromCachedFragmentChunks;
 }
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2006,6 +2006,18 @@ void MediaTrack::FlushFragments()
 	totalFragmentChunksDownloaded = 0;
 	// We need to revisit if these variables should be also sync using mTrackParamsMutex
 	totalInjectedChunksDuration = 0;
+
+	// For audio/subtitle tracks that are not mid-switch, reset the business-logic
+	// lifetime counters so that post-flush callers (GetBufferStatus, HandleTrackChange,
+	// ABR) start from a clean slate for the new track content.  These counters are
+	// protected by mTrackParamsMutex (separate from the ring-buffer mutex above).
+	if (( type == eTRACK_AUDIO && !loadNewAudio ) || ( type == eTRACK_SUBTITLE && !loadNewSubtitle ))
+	{
+		std::lock_guard<std::mutex> lock(mTrackParamsMutex);
+		totalFetchedDuration = 0;
+		totalFragmentsDownloaded = 0;
+		totalInjectedDuration = 0;
+	}
 }
 
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3552,7 +3552,7 @@ bool MediaTrack::CheckForFutureDiscontinuity(double &cachedDuration)
 		}
 		count--;
 	}
-	AAMPLOG_WARN("track %s numberOfFragmentChunksCached - %d, cachedDuration - %f", name, numberOfFragmentChunksCached, cachedDuration);
+	AAMPLOG_WARN("track %s numberOfFragmentChunksCached %d, cachedDuration %f", name, numberOfFragmentChunksCached, cachedDuration);
 
 	return ret;
 }

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -810,7 +810,7 @@ bool MediaTrack::WaitForCachedFragmentChunkInjected(int timeoutMs)
 		else
 		{
 			AAMPLOG_DEBUG("[%s] waiting for fragmentChunkInjected condition", name);
-			fragmentChunkInjected.wait(lock, [this] { //DJH - testing add predicate to avoid spurious wakeups
+			fragmentChunkInjected.wait(lock, [this] { //DJH - testing add predicate to avoid spurious wake ups
 				return numberOfFragmentChunksCached < mCachedFragmentChunksSize || abort;
 			});
 			AAMPLOG_DEBUG("[%s] wait complete for fragmentChunkInjected", name);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -150,7 +150,9 @@ BufferHealthStatus MediaTrack::GetBufferStatus()
 	else if (pContext)
 	{
 		bufferedTime 	    = injectedDuration - pContext->GetElapsedTime();
-		CachedFragmentsOrChunks = numberOfFragmentsCached ;
+		CachedFragmentsOrChunks = IsInjectionFromCachedFragmentChunks()
+			? numberOfFragmentChunksCached
+			: numberOfFragmentsCached;
 	}
 
 	if ( CachedFragmentsOrChunks <= 0  && (bufferedTime <= thresholdBuffer) && pContext)
@@ -3044,8 +3046,14 @@ bool StreamAbstractionAAMP::CheckIfPlayerRunningDry()
 	{
 		return false;
 	}
-	bool videoBufferIsEmpty = videoTrack->numberOfFragmentsCached == 0 && aamp->IsSinkCacheEmpty(eMEDIATYPE_VIDEO);
-	bool audioBufferIsEmpty = (audioTrack->Enabled() ? (audioTrack->numberOfFragmentsCached == 0) : true) && aamp->IsSinkCacheEmpty(eMEDIATYPE_AUDIO);
+	bool videoBufferIsEmpty = (videoTrack->IsInjectionFromCachedFragmentChunks()
+		? videoTrack->numberOfFragmentChunksCached == 0
+		: videoTrack->numberOfFragmentsCached == 0) && aamp->IsSinkCacheEmpty(eMEDIATYPE_VIDEO);
+	bool audioBufferIsEmpty = (audioTrack->Enabled()
+		? (audioTrack->IsInjectionFromCachedFragmentChunks()
+			? audioTrack->numberOfFragmentChunksCached == 0
+			: audioTrack->numberOfFragmentsCached == 0)
+		: true) && aamp->IsSinkCacheEmpty(eMEDIATYPE_AUDIO);
 	if (videoBufferIsEmpty || audioBufferIsEmpty) /* Changed the condition from '&&' to '||', because if video getting stalled it doesn't need to wait until audio become dry */
 	{
 		AAMPLOG_WARN("StreamAbstractionAAMP: Stall detected. Buffer status is RED!");
@@ -3257,7 +3265,10 @@ void StreamAbstractionAAMP::CheckForPlaybackStall(bool fragmentParsed)
 		if(mediatrack != NULL)
 		{
 			int stalltimeout = GETCONFIGVALUE(eAAMPConfig_StallTimeoutMS);
-			if (!mNetworkDownDetected && (timeElapsedSinceLastFragment > stalltimeout) && mediatrack->numberOfFragmentsCached == 0)
+			bool cacheEmpty = mediatrack->IsInjectionFromCachedFragmentChunks()
+				? mediatrack->numberOfFragmentChunksCached == 0
+				: mediatrack->numberOfFragmentsCached == 0;
+			if (!mNetworkDownDetected && (timeElapsedSinceLastFragment > stalltimeout) && cacheEmpty)
 			{
 				AAMPLOG_INFO("StreamAbstractionAAMP: Didn't download a new fragment for a long time(%f) and cache empty!", timeElapsedSinceLastFragment);
 				mIsPlaybackStalled = true;

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1975,7 +1975,7 @@ void MediaTrack::FlushFetchedFragments()
 		mCachedFragmentChunks[fragmentChunkIdxToInject].Clear();
 
 		fragmentChunkIdxToInject++;
-		if (fragmentChunkIdxToInject == maxCachedFragmentChunksPerTrack)
+		if (fragmentChunkIdxToInject == mCachedFragmentChunksSize)
 		{
 			fragmentChunkIdxToInject = 0;
 		}
@@ -1992,7 +1992,7 @@ void MediaTrack::FlushFetchedFragments()
 void MediaTrack::FlushFragments()
 {
 	AAMPLOG_WARN("[%s]", name);
-	for (int i = 0; i < maxCachedFragmentChunksPerTrack; i++)
+	for (size_t i = 0; i < mCachedFragmentChunksSize; i++)
 	{
 		mCachedFragmentChunks[i].Clear();
 	}
@@ -3532,7 +3532,7 @@ bool MediaTrack::CheckForFutureDiscontinuity(double &cachedDuration)
 
 	index = fragmentChunkIdxToInject;
 	count = numberOfFragmentChunksCached;
-	maxFrags = maxCachedFragmentChunksPerTrack;
+	maxFrags = static_cast<int>(mCachedFragmentChunksSize);
 	pCachedFragment = mCachedFragmentChunks;
 
 	while (count > 0)

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -575,6 +575,100 @@ void MediaTrack::UpdateTSAfterFetch(bool IsInitSegment)
 }
 
 /**
+ * @brief Updates fetch statistics using a caller-supplied fragment without
+ *        touching the mCachedFragment ring buffer.
+ *
+ * Use in place of UpdateTSAfterFetch() + UpdateTSAfterInject() when the
+ * fragment goes directly into mCachedFragmentChunks, so there is no need
+ * to allocate a ring buffer slot via GetFetchBuffer() only to free it
+ * immediately afterwards.
+ *
+ * @param[in] cachedFragment - Fragment supplying duration and metadata
+ * @param[in] isInitSegment  - true for initialization segments
+ */
+void MediaTrack::UpdateTSAfterFetchStats(CachedFragment* cachedFragment, bool isInitSegment)
+{
+	bool notifyCacheCompleted = false;
+	class StreamAbstractionAAMP* pContext = GetContext();
+	std::unique_lock<std::mutex> lock(mutex);
+
+	if (pContext)
+	{
+		cachedFragment->profileIndex = pContext->profileIdxForBandwidthNotification;
+		pContext->UpdateStreamInfoBitrateData(cachedFragment->profileIndex, cachedFragment->cacheFragStreamInfo);
+	}
+	totalFetchedDuration += cachedFragment->duration;
+	currentInitialCacheDurationSeconds += cachedFragment->duration;
+
+	if ((eTRACK_VIDEO == type)
+		&& aamp->IsFragmentCachingRequired()
+		&& !cachingCompleted)
+	{
+		const int minInitialCacheSeconds = aamp->GetInitialBufferDuration();
+		if (currentInitialCacheDurationSeconds >= minInitialCacheSeconds)
+		{
+			AAMPLOG_WARN("##[%s] Caching Complete cacheDuration %d minInitialCacheSeconds %d##",
+						 name, currentInitialCacheDurationSeconds, minInitialCacheSeconds);
+			notifyCacheCompleted = true;
+			cachingCompleted = true;
+		}
+		else if (sinkBufferIsFull && numberOfFragmentChunksCached == mCachedFragmentChunksSize)
+		{
+			AAMPLOG_WARN("## [%s] Chunk Cache is Full cacheDuration %d minInitialCacheSeconds %d, aborting caching!##",
+						 name, currentInitialCacheDurationSeconds, minInitialCacheSeconds);
+			notifyCacheCompleted = true;
+			cachingCompleted = true;
+		}
+		else
+		{
+			AAMPLOG_INFO("## [%s] Caching Ongoing cacheDuration %d minInitialCacheSeconds %d##",
+						 name, currentInitialCacheDurationSeconds, minInitialCacheSeconds);
+		}
+	}
+	if (loadNewAudio && (eTRACK_AUDIO == type) && !isInitSegment)
+	{
+		if (playContext)
+		{
+			AAMPLOG_INFO("Resetting PTS on audio track switch with MediaProcessor enabled. position: %f PTSOffsetSec: %f",
+						 cachedFragment->position, cachedFragment->PTSOffsetSec);
+			playContext->resetPTSOnAudioSwitch(cachedFragment->fragment, cachedFragment->position, cachedFragment->PTSOffsetSec);
+		}
+		else
+		{
+			FlushAudioPositionDuringTrackSwitch(cachedFragment);
+		}
+		aamp->ResumeTrackInjection((AampMediaType)eMEDIATYPE_AUDIO);
+		NotifyCachedAudioFragmentAvailable();
+		loadNewAudio = false;
+		aamp->mDisableRateCorrection = false;
+	}
+	if (loadNewSubtitle && (eTRACK_SUBTITLE == type) && !isInitSegment)
+	{
+		if (playContext)
+		{
+			playContext->resetPTSOnSubtitleSwitch(cachedFragment->fragment, cachedFragment->position);
+		}
+		else
+		{
+			FlushSubtitlePositionDuringTrackSwitch(cachedFragment);
+		}
+		aamp->ResumeTrackInjection((AampMediaType)eMEDIATYPE_SUBTITLE);
+		NotifyCachedSubtitleFragmentAvailable();
+		loadNewSubtitle = false;
+		aamp->mDisableRateCorrection = false;
+	}
+	if (!isInitSegment)
+	{
+		totalFragmentsDownloaded++;
+	}
+	lock.unlock();
+	if (notifyCacheCompleted)
+	{
+		aamp->NotifyFragmentCachingComplete();
+	}
+}
+
+/**
  * @brief Process New Audio On Lang Switch
  */
 void MediaTrack::LoadNewAudio(bool val)

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -808,7 +808,9 @@ bool MediaTrack::WaitForCachedFragmentChunkInjected(int timeoutMs)
 		else
 		{
 			AAMPLOG_DEBUG("[%s] waiting for fragmentChunkInjected condition", name);
-			fragmentChunkInjected.wait(lock);
+			fragmentChunkInjected.wait(lock, [this] { //DJH - testing add predicate to avoid spurious wakeups
+				return numberOfFragmentChunksCached < mCachedFragmentChunksSize || abort;
+			});
 			AAMPLOG_DEBUG("[%s] wait complete for fragmentChunkInjected", name);
 		}
 		if (abort)

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -573,19 +573,6 @@ void MediaTrack::FlushFragmentChunks()
 {
 }
 
-bool MediaTrack::IsInjectionFromCachedFragmentChunks()
-{
-	if (g_mockMediaTrack != nullptr)
-	{
-		return g_mockMediaTrack->IsInjectionFromCachedFragmentChunks();
-	}
-	else
-	{
-		bool ret = false;
-		return ret;
-	}
-}
-
 void MediaTrack::ClearMediaHeaderDuration(CachedFragment* cachedFragment)
 {
 }

--- a/test/utests/fakes/FakeStreamAbstractionAamp.cpp
+++ b/test/utests/fakes/FakeStreamAbstractionAamp.cpp
@@ -319,6 +319,10 @@ void MediaTrack::UpdateTSAfterFetch(bool isInitSegment)
 	}
 }
 
+void MediaTrack::UpdateTSAfterFetchStats(CachedFragment* cachedFragment, bool isInitSegment)
+{
+}
+
 bool MediaTrack::WaitForFreeFragmentAvailable( int timeoutMs)
 {
 	return true;

--- a/test/utests/mocks/MockMediaTrack.h
+++ b/test/utests/mocks/MockMediaTrack.h
@@ -35,7 +35,6 @@ public:
 	MOCK_METHOD(void, UpdateTSAfterFetch, (bool isInitSegment));
 	MOCK_METHOD(void, UpdateTSAfterChunkFetch, ());
 	MOCK_METHOD(void, UpdateTSAfterInject, ());
-	MOCK_METHOD(bool, IsInjectionFromCachedFragmentChunks, ());
 	MOCK_METHOD(void, SetLocalTSBInjection, (bool value));
 	MOCK_METHOD(bool, IsLocalTSBInjection, ());
 	MOCK_METHOD(bool, Enabled, ());

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -64,8 +64,8 @@ TestParams testCases[] =
 {
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	// Non-TSB, non-LLD-chunk DASH: isDash=1 in IsInjectionFromCachedFragmentChunks() routes
-	// fragments through CacheTsbFragment → chunk cache, so expectedFragmentChunksCached=1.
+	// Non-TSB, non-LLD-chunk DASH: CacheStagingFragmentForInjection() routes all plain SLD
+	// DASH fragments through the chunk cache, so expectedFragmentChunksCached=1.
 	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -64,10 +64,12 @@ TestParams testCases[] =
 {
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	// Non-TSB, non-LLD-chunk DASH: isDash=1 in IsInjectionFromCachedFragmentChunks() routes
+	// fragments through CacheTsbFragment → chunk cache, so expectedFragmentChunksCached=1.
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 
 	// Test with AAMP TSB enabled, chunk cache is used for non-chunked fragments
 	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = false, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
@@ -88,10 +90,12 @@ TestParams testCases[] =
 	// Test with pipeline paused
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
-	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 1},
+	// Non-TSB, non-LLD-chunk DASH paused (no underflow): no tsbSessionManager so the paused
+	// guard doesn't apply; else block calls CacheTsbFragment → chunk cache.
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
+	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 
 	// Test with AAMP TSB enabled and pipeline paused
 	{.lowlatency = true, .chunk = true, .tsb = true, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},

--- a/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
+++ b/test/utests/tests/CacheFragmentTests/CacheFragmentTests.cpp
@@ -91,7 +91,7 @@ TestParams testCases[] =
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 0, .expectedFragmentCached = 0},
 	{.lowlatency = true, .chunk = true, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 	// Non-TSB, non-LLD-chunk DASH paused (no underflow): no tsbSessionManager so the paused
-	// guard doesn't apply; else block calls CacheTsbFragment → chunk cache.
+	// guard doesn't apply; else block calls CacheStagingFragmentForInjection → chunk cache.
 	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 	{.lowlatency = true, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = false, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},
 	{.lowlatency = false, .chunk = false, .tsb = false, .eos = false, .paused = true, .underflow = false, .init = true, .rate = AAMP_NORMAL_PLAY_RATE, .expectedFragmentChunksCached = 1, .expectedFragmentCached = 0},

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -854,11 +854,18 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_UnderflowRecoveryRace_Fr
 		mPrivateInstanceAAMP->mSinkPaused.store(true);  // re-set by GStreamer buffering(0)
 	};
 
-	// An empty cachedFragment: skips EnqueueWrite (avoids GetPeriod call) but
-	// still lets the discard check run with tsbSessionManager != null.
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	// fragment data left intentionally empty — triggers the EnqueueWrite guard
-	// (if(tsbSessionManager && cachedFragment->fragment.size())) to be false.
+	// Pre-populate the staging fragment so CacheTsbFragment has data to write.
+	// An empty fragment would short-circuit through the "Empty cachedFragment ignored"
+	// warning path, preventing GetFetchChunkBuffer from ever being called.
+	// EnqueueWrite (fake no-op) evaluates context->GetPeriod()->GetId() as an
+	// argument, so GetPeriod() must be stubbed to return a valid period.
+	static constexpr uint8_t kTestData[] = {0xAA, 0xBB, 0xCC, 0xDD};
+	mMediaStreamContext->mStagingFragment.fragment.assign(
+		kTestData, kTestData + sizeof(kTestData));
+
+	DummyPeriod dummyPeriod;
+	// A CachedFragment for CacheTsbFragment's GetFetchChunkBuffer call.
+	auto chunkBuffer = std::make_shared<CachedFragment>();
 
 	// --- Mock setup ---
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
@@ -867,18 +874,18 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_UnderflowRecoveryRace_Fr
 		.WillOnce(Return(mMockTSBSessionMgr.get())); // non-null → discard guard activates
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode())
 		.WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
-	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks())
-		.WillRepeatedly(Return(false));
+	// EnqueueWrite evaluates context->GetPeriod()->GetId() as an argument.
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, GetPeriod())
+		.WillOnce(Return(&dummyPeriod));
 
-	// KEY assertion: UpdateTSAfterFetch is called iff the fragment is NOT discarded.
-	// Without the !wasUnderFlowActive guard this call would be suppressed (bug).
-	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterFetch(false)).Times(1);
-	// IsLocalTSBInjection() is called twice in OnFragmentDownloadSuccess:
-	//   1. in the discard-guard condition
-	//   2. in the SLD-copy-to-TSB guard inside the inject path
-	// Both must be non-blocking with StrictMock.
+	// KEY assertion: GetFetchChunkBuffer + UpdateTSAfterChunkFetch are called iff
+	// the fragment is NOT discarded.  Without the !wasUnderFlowActive guard the
+	// discard path would be taken and neither call would occur (stall bug).
+	EXPECT_CALL(*g_mockMediaTrack, GetFetchChunkBuffer(true))
+		.WillOnce(Return(chunkBuffer.get()));
+	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch()).Times(1);
+	// IsLocalTSBInjection() is checked in the discard-guard condition;
+	// must be non-blocking with StrictMock.
 	EXPECT_CALL(*g_mockMediaTrack, IsLocalTSBInjection()).WillRepeatedly(Return(false));
 
 	// --- Build dlInfo ---

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -177,13 +177,13 @@ class FragmentDownloadSuccessParamTest
 /**
  * @brief Test case for OnFragmentDownloadSuccess with various configurations
  *
- * After unifying DASH to use the chunk cache path (IsInjectionFromCachedFragmentChunks
- * returns true for all DASH), OnFragmentDownloadSuccess no longer uses the ring buffer
- * (GetFetchBuffer / UpdateTSAfterFetch).  Instead:
- *  - Non-LLD (chunkMode=false): CacheTsbFragment is called, which writes the staging
- *    fragment into a chunk buffer slot via GetFetchChunkBuffer / UpdateTSAfterChunkFetch.
- *  - LLD (chunkMode=true): media data was already pushed during SSL callbacks; here only
- *    the time-based buffer counter is consumed.
+ * After unifying DASH onto the chunk cache, OnFragmentDownloadSuccess no longer
+ * uses the per-fragment ring buffer (GetFetchBuffer / UpdateTSAfterFetch). Instead:
+ *  - Non-LLD (chunkMode=false): CacheStagingFragmentForInjection() copies the
+ *    staging fragment into a chunk-buffer slot via GetFetchChunkBuffer /
+ *    UpdateTSAfterChunkFetch so the inject thread picks it up.
+ *  - LLD (chunkMode=true): media data was already pushed during SSL callbacks;
+ *    here only the time-based buffer counter is consumed.
  */
 TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 {
@@ -198,8 +198,9 @@ TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 	dlInfo->isDiscontinuity = false;
 	dlInfo->ptsOffset = 1000;
 
-	// Pre-populate the staging fragment so CacheTsbFragment has data to process on the
-	// non-LLD path.  Without this the fragment is empty and CacheTsbFragment is a no-op.
+	// Pre-populate the staging fragment so CacheStagingFragmentForInjection has data
+	// to process on the non-LLD path.  Without this the fragment is empty and
+	// CacheStagingFragmentForInjection is a no-op.
 	static constexpr uint8_t kTestData[] = {0xAA, 0xBB, 0xCC, 0xDD};
 	mMediaStreamContext->mStagingFragment.fragment.assign(kTestData, kTestData + sizeof(kTestData));
 
@@ -216,8 +217,8 @@ TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 	// true, which it is not in this test.
 	EXPECT_CALL(*g_mockAampTimeBasedBufferManager, ConsumeBuffer(dlInfo->fragmentDurationSec)).Times(chunkMode ? 1 : 0);
 
-	// For non-LLD DASH, CacheTsbFragment writes the staging fragment into a chunk buffer
-	// slot.  Verify the position is propagated correctly.
+	// For non-LLD DASH, CacheStagingFragmentForInjection writes the staging fragment
+	// into a chunk buffer slot.  Verify the position is propagated correctly.
 	auto chunkSlot = std::make_shared<CachedFragment>();
 	if (!chunkMode)
 	{
@@ -227,8 +228,9 @@ TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 
 	EXPECT_NO_THROW(mMediaStreamContext->OnFragmentDownloadSuccess(dlInfo));
 
-	// PTS restamp expectation — verified through the chunk slot that CacheTsbFragment
-	// populated (non-LLD only; in LLD mode data is pre-injected via SSL callbacks).
+	// PTS restamp expectation — verified through the chunk slot that
+	// CacheStagingFragmentForInjection populated (non-LLD only; in LLD mode data
+	// is pre-injected via SSL callbacks).
 	if (!chunkMode)
 	{
 		if (ptsRestampEnabled)
@@ -690,7 +692,7 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 		reinterpret_cast<const uint8_t*>(testData.data()),
 		reinterpret_cast<const uint8_t*>(testData.data()) + testData.size());
 
-	// A CachedFragment for CacheTsbFragment's GetFetchChunkBuffer call.
+	// A CachedFragment for CacheStagingFragmentForInjection's GetFetchChunkBuffer call.
 	auto chunkBuffer = std::make_shared<CachedFragment>();
 
 	mMediaStreamContext->mActiveDownloadInfo = std::make_shared<DownloadInfo>();
@@ -731,8 +733,8 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, GetPeriod())
 		.WillOnce(Return(&dummyPeriod));
 
-	// LLDash chunk mode off: CacheTsbFragment skipped inside CheckEos,
-	// but called in the SLD re-cache path after the TSB injection check.
+	// LLDash chunk mode off: the LLD CacheTsbFragment branch inside CheckEos is
+	// skipped; the SLD re-cache path below runs via CacheStagingFragmentForInjection.
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode())
 		.WillRepeatedly(Return(false));
 
@@ -740,7 +742,7 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, UpdateLocalAAMPTsbInjection())
 		.Times(1);
 
-	// Else block: SLD re-cache via CacheTsbFragment.
+	// Else block: SLD re-cache via CacheStagingFragmentForInjection.
 	EXPECT_CALL(*g_mockMediaTrack, GetFetchChunkBuffer(true))
 		.WillOnce(Return(chunkBuffer.get()));
 	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch());
@@ -862,7 +864,8 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_UnderflowRecoveryRace_Fr
 		mPrivateInstanceAAMP->mSinkPaused.store(true);  // re-set by GStreamer buffering(0)
 	};
 
-	// Pre-populate the staging fragment so CacheTsbFragment has data to write.
+	// Pre-populate the staging fragment so CacheStagingFragmentForInjection has
+	// data to write.
 	// An empty fragment would short-circuit through the "Empty cachedFragment ignored"
 	// warning path, preventing GetFetchChunkBuffer from ever being called.
 	// EnqueueWrite (fake no-op) evaluates context->GetPeriod()->GetId() as an
@@ -872,7 +875,7 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_UnderflowRecoveryRace_Fr
 		kTestData, kTestData + sizeof(kTestData));
 
 	DummyPeriod dummyPeriod;
-	// A CachedFragment for CacheTsbFragment's GetFetchChunkBuffer call.
+	// A CachedFragment for CacheStagingFragmentForInjection's GetFetchChunkBuffer call.
 	auto chunkBuffer = std::make_shared<CachedFragment>();
 
 	// --- Mock setup ---

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -19,6 +19,14 @@
 #include <gtest/gtest.h>
 #include "MediaStreamContext.h"
 #include "fragmentcollector_mpd.h"
+
+/** Thin subclass that promotes protected members needed by unit tests. */
+class TestableMediaStreamContext : public MediaStreamContext
+{
+public:
+	using MediaStreamContext::MediaStreamContext;
+	using MediaStreamContext::mStagingFragment;
+};
 #include "isobmff/isobmffbuffer.h"
 #include "AampCacheHandler.h"
 #include "AampUtils.h"
@@ -62,7 +70,7 @@ protected:
 		}
 		mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
 		mStreamAbstractionAAMP_MPD = new StreamAbstractionAAMP_MPD(mPrivateInstanceAAMP, 123.45, 12.34);
-		mMediaStreamContext = new MediaStreamContext(eTRACK_VIDEO, mStreamAbstractionAAMP_MPD, mPrivateInstanceAAMP, "SAMPLETEXT");
+		mMediaStreamContext = new TestableMediaStreamContext(eTRACK_VIDEO, mStreamAbstractionAAMP_MPD, mPrivateInstanceAAMP, "SAMPLETEXT");
 		g_mockAampConfig = new NiceMock<MockAampConfig>();
 		g_mockMediaTrack = new StrictMock<MockMediaTrack>();
 		g_mockStreamAbstractionAAMP = new NiceMock<MockStreamAbstractionAAMP>(mPrivateInstanceAAMP);
@@ -120,7 +128,7 @@ protected:
 public:
 	StreamAbstractionAAMP_MPD *mStreamAbstractionAAMP_MPD;
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
-	MediaStreamContext *mMediaStreamContext;
+	TestableMediaStreamContext *mMediaStreamContext;
 	std::unique_ptr<AampTSBSessionManager> mTsbSessionMgr;
 	std::unique_ptr<NiceMock<MockTSBSessionManager>> mMockTSBSessionMgr;
 	std::shared_ptr<AampTsbReader> mTsbReader;

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -168,6 +168,14 @@ class FragmentDownloadSuccessParamTest
 
 /**
  * @brief Test case for OnFragmentDownloadSuccess with various configurations
+ *
+ * After unifying DASH to use the chunk cache path (IsInjectionFromCachedFragmentChunks
+ * returns true for all DASH), OnFragmentDownloadSuccess no longer uses the ring buffer
+ * (GetFetchBuffer / UpdateTSAfterFetch).  Instead:
+ *  - Non-LLD (chunkMode=false): CacheTsbFragment is called, which writes the staging
+ *    fragment into a chunk buffer slot via GetFetchChunkBuffer / UpdateTSAfterChunkFetch.
+ *  - LLD (chunkMode=true): media data was already pushed during SSL callbacks; here only
+ *    the time-based buffer counter is consumed.
  */
 TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 {
@@ -182,40 +190,49 @@ TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 	dlInfo->isDiscontinuity = false;
 	dlInfo->ptsOffset = 1000;
 
+	// Pre-populate the staging fragment so CacheTsbFragment has data to process on the
+	// non-LLD path.  Without this the fragment is empty and CacheTsbFragment is a no-op.
+	static constexpr uint8_t kTestData[] = {0xAA, 0xBB, 0xCC, 0xDD};
+	mMediaStreamContext->mStagingFragment.fragment.assign(kTestData, kTestData + sizeof(kTestData));
+
 	// Mock necessary method calls and return values
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
-
-	// Mock buffer slot returned when staging fragment is moved to the cache slot for injection.
-	// CacheFragment populates mStagingFragment; OnFragmentDownloadSuccess moves it into this slot.
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false)).WillOnce(Return(cachedFragment.get()));
-
-	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(chunkMode));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(chunkMode));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp)).WillRepeatedly(Return(ptsRestampEnabled));
+
+	// LLD path: staging data was already pushed to the pipeline via SSL callbacks;
+	// OnFragmentDownloadSuccess only consumes the time-based buffer entry.
+	// Non-LLD path: time-based buffer consumption only happens when IsLocalAAMPTsb() is
+	// true, which it is not in this test.
 	EXPECT_CALL(*g_mockAampTimeBasedBufferManager, ConsumeBuffer(dlInfo->fragmentDurationSec)).Times(chunkMode ? 1 : 0);
 
-	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterFetch(_));
-	if (chunkMode)
+	// For non-LLD DASH, CacheTsbFragment writes the staging fragment into a chunk buffer
+	// slot.  Verify the position is propagated correctly.
+	auto chunkSlot = std::make_shared<CachedFragment>();
+	if (!chunkMode)
 	{
-		EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterInject());
+		EXPECT_CALL(*g_mockMediaTrack, GetFetchChunkBuffer(true)).WillOnce(Return(chunkSlot.get()));
+		EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch());
 	}
 
 	EXPECT_NO_THROW(mMediaStreamContext->OnFragmentDownloadSuccess(dlInfo));
 
-	// PTS restamp expectation
-	if (ptsRestampEnabled)
+	// PTS restamp expectation — verified through the chunk slot that CacheTsbFragment
+	// populated (non-LLD only; in LLD mode data is pre-injected via SSL callbacks).
+	if (!chunkMode)
 	{
-		EXPECT_EQ(cachedFragment->position, dlInfo->pts + dlInfo->ptsOffset.inSeconds());
+		if (ptsRestampEnabled)
+		{
+			EXPECT_EQ(chunkSlot->position, dlInfo->pts + dlInfo->ptsOffset.inSeconds());
+		}
+		else
+		{
+			EXPECT_EQ(chunkSlot->position, dlInfo->pts);
+		}
+		aamp_utils::ClearAndRelease(chunkSlot->fragment);
 	}
-	else
-	{
-		EXPECT_EQ(cachedFragment->position, dlInfo->pts);
-	}
-
-	aamp_utils::ClearAndRelease(cachedFragment->fragment);
 }
 
 /**
@@ -665,10 +682,8 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 		reinterpret_cast<const uint8_t*>(testData.data()),
 		reinterpret_cast<const uint8_t*>(testData.data()) + testData.size());
 
-	// A second CachedFragment for CacheTsbFragment's GetFetchChunkBuffer call.
+	// A CachedFragment for CacheTsbFragment's GetFetchChunkBuffer call.
 	auto chunkBuffer = std::make_shared<CachedFragment>();
-	// A CachedFragment for the injection slot returned by GetFetchBuffer(false) in the else branch.
-	auto cachedFragment = std::make_shared<CachedFragment>();
 
 	mMediaStreamContext->mActiveDownloadInfo = std::make_shared<DownloadInfo>();
 	DownloadInfoPtr dlInfo = std::make_shared<DownloadInfo>();
@@ -682,10 +697,6 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 	// --- Mock expectations ---
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
 		.WillRepeatedly(Return(true));
-
-	// GetFetchBuffer returns our cachedFragment with data.
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
 
 	// TSB session manager is non-null to trigger the CheckEos path.
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager())
@@ -721,13 +732,10 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, UpdateLocalAAMPTsbInjection())
 		.Times(1);
 
-	// Else block: UpdateTSAfterFetch, SLD re-cache via CacheTsbFragment.
-	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterFetch(false));
+	// Else block: SLD re-cache via CacheTsbFragment.
 	EXPECT_CALL(*g_mockMediaTrack, GetFetchChunkBuffer(true))
 		.WillOnce(Return(chunkBuffer.get()));
 	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch());
-	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks())
-		.WillOnce(Return(false));
 
 	// --- Execute ---
 	EXPECT_NO_THROW(mMediaStreamContext->OnFragmentDownloadSuccess(dlInfo));

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -187,10 +187,9 @@ TEST_P(FragmentDownloadSuccessParamTest, OnFragmentDownloadSuccess)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
 
-	// Mock buffer creation for the test
+	// Mock buffer slot returned when staging fragment is moved to the cache slot for injection.
+	// CacheFragment populates mStagingFragment; OnFragmentDownloadSuccess moves it into this slot.
 	auto cachedFragment = std::make_shared<CachedFragment>();
-	static constexpr auto testData = "test"sv;
-	cachedFragment->fragment.assign(testData.begin(), testData.end());
 	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false)).WillOnce(Return(cachedFragment.get()));
 
 	EXPECT_CALL(*g_mockMediaTrack, IsInjectionFromCachedFragmentChunks()).WillRepeatedly(Return(chunkMode));
@@ -253,11 +252,6 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadFailed_RampDownAttempt)
 	mMediaStreamContext->segDLFailCount = 0;
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_FragmentDownloadFailThreshold)).WillRepeatedly(Return(10));
 
-	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
-
 	// Return false for CheckForRampDownLimitReached to allow ramp down, and true for CheckForRampDownProfile
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, CheckForRampDownLimitReached())
 		.WillOnce(Return(false));
@@ -285,11 +279,6 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadFailed_ValidDownloadInfoLowestPr
 	mMediaStreamContext->mSkipSegmentOnError = false;
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_FragmentDownloadFailThreshold)).WillRepeatedly(Return(10));
 
-	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
-	
 	// Return true for CheckForRampDownLimitReached to indicate that the limit is reached
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, CheckForRampDownLimitReached())
 		.WillOnce(Return(true));
@@ -332,11 +321,6 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadFailed_LowestProfile_ConsumesTim
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_))
 		.WillRepeatedly(Return(false));
 
-	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
-
 	// Return false for CheckForRampDownLimitReached to indicate that the limit is reached
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, CheckForRampDownLimitReached())
 		.WillOnce(Return(false));
@@ -367,11 +351,6 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadFailed_RetryAttemptThreshold)
 	// This should not trigger a ramp down
 	mMediaStreamContext->segDLFailCount = 10;
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_FragmentDownloadFailThreshold)).WillRepeatedly(Return(10));
-
-	// Mock the behavior of GetFetchBuffer, create a dummy CachedFragment
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(false))
-		.WillOnce(Return(cachedFragment.get()));
 
 	//Ensure proper error event is sent
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendDownloadErrorEvent(AAMP_TUNE_FRAGMENT_DOWNLOAD_FAILURE, _))
@@ -418,10 +397,6 @@ TEST_F(FragmentDownloadTests, DownloadFragment_ValidDownloadInfo)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(_, _, _, _, _, _, _, _, _, _, _, _, _, _)).WillOnce(Return(true));
-
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(true))
-		.WillOnce(Return(cachedFragment.get()));
 
 	EXPECT_NO_THROW({
 		bool result = mMediaStreamContext->DownloadFragment(dlInfo);
@@ -565,10 +540,7 @@ TEST_F(FragmentDownloadTests, DownloadFragment_LLD_LocalTSBInjection_Caches)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
 		.WillRepeatedly(Return(true));
 
-	// Expect exactly one cache buffer allocation and one successful "download".
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(true))
-		.WillOnce(Return(cachedFragment.get()));
+	// Expect exactly one successful "download".
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(_, _, _, _, _, _, _, _, _, _, _, _, _, _))
 		.WillOnce(Return(true));
 
@@ -613,11 +585,7 @@ TEST_F(FragmentDownloadTests, DownloadFragment_NotBlocked_CachesExpected)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection())
 		.WillRepeatedly(Return(false));
 
-	// Expect one buffer request and one "download" per call.
-	auto cachedFragment = std::make_shared<CachedFragment>();
-	EXPECT_CALL(*g_mockMediaTrack, GetFetchBuffer(true))
-		.Times(numCalls)
-		.WillRepeatedly(Return(cachedFragment.get()));
+	// Expect one successful "download" per call.
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetFile(_, _, _, _, _, _, _, _, _, _, _, _, _, _))
 		.Times(numCalls)
 		.WillRepeatedly(Return(true));
@@ -691,15 +659,16 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 	mPrivateInstanceAAMP->SetBufUnderFlowStatus(true);
 	mStreamAbstractionAAMP_MPD->mTuneType = eTUNETYPE_SEEKTOLIVE;
 
-	// Populate fragment data so the tsbSessionManager block is entered.
-	auto cachedFragment = std::make_shared<CachedFragment>();
+	// Populate staging fragment with data so the tsbSessionManager block is entered.
 	constexpr std::string_view testData{"test_fragment_data"};
-	cachedFragment->fragment.assign(
+	mMediaStreamContext->mStagingFragment.fragment.assign(
 		reinterpret_cast<const uint8_t*>(testData.data()),
 		reinterpret_cast<const uint8_t*>(testData.data()) + testData.size());
 
 	// A second CachedFragment for CacheTsbFragment's GetFetchChunkBuffer call.
 	auto chunkBuffer = std::make_shared<CachedFragment>();
+	// A CachedFragment for the injection slot returned by GetFetchBuffer(false) in the else branch.
+	auto cachedFragment = std::make_shared<CachedFragment>();
 
 	mMediaStreamContext->mActiveDownloadInfo = std::make_shared<DownloadInfo>();
 	DownloadInfoPtr dlInfo = std::make_shared<DownloadInfo>();

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -19,14 +19,6 @@
 #include <gtest/gtest.h>
 #include "MediaStreamContext.h"
 #include "fragmentcollector_mpd.h"
-
-/** Thin subclass that promotes protected members needed by unit tests. */
-class TestableMediaStreamContext : public MediaStreamContext
-{
-public:
-	using MediaStreamContext::MediaStreamContext;
-	using MediaStreamContext::mStagingFragment;
-};
 #include "isobmff/isobmffbuffer.h"
 #include "AampCacheHandler.h"
 #include "AampUtils.h"
@@ -45,6 +37,14 @@ public:
 #include "AampDownloadInfo.hpp"
 #include <functional>
 #include <string_view>
+
+/** Thin subclass that promotes protected members needed by unit tests. */
+class TestableMediaStreamContext : public MediaStreamContext
+{
+public:
+	using MediaStreamContext::MediaStreamContext;
+	using MediaStreamContext::mStagingFragment;
+};
 
 using namespace testing;
 using namespace std::literals;

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -94,6 +94,9 @@ public:
 	void abortWaitForVideoPTS() override {};
 	double GetBufferedDuration() override { return 0; };
 
+	// Promote protected members so tests can set them directly.
+	using MediaTrack::fragmentChunkIdxToFetch;
+
 protected:
 	// Must return something non-null to avoid a crash
 	StreamAbstractionAAMP* GetContext() override { return mContext; };
@@ -163,20 +166,9 @@ protected:
 		// A pointer to the test fragment in the cache buffer
 		CachedFragment* bufferedFragment{nullptr};
 
-		// Chunk buffer is used for low-latency, AAMP TSB, or any DASH content
-		// (mirrors IsInjectionFromCachedFragmentChunks() in MediaTrack)
-		bool isDash = (mPrivateInstanceAAMP->mMediaFormat == eMEDIAFORMAT_DASH);
-		if (lowLatencyMode || aampTsb || isDash)
-		{
-			bufferedFragment = mediaTrack.GetFetchChunkBuffer(true);
-			mediaTrack.numberOfFragmentChunksCached = 1;
-		}
-		// Standard buffer is used for non-DASH SLD when AAMP TSB is disabled
-		else
-		{
-			bufferedFragment = mediaTrack.GetFetchBuffer(true);
-			mediaTrack.numberOfFragmentsCached = 1;
-		}
+		// Always use the chunk cache buffer
+		bufferedFragment = mediaTrack.GetFetchChunkBuffer(true);
+		mediaTrack.numberOfFragmentChunksCached = 1;
 		bufferedFragment->Copy(testFragment);
 		if (lowLatencyMode && !bufferedFragment->initFragment)
 		{
@@ -843,9 +835,6 @@ TEST_F(MediaTrackTests, FlushFetchedFragmentsTest)
 	CachedFragment* bufferedFragment3{nullptr};
 
 	mPrivateInstanceAAMP->rate = FASTEST_TRICKPLAY_RATE;
-	// HLS format: IsInjectionFromCachedFragmentChunks() returns false, so
-	// FlushFetchedFragments operates on the ring buffer that this test populates.
-	mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_HLS;
 	mStreamAbstractionAAMP_MPD->trickplayMode = true;
 
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
@@ -859,36 +848,38 @@ TEST_F(MediaTrackTests, FlushFetchedFragmentsTest)
 
 	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
 
-	bufferedFragment1 = videoTrack.GetFetchBuffer(true);
+	// Init fragment at chunk slot 0
+	bufferedFragment1 = videoTrack.GetFetchChunkBuffer(true);
 	bufferedFragment1->initFragment = true;
 	bufferedFragment1->fragment.assign(FRAGMENT_TEST_DATA, FRAGMENT_TEST_DATA + FRAGMENT_TEST_DATA_SIZE);
-	videoTrack.UpdateTSAfterFetch(bufferedFragment1->initFragment);
+	videoTrack.numberOfFragmentChunksCached = 1;
+	videoTrack.fragmentChunkIdxToFetch = 1;
 
-	// First media segment
-	bufferedFragment2 = videoTrack.GetFetchBuffer(true);
+	// First media fragment at chunk slot 1
+	bufferedFragment2 = videoTrack.GetFetchChunkBuffer(true);
 	bufferedFragment2->initFragment = false;
 	bufferedFragment2->duration = FRAGMENT_DURATION.inSeconds();
 	bufferedFragment2->position = FIRST_PTS.inSeconds();
 	bufferedFragment2->fragment.assign(FRAGMENT_TEST_DATA, FRAGMENT_TEST_DATA + FRAGMENT_TEST_DATA_SIZE);
-	videoTrack.UpdateTSAfterFetch(bufferedFragment2->initFragment);
+	videoTrack.numberOfFragmentChunksCached = 2;
+	videoTrack.fragmentChunkIdxToFetch = 2;
 
-	// Second media segment, not updated for injection
-	bufferedFragment3 = videoTrack.GetFetchBuffer(true);
+	// Second media fragment at chunk slot 2 (not counted for injection)
+	bufferedFragment3 = videoTrack.GetFetchChunkBuffer(true);
 	bufferedFragment3->initFragment = false;
 	bufferedFragment3->duration = FRAGMENT_DURATION.inSeconds();
 	bufferedFragment3->position = 2 * FIRST_PTS.inSeconds();
 	bufferedFragment3->fragment.assign(FRAGMENT_TEST_DATA, FRAGMENT_TEST_DATA + FRAGMENT_TEST_DATA_SIZE);
 
-	ASSERT_EQ(videoTrack.numberOfFragmentsCached, 2);
+	ASSERT_EQ(videoTrack.numberOfFragmentChunksCached, 2);
 	ASSERT_EQ(bufferedFragment1->position, 0);
 	ASSERT_EQ(bufferedFragment2->position, FIRST_PTS.inSeconds());
 	ASSERT_EQ(bufferedFragment3->position, (2 * FIRST_PTS.inSeconds()));
 
 	videoTrack.FlushFetchedFragments();
 
-	// Check that the fragments added for injection have been removed
-	// But the current fragment has not been cleared
-	EXPECT_EQ(videoTrack.numberOfFragmentsCached, 0);
+	// Fragments at slots 0 and 1 (counted) should be cleared; slot 2 (uncounted) should not
+	EXPECT_EQ(videoTrack.numberOfFragmentChunksCached, 0);
 	EXPECT_EQ(bufferedFragment1->position, 0);
 	EXPECT_EQ(bufferedFragment2->position, 0);
 	EXPECT_EQ(bufferedFragment3->position, (2 * FIRST_PTS.inSeconds()));

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -163,13 +163,15 @@ protected:
 		// A pointer to the test fragment in the cache buffer
 		CachedFragment* bufferedFragment{nullptr};
 
-		// Chunk buffer is used for low-latency or for all content if AAMP TSB is enabled
-		if (lowLatencyMode || aampTsb)
+		// Chunk buffer is used for low-latency, AAMP TSB, or any DASH content
+		// (mirrors IsInjectionFromCachedFragmentChunks() in MediaTrack)
+		bool isDash = (mPrivateInstanceAAMP->mMediaFormat == eMEDIAFORMAT_DASH);
+		if (lowLatencyMode || aampTsb || isDash)
 		{
 			bufferedFragment = mediaTrack.GetFetchChunkBuffer(true);
 			mediaTrack.numberOfFragmentChunksCached = 1;
 		}
-		// Standard buffer is used for SLD when AAMP TSB is disabled
+		// Standard buffer is used for non-DASH SLD when AAMP TSB is disabled
 		else
 		{
 			bufferedFragment = mediaTrack.GetFetchBuffer(true);

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -843,7 +843,9 @@ TEST_F(MediaTrackTests, FlushFetchedFragmentsTest)
 	CachedFragment* bufferedFragment3{nullptr};
 
 	mPrivateInstanceAAMP->rate = FASTEST_TRICKPLAY_RATE;
-	mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_DASH;
+	// HLS format: IsInjectionFromCachedFragmentChunks() returns false, so
+	// FlushFetchedFragments operates on the ring buffer that this test populates.
+	mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_HLS;
 	mStreamAbstractionAAMP_MPD->trickplayMode = true;
 
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -1922,6 +1922,10 @@ TEST_F(TrackStateTests, GetBufferStatusTest)
 TEST_F(TrackStateTests, WaitForFreeFragmentAvailableTests)
 {
 	int timeoutMs = 100;
+	// Ensure the chunk cache has capacity so WaitForCachedFragmentChunkInjected
+	// can return true immediately (numberOfFragmentChunksCached=0 < size=4).
+	TrackStateobj->maxCachedFragmentChunksPerTrack = DEFAULT_CACHED_FRAGMENT_CHUNKS_PER_TRACK;
+	TrackStateobj->SetCachedFragmentChunksSize(DEFAULT_CACHED_FRAGMENTS_PER_TRACK);
 	bool result = TrackStateobj->WaitForFreeFragmentAvailable(timeoutMs);
 	ASSERT_TRUE(result);
 }

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -111,35 +111,18 @@ public:
 													  cachedFragment->position, cachedFragment->duration, 0.0, cachedFragment->initFragment, cachedFragment->discontinuity);
 	}
 
-	void fillCachedFragment(bool isInit, bool isDisc, bool isLLD)
+	void fillCachedFragment(bool isInit, bool isDisc, bool /*isLLD*/)
 	{
 		const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
-		int fragmentIdxToFetch = 0;
-		// int fragmentIdxToFetch = 0;
-		CachedFragment *cachFragment = nullptr;
-		if (isLLD)
-		{
-			cachFragment = &this->mCachedFragmentChunks[fragmentIdxToFetch];
-		}
-		else
-		{
-			// cachFragment = GetFetchBuffer(true);
-			this->mCachedFragment = new CachedFragment[3];
-			cachFragment = &this->mCachedFragment[fragmentIdxToFetch];
-		}
+		// All paths now use the chunk cache: the old ring-buffer path is dead code
+		// after IsInjectionFromCachedFragmentChunks() was removed.
+		CachedFragment *cachFragment = &this->mCachedFragmentChunks[0];
 		cachFragment->timeScale = PLAYBACK_TIMESCALE;
 		cachFragment->initFragment = isInit;
 		cachFragment->discontinuity = isDisc;
 		cachFragment->type = isInit ? eMEDIATYPE_INIT_VIDEO : eMEDIATYPE_VIDEO;
 		cachFragment->fragment.assign(data, data + sizeof(data));
-		if (isLLD)
-		{
-			UpdateTSAfterChunkFetch();
-		}
-		else
-		{
-			UpdateTSAfterFetch(false);
-		}
+		UpdateTSAfterChunkFetch();
 	}
 };
 

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -114,8 +114,9 @@ public:
 	void fillCachedFragment(bool isInit, bool isDisc, bool /*isLLD*/)
 	{
 		const uint8_t data[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
-		// All paths now use the chunk cache: the old ring-buffer path is dead code
-		// after IsInjectionFromCachedFragmentChunks() was removed.
+		// DASH now routes all fragments through the chunk cache (see
+		// MediaStreamContext::CacheStagingFragmentForInjection); the old per-fragment
+		// ring-buffer path is no longer populated here.
 		CachedFragment *cachFragment = &this->mCachedFragmentChunks[0];
 		cachFragment->timeScale = PLAYBACK_TIMESCALE;
 		cachFragment->initFragment = isInit;


### PR DESCRIPTION
**Summary**
Unify the cached-fragment fetch/inject path across chunked and non chunked flows. 

**This is delivery 1 of 3 - intentionally incremental**
Note for reviewers (including automated review tools): This PR is the first of three deliberately small, incremental deliveries. Please do not raise suggestions about dead code, naming, or further restructuring — those are the explicit subjects of the two follow-on PRs:

Delivery 2: Remove the old dead code that is now superseded by this unification.
Delivery 3: Rename and tidy the new shared path to its final, more descriptive API surface.
Keeping reviews small and focused is intentional. Feedback on those concerns is welcome on the appropriate follow-on PR.