### PR TITLE
VPLAY-13232:Observing abnormal position value jump after CDAI ad break in VOD assets

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2310,7 +2310,7 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRem
 	}
 
 	int nextPeriodIdx = mCurrentPeriodIdx + 1;
-	while ((nextPeriodIdx < mMPDParseHelper->GetNumberOfPeriods()) && IsEmptyPeriod(nextPeriodIdx))
+	while ((nextPeriodIdx < mMPDParseHelper->GetNumberOfPeriods()) && mMPDParseHelper->IsEmptyPeriod(nextPeriodIdx, (mPlayRate != AAMP_NORMAL_PLAY_RATE)))
 	{
 		nextPeriodIdx++;
 	}
@@ -2326,8 +2326,8 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRem
 	mBasePeriodId = mCurrentPeriod->GetId();
 	AAMPLOG_INFO("SeekInPeriod: Switching to next period %d with id %s for seek remainder %lf", mCurrentPeriodIdx, mBasePeriodId.c_str(), videoRemainingSeek);
 	mPeriodStartTime = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs);
-	mPeriodDuration = mMPDParseHelper->GetPeriodDuration(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, ShouldCheckOnlyIframeAdaptation(), aamp->IsUninterruptedTSB());
-	mPeriodEndTime = mMPDParseHelper->GetPeriodEndTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, ShouldCheckOnlyIframeAdaptation(), aamp->IsUninterruptedTSB());
+	mPeriodDuration = mMPDParseHelper->GetPeriodDuration(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, (mPlayRate != AAMP_NORMAL_PLAY_RATE), aamp->IsUninterruptedTSB());
+	mPeriodEndTime = mMPDParseHelper->GetPeriodEndTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, (mPlayRate != AAMP_NORMAL_PLAY_RATE), aamp->IsUninterruptedTSB());
 
 	mUpdateStreamInfo = true;
 	AAMPStatusType ret = UpdateTrackInfo(true, true);

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2287,14 +2287,18 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
  * @brief If SkipFragments reaches EOS and an additional playable period is available, switch to the next period.
  */
 bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainingSeek,
-	MediaStreamContext *pMediaStreamContext,
 	bool skipToEnd)
 {
-	bool switchToNextPeriod = (!skipToEnd) &&
-		(mpd != NULL) &&
-		(mMPDParseHelper != NULL) &&
-		(pMediaStreamContext != NULL) &&
-		(pMediaStreamContext->eos);
+	bool switchToNextPeriod = false;
+
+	for (int i = 0; i < mNumberOfTracks; i++)
+	{
+		if (mMediaStreamContext[i] != NULL && mMediaStreamContext[i]->eos)
+		{
+			switchToNextPeriod = true;
+			break;
+		}
+	}
 
 	if (!switchToNextPeriod)
 	{
@@ -2342,6 +2346,7 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
  */
 void StreamAbstractionAAMP_MPD::SeekInPeriod( double seekPositionSeconds, bool skipToEnd)
 {
+	double trackRemainingSeek = 0.0;
 	for (int i = 0; i < mNumberOfTracks; i++)
 	{
 		if (!mMediaStreamContext[i])
@@ -2349,7 +2354,6 @@ void StreamAbstractionAAMP_MPD::SeekInPeriod( double seekPositionSeconds, bool s
 			continue;
 		}
 
-		double trackRemainingSeek = 0.0;
 		if (eMEDIATYPE_SUBTITLE == i)
 		{
 			double skipTime = seekPositionSeconds;
@@ -2360,8 +2364,8 @@ void StreamAbstractionAAMP_MPD::SeekInPeriod( double seekPositionSeconds, bool s
 			trackRemainingSeek = SkipFragments(mMediaStreamContext[i], seekPositionSeconds, true, skipToEnd);
 		}
 
-		HandleSeekEOSAndPeriodTransition(trackRemainingSeek, mMediaStreamContext[i], skipToEnd);
 	}
+	HandleSeekEOSAndPeriodTransition(trackRemainingSeek, skipToEnd);
 }
 
 /**

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2332,14 +2332,7 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 
 	AAMPLOG_INFO("SeekInPeriod: Switched to period %d, calling SkipFragments with remaining seek %lf", mCurrentPeriodIdx, remainingSeek);
 
-	if (eMEDIATYPE_SUBTITLE == pMediaStreamContext->type)
-	{
-		SkipFragments(pMediaStreamContext, remainingSeek, true);
-	}
-	else
-	{
-		SkipFragments(pMediaStreamContext, remainingSeek, true, skipToEnd);
-	}
+	SeekInPeriod(remainingSeek, skipToEnd);
 	return true;
 }
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2284,28 +2284,21 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 }
 
 /**
- * @brief If the current SkipFragments loop reaches EOS and additional periods are available, switch to the next period. Return true if the switch succeeds and the seek should be retried; otherwise, return false.
+ * @brief If SkipFragments reaches EOS and an additional playable period is available, switch to the next period.
  */
-bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRemainingSeek,
-	bool skipToEnd, int maxPeriodSwitchCount, int &periodSwitchCount,
-	double &remainingSeekPosition)
+bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainingSeek,
+	MediaStreamContext *pMediaStreamContext,
+	bool skipToEnd)
 {
-	MediaStreamContext *videoContext = mMediaStreamContext[eMEDIATYPE_VIDEO];
 	bool switchToNextPeriod = (!skipToEnd) &&
 		(mpd != NULL) &&
 		(mMPDParseHelper != NULL) &&
-		(videoContext != NULL) &&
-		(videoContext->eos);
+		(pMediaStreamContext != NULL) &&
+		(pMediaStreamContext->eos);
 
 	if (!switchToNextPeriod)
 	{
-		AAMPLOG_INFO("SeekInPeriod: Seek completed within current period with remaining seek %lf", videoRemainingSeek);
-		return false;
-	}
-
-	if (periodSwitchCount >= maxPeriodSwitchCount)
-	{
-		AAMPLOG_WARN("SeekInPeriod: Reached max period-switch attempts while carrying seek remainder %lf", videoRemainingSeek);
+		AAMPLOG_INFO("SeekInPeriod: Seek completed within current period with remaining seek %lf", remainingSeek);
 		return false;
 	}
 
@@ -2317,18 +2310,18 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRem
 
 	if (nextPeriodIdx >= mMPDParseHelper->GetNumberOfPeriods())
 	{
-		AAMPLOG_INFO("SeekInPeriod: No next playable period available for seek remainder %lf", videoRemainingSeek);
+		AAMPLOG_INFO("SeekInPeriod: No next playable period available for seek remainder %lf", remainingSeek);
 		return false;
 	}
 
 	mCurrentPeriodIdx = nextPeriodIdx;
 	mCurrentPeriod = mpd->GetPeriods().at(mCurrentPeriodIdx);
 	mBasePeriodId = mCurrentPeriod->GetId();
-	AAMPLOG_INFO("SeekInPeriod: Switching to next period %d with id %s for seek remainder %lf", mCurrentPeriodIdx, mBasePeriodId.c_str(), videoRemainingSeek);
+	AAMPLOG_INFO("SeekInPeriod: Switching to next period %d with id %s for seek remainder %lf", mCurrentPeriodIdx, mBasePeriodId.c_str(), remainingSeek);
 	mPeriodStartTime = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs);
 	mPeriodDuration = mMPDParseHelper->GetPeriodDuration(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, (mPlayRate != AAMP_NORMAL_PLAY_RATE), aamp->IsUninterruptedTSB());
 	mPeriodEndTime = mMPDParseHelper->GetPeriodEndTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, (mPlayRate != AAMP_NORMAL_PLAY_RATE), aamp->IsUninterruptedTSB());
-
+	StreamSelection(true);
 	mUpdateStreamInfo = true;
 	AAMPStatusType ret = UpdateTrackInfo(true, true);
 	if (ret != eAAMPSTATUS_OK)
@@ -2337,17 +2330,16 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRem
 		return false;
 	}
 
-	for (int i = 0; i < mNumberOfTracks; i++)
-	{
-		if (mMediaStreamContext[i])
-		{
-			mMediaStreamContext[i]->eos = false;
-		}
-	}
+	AAMPLOG_INFO("SeekInPeriod: Switched to period %d, calling SkipFragments with remaining seek %lf", mCurrentPeriodIdx, remainingSeek);
 
-	AAMPLOG_INFO("SeekInPeriod: Switched to period %d and re-seeking with remainder %lf", mCurrentPeriodIdx, videoRemainingSeek);
-	remainingSeekPosition = videoRemainingSeek;
-	periodSwitchCount++;
+	if (eMEDIATYPE_SUBTITLE == pMediaStreamContext->type)
+	{
+		SkipFragments(pMediaStreamContext, remainingSeek, true);
+	}
+	else
+	{
+		SkipFragments(pMediaStreamContext, remainingSeek, true, skipToEnd);
+	}
 	return true;
 }
 
@@ -2357,41 +2349,25 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRem
  */
 void StreamAbstractionAAMP_MPD::SeekInPeriod( double seekPositionSeconds, bool skipToEnd)
 {
-double remainingSeekPosition = seekPositionSeconds;
-	int maxPeriodSwitchCount = (mpd != NULL) ? (int)mpd->GetPeriods().size() : 0;
-	int periodSwitchCount = 0;
-
-	while (true)
+	for (int i = 0; i < mNumberOfTracks; i++)
 	{
-		double videoRemainingSeek = 0.0;
-		for (int i = 0; i < mNumberOfTracks; i++)
+		if (!mMediaStreamContext[i])
 		{
-			if (!mMediaStreamContext[i])
-			{
-				continue;
-			}
-
-			double trackRemainingSeek = 0.0;
-			if (eMEDIATYPE_SUBTITLE == i)
-			{
-				trackRemainingSeek = SkipFragments(mMediaStreamContext[i], remainingSeekPosition, true);
-			}
-			else
-			{
-				trackRemainingSeek = SkipFragments(mMediaStreamContext[i], remainingSeekPosition, true, skipToEnd);
-			}
-
-			if (i == eMEDIATYPE_VIDEO)
-			{
-				videoRemainingSeek = trackRemainingSeek;
-			}
+			continue;
 		}
 
-		if (!HandleSeekEOSAndPeriodTransition(videoRemainingSeek, skipToEnd,
-			maxPeriodSwitchCount, periodSwitchCount, remainingSeekPosition))
+		double trackRemainingSeek = 0.0;
+		if (eMEDIATYPE_SUBTITLE == i)
 		{
-			break;
+			double skipTime = seekPositionSeconds;
+			trackRemainingSeek = SkipFragments(mMediaStreamContext[i], skipTime, true);
 		}
+		else
+		{
+			trackRemainingSeek = SkipFragments(mMediaStreamContext[i], seekPositionSeconds, true, skipToEnd);
+		}
+
+		HandleSeekEOSAndPeriodTransition(trackRemainingSeek, mMediaStreamContext[i], skipToEnd);
 	}
 }
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2291,6 +2291,14 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 {
 	bool switchToNextPeriod = false;
 
+	// Check whether any track hit EOS during the seek. Any enabled track reaching EOS
+	// is sufficient to trigger a period transition: DASH spec requires all tracks in a
+	// period to end at the same presentation time, so this is safe for well-formed content.
+	// The mPlayRate and remainingSeek guards (comment 2 & 3) prevent false positives:
+	//   - mPlayRate >= AAMP_RATE_PAUSE: for reverse playback (mPlayRate < 0), EOS means
+	//     beginning-of-period, not end-of-period, so we must not advance to the next period.
+	//   - remainingSeek >= 0: a negative remainder also indicates the seek overshot backward
+	//     rather than forward, so no forward period transition is appropriate.
 	for (int i = 0; i < mNumberOfTracks; i++)
 	{
 		if (mMediaStreamContext[i] != NULL && mMediaStreamContext[i]->eos && (mPlayRate >= AAMP_RATE_PAUSE) &&  remainingSeek >= 0)
@@ -2336,6 +2344,11 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 
 	AAMPLOG_INFO("SeekInPeriod: Switched to period %d, calling SkipFragments with remaining seek %lf", mCurrentPeriodIdx, remainingSeek);
 
+	// TODO: This recursive call works correctly for the expected case where remainingSeek
+	// is fully absorbed by the next period (recursion depth = 1). On content with many
+	// consecutive short periods it could theoretically recurse once per period. A future
+	// refactor should convert SeekInPeriod into an iterative loop (driven by the bool
+	// return value of this function) to eliminate the theoretical stack-growth risk.
 	SeekInPeriod(remainingSeek, skipToEnd);
 	return true;
 }
@@ -2365,6 +2378,11 @@ void StreamAbstractionAAMP_MPD::SeekInPeriod( double seekPositionSeconds, bool s
 		}
 
 	}
+	// trackRemainingSeek holds the SkipFragments return value of the last processed
+	// track (comment 1). All non-subtitle tracks seek to the same seekPositionSeconds so
+	// their remaining-seek values are expected to converge. HandleSeekEOSAndPeriodTransition
+	// only uses this value for a sign check (>= 0) and as the carry-over seek offset into
+	// the next period, so using the last track's value is acceptable in practice.
 	HandleSeekEOSAndPeriodTransition(trackRemainingSeek, skipToEnd);
 }
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2293,7 +2293,7 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 
 	for (int i = 0; i < mNumberOfTracks; i++)
 	{
-		if (mMediaStreamContext[i] != NULL && mMediaStreamContext[i]->eos)
+		if (mMediaStreamContext[i] != NULL && mMediaStreamContext[i]->eos && (mPlayRate >= AAMP_RATE_PAUSE) &&  remainingSeek >= 0)
 		{
 			switchToNextPeriod = true;
 			break;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2283,22 +2283,114 @@ bool StreamAbstractionAAMP_MPD::PushNextFragment( class MediaStreamContext *pMed
 	return retval;
 }
 
+/**
+ * @brief If the current SkipFragments loop reaches EOS and additional periods are available, switch to the next period. Return true if the switch succeeds and the seek should be retried; otherwise, return false.
+ */
+bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double videoRemainingSeek,
+	bool skipToEnd, int maxPeriodSwitchCount, int &periodSwitchCount,
+	double &remainingSeekPosition)
+{
+	MediaStreamContext *videoContext = mMediaStreamContext[eMEDIATYPE_VIDEO];
+	bool switchToNextPeriod = (!skipToEnd) &&
+		(mpd != NULL) &&
+		(mMPDParseHelper != NULL) &&
+		(videoContext != NULL) &&
+		(videoContext->eos);
+
+	if (!switchToNextPeriod)
+	{
+		AAMPLOG_INFO("SeekInPeriod: Seek completed within current period with remaining seek %lf", videoRemainingSeek);
+		return false;
+	}
+
+	if (periodSwitchCount >= maxPeriodSwitchCount)
+	{
+		AAMPLOG_WARN("SeekInPeriod: Reached max period-switch attempts while carrying seek remainder %lf", videoRemainingSeek);
+		return false;
+	}
+
+	int nextPeriodIdx = mCurrentPeriodIdx + 1;
+	while ((nextPeriodIdx < mMPDParseHelper->GetNumberOfPeriods()) && IsEmptyPeriod(nextPeriodIdx))
+	{
+		nextPeriodIdx++;
+	}
+
+	if (nextPeriodIdx >= mMPDParseHelper->GetNumberOfPeriods())
+	{
+		AAMPLOG_INFO("SeekInPeriod: No next playable period available for seek remainder %lf", videoRemainingSeek);
+		return false;
+	}
+
+	mCurrentPeriodIdx = nextPeriodIdx;
+	mCurrentPeriod = mpd->GetPeriods().at(mCurrentPeriodIdx);
+	mBasePeriodId = mCurrentPeriod->GetId();
+	AAMPLOG_INFO("SeekInPeriod: Switching to next period %d with id %s for seek remainder %lf", mCurrentPeriodIdx, mBasePeriodId.c_str(), videoRemainingSeek);
+	mPeriodStartTime = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs);
+	mPeriodDuration = mMPDParseHelper->GetPeriodDuration(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, ShouldCheckOnlyIframeAdaptation(), aamp->IsUninterruptedTSB());
+	mPeriodEndTime = mMPDParseHelper->GetPeriodEndTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs, ShouldCheckOnlyIframeAdaptation(), aamp->IsUninterruptedTSB());
+
+	mUpdateStreamInfo = true;
+	AAMPStatusType ret = UpdateTrackInfo(true, true);
+	if (ret != eAAMPSTATUS_OK)
+	{
+		AAMPLOG_WARN("SeekInPeriod: UpdateTrackInfo failed while switching to period %d", mCurrentPeriodIdx);
+		return false;
+	}
+
+	for (int i = 0; i < mNumberOfTracks; i++)
+	{
+		if (mMediaStreamContext[i])
+		{
+			mMediaStreamContext[i]->eos = false;
+		}
+	}
+
+	AAMPLOG_INFO("SeekInPeriod: Switched to period %d and re-seeking with remainder %lf", mCurrentPeriodIdx, videoRemainingSeek);
+	remainingSeekPosition = videoRemainingSeek;
+	periodSwitchCount++;
+	return true;
+}
+
 
 /**
  * @brief Seek current period by a given time
  */
 void StreamAbstractionAAMP_MPD::SeekInPeriod( double seekPositionSeconds, bool skipToEnd)
 {
-	for (int i = 0; i < mNumberOfTracks; i++)
+double remainingSeekPosition = seekPositionSeconds;
+	int maxPeriodSwitchCount = (mpd != NULL) ? (int)mpd->GetPeriods().size() : 0;
+	int periodSwitchCount = 0;
+
+	while (true)
 	{
-		if (eMEDIATYPE_SUBTITLE == i)
+		double videoRemainingSeek = 0.0;
+		for (int i = 0; i < mNumberOfTracks; i++)
 		{
-			double skipTime = seekPositionSeconds;
-			SkipFragments(mMediaStreamContext[i], skipTime, true);
+			if (!mMediaStreamContext[i])
+			{
+				continue;
+			}
+
+			double trackRemainingSeek = 0.0;
+			if (eMEDIATYPE_SUBTITLE == i)
+			{
+				trackRemainingSeek = SkipFragment(mMediaStreamContext[i], remainingSeekPosition, true);
+			}
+			else
+			{
+				trackRemainingSeek = SkipFragments(mMediaStreamContext[i], remainingSeekPosition, true, skipToEnd);
+			}
+
+			if (i == eMEDIATYPE_VIDEO)
+			{
+				videoRemainingSeek = trackRemainingSeek;
+			}
 		}
-		else
+
+		if (!HandleSeekEOSAndPeriodTransition(videoRemainingSeek, skipToEnd,
+			maxPeriodSwitchCount, periodSwitchCount, remainingSeekPosition))
 		{
-			SkipFragments(mMediaStreamContext[i], seekPositionSeconds, true, skipToEnd);
+			break;
 		}
 	}
 }

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2374,7 +2374,7 @@ double remainingSeekPosition = seekPositionSeconds;
 			double trackRemainingSeek = 0.0;
 			if (eMEDIATYPE_SUBTITLE == i)
 			{
-				trackRemainingSeek = SkipFragment(mMediaStreamContext[i], remainingSeekPosition, true);
+				trackRemainingSeek = SkipFragments(mMediaStreamContext[i], remainingSeekPosition, true);
 			}
 			else
 			{

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -921,16 +921,12 @@ protected:
 
 	/**
 	 * @fn HandleSeekEOSAndPeriodTransition
-	 * @param videoRemainingSeek remaining seek time after skipping fragments
+	 * @param remainingSeek remaining seek time after skipping fragments
+	 * @param pMediaStreamContext current track context from SeekInPeriod
 	 * @param skipToEnd true when seek operation is a seek-to-end
-	 * @param maxPeriodSwitchCount maximum allowed period switches for this seek
-	 * @param periodSwitchCount running period switch counter
-	 * @param remainingSeekPosition updated seek remainder after period switch
-	 * @return true if period switched and caller should continue seek loop
+	 * @return true if period switched; false otherwise
 	 */
-	bool HandleSeekEOSAndPeriodTransition(double videoRemainingSeek, bool skipToEnd,
-		int maxPeriodSwitchCount, int &periodSwitchCount,
-		double &remainingSeekPosition);
+	bool HandleSeekEOSAndPeriodTransition(double remainingSeek, MediaStreamContext *pMediaStreamContext, bool skipToEnd);
 
 	/**
 	 * @fn SeekInPeriod

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -920,6 +920,19 @@ protected:
 	void SkipToEnd( class MediaStreamContext *pMediaStreamContext); //Added to support rewind in multiperiod assets
 
 	/**
+	 * @fn HandleSeekEOSAndPeriodTransition
+	 * @param videoRemainingSeek remaining seek time after skipping fragments
+	 * @param skipToEnd true when seek operation is a seek-to-end
+	 * @param maxPeriodSwitchCount maximum allowed period switches for this seek
+	 * @param periodSwitchCount running period switch counter
+	 * @param remainingSeekPosition updated seek remainder after period switch
+	 * @return true if period switched and caller should continue seek loop
+	 */
+	bool HandleSeekEOSAndPeriodTransition(double videoRemainingSeek, bool skipToEnd,
+		int maxPeriodSwitchCount, int &periodSwitchCount,
+		double &remainingSeekPosition);
+
+	/**
 	 * @fn SeekInPeriod
 	 * @param seekPositionSeconds seek position in seconds
 	 */

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -922,11 +922,10 @@ protected:
 	/**
 	 * @fn HandleSeekEOSAndPeriodTransition
 	 * @param remainingSeek remaining seek time after skipping fragments
-	 * @param pMediaStreamContext current track context from SeekInPeriod
 	 * @param skipToEnd true when seek operation is a seek-to-end
 	 * @return true if period switched; false otherwise
 	 */
-	bool HandleSeekEOSAndPeriodTransition(double remainingSeek, MediaStreamContext *pMediaStreamContext, bool skipToEnd);
+	bool HandleSeekEOSAndPeriodTransition(double remainingSeek, bool skipToEnd);
 
 	/**
 	 * @fn SeekInPeriod

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -3904,8 +3904,6 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 // L1: Verify mFirstPTS is updated via SeekInPeriod when seek crosses from period-1 to period-2.
 TEST_F(FunctionalTests, L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS)
 {
-	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: start\n");
-	fflush(stdout);
 	AAMPStatusType status;
 	static const char *manifest =
 R"(<?xml version="1.0" encoding="utf-8"?>
@@ -3939,13 +3937,8 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 		.WillRepeatedly(Return(true));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetLLDashChunkMode(_));
 
-	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: before InitializeMPD\n");
-	fflush(stdout);
 	status = InitializeMPD(manifest, eTUNETYPE_NEW_NORMAL, 0.0, AAMP_NORMAL_PLAY_RATE, false);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
-	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: after InitializeMPD status=%d\n", status);
-	fflush(stdout);
-
 	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
 	ASSERT_NE(track, nullptr);
 	MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
@@ -3958,16 +3951,12 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 	// Seek position is greater than period-1 duration (10s), so SeekInPeriod should transition to period-2
 	// with remaining seek value and still update mFirstPTS from SkipFragments path.
 	const double seekPositionSeconds = 12.0;
-	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: before CallSeekInPeriod seek=%f\n", seekPositionSeconds);
-	fflush(stdout);
-	static_cast<TestableFunctionalStreamAbstractionAAMP_MPD *>(mStreamAbstractionAAMP_MPD)->CallSeekInPeriod(seekPositionSeconds);
-	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: after CallSeekInPeriod\n");
-	fflush(stdout);
-
+	TestableFunctionalStreamAbstractionAAMP_MPD *testableStreamAbstractionAAMP_MPD =
+    dynamic_cast<TestableFunctionalStreamAbstractionAAMP_MPD *>(mStreamAbstractionAAMP_MPD);
+	ASSERT_NE(testableStreamAbstractionAAMP_MPD, nullptr);
+	testableStreamAbstractionAAMP_MPD->CallSeekInPeriod(seekPositionSeconds);
 	// Verify: mFirstPTS updated after period transition and remaining-seek skip in period-2.
 	EXPECT_DOUBLE_EQ(mStreamAbstractionAAMP_MPD->GetFirstPTS(), 102.000000);
-	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: end\n");
-	fflush(stdout);
 }
 
 TEST_F(StreamAbstractionAAMP_MPDTest, clearFirstPTS)

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -60,6 +60,20 @@ AampConfig *gpGlobalConfig{nullptr};
 class FunctionalTestsBase
 {
 protected:
+	class TestableFunctionalStreamAbstractionAAMP_MPD : public StreamAbstractionAAMP_MPD
+	{
+	public:
+		TestableFunctionalStreamAbstractionAAMP_MPD(PrivateInstanceAAMP *aamp, double seekpos, float rate)
+			: StreamAbstractionAAMP_MPD(aamp, seekpos, rate)
+		{
+		}
+
+		void CallSeekInPeriod(double seekPositionSeconds, bool skipToEnd = false)
+		{
+			SeekInPeriod(seekPositionSeconds, skipToEnd);
+		}
+	};
+
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
 	StreamAbstractionAAMP_MPD *mStreamAbstractionAAMP_MPD;
 	CDAIObject *mCdaiObj;
@@ -345,7 +359,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 			}
 		}
 		/* Create MPD instance. */
-		mStreamAbstractionAAMP_MPD = new StreamAbstractionAAMP_MPD(mPrivateInstanceAAMP, seekPos, rate);
+		mStreamAbstractionAAMP_MPD = new TestableFunctionalStreamAbstractionAAMP_MPD(mPrivateInstanceAAMP, seekPos, rate);
 		mCdaiObj = new CDAIObjectMPD(mPrivateInstanceAAMP);
 		mStreamAbstractionAAMP_MPD->SetCDAIObject(mCdaiObj);
 
@@ -3885,6 +3899,75 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 	EXPECT_EQ(pMediaStreamContext->fragmentTime, 0.00);
 	EXPECT_EQ(pMediaStreamContext->fragmentDescriptor.Number,1);
 	EXPECT_EQ(pMediaStreamContext->fragmentDescriptor.Time,0.00);
+}
+
+// L1: Verify mFirstPTS is updated via SeekInPeriod when seek crosses from period-1 to period-2.
+TEST_F(FunctionalTests, L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS)
+{
+	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: start\n");
+	fflush(stdout);
+	AAMPStatusType status;
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT0H0M30.00S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264">
+	<Period id="p0" start="PT0S" duration="PT10S">
+		<AdaptationSet contentType="video" segmentAlignment="true" startWithSAP="1">
+			<Representation id="v1" mimeType="video/mp4" codecs="avc1.640028" width="640" height="360" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_$Time$.m4s" initialization="video_init.mp4" startNumber="1">
+					<SegmentTimeline>
+						<S t="90000" d="2000" r="4" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<Period id="p1" start="PT10S" duration="PT20S">
+		<AdaptationSet contentType="video" segmentAlignment="true" startWithSAP="1">
+			<Representation id="v1" mimeType="video/mp4" codecs="avc1.640028" width="640" height="360" bandwidth="1000000">
+				<SegmentTemplate timescale="1000" media="video_p1_$Time$.m4s" initialization="video_init.mp4" startNumber="1">
+					<SegmentTimeline>
+						<S t="100000" d="2000" r="9" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _, _, _))
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetLLDashChunkMode(_));
+
+	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: before InitializeMPD\n");
+	fflush(stdout);
+	status = InitializeMPD(manifest, eTUNETYPE_NEW_NORMAL, 0.0, AAMP_NORMAL_PLAY_RATE, false);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: after InitializeMPD status=%d\n", status);
+	fflush(stdout);
+
+	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
+	ASSERT_NE(track, nullptr);
+	MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
+	//EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
+
+	// Reset mFirstPTS before seek
+	mStreamAbstractionAAMP_MPD->clearFirstPTS();
+	EXPECT_DOUBLE_EQ(mStreamAbstractionAAMP_MPD->GetFirstPTS(), 0.0);
+
+	// Seek position is greater than period-1 duration (10s), so SeekInPeriod should transition to period-2
+	// with remaining seek value and still update mFirstPTS from SkipFragments path.
+	const double seekPositionSeconds = 12.0;
+	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: before CallSeekInPeriod seek=%f\n", seekPositionSeconds);
+	fflush(stdout);
+	static_cast<TestableFunctionalStreamAbstractionAAMP_MPD *>(mStreamAbstractionAAMP_MPD)->CallSeekInPeriod(seekPositionSeconds);
+	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: after CallSeekInPeriod\n");
+	fflush(stdout);
+
+	// Verify: mFirstPTS updated after period transition and remaining-seek skip in period-2.
+	EXPECT_DOUBLE_EQ(mStreamAbstractionAAMP_MPD->GetFirstPTS(), 102.000000);
+	printf("[TRACE] L1_SeekInPeriod_TwoPeriods_UpdatesFirstPTS: end\n");
+	fflush(stdout);
 }
 
 TEST_F(StreamAbstractionAAMP_MPDTest, clearFirstPTS)


### PR DESCRIPTION
If the current SkipFragments loop reaches EOS and another playable period is available, switch to that period and return true so the seek can be retried. This path is required to update mFirstPTS correctly; otherwise, mFirstPTS may be updated incorrectly and cause a position jump.