### PR TITLE
VPAAMP-166 OSX-specific tuneTimeStrPrefix crash when running l1 AampProfilertests

### DIFF
--- a/test/utests/tests/AampProfilerTests/AampProfilerTests.cpp
+++ b/test/utests/tests/AampProfilerTests/AampProfilerTests.cpp
@@ -64,9 +64,8 @@ TEST_F(AampProfilertests, SetLatencyParamTest13)
 TEST_F(AampProfilertests, GetTuneTimeMetricAsJsonTest)
 {
     TuneEndMetrics tuneMetricsData;
-    char tuneTimeStrPrefixdata[] = {1,2,3,4,5};
-    char *tuneTimeStrPrefix = tuneTimeStrPrefixdata;
-    unsigned int licenseAcqNWTime = 2;
+	const char *tuneTimeStrPrefix = "[tuneTimeStrPrefix]";
+	unsigned int licenseAcqNWTime = 2;
     bool playerPreBuffered = true;
     unsigned int durationSeconds = 3;
     bool interfaceWifi = true;


### PR DESCRIPTION
Reason for Change: Replaced invalid non-nul terminated cstring tuneTimeStrPrefix to avoid crash in cJSON_AddStringToObject

Test Guidance: all l1tests passing on OSX without crash or failures

Risk: None