### PR TITLE
Feature/vpaamp 172

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1022,7 +1022,7 @@ void ABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfile
 		AAMPLOG_INFO("nwBandwidth is %" BITSPERSECOND_FORMAT ", skipping rampup check", nwBandwidth);
 		return;
 	}
-	int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;
+	int abrThreshold = (int)(((int64_t)(newBandwidth - nwBandwidth) * 100) / (int64_t)nwBandwidth);
 	AAMPLOG_INFO("currProfileIndex %d newProfileIndex %d nwBandwidth %" BITSPERSECOND_FORMAT " bufferValue %lf newBandwidth %" BITSPERSECOND_FORMAT " threshold %d", currProfileIndex, newProfileIndex, nwBandwidth, bufferValue, newBandwidth, abrThreshold);
 	int nProfileIdx = getRampedUpProfileIndex(currProfileIndex,periodId);
 	// switch to new profile only on bitrate difference is less than 30 percentage

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1017,6 +1017,11 @@ void ABRManager::GetDesiredProfileOnBuffer(int currProfileIndex,int &newProfileI
 
 void ABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfileIndex,BitsPerSecond nwBandwidth,double bufferValue,BitsPerSecond newBandwidth,BitrateChangeReason &mhBitrateReason,int &mMaxBufferCountCheck,const std::string& periodId)
 {
+	if (nwBandwidth <= 0)
+	{
+		AAMPLOG_WARN("nwBandwidth is %" BITSPERSECOND_FORMAT ", skipping rampup check", nwBandwidth);
+		return;
+	}
 	int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;
 	AAMPLOG_INFO("currProfileIndex %d newProfileIndex %d nwBandwidth %" BITSPERSECOND_FORMAT " bufferValue %lf newBandwidth %" BITSPERSECOND_FORMAT " threshold %d", currProfileIndex, newProfileIndex, nwBandwidth, bufferValue, newBandwidth, abrThreshold);
 	int nProfileIdx = getRampedUpProfileIndex(currProfileIndex,periodId);

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1019,7 +1019,7 @@ void ABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfile
 {
 	if (nwBandwidth <= 0)
 	{
-		AAMPLOG_WARN("nwBandwidth is %" BITSPERSECOND_FORMAT ", skipping rampup check", nwBandwidth);
+		AAMPLOG_INFO("nwBandwidth is %" BITSPERSECOND_FORMAT ", skipping rampup check", nwBandwidth);
 		return;
 	}
 	int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -296,7 +296,7 @@ void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newP
 {
 	if (nwBandwidth <= 0)
 	{
-		AAMPABRLOG_WARN("nwBandwidth is %ld, skipping rampup check", nwBandwidth);
+		AAMPABRLOG_INFO("nwBandwidth is %ld, skipping rampup check", nwBandwidth);
 		return;
 	}
 	int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -299,7 +299,7 @@ void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newP
 		AAMPABRLOG_INFO("nwBandwidth is %ld, skipping rampup check", nwBandwidth);
 		return;
 	}
-	int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;
+	int abrThreshold = (int)(((int64_t)(newBandwidth - nwBandwidth) * 100) / (int64_t)nwBandwidth);
 	AAMPABRLOG_INFO("[%s][%d]  currProfileIndex %d, newProfileIndex %d ,nwBandwidth %ld ,bufferValue %lf ,newBandwidth %ld threshold %d(30)",__FUNCTION__,__LINE__,currProfileIndex,newProfileIndex,nwBandwidth,bufferValue,newBandwidth, abrThreshold);
 	int nProfileIdx = getRampedUpProfileIndex(currProfileIndex,periodId);
 	// switch to new profile only on bitrate difference is less than 30 percentage

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -294,6 +294,11 @@ void HybridABRManager::GetDesiredProfileOnBuffer(int currProfileIndex,int &newPr
 
 void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfileIndex,long nwBandwidth,double bufferValue,long newBandwidth,BitrateChangeReason &mhBitrateReason,int &mMaxBufferCountCheck,const std::string& periodId)
 {
+	if (nwBandwidth <= 0)
+	{
+		AAMPABRLOG_WARN("nwBandwidth is %ld, skipping rampup check", nwBandwidth);
+		return;
+	}
 	int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;
 	AAMPABRLOG_INFO("[%s][%d]  currProfileIndex %d, newProfileIndex %d ,nwBandwidth %ld ,bufferValue %lf ,newBandwidth %ld threshold %d(30)",__FUNCTION__,__LINE__,currProfileIndex,newProfileIndex,nwBandwidth,bufferValue,newBandwidth, abrThreshold);
 	int nProfileIdx = getRampedUpProfileIndex(currProfileIndex,periodId);

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -254,3 +254,104 @@ TEST_F(AbrTests, SwitchingEstimatorsUsesNewEstimatorState)
 	abrManager.ReportDownloadComplete(0, false, metrics);
 	EXPECT_EQ(abrManager.GetCurrentlyAvailableBandwidth(), expectedBitsPerSecond);
 }
+
+/**
+ * @brief Helper to add video profiles to an ABRManager for rampup tests.
+ */
+static void AddTestProfiles(ABRManager &mgr)
+{
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	p.bandwidthBitsPerSecond = 1000000; // index 0
+	mgr.addProfile(p);
+
+	p.bandwidthBitsPerSecond = 2000000; // index 1
+	mgr.addProfile(p);
+
+	p.bandwidthBitsPerSecond = 4000000; // index 2
+	mgr.addProfile(p);
+}
+
+/**
+ * @brief CheckRampupFromSteadyState must not modify newProfileIndex
+ *        when nwBandwidth is zero (divide-by-zero guard).
+ */
+TEST_F(AbrTests, CheckRampupFromSteadyState_ZeroBandwidth_NoChange)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	AddTestProfiles(abrManager);
+
+	int currProfileIndex = 0;
+	int newProfileIndex = currProfileIndex;
+	BitsPerSecond nwBandwidth = 0;
+	double bufferValue = 20.0;
+	BitsPerSecond newBandwidth = 2000000;
+	ABRManager::BitrateChangeReason reason = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBufferCountCheck = 1;
+
+	abrManager.CheckRampupFromSteadyState(
+		currProfileIndex, newProfileIndex, nwBandwidth, bufferValue,
+		newBandwidth, reason, maxBufferCountCheck);
+
+	EXPECT_EQ(newProfileIndex, currProfileIndex);
+	EXPECT_EQ(reason, ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR);
+	EXPECT_EQ(maxBufferCountCheck, 1);
+}
+
+/**
+ * @brief CheckRampupFromSteadyState must not modify newProfileIndex
+ *        when nwBandwidth is negative.
+ */
+TEST_F(AbrTests, CheckRampupFromSteadyState_NegativeBandwidth_NoChange)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	AddTestProfiles(abrManager);
+
+	int currProfileIndex = 1;
+	int newProfileIndex = currProfileIndex;
+	BitsPerSecond nwBandwidth = -1;
+	double bufferValue = 15.0;
+	BitsPerSecond newBandwidth = 4000000;
+	ABRManager::BitrateChangeReason reason = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBufferCountCheck = 1;
+
+	abrManager.CheckRampupFromSteadyState(
+		currProfileIndex, newProfileIndex, nwBandwidth, bufferValue,
+		newBandwidth, reason, maxBufferCountCheck);
+
+	EXPECT_EQ(newProfileIndex, currProfileIndex);
+	EXPECT_EQ(reason, ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR);
+}
+
+/**
+ * @brief CheckRampupFromSteadyState allows rampup when nwBandwidth is valid
+ *        and threshold is within range.
+ */
+TEST_F(AbrTests, CheckRampupFromSteadyState_ValidBandwidth_RampsUp)
+{
+	eAAMPAbrConfig.abrBufferCounter = 2;
+
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	AddTestProfiles(abrManager);
+
+	int currProfileIndex = 0;
+	int newProfileIndex = currProfileIndex;
+	BitsPerSecond nwBandwidth = 1800000;
+	double bufferValue = 20.0;
+	// newBandwidth 2000000 is ~11% above nwBandwidth, within the 0-30% threshold
+	BitsPerSecond newBandwidth = 2000000;
+	ABRManager::BitrateChangeReason reason = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBufferCountCheck = 1;
+
+	abrManager.CheckRampupFromSteadyState(
+		currProfileIndex, newProfileIndex, nwBandwidth, bufferValue,
+		newBandwidth, reason, maxBufferCountCheck);
+
+	// Should ramp up to the next profile (index 1)
+	EXPECT_EQ(newProfileIndex, 1);
+	EXPECT_EQ(reason, ABRManager::eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL);
+}


### PR DESCRIPTION
This bug is present in both the legacy (FOG) and current ABR algorithms.

int abrThreshold = (int)((newBandwidth - nwBandwidth) * 100) / (int)nwBandwidth;            

If nwBandwidth is 0 (which can happen when the bandwidth estimator has no data — it's initialized to 0), this is a divide by zero (undefined behavior on the integer path).

The caller GetDesiredProfileOnSteadyState passes networkBandwidth from GetCurrentlyAvailableBandwidth(), which returns 0 when no samples exist. The caller only guards against -1, so 0 reaches this code.