### PR TITLE
VPLAY-12917: missing closed caption after seek to advert

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -1323,7 +1323,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 			std::string tempEffectiveUrl;
 			AAMPLOG_TRACE(" Calling Getfile . buffer %p avail %d", &cachedFragment->fragment, (int)cachedFragment->fragment.GetAvail());
 			double downloadTime = 0;
-			
+
 			cachedFragment->discontinuityIndex = 0;
 			if( ISCONFIGSET(eAAMPConfig_HlsTsEnablePTSReStamp) )
 			{ // TODO: optimize me
@@ -1352,7 +1352,7 @@ bool TrackState::FetchFragmentHelper(int &http_error, bool &decryption_error, bo
 					}
 				}
 			}
-			
+
 			bool fetched = aamp->GetFile(fragmentUrl, (AampMediaType)(type), &cachedFragment->fragment,
 			 tempEffectiveUrl, &http_error, &downloadTime, range, type, false, NULL, NULL, fragmentDurationSeconds);
 			//Workaround for 404 of subtitle fragments
@@ -7130,7 +7130,12 @@ void StreamAbstractionAAMP_HLS::ConfigureTextTrack()
 			}
 		}
 	}
-	AAMPLOG_WARN("TextTrack Selected :%d", currentTextTrackProfileIndex);
+
+	if(currentTextTrackProfileIndex > -1 )
+	{
+		aamp->mIsInbandCC = mediaInfoStore[currentTextTrackProfileIndex].isCC;
+	}
+	AAMPLOG_WARN("TextTrack Selected :%d inBandCC:%d", currentTextTrackProfileIndex, aamp->mIsInbandCC);
 }
 /**
  * @brief Stops the Track Injection,Restarts once the track has been changed
@@ -7274,6 +7279,7 @@ void TrackState::SwitchAudioTrack()
  */
 void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 {
+	const bool disableWebVTT = ISCONFIGSET(eAAMPConfig_DisableWebVTT);
 	if (mMediaCount > 0 && mProfileCount > 0)
 	{
 		bool tracksChanged{false};
@@ -7293,7 +7299,10 @@ void StreamAbstractionAAMP_HLS::PopulateAudioAndTextTracks()
 				std::string index = std::to_string(i);
 				std::string language = (!media.language.empty()) ? GetLanguageCode(i) : std::string();
 //				AAMPLOG_WARN("StreamAbstractionAAMP_HLS:: Text Track - lang:%s, isCC:%d, group_id:%s, name:%s, instreamID:%s, characteristics:%s", language.c_str(), media.isCC, group_id.c_str(), name.c_str(), instreamID.c_str(), characteristics.c_str());
-				mTextTracks.push_back(TextTrackInfo(index, language, media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));
+				if (!disableWebVTT || media.isCC)
+				{
+					mTextTracks.push_back(TextTrackInfo(index, language, media.isCC, media.group_id, media.name, media.instreamID, media.characteristics,0));	
+				}
 			}
 			i++;
 		}

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1530,6 +1530,7 @@ void PlayerInstanceAAMP::SetSubtitleMute(bool muted)
 		aamp->AcquireStreamLock();
 		if (aamp->mpStreamAbstractionAAMP)
 		{
+			aamp->SetCCStatusSetByApp();				
 			aamp->SetSubtitleMute(muted);
 		}
 		else
@@ -2921,6 +2922,8 @@ int PlayerInstanceAAMP::GetTextTrack()
  */
 void PlayerInstanceAAMP::SetCCStatus(bool enabled)
 {
+	AAMPLOG_WARN("enabled %s", enabled?"true":"false");
+	aamp->SetCCStatusSetByApp();	
 	aamp->SetCCStatus(enabled);
 }
 

--- a/middleware/closedcaptions/PlayerCCManager.cpp
+++ b/middleware/closedcaptions/PlayerCCManager.cpp
@@ -725,10 +725,17 @@ int PlayerCCManagerBase::SetTrack(const std::string &track, const CCFormat forma
 }
 
 /**
- *  @brief To restore cc state after new tune
+ * @brief Restores the closed captions state after a new tune operation.
+ *
+ * @param shouldRestoreCC Indicates whether the closed captions state
+ * should be restored.
  */
-void PlayerCCManagerBase::RestoreCC()
+void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
+	if(!mEnabled && shouldRestoreCC)
+	{
+		mEnabled = shouldRestoreCC;
+	}
 	MW_LOG_WARN("PlayerCCManagerBase::mEnabled: %d, mTrickplayStarted: %d, mParentalCtrlLocked: %d, mCCHandle: %s",
 			mEnabled, mTrickplayStarted, mParentalCtrlLocked, (CheckCCHandle()) ? "set" : "not set");
 

--- a/middleware/closedcaptions/PlayerCCManager.h
+++ b/middleware/closedcaptions/PlayerCCManager.h
@@ -137,9 +137,10 @@ public:
 	/**
 	 * @fn RestoreCC 
 	 *
+	 * @param[in] shouldRestoreCC - previously captured CC enabled state to be restored after teardown
 	 * @return void
 	 */
-	void RestoreCC();
+	void RestoreCC(bool shouldRestoreCC = false);
 
 	virtual ~PlayerCCManagerBase(){ };
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5129,6 +5129,7 @@ static int aampApplyThreadPrioFromEnv(const char *env, int defaultPolicy, int de
 void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 {
 	bool newTune;
+	bool previousCCEnabled = false;
 
 	aampApplyThreadPrioFromEnv("AAMP_AV_PIPELINE_PRIORITY", SCHED_OTHER, 0);
 	for (int i = 0; i < AAMP_TRACK_COUNT; i++)
@@ -5587,6 +5588,17 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			IncreaseGSTBufferSize();
 		}
 
+		// Retrieve the current closed‑captioning state and log it along with the in‑band CC flag.
+		previousCCEnabled = PlayerCCManager::GetInstance()->GetStatus();
+		if (mIsInbandCC && !mCCStatusSetByApp.load())
+		{
+			// No API to set CC or subtitles has been called, so AAMP assumes that the app talks to CCManager directly.
+			// Set subtitles_muted based on the current CC status to ensure correct subtitle state is applied later on.
+			subtitles_muted = !previousCCEnabled;
+		}
+		AAMPLOG_WARN("previousCCEnabled:%d isCCinBand:%d subtitles_muted:%d mCCStatusSetByApp:%d",
+			previousCCEnabled, mIsInbandCC, subtitles_muted, mCCStatusSetByApp.load());
+
 		if (!mbUsingExternalPlayer)
 		{
 			StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
@@ -5699,7 +5711,9 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 		}
 		//restore CC if it was enabled for previous content.
 		if(mIsInbandCC)
-			PlayerCCManager::GetInstance()->RestoreCC();
+		{
+			PlayerCCManager::GetInstance()->RestoreCC(previousCCEnabled);
+		}
 	}
 
 	if (newTune && !mIsFakeTune)
@@ -7153,6 +7167,11 @@ void PrivateInstanceAAMP::SetVideoMute(bool muted)
 	{
 		mDRMLicenseManager->setVideoMute(IsLive(), GetCurrentLatency(), IsAtLivePoint(), GetLiveOffsetMs(),muted, GetStreamPositionMs());
 	}
+}
+
+void PrivateInstanceAAMP::SetCCStatusSetByApp()
+{
+	mCCStatusSetByApp = true;
 }
 
 /**
@@ -10250,11 +10269,7 @@ std::string PrivateInstanceAAMP::GetAvailableTextTracks(bool allTrack)
 		std::vector<CCTrackInfo> updatedTextTracks;
 		UpdateCCTrackInfo(textTracksCopy,updatedTextTracks);
 		PlayerCCManager::GetInstance()->updateLastTextTracks(updatedTextTracks);
-		if( ISCONFIGSET_PRIV(eAAMPConfig_DisableWebVTT) )
-		{
-			trackInfo.swap(textTracksCopy);
-			AAMPLOG_DEBUG("Filtered track list to include only in-band CC tracks");
-		}
+
 		if (!trackInfo.empty())
 		{
 			//Convert to JSON format
@@ -10662,7 +10677,7 @@ std::string PrivateInstanceAAMP::GetAudioTrackInfo()
 }
 
 /**
- * @brief Get current audio track index
+ * @brief Get current text track index
  */
 std::string PrivateInstanceAAMP::GetTextTrackInfo()
 {
@@ -10990,18 +11005,32 @@ int PrivateInstanceAAMP::GetTextTrack()
  */
 void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 {
-	PlayerCCManager::GetInstance()->SetStatus(enabled);
+	AAMPLOG_INFO("enabled %s", enabled?"true":"false");
 	AcquireStreamLock();
 	subtitles_muted = !enabled;
+	// Mute subtitles if either video is muted or subtitles are muted
+	bool mute_subtitles_applied = video_muted || subtitles_muted;
+	bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
+	AAMPLOG_INFO("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
+					  mIsInbandCC, isGstSubtecEnabled, mute_subtitles_applied, video_muted, subtitles_muted);
 	if (mpStreamAbstractionAAMP)
 	{
-		mpStreamAbstractionAAMP->MuteSubtitles(subtitles_muted);
-		if (HasSidecarData())
-		{ // has sidecar data
-			mpStreamAbstractionAAMP->MuteSidecarSubtitles(subtitles_muted);
+		
+		
+		if (mIsInbandCC || !isGstSubtecEnabled)
+		{
+			PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
+		}
+		else
+		{
+			mpStreamAbstractionAAMP->MuteSubtitles(mute_subtitles_applied);
+			if (HasSidecarData())
+			{ // has sidecar data
+				mpStreamAbstractionAAMP->MuteSidecarSubtitles(mute_subtitles_applied);
+			}
 		}
 	}
-	SetSubtitleMute(subtitles_muted);
+	SetSubtitleMute(mute_subtitles_applied);
 	ReleaseStreamLock();
 }
 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1030,6 +1030,9 @@ public:
 	VideoZoomMode zoom_mode;
 	bool video_muted; /**< true iff video plane is logically muted */
 	bool subtitles_muted; /**< true iff subtitle plane is logically muted */
+	std::atomic<bool> mCCStatusSetByApp{false}; /**< true once an AAMP CC/subtitle API has been called,
+												 * false while app talks to CCManager directly.*/
+			
 	int audio_volume;
 	std::vector<std::string> subscribedTags;
 	std::vector<TimedMetadata> timedMetadata;
@@ -2241,6 +2244,13 @@ public:
 	 *   @return void
 	 */
 	void SetVideoMute(bool muted);
+
+	/**
+	 *   @brief Mark that the application has called an external CC/subtitle API.
+	 *
+	 *   Sets mCCStatusSetByApp to true.
+	 */
+	void SetCCStatusSetByApp();
 
 	/**
 	 *   @brief Set subtitle mute state

--- a/test/utests/fakes/FakeAampCCManager.cpp
+++ b/test/utests/fakes/FakeAampCCManager.cpp
@@ -27,7 +27,7 @@ int PlayerCCManagerBase::Init(void *handle)
 {
 	return 0;
 }
-void PlayerCCManagerBase::RestoreCC()
+void PlayerCCManagerBase::RestoreCC(bool shouldRestoreCC)
 {
 }
 void PlayerCCManagerBase::Release(int iID)

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -372,6 +372,15 @@ void PrivateInstanceAAMP::SetVideoMute(bool muted)
 {
 }
 
+void PrivateInstanceAAMP::SetCCStatusSetByApp()
+{
+	mCCStatusSetByApp = true;
+	if (g_mockPrivateInstanceAAMP != nullptr)
+	{
+		g_mockPrivateInstanceAAMP->SetCCStatusSetByApp();
+	}
+}
+
 void PrivateInstanceAAMP::SetSubtitleMute(bool muted)
 {
 }

--- a/test/utests/mocks/MockPlayerCCManager.h
+++ b/test/utests/mocks/MockPlayerCCManager.h
@@ -1,0 +1,57 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef AAMP_MOCK_PLAYER_CC_MANAGER_H
+#define AAMP_MOCK_PLAYER_CC_MANAGER_H
+
+#include <gmock/gmock.h>
+#include "PlayerCCManager.h"
+
+class MockPlayerCCManager
+{
+public:
+	MOCK_METHOD(int, Init, (void *handle));
+	MOCK_METHOD(void, RestoreCC, (bool shouldRestoreCC));
+	MOCK_METHOD(void, Release, (int iID));
+	MOCK_METHOD(bool, IsOOBCCRenderingSupported, ());
+	MOCK_METHOD(int, SetStatus, (bool enable));
+	MOCK_METHOD(int, SetStyle, (const std::string &options));
+	MOCK_METHOD(int, SetTrack, (const std::string &track, const CCFormat format));
+	MOCK_METHOD(void, SetTrickplayStatus, (bool enable));
+	MOCK_METHOD(void, SetParentalControlStatus, (bool locked));
+	MOCK_METHOD(void, StartRendering, ());
+	MOCK_METHOD(void, StopRendering, ());
+	MOCK_METHOD(int, SetDigitalChannel, (unsigned int id));
+	MOCK_METHOD(int, SetAnalogChannel, (unsigned int id));
+
+	MOCK_METHOD(bool, CheckCCHandle, (), (const));
+
+	// Virtual methods with default implementations
+	MOCK_METHOD(int, GetId, ());
+	MOCK_METHOD(void, updateLastTextTracks, (const std::vector<CCTrackInfo> &newTextTracks));
+
+	// Non-virtual methods for additional testing flexibility
+	MOCK_METHOD(void, EnsureInitialized, ());
+	MOCK_METHOD(void, EnsureHALInitialized, ());
+	MOCK_METHOD(void, EnsureRendererCommsInitialized, ());
+	MOCK_METHOD(int, Initialize, (void *handle));
+};
+
+extern std::shared_ptr<MockPlayerCCManager> g_mockPlayerCCManager;
+
+#endif /* AAMP_MOCK_PLAYER_CC_MANAGER_H */

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -81,6 +81,7 @@ public:
 	MOCK_METHOD(void, NotifyOnEnteringLive, ());
 
 	MOCK_METHOD(void, SendAdPlacementEvent, (AAMPEventType, const std::string &, uint32_t, uint64_t, uint32_t, uint32_t, bool, long));
+	MOCK_METHOD(void, SetCCStatusSetByApp, ());
 	MOCK_METHOD(void, SendAdReservationEvent, (AAMPEventType, const std::string &, uint64_t, uint64_t, bool));
 	MOCK_METHOD(void, CalculateTrickModePositionEOS, ());
 	MOCK_METHOD(void, BlockUntilGstreamerWantsData, (void(*cb)(void), int , int ));

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -643,12 +643,14 @@ TEST_F(PlayerInstanceAAMPTests, SetVideoMute_NotNullAamp2) {
 }
 TEST_F(PlayerInstanceAAMPTests, SetSubtitleMuteTest1) {
     //checking true condition
-    bool muted = true; 
+    bool muted = true;
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetCCStatusSetByApp());
    mPlayerInstance->SetSubtitleMute(muted);
 }
 TEST_F(PlayerInstanceAAMPTests, SetSubtitleMuteTest2) {
     //checking false condition
-    bool muted = false; 
+    bool muted = false;
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetCCStatusSetByApp());
    mPlayerInstance->SetSubtitleMute(muted);
 }
 TEST_F(PlayerInstanceAAMPTests, SetAudioVolumeTest1) {
@@ -1741,8 +1743,9 @@ TEST_F(PlayerInstanceAAMPTests, GetTextTrackTest)
 
 TEST_F(PlayerInstanceAAMPTests, SetCCStatusTest)
 {
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetCCStatusSetByApp());
     mPlayerInstance->SetCCStatus(true);
-    EXPECT_FALSE(mPlayerInstance->GetCCStatus()); 
+    EXPECT_FALSE(mPlayerInstance->GetCCStatus());
 }
 
 TEST_F(PlayerInstanceAAMPTests, SetTextStyleTest)

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -48,10 +48,12 @@
 #include "MockTSBStore.h"
 #include "fragmentcollector_mpd.h"
 #include "MockAdManager.h"
+#include "MockPlayerCCManager.h"
 
 using ::testing::An;
 using ::testing::DoAll;
 using ::testing::InvokeWithoutArgs;
+using ::testing::Invoke;
 using ::testing::Matcher;
 using ::testing::NiceMock;
 using ::testing::Return;
@@ -95,10 +97,13 @@ protected:
 		g_mockCurl = new NiceMock<MockCurl>();
 		g_mockAampCurlStore = new NiceMock<MockAampCurlStore>();
 		g_MockPrivateCDAIObjectMPD = new MockPrivateCDAIObjectMPD();
+		g_mockPlayerCCManager = std::make_shared<NiceMock<MockPlayerCCManager>>();
 	}
 
 	void TearDown() override
 	{
+		g_mockPlayerCCManager.reset();
+
 		delete g_MockPrivateCDAIObjectMPD;
 		g_MockPrivateCDAIObjectMPD = nullptr;
 		
@@ -3237,15 +3242,269 @@ TEST_F(PrivAampTests,SetTextTrackTest_1)
 	EXPECT_EQ(-1,val);
 }
 
-TEST_F(PrivAampTests,SetCCStatusTest)
+TEST_F(PrivAampTests,SetCCStatusPreTune)
 {
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
 
+	// Enable CC and check that status is stored,
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	p_aamp->SetCCStatusSetByApp();
 	p_aamp->SetCCStatus(true);
 	EXPECT_TRUE(p_aamp->GetCCStatus());
 
+	// Now call TuneHelper - subtitles_muted is false (from SetCCStatus(true) above)
+	// SetCCStatusInternal sees mute_subtitles_applied=false, calls SetStatus(true)
+	// RestoreCC(false) reflects the CC manager state was false before this tune
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(false)).Times(1);
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// Disable CC and check that status is stored,
+	// and SetStatus(false) is called since we are now tuned
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
 	p_aamp->SetCCStatus(false);
+	EXPECT_FALSE(p_aamp->GetCCStatus()); // Preference is stored
+}
+
+TEST_F(PrivAampTests,SetCCStatusPreTuneOOB)
+{
+	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_GstSubtecEnabled)).WillByDefault(Return(true));
+
+	//Set OOB path before SetCCStatus() is called - order matters
+	p_aamp->mIsInbandCC = false;
+
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
 	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Enable CCStatus and check that status is stored, 
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	p_aamp->SetCCStatusSetByApp();
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Clear pre-tune expectations before entering tune phase
+	::testing::Mock::VerifyAndClearExpectations(g_mockPlayerCCManager.get());
+	::testing::Mock::VerifyAndClearExpectations(g_mockAampGstPlayer);
+
+	// During TuneHelper: OOB path calls SetSubtitleMute(false) since
+	// subtitles_muted=false from the pre-tune SetCCStatus(true) call
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(false)).Times(1);
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// Clear tune phase expectations before post-tune phase
+	::testing::Mock::VerifyAndClearExpectations(g_mockAampGstPlayer);
+
+	// Post-tune: disabling CC calls SetSubtitleMute(true) since OOB path uses GstPlayer directly
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(true)).Times(1);
+	p_aamp->SetCCStatus(false);
+	EXPECT_FALSE(p_aamp->GetCCStatus()); // Preference is stored
+}
+
+TEST_F(PrivAampTests,SetCCStatusPreTuneWithVideoMute01)
+{
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Enable CC and check that status is stored, 
+	// but neither SetStatus() nor SetSubtitleMute() are called since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	p_aamp->SetCCStatusSetByApp();
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Set video mute - should not call SetStatus() since we are not yet tuned
+	p_aamp->SetVideoMute(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Clear pre-tune expectations before entering tune phase
+	::testing::Mock::VerifyAndClearExpectations(g_mockPlayerCCManager.get());
+	::testing::Mock::VerifyAndClearExpectations(g_mockAampGstPlayer);
+
+	// During TuneHelper: video is muted so CC is forced off via SetStatus(false)
+	// RestoreCC(false) is called because CC manager internal state was false before this tune
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(false)).Times(1);
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// After tune with video muted: app's CC preference is preserved (subtitles_muted not overwritten)
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Clear tune phase expectations before post-tune phase
+	::testing::Mock::VerifyAndClearExpectations(g_mockPlayerCCManager.get());
+
+	// Post-tune: unmuting video calls SetCCStatusInternal which calls SetStatus(true)
+	// because stored CC preference was preserved during tune
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetVideoMute(false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+}
+
+// Same as previous test but video mute is set before CC enable
+TEST_F(PrivAampTests,SetCCStatusPreTuneWithVideoMute02)
+{
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Set video mute - should not call SetStatus() since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	p_aamp->SetVideoMute(true);
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Enable CC and check that status is stored, 
+	p_aamp->SetCCStatusSetByApp();
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Clear pre-tune expectations before entering tune phase
+	::testing::Mock::VerifyAndClearExpectations(g_mockPlayerCCManager.get());
+	::testing::Mock::VerifyAndClearExpectations(g_mockAampGstPlayer);
+
+	// During TuneHelper: video is muted so CC is forced off via SetStatus(false)
+	// RestoreCC(false) is called because CC manager internal state was false before this tune
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(false)).Times(1);
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// After tune with video muted: app's CC preference is preserved (subtitles_muted not overwritten)
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Clear tune phase expectations before post-tune phase
+	::testing::Mock::VerifyAndClearExpectations(g_mockPlayerCCManager.get());
+
+	// Post-tune: unmuting video calls SetCCStatusInternal which calls SetStatus(true)
+	// because stored CC preference was preserved during tune
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetVideoMute(false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+}
+
+TEST_F(PrivAampTests,SetCCStatusPostTuneWithVideoMute)
+{
+	// Test basic CC status functionality
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC should be disabled by default (subtitles_muted=true)
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Set video mute - should not call SetStatus() since we are not yet tuned
+	EXPECT_CALL(*g_mockAampGstPlayer, SetSubtitleMute(_)).Times(0);
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(_)).Times(0);
+	p_aamp->SetVideoMute(true);
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Now call TuneHelper to create the StreamAbstraction object
+	// SetStatus(false) should be called due to video being muted
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Enable CC and check that status is stored, however SetStatus(false) is called since video is still muted
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	p_aamp->SetCCStatusSetByApp();
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Disable video mute - SetVideoMute will trigger SetCCStatusInternal
+	// and SetStatus(true) is called since we are now tuned and stored CC status is true
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetVideoMute(false);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+}
+
+TEST_F(PrivAampTests,RestoreCCWhenCCWasEnabledBeforeTune)
+{
+	// Test that RestoreCC(true) is called when CC was enabled before tune
+	p_aamp->mIsInbandCC = true;
+
+	// Initial tune - SetStatus(false) is called in SetCCStatusInternal during TuneHelper
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+
+	// Enable CC after tune - SetStatus(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetCCStatusSetByApp();
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Now tune again (simulating a new content tune)
+	// RestoreCC(true) should be called based on the tracked state
+	// SetCCStatusInternal is called during tune setup which calls SetStatus(true)
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+}
+
+TEST_F(PrivAampTests,RestoreCCWhenCCWasDisabledBeforeTune)
+{
+	// Test that RestoreCC(false) is called when CC was disabled before tune
+	p_aamp->mIsInbandCC = true;
+
+	// Initial state - CC is disabled by default
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+
+	// Call TuneHelper - SetStatus(false) is called first, then RestoreCC(false) should be called since CC is disabled
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(false)).Times(1);
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	EXPECT_FALSE(p_aamp->GetCCStatus());
+}
+
+TEST_F(PrivAampTests,RestoreCCPreservesStateAcrossMultipleTunes)
+{
+	// Test that CC state is preserved and RestoreCC is called on consecutive tunes
+	p_aamp->mIsInbandCC = true;
+
+	// Initial tune - SetStatus(false) is called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(false)).WillOnce(Return(0));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_)).WillRepeatedly(Return(g_mockAampGstPlayer));
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	// Enable CC - SetStatus(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).WillOnce(Return(0));
+	p_aamp->SetCCStatusSetByApp();
+	p_aamp->SetCCStatus(true);
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Second tune - SetStatus(true) and RestoreCC(true) should be called
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	// CC should still be enabled after second tune
+	EXPECT_TRUE(p_aamp->GetCCStatus());
+
+	// Third tune - SetStatus(true) and RestoreCC(true) should be called again
+	EXPECT_CALL(*g_mockPlayerCCManager, SetStatus(true)).Times(1);
+	EXPECT_CALL(*g_mockPlayerCCManager, RestoreCC(true)).Times(1);
+	p_aamp->TuneHelper(eTUNETYPE_NEW_NORMAL, false);
+	
+	// CC should still be enabled after third tune
+	EXPECT_TRUE(p_aamp->GetCCStatus());
 }
 
 TEST_F(PrivAampTests,NotifyAudioTracksChangedTest)

--- a/test/utests/tests/PrivateInstanceAAMP/ClosedCaptionTests.cpp
+++ b/test/utests/tests/PrivateInstanceAAMP/ClosedCaptionTests.cpp
@@ -1,0 +1,396 @@
+/*
+* If not stated otherwise in this file or this component's license file the
+* following copyright and licenses apply:
+*
+* Copyright 2025 RDK Management
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <cjson/cJSON.h>
+
+#include "priv_aamp.h"
+
+#include "AampConfig.h"
+#include "MockAampGstPlayer.h"
+#include "MockStreamAbstractionAAMP.h"
+#include "MockAampStreamSinkManager.h"
+#include "TextTrackInfo.h"
+#include "MockCJsonManager.h"
+
+// External declaration of global mock pointer
+extern MockCJsonManager *g_mockCJsonManager;
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::NiceMock;
+using ::testing::ReturnRef;
+using ::testing::DoAll;
+using ::testing::SetArgReferee;
+using ::testing::AtLeast;
+
+// Fake cJSON objects for mock returns
+static cJSON fake_array_object = { nullptr, nullptr, nullptr, cJSON_Array, nullptr, 0, 0.0, nullptr };
+static cJSON fake_object = { nullptr, nullptr, nullptr, cJSON_Object, nullptr, 0, 0.0, nullptr };
+static cJSON fake_item = { nullptr, nullptr, nullptr, cJSON_String, nullptr, 0, 0.0, nullptr };
+
+class ClosedCaptionTests : public ::testing::Test
+{
+protected:
+	PrivateInstanceAAMP *mPrivateInstanceAAMP{};
+	std::vector<TextTrackInfo> mockTextTracks;
+
+	void SetUp() override
+	{
+		// Initialize config and PrivateInstanceAAMP object first
+		gpGlobalConfig = new AampConfig();
+		mPrivateInstanceAAMP = new PrivateInstanceAAMP(gpGlobalConfig);
+
+		// Create mocks (StreamAbstractionAAMP requires PrivateInstanceAAMP*)
+		g_mockStreamAbstractionAAMP = new MockStreamAbstractionAAMP(mPrivateInstanceAAMP);
+		g_mockAampGstPlayer = new MockAAMPGstPlayer(mPrivateInstanceAAMP);
+		g_mockAampStreamSinkManager = new MockAampStreamSinkManager();
+
+		// Set the stream abstraction in the PrivateInstanceAAMP object
+		mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+
+		// Create and set up cJSON mock manager
+		g_mockCJsonManager = new MockCJsonManager();
+
+		// Setup the mock data
+		setupMockTextTracks();
+	}
+
+	void TearDown() override
+	{
+		// Clear the stream abstraction pointer before deleting PrivateInstanceAAMP
+		// to avoid double deletion
+		if (mPrivateInstanceAAMP) {
+			mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
+		}
+
+		delete mPrivateInstanceAAMP;
+		mPrivateInstanceAAMP = nullptr;
+
+		delete g_mockStreamAbstractionAAMP;
+		g_mockStreamAbstractionAAMP = nullptr;
+
+		delete g_mockAampGstPlayer;
+		g_mockAampGstPlayer = nullptr;
+
+		delete gpGlobalConfig;
+		gpGlobalConfig = nullptr;
+
+		delete g_mockAampStreamSinkManager;
+		g_mockAampStreamSinkManager = nullptr;
+
+		// Clean up cJSON mock
+		delete g_mockCJsonManager;
+		g_mockCJsonManager = nullptr;
+
+		mockTextTracks.clear();
+	}
+
+public:
+	// Helper function to set up basic cJSON expectations (array creation, object creation, etc.)
+	std::vector<cJSON*> setupBasicCJsonExpectations(cJSON* mockArray, cJSON* mockItem)
+	{
+		// Generate unique mock pointers for each track object
+		std::vector<cJSON*> mockObjects;
+		for (size_t i = 0; i < mockTextTracks.size(); i++) {
+			mockObjects.push_back(reinterpret_cast<cJSON*>(0x7000 + i));
+		}
+
+		EXPECT_CALL(*g_mockCJsonManager, CreateArray())
+			.WillOnce(Return(mockArray));
+
+		// Set up object creation expectations - one for each track
+		EXPECT_CALL(*g_mockCJsonManager, CreateObject())
+			.WillOnce(Return(mockObjects[0]))
+			.WillOnce(Return(mockObjects[1]))
+			.WillOnce(Return(mockObjects[2]))
+			.WillOnce(Return(mockObjects[3]));
+
+		return mockObjects;
+	}
+
+	// Helper function to set up string field expectations for a track
+	void setupTrackStringFieldExpectations(const TextTrackInfo& track, cJSON* mockObj, cJSON* mockItem)
+	{
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("name"), ::testing::StrEq(track.name)))
+			.WillOnce(Return(mockItem));
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("label"), ::testing::StrEq(track.label)))
+			.WillOnce(Return(mockItem));
+
+		// Add sub-type field based on isCC flag
+		std::string expectedSubType = track.isCC ? "CLOSED-CAPTIONS" : "SUBTITLES";
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("sub-type"), ::testing::StrEq(expectedSubType)))
+			.WillOnce(Return(mockItem));
+
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("language"), ::testing::StrEq(track.language)))
+			.WillOnce(Return(mockItem));
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("rendition"), ::testing::StrEq(track.rendition)))
+			.WillOnce(Return(mockItem));
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("instreamId"), ::testing::StrEq(track.instreamId)))
+			.WillOnce(Return(mockItem));
+		EXPECT_CALL(*g_mockCJsonManager, AddStringToObject(mockObj, ::testing::StrEq("codec"), ::testing::StrEq(track.codec)))
+			.WillOnce(Return(mockItem));
+	}
+
+	// Helper function to set up availability expectation for a track
+	void setupTrackAvailabilityExpectation(const TextTrackInfo& track, cJSON* mockObj, cJSON* mockItem, bool expectedAvailability)
+	{
+		EXPECT_CALL(*g_mockCJsonManager, AddBoolToObject(mockObj, ::testing::StrEq("availability"), expectedAvailability))
+			.WillOnce(Return(mockItem));
+	}
+
+	// Helper function to set up array finalization expectations
+	void setupArrayFinalizationExpectations(cJSON* mockArray, const std::vector<cJSON*>& mockObjects)
+	{
+		for (size_t i = 0; i < mockTextTracks.size(); i++) {
+			EXPECT_CALL(*g_mockCJsonManager, AddItemToArray(mockArray, mockObjects[i]))
+				.WillOnce(Return(cJSON_True));
+		}
+
+		// Set up a lenient expectation for Print() - we don't care about the exact output
+		// since our real verification is in the structure building calls above
+		EXPECT_CALL(*g_mockCJsonManager, Print(mockArray))
+			.WillOnce(Return("[]")); // Return minimal valid JSON - actual content doesn't matter for this test
+
+		EXPECT_CALL(*g_mockCJsonManager, Delete(mockArray))
+			.Times(1);
+	}
+
+	// Helper function to calculate TSB availability for a track
+	bool calculateTsbAvailability(const TextTrackInfo& track, const std::string& currentTrackIndex, bool getCurrentTrackSuccess)
+	{
+		if (track.isCC) {
+			return true;  // CC tracks are always available in TSB mode
+		} else if (!getCurrentTrackSuccess) {
+			return false; // No subtitle tracks available when GetCurrentTextTrack fails
+		} else {
+			return (track.index == currentTrackIndex); // Only current track is available
+		}
+	}
+
+private:
+	void setupMockTextTracks()
+	{
+		// Create sample text tracks for testing
+		TextTrackInfo track1;
+		track1.index = "0";
+		track1.language = "en";
+		track1.isCC = true;
+		track1.rendition = "main";
+		track1.name = "English CC";
+		track1.instreamId = "CC1";
+		track1.codec = "stpp";
+		track1.label = "English Closed Captions";
+		track1.isAvailable = true;
+
+		TextTrackInfo track2;
+		track2.index = "1";
+		track2.language = "es";
+		track2.isCC = true;
+		track2.rendition = "main";
+		track2.name = "Spanish CC";
+		track2.instreamId = "CC2";
+		track2.codec = "stpp";
+		track2.label = "Spanish Closed Captions";
+		track2.isAvailable = true;
+
+		TextTrackInfo track3;
+		track3.index = "2";
+		track3.language = "fr";
+		track3.isCC = false;  // This is a subtitle, not CC
+		track3.rendition = "main";
+		track3.name = "French Subtitles";
+		track3.instreamId = "SUB1";
+		track3.codec = "stpp";
+		track3.label = "French Subtitles";
+		track3.isAvailable = true;
+
+		TextTrackInfo track4;
+		track4.index = "3";
+		track4.language = "de";
+		track4.isCC = false;  // This is a subtitle, not CC
+		track4.rendition = "main";
+		track4.name = "German Subtitles";
+		track4.instreamId = "SUB2";
+		track4.codec = "stpp";
+		track4.label = "German Subtitles";
+		track4.isAvailable = true;
+
+		mockTextTracks.push_back(track1);
+		mockTextTracks.push_back(track2);
+		mockTextTracks.push_back(track3);
+		mockTextTracks.push_back(track4);
+	}
+};
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithValidTracks_ReturnsAllAvailableTracks)
+{
+	cJSON *mockArray = reinterpret_cast<cJSON*>(0x1001);
+	cJSON *mockItem = reinterpret_cast<cJSON*>(0x1003);
+
+	std::vector<cJSON*> mockObjects = setupBasicCJsonExpectations(mockArray, mockItem);
+
+	// Set up expectations for each track
+	for (size_t i = 0; i < mockTextTracks.size(); i++) {
+		const auto& track = mockTextTracks[i];
+		cJSON* mockObj = mockObjects[i];
+
+		// Set up string field expectations - verify production code adds correct fields with correct values
+		setupTrackStringFieldExpectations(track, mockObj, mockItem);
+
+		// In normal mode (non-TSB), all tracks are available
+		setupTrackAvailabilityExpectation(track, mockObj, mockItem, true);
+	}
+
+	// Set up array finalization expectations - verify objects are added to array correctly
+	setupArrayFinalizationExpectations(mockArray, mockObjects);
+
+	// Mock StreamAbstraction to return our test tracks
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(false))
+		.WillOnce(ReturnRef(mockTextTracks));
+
+	std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+	// Assert - The REAL test verification is in the EXPECT_CALL expectations above,
+	// which ensure the correct cJSON structure is built with the right field names and values.
+
+	// We only do basic sanity checks since the mock Print returns minimal JSON
+	EXPECT_FALSE(result.empty()) << "Should return non-empty result when tracks are available";
+}
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithEmptyTracks_ReturnsEmptyString)
+{
+	// Create empty tracks vector
+	std::vector<TextTrackInfo> emptyTracks;
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(false))
+		.WillOnce(ReturnRef(emptyTracks));
+
+	// No cJSON expectations needed - function returns early when no tracks available
+
+	std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+	// Should return empty string when no tracks are available
+	EXPECT_EQ(result, "") << "Should return empty string when no tracks are available";
+}
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithNullStreamAbstraction_ReturnsEmptyString)
+{
+	// Set stream abstraction to null
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
+
+	std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+	// Should return empty string when stream abstraction is null
+	EXPECT_TRUE(result.empty());
+}
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithLocalAAMPTsb_CallsGetCurrentTextTrack)
+{
+	cJSON *mockArray = reinterpret_cast<cJSON*>(0x5001);
+	cJSON *mockItem = reinterpret_cast<cJSON*>(0x5003);
+
+	// Set up basic cJSON expectations (array, object creation)
+	std::vector<cJSON*> mockObjects = setupBasicCJsonExpectations(mockArray, mockItem);
+
+	// Set up expectations for each track - verify TSB availability logic
+	std::string currentTrackIndex = "2"; // French Subtitles is the current track
+	for (size_t i = 0; i < mockTextTracks.size(); i++) {
+		const auto& track = mockTextTracks[i];
+		cJSON* mockObj = mockObjects[i];
+
+		// Set up string field expectations - verify production code adds correct fields
+		setupTrackStringFieldExpectations(track, mockObj, mockItem);
+
+		// Calculate and verify TSB availability logic: CC tracks always available,
+		// subtitle tracks only available if they match current track
+		bool expectedAvailability = calculateTsbAvailability(track, currentTrackIndex, true);
+		setupTrackAvailabilityExpectation(track, mockObj, mockItem, expectedAvailability);
+	}
+
+	// Set up array finalization expectations - verify objects are added to array correctly
+	setupArrayFinalizationExpectations(mockArray, mockObjects);
+
+	// Enable local AAMP TSB mode
+	mPrivateInstanceAAMP->SetLocalAAMPTsb(true);
+
+	// Setup current text track info (this will be the "currently selected" track)
+	TextTrackInfo currentTrack;
+	currentTrack.index = currentTrackIndex;
+	currentTrack.language = "fr";
+	currentTrack.isCC = false;
+
+	// Mock the GetCurrentTextTrack call to succeed
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetCurrentTextTrack(::testing::_))
+		.WillOnce(::testing::DoAll(
+			::testing::SetArgReferee<0>(currentTrack),
+			::testing::Return(true)
+		));
+
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(false))
+		.WillOnce(ReturnRef(mockTextTracks));
+
+	std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+	// Basic sanity check since the mock Print returns minimal JSON
+	EXPECT_FALSE(result.empty()) << "Should return non-empty result in TSB mode";
+}
+
+TEST_F(ClosedCaptionTests, GetAvailableTextTracks_WithLocalAAMPTsb_GetCurrentTextTrackFails)
+{
+	cJSON *mockArray = reinterpret_cast<cJSON*>(0x6001);
+	cJSON *mockItem = reinterpret_cast<cJSON*>(0x6003);
+
+	// Set up basic cJSON expectations (array, object creation)
+	std::vector<cJSON*> mockObjects = setupBasicCJsonExpectations(mockArray, mockItem);
+
+	// Set up expectations for each track - verify TSB failure availability logic
+	for (size_t i = 0; i < mockTextTracks.size(); i++) {
+		const auto& track = mockTextTracks[i];
+		cJSON* mockObj = mockObjects[i];
+
+		// Set up string field expectations - verify production code adds correct fields
+		setupTrackStringFieldExpectations(track, mockObj, mockItem);
+
+		// Calculate and verify TSB failure availability logic: CC tracks still available,
+		// but no subtitle tracks available when GetCurrentTextTrack fails
+		bool expectedAvailability = calculateTsbAvailability(track, "", false);
+		setupTrackAvailabilityExpectation(track, mockObj, mockItem, expectedAvailability);
+	}
+
+	// Set up array finalization expectations - verify objects are added to array correctly
+	setupArrayFinalizationExpectations(mockArray, mockObjects);
+
+	// Enable local AAMP TSB mode
+	mPrivateInstanceAAMP->SetLocalAAMPTsb(true);
+
+	// Mock GetCurrentTextTrack to return false (failure case)
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetCurrentTextTrack(::testing::_))
+		.WillOnce(::testing::Return(false));
+
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(false))
+		.WillOnce(ReturnRef(mockTextTracks));
+
+	std::string result = mPrivateInstanceAAMP->GetAvailableTextTracks(false);
+
+	// Basic sanity check since the mock Print returns minimal JSON
+	EXPECT_FALSE(result.empty()) << "Should return non-empty result even when GetCurrentTextTrack fails";
+}
+
+

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -2868,3 +2868,225 @@ TEST_F(StreamAbstractionAAMP_HLSTest,SelectPreferredTextTrack)
 	EXPECT_EQ("rend0",trackInfo.rendition);
 	EXPECT_EQ("trackName0",trackInfo.name);
 }
+
+TEST_F(StreamAbstractionAAMP_HLSTest,SelectPreferredTextTrackSubType)
+{
+	std::vector<TextTrackInfo> tracks;
+	TextTrackInfo trackInfo;
+
+	tracks.push_back(TextTrackInfo("idx0", "lang0", false, "","","","",0));
+	tracks.push_back(TextTrackInfo("idx1", "lang0", true, "","","","",0));
+	mStreamAbstractionAAMP_HLS->CallSetAvailableTextTracks(tracks);
+
+	// Verify CLOSED-CAPTIONS preference selects CC track (isCC=true)
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang0";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "CLOSED-CAPTIONS";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang0",trackInfo.language);
+	EXPECT_EQ("idx1",trackInfo.index);
+	EXPECT_TRUE(trackInfo.isCC) << "CLOSED-CAPTIONS preference should select CC track";
+
+	// Verify SUBTITLES preference selects subtitle track (isCC=false)
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang0";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "SUBTITLES";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang0",trackInfo.language);
+	EXPECT_EQ("idx0",trackInfo.index);
+	EXPECT_FALSE(trackInfo.isCC) << "SUBTITLES preference should select subtitle track";
+
+	// Verify SUBTITLES preference still selects subtitle track (repeated)
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang0";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "SUBTITLES";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang0",trackInfo.language);
+	EXPECT_EQ("idx0",trackInfo.index);
+	EXPECT_FALSE(trackInfo.isCC) << "SUBTITLES preference should select subtitle track";
+
+	// Verify CLOSED-CAPTIONS preference still selects CC track (repeated)
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang0";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "CLOSED-CAPTIONS";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang0",trackInfo.language);
+	EXPECT_EQ("idx1",trackInfo.index);
+	EXPECT_TRUE(trackInfo.isCC) << "CLOSED-CAPTIONS preference should select CC track";
+
+	// Verify empty sub-type preference doesn't award bonus
+	// With no sub-type preference, both tracks have equal language score,
+	// so the first track (idx0) should be selected
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang0";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang0",trackInfo.language);
+	EXPECT_EQ("idx0",trackInfo.index) << "Empty sub-type preference should not award bonus";
+
+	// Verify unrecognized sub-type preference doesn't award bonus
+	// With unrecognized preference, both tracks have equal language score,
+	// so the first track (idx0) should be selected
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang0";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "UNKNOWN";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang0",trackInfo.language);
+	EXPECT_EQ("idx0",trackInfo.index) << "Unrecognized sub-type preference should not award bonus";
+
+	// Verify sub-type bonus overrides track order
+	// Create tracks with different languages but matching sub-type
+	tracks.clear();
+	tracks.push_back(TextTrackInfo("idx0", "lang1", false, "","","","",0)); // First, but wrong sub-type
+	tracks.push_back(TextTrackInfo("idx1", "lang1", true, "","","","",0));  // Second, but matches sub-type
+	mStreamAbstractionAAMP_HLS->CallSetAvailableTextTracks(tracks);
+
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang1";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "CLOSED-CAPTIONS";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang1",trackInfo.language);
+	EXPECT_EQ("idx1",trackInfo.index) << "Sub-type bonus should select CC track even if not first";
+	EXPECT_TRUE(trackInfo.isCC);
+
+	// Verify SUBTITLES sub-type bonus overrides track order
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextLanguagesString = "lang1";
+	mStreamAbstractionAAMP_HLS->aamp->preferredTextSubTypeString = "SUBTITLES";
+	mStreamAbstractionAAMP_HLS->SelectPreferredTextTrack(trackInfo);
+	EXPECT_EQ("lang1",trackInfo.language);
+	EXPECT_EQ("idx0",trackInfo.index) << "Sub-type bonus should select subtitle track";
+	EXPECT_FALSE(trackInfo.isCC);
+}
+
+/**
+ * @brief Test that when DisableWebVTT is enabled, non-CC subtitle tracks are
+ *        excluded from the text track list by PopulateAudioAndTextTracks.
+ */
+TEST_F(StreamAbstractionAAMP_HLSTest, PopulateAudioAndTextTracks_DisableWebVTT_ExcludesSubtitleTracks)
+{
+	// Set up a stream profile so the media population path is entered
+	HlsStreamInfo streamInfo;
+	streamInfo.enabled = true;
+	streamInfo.isIframeTrack = false;
+	streamInfo.validity = true;
+	streamInfo.codecs = "h264";
+	mStreamAbstractionAAMP_HLS->streamInfoStore.push_back(streamInfo);
+
+	// Add a non-CC subtitle track (WebVTT) and a CC track to mediaInfoStore
+	MediaInfo subtitleMedia;
+	subtitleMedia.type = eMEDIATYPE_SUBTITLE;
+	subtitleMedia.language = "en";
+	subtitleMedia.group_id = "subs";
+	subtitleMedia.name = "English";
+	subtitleMedia.isCC = false; // non-CC / WebVTT subtitle
+	mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(subtitleMedia);
+
+	MediaInfo ccMedia;
+	ccMedia.type = eMEDIATYPE_SUBTITLE;
+	ccMedia.language = "en";
+	ccMedia.group_id = "cc";
+	ccMedia.name = "CC1";
+	ccMedia.instreamID = "CC1";
+	ccMedia.isCC = true; // Closed caption track
+	mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(ccMedia);
+
+	// Expect DisableWebVTT to return true, which should filter out non-CC subtitles
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_DisableWebVTT))
+		.WillOnce(Return(true));
+
+	mStreamAbstractionAAMP_HLS->CallPopulateAudioAndTextTracks();
+
+	const auto& textTracks = mStreamAbstractionAAMP_HLS->GetAvailableTextTracks();
+	ASSERT_EQ(textTracks.size(), 1u) << "Only CC tracks should be present when DisableWebVTT is set";
+	EXPECT_TRUE(textTracks[0].isCC) << "The remaining track must be a CC track";
+}
+
+/**
+ * @brief Test that when DisableWebVTT is enabled, CC subtitle tracks are
+ *        retained in the text track list by PopulateAudioAndTextTracks.
+ */
+TEST_F(StreamAbstractionAAMP_HLSTest, PopulateAudioAndTextTracks_DisableWebVTT_RetainsCCTracks)
+{
+	HlsStreamInfo streamInfo;
+	streamInfo.enabled = true;
+	streamInfo.isIframeTrack = false;
+	streamInfo.validity = true;
+	streamInfo.codecs = "h264";
+	mStreamAbstractionAAMP_HLS->streamInfoStore.push_back(streamInfo);
+
+	// Add two CC tracks to mediaInfoStore
+	MediaInfo ccMedia1;
+	ccMedia1.type = eMEDIATYPE_SUBTITLE;
+	ccMedia1.language = "en";
+	ccMedia1.group_id = "cc";
+	ccMedia1.name = "CC1";
+	ccMedia1.instreamID = "CC1";
+	ccMedia1.isCC = true;
+	mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(ccMedia1);
+
+	MediaInfo ccMedia2;
+	ccMedia2.type = eMEDIATYPE_SUBTITLE;
+	ccMedia2.language = "fr";
+	ccMedia2.group_id = "cc";
+	ccMedia2.name = "CC3";
+	ccMedia2.instreamID = "CC3";
+	ccMedia2.isCC = true;
+	mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(ccMedia2);
+
+	// Expect DisableWebVTT to return true
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_DisableWebVTT))
+		.WillOnce(Return(true));
+
+	mStreamAbstractionAAMP_HLS->CallPopulateAudioAndTextTracks();
+
+	const auto& textTracks = mStreamAbstractionAAMP_HLS->GetAvailableTextTracks();
+	ASSERT_EQ(textTracks.size(), 2u) << "All CC tracks should be retained when DisableWebVTT is set";
+	for (const auto& track : textTracks)
+	{
+		EXPECT_TRUE(track.isCC) << "Every retained track must be a CC track";
+	}
+}
+
+/**
+ * @brief Test that when DisableWebVTT is disabled, both CC and non-CC subtitle
+ *        tracks are included by PopulateAudioAndTextTracks.
+ */
+TEST_F(StreamAbstractionAAMP_HLSTest, PopulateAudioAndTextTracks_WebVTTEnabled_IncludesAllSubtitleTracks)
+{
+	HlsStreamInfo streamInfo;
+	streamInfo.enabled = true;
+	streamInfo.isIframeTrack = false;
+	streamInfo.validity = true;
+	streamInfo.codecs = "h264";
+	mStreamAbstractionAAMP_HLS->streamInfoStore.push_back(streamInfo);
+
+	// Add one non-CC subtitle and one CC track
+	MediaInfo subtitleMedia;
+	subtitleMedia.type = eMEDIATYPE_SUBTITLE;
+	subtitleMedia.language = "en";
+	subtitleMedia.group_id = "subs";
+	subtitleMedia.name = "English";
+	subtitleMedia.isCC = false;
+	mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(subtitleMedia);
+
+	MediaInfo ccMedia;
+	ccMedia.type = eMEDIATYPE_SUBTITLE;
+	ccMedia.language = "en";
+	ccMedia.group_id = "cc";
+	ccMedia.name = "CC1";
+	ccMedia.instreamID = "CC1";
+	ccMedia.isCC = true;
+	mStreamAbstractionAAMP_HLS->mediaInfoStore.push_back(ccMedia);
+
+	// DisableWebVTT is false, so all tracks should be included
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_DisableWebVTT))
+		.WillOnce(Return(false));
+
+	mStreamAbstractionAAMP_HLS->CallPopulateAudioAndTextTracks();
+
+	const auto& textTracks = mStreamAbstractionAAMP_HLS->GetAvailableTextTracks();
+	ASSERT_EQ(textTracks.size(), 2u) << "Both CC and subtitle tracks should be present when DisableWebVTT is not set";
+
+	bool foundCC = false;
+	bool foundSubtitle = false;
+	for (const auto& track : textTracks)
+	{
+		if (track.isCC) foundCC = true;
+		else foundSubtitle = true;
+	}
+	EXPECT_TRUE(foundCC) << "CC track should be present";
+	EXPECT_TRUE(foundSubtitle) << "Non-CC subtitle track should be present";
+}


### PR DESCRIPTION
VPLAY-12898: Subtitles Fails to display after Ad break point on VOD asset on perform FF till the ad break point
VPLAY-12203: - Subtitles Fails to display after Ad break point on VOD asset on perform FF till the ad break point

Reason for Change: filter webVTT while parsing

Test Guidance: updated in ticket

Risk: Low