### PR TITLE
VPLAY-13206: Ad rewind results in playing at 1x speed for 1-2s

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2124,15 +2124,9 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 		// If beginningOfStream is true or position < start, it means rewind has reached BoS
 		// Note: position could be = start immediately after tuning
 		else if (position < start || beginningOfStream)
-		{ // clamp start or handle BOS during rewind
-			AAMPLOG_TRACE("Reached start of TSB, position %fms < start %fms, beginningOfStream %d, rate %f",
-				position, start, beginningOfStream, rate);
+		{
+			AAMPLOG_WARN( "clamp position %fms < start %fms", position, start );
 			position = start;
-			// Check the rate so that PlayFromTsbStart() is not called repeatedly
-			if (rate < AAMP_RATE_PAUSE)
-			{
-				PlayFromTsbStart();
-			}
 		}
 		DeliverAdEvents(false, position); // use progress reporting as trigger to belatedly deliver ad events
 		ReportAdProgress(position);
@@ -3360,8 +3354,27 @@ void PrivateInstanceAAMP::NotifyEOSReached()
 		/* If rate is normal play, no need to seek to live etc. This can be due to the EPG changing rate from RWD to play near begging of the TSB. */
 		if (rate < AAMP_RATE_PAUSE)
 		{
+			seek_pos_seconds = culledSeconds;
+			AAMPLOG_WARN("Updated seek_pos_seconds %f on BOS", seek_pos_seconds);
+			if (trickStartUTCMS == -1)
+			{
+				// Resetting trickStartUTCMS if it's default due to no first frame on high speed rewind. This enables MonitorProgress to
+				// send BOS event to JSPP
+				ResetTrickStartUTCTime();
+				AAMPLOG_INFO("Resetting trickStartUTCMS to %lld since no first frame on trick play rate %f", trickStartUTCMS, rate);
+			}
 			// A new report progress event to be emitted with position 0 when rewind reaches BOS
 			MonitorProgress(true, true);
+			if (mAdProgressId.empty() && culledSeconds == 0)
+			{
+				// Main content reached BOS - reset to normal playback
+				rate = AAMP_NORMAL_PLAY_RATE;
+				AAMPLOG_WARN("HariPriya Main content reached EOS (position 0), resetting to normal rate");
+			}
+			AcquireStreamLock();
+			TuneHelper(eTUNETYPE_SEEK);
+			ReleaseStreamLock();
+			NotifySpeedChanged(rate);
 		}
 		else if (rate > AAMP_NORMAL_PLAY_RATE)
 		{


### PR DESCRIPTION
Reason for change: Change the order of TuneHelper and MonitorProgress calls, so that progress event with position=0 will be sent before the AAMP starts playback at 1x speed to trigger the PPJS AdRewindController logic
Test Procedure: As mentioned in the ticket
Risks: High