### PR TITLE
VPAAMP-168 utests: deduplicate gtest/gmock link libraries to fix macOS linker warning

### DIFF
--- a/test/utests/CMakeLists.txt
+++ b/test/utests/CMakeLists.txt
@@ -48,10 +48,8 @@ pkg_check_modules(GMOCK REQUIRED gmock)
 # "ignoring duplicate libraries".  Tests that only link GTEST_LINK_LIBRARIES
 # are unaffected because they don't use gmock and won't see duplication.
 foreach(_lib IN LISTS GMOCK_LINK_LIBRARIES)
-    list(REMOVE_ITEM GTEST_LINK_LIBRARIES ${_lib})
+	list(REMOVE_ITEM GTEST_LINK_LIBRARIES ${_lib})
 endforeach()
-message(STATUS "  GTest libraries: ${GTEST_LINK_LIBRARIES}")
-message(STATUS "  GMock libraries: ${GMOCK_LINK_LIBRARIES}")
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
 pkg_check_modules(GSTREAMERBASE REQUIRED gstreamer-app-1.0)
 pkg_check_modules(GLIB REQUIRED glib-2.0)

--- a/test/utests/CMakeLists.txt
+++ b/test/utests/CMakeLists.txt
@@ -41,6 +41,17 @@ include_directories(${OPENSSL_INCLUDE_DIRS})
 
 pkg_check_modules(GTEST REQUIRED gtest)
 pkg_check_modules(GMOCK REQUIRED gmock)
+# GMOCK_LINK_LIBRARIES already contains libgtest (gmock depends on gtest).
+# Strip any items from GTEST_LINK_LIBRARIES that are already covered by
+# GMOCK_LINK_LIBRARIES so that tests linking both variables don't put
+# libgtest on the link line twice, which triggers the macOS linker warning
+# "ignoring duplicate libraries".  Tests that only link GTEST_LINK_LIBRARIES
+# are unaffected because they don't use gmock and won't see duplication.
+foreach(_lib IN LISTS GMOCK_LINK_LIBRARIES)
+    list(REMOVE_ITEM GTEST_LINK_LIBRARIES ${_lib})
+endforeach()
+message(STATUS "  GTest libraries: ${GTEST_LINK_LIBRARIES}")
+message(STATUS "  GMock libraries: ${GMOCK_LINK_LIBRARIES}")
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0)
 pkg_check_modules(GSTREAMERBASE REQUIRED gstreamer-app-1.0)
 pkg_check_modules(GLIB REQUIRED glib-2.0)


### PR DESCRIPTION
Reason for Change: avoid noise while building l1tests

GMOCK_LINK_LIBRARIES already contains libgtest.a (since gmock depends on gtest).  Tests that link both ${GMOCK_LINK_LIBRARIES} and ${GTEST_LINK_LIBRARIES} therefore put libgtest.a on the link line twice, triggering the macOS linker warning:

  ld: warning: ignoring duplicate libraries: '.../libgtest.a'

Fix: after both pkg_check_modules calls, remove from GTEST_LINK_LIBRARIES any entries already present in GMOCK_LINK_LIBRARIES.  Tests only ever need to link one of the two variables (or both) without seeing duplicates.