### PR TITLE
Fix static loop counter in HybridABRManager and mutex unlock-before-r…

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -278,7 +278,6 @@ void ABRManager::updateProfile()
 			iframeTrackInfo.push_back(info);
 		}
 	}
-	lock.unlock();
 	
 	// Exists iframe track
 	size_t iframeTrackCount = iframeTrackInfo.size();
@@ -336,6 +335,7 @@ void ABRManager::updateProfile()
 			}
 		}
 	}
+	lock.unlock();
 	
 #if defined(DEBUG_ENABLED)
 	AAMPLOG_MIL("Update profile info, mDesiredIframeProfile = %d, mLowestIframeProfile = %d", mDesiredIframeProfile, mLowestIframeProfile);

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -222,7 +222,6 @@ void ABRManager::updateProfile() {
       iframeTrackInfo[iframeTrackIdx].idx = i;
     }
   }
-  lock.unlock();
 
   // Exists iframe track
   if(iframeTrackIdx >= 0) {
@@ -286,6 +285,7 @@ void ABRManager::updateProfile() {
       }
     }
   }
+  lock.unlock();
   delete[] iframeTrackInfo;
 
 #if defined(DEBUG_ENABLED)

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -307,11 +307,10 @@ void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newP
 		newProfileIndex = nProfileIdx;
 	if(newProfileIndex  != currProfileIndex)
 	{
-		static int loop = 1;
 		AAMPABRLOG_WARN("Attempted rampup from steady state ->currProf:%d newProf:%d bufferValue:%lf threshold:%d(30)",
 				currProfileIndex,newProfileIndex,bufferValue,abrThreshold);
-		loop = (++loop >4)?1:loop;
-		mMaxBufferCountCheck =  pow(eAAMPAbrConfig.abrBufferCounter,loop);
+		mRampupFromSteadyStateLoop = (++mRampupFromSteadyStateLoop >4)?1:mRampupFromSteadyStateLoop;
+		mMaxBufferCountCheck =  pow(eAAMPAbrConfig.abrBufferCounter,mRampupFromSteadyStateLoop);
 		mhBitrateReason = eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL;
 	}
 }

--- a/support/aampabr/HybridABRManager.h
+++ b/support/aampabr/HybridABRManager.h
@@ -122,6 +122,7 @@ class HybridABRManager:public ABRManager
 
 		int mABRHighBufferCounter;	    /**< ABR High buffer counter */
 		int mABRLowBufferCounter;	    /**< ABR Low Buffer counter */
+		int mRampupFromSteadyStateLoop{1};	/**< Per-instance exponential backoff counter for steady-state rampup */
 
 		/**
 		 * @brief Different reasons for bitrate change

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -357,52 +357,6 @@ TEST_F(AbrTests, CheckRampupFromSteadyState_ValidBandwidth_RampsUp)
 }
 
 /**
- * @brief Two ABRManager instances must have independent rampup loop
- *        counters. Verifies bug #2 fix: loop is per-instance, not static.
- */
-TEST_F(AbrTests, CheckRampupFromSteadyState_LoopIsPerInstance)
-{
-	eAAMPAbrConfig.abrBufferCounter = 2;
-
-	ABRManager mgr1;
-	mgr1.ReadPlayerConfig(&eAAMPAbrConfig);
-	AddTestProfiles(mgr1);
-
-	ABRManager mgr2;
-	mgr2.ReadPlayerConfig(&eAAMPAbrConfig);
-	AddTestProfiles(mgr2);
-
-	int currIdx = 0;
-	int newIdx1 = currIdx;
-	int newIdx2 = currIdx;
-	BitsPerSecond nwBw = 1800000;
-	BitsPerSecond newBw = 2000000;
-	ABRManager::BitrateChangeReason reason1 = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
-	ABRManager::BitrateChangeReason reason2 = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
-	int maxBuf1 = 1;
-	int maxBuf2 = 1;
-
-	// Ramp up mgr1 three times to advance its loop counter
-	for (int i = 0; i < 3; i++)
-	{
-		newIdx1 = currIdx;
-		reason1 = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
-		mgr1.CheckRampupFromSteadyState(
-			currIdx, newIdx1, nwBw, 20.0, newBw, reason1, maxBuf1);
-	}
-
-	// Now ramp up mgr2 once — its loop should be independent
-	mgr2.CheckRampupFromSteadyState(
-		currIdx, newIdx2, nwBw, 20.0, newBw, reason2, maxBuf2);
-
-	// mgr2's first rampup: loop goes from 1 to 2, so maxBuf = abrBufferCounter^2 = 4
-	// If the loop were shared (static), mgr2 would inherit mgr1's advanced counter
-	EXPECT_EQ(maxBuf2, 4);
-	// mgr1 has been called 3 times: loop went 1->2->3->4, maxBuf = 2^4 = 16
-	EXPECT_EQ(maxBuf1, 16);
-}
-
-/**
  * @brief updateProfile correctly selects the desired iframe profile
  *        from a set of mixed video + iframe profiles.
  */

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -355,3 +355,128 @@ TEST_F(AbrTests, CheckRampupFromSteadyState_ValidBandwidth_RampsUp)
 	EXPECT_EQ(newProfileIndex, 1);
 	EXPECT_EQ(reason, ABRManager::eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL);
 }
+
+/**
+ * @brief Two ABRManager instances must have independent rampup loop
+ *        counters. Verifies bug #2 fix: loop is per-instance, not static.
+ */
+TEST_F(AbrTests, CheckRampupFromSteadyState_LoopIsPerInstance)
+{
+	eAAMPAbrConfig.abrBufferCounter = 2;
+
+	ABRManager mgr1;
+	mgr1.ReadPlayerConfig(&eAAMPAbrConfig);
+	AddTestProfiles(mgr1);
+
+	ABRManager mgr2;
+	mgr2.ReadPlayerConfig(&eAAMPAbrConfig);
+	AddTestProfiles(mgr2);
+
+	int currIdx = 0;
+	int newIdx1 = currIdx;
+	int newIdx2 = currIdx;
+	BitsPerSecond nwBw = 1800000;
+	BitsPerSecond newBw = 2000000;
+	ABRManager::BitrateChangeReason reason1 = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	ABRManager::BitrateChangeReason reason2 = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBuf1 = 1;
+	int maxBuf2 = 1;
+
+	// Ramp up mgr1 three times to advance its loop counter
+	for (int i = 0; i < 3; i++)
+	{
+		newIdx1 = currIdx;
+		reason1 = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+		mgr1.CheckRampupFromSteadyState(
+			currIdx, newIdx1, nwBw, 20.0, newBw, reason1, maxBuf1);
+	}
+
+	// Now ramp up mgr2 once — its loop should be independent
+	mgr2.CheckRampupFromSteadyState(
+		currIdx, newIdx2, nwBw, 20.0, newBw, reason2, maxBuf2);
+
+	// mgr2's first rampup: loop goes from 1 to 2, so maxBuf = abrBufferCounter^2 = 4
+	// If the loop were shared (static), mgr2 would inherit mgr1's advanced counter
+	EXPECT_EQ(maxBuf2, 4);
+	// mgr1 has been called 3 times: loop went 1->2->3->4, maxBuf = 2^4 = 16
+	EXPECT_EQ(maxBuf1, 16);
+}
+
+/**
+ * @brief updateProfile correctly selects the desired iframe profile
+ *        from a set of mixed video + iframe profiles.
+ */
+TEST_F(AbrTests, UpdateProfile_SelectsCorrectIframeProfile)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	// Add video profiles (not iframe)
+	ABRManager::ProfileInfo video{};
+	video.isIframeTrack = false;
+	video.bandwidthBitsPerSecond = 3000000;
+	video.width = 1920;
+	video.height = 1080;
+	abrManager.addProfile(video); // index 0
+
+	video.bandwidthBitsPerSecond = 6000000;
+	abrManager.addProfile(video); // index 1
+
+	// Add iframe profiles
+	ABRManager::ProfileInfo iframe{};
+	iframe.isIframeTrack = true;
+	iframe.width = 640;
+	iframe.height = 360;
+
+	iframe.bandwidthBitsPerSecond = 500000;
+	abrManager.addProfile(iframe); // index 2
+
+	iframe.bandwidthBitsPerSecond = 1500000;
+	abrManager.addProfile(iframe); // index 3
+
+	abrManager.updateProfile();
+
+	// Non-4K, no default iframe bitrate: should pick lowest as lowest,
+	// second as desired (legacy "first two" logic)
+	EXPECT_EQ(abrManager.getLowestIframeProfile(), 2);
+	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 3);
+}
+
+/**
+ * @brief updateProfile with default iframe bitrate selects the profile
+ *        below the configured default.
+ */
+TEST_F(AbrTests, UpdateProfile_DefaultIframeBitrate_SelectsBelowDefault)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	abrManager.setDefaultIframeBitrate(1200000);
+
+	ABRManager::ProfileInfo video{};
+	video.isIframeTrack = false;
+	video.bandwidthBitsPerSecond = 3000000;
+	video.width = 1920;
+	video.height = 1080;
+	abrManager.addProfile(video); // index 0
+
+	ABRManager::ProfileInfo iframe{};
+	iframe.isIframeTrack = true;
+	iframe.width = 640;
+	iframe.height = 360;
+
+	iframe.bandwidthBitsPerSecond = 500000;
+	abrManager.addProfile(iframe); // index 1
+
+	iframe.bandwidthBitsPerSecond = 1000000;
+	abrManager.addProfile(iframe); // index 2
+
+	iframe.bandwidthBitsPerSecond = 2000000;
+	abrManager.addProfile(iframe); // index 3
+
+	abrManager.updateProfile();
+
+	// Default iframe bitrate = 1200000: should pick highest below that = index 2 (1000000)
+	EXPECT_EQ(abrManager.getLowestIframeProfile(), 1);
+	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 2);
+}
+

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -48,6 +48,63 @@ TEST_F(HybridAbrTests, UpdateABRBitrateDataBasedOnCacheOutlierEven)
 	ASSERT_EQ(result, 350);
 }
 
+/**
+ * @brief Two HybridABRManager instances must have independent rampup loop
+ *        counters. Verifies the per-instance mRampupFromSteadyStateLoop fix
+ *        in HybridABRManager (VPAAMP-173).
+ */
+TEST_F(HybridAbrTests, CheckRampupFromSteadyState_LoopIsPerInstance)
+{
+	eAAMPAbrConfig.abrBufferCounter = 2;
+
+	HybridABRManager mgr1;
+	mgr1.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	HybridABRManager mgr2;
+	mgr2.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	// Add two video profiles to each manager so rampup has a target
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	mgr1.addProfile(p);
+	mgr2.addProfile(p);
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	mgr1.addProfile(p);
+	mgr2.addProfile(p);
+
+	int currIdx = 0;
+	int newIdx1 = currIdx;
+	int newIdx2 = currIdx;
+	long nwBw = 1800000;
+	long newBw = 2000000;
+	HybridABRManager::BitrateChangeReason reason1 = HybridABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	HybridABRManager::BitrateChangeReason reason2 = HybridABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBuf1 = 1;
+	int maxBuf2 = 1;
+
+	// Ramp up mgr1 three times to advance its loop counter
+	for (int i = 0; i < 3; i++)
+	{
+		newIdx1 = currIdx;
+		reason1 = HybridABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+		mgr1.CheckRampupFromSteadyState(
+			currIdx, newIdx1, nwBw, 20.0, newBw, reason1, maxBuf1);
+	}
+
+	// Now ramp up mgr2 once — its loop should be independent
+	mgr2.CheckRampupFromSteadyState(
+		currIdx, newIdx2, nwBw, 20.0, newBw, reason2, maxBuf2);
+
+	// mgr2's first rampup: loop goes 1->2, maxBuf = 2^2 = 4
+	// If mRampupFromSteadyStateLoop were static, mgr2 would inherit mgr1's counter
+	EXPECT_EQ(maxBuf2, 4);
+	// mgr1 called 3 times: loop went 1->2->3->4, maxBuf = 2^4 = 16
+	EXPECT_EQ(maxBuf1, 16);
+}
+
 TEST_F(HybridAbrTests, UpdateABRBitrateDataBasedOnCacheOutlierOdd)
 {
 	std::vector<long> tmpData = {100, 200, 300, 400, 500};


### PR DESCRIPTION


- Bug 1: Replace static int loop with per-instance mRampupFromSteadyStateLoop in HybridABRManager::CheckRampupFromSteadyState, matching the new ABR implementation.
- Bug 2: Move lock.unlock() after all mProfiles reads in updateProfile() for both legacy ABRManager and new abr/abr.cpp to prevent races during period transitions.
- Add unit tests for per-instance loop independence and updateProfile iframe selection.