### PR TITLE
Replace global eAAMPAbrConfig with per-instance mAbrConfig member

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -39,8 +39,6 @@
 #define DEFAULT_ABR_ELAPSED_MILLIS_FOR_ESTIMATE	100			/**< Duration(ms) to check Chunk Speed */
 #define MAX_LOW_LATENCY_DASH_ABR_SPEEDSTORE_SIZE 10
 
-ABRManager::AampAbrConfig eAAMPAbrConfig;
-
 BitsPerSecond ABRManager::mPersistBandwidth = 0;
 long long ABRManager::mPersistBandwidthUpdatedTime = 0;
 
@@ -866,41 +864,41 @@ struct SpeedCache
  */
 void ABRManager::ReadPlayerConfig(AampAbrConfig *mAampAbrConfig)
 {
-	eAAMPAbrConfig.abrCacheLife     =  mAampAbrConfig->abrCacheLife;
-	eAAMPAbrConfig.abrCacheLength   =  mAampAbrConfig->abrCacheLength;
-	eAAMPAbrConfig.abrSkipDuration  =  mAampAbrConfig->abrSkipDuration;
-	eAAMPAbrConfig.abrNwConsistency =  mAampAbrConfig->abrNwConsistency;
-	eAAMPAbrConfig.abrThresholdSize =  mAampAbrConfig->abrThresholdSize;
-	eAAMPAbrConfig.abrMaxBuffer     =  mAampAbrConfig->abrMaxBuffer;
-	eAAMPAbrConfig.abrMinBuffer     =  mAampAbrConfig->abrMinBuffer;
-	eAAMPAbrConfig.abrCacheOutlier  =  mAampAbrConfig->abrCacheOutlier;
-	eAAMPAbrConfig.abrBufferCounter =  mAampAbrConfig->abrBufferCounter;
-	eAAMPAbrConfig.bandwidthEstimatorType = mAampAbrConfig->bandwidthEstimatorType;
+	mAbrConfig.abrCacheLife     =  mAampAbrConfig->abrCacheLife;
+	mAbrConfig.abrCacheLength   =  mAampAbrConfig->abrCacheLength;
+	mAbrConfig.abrSkipDuration  =  mAampAbrConfig->abrSkipDuration;
+	mAbrConfig.abrNwConsistency =  mAampAbrConfig->abrNwConsistency;
+	mAbrConfig.abrThresholdSize =  mAampAbrConfig->abrThresholdSize;
+	mAbrConfig.abrMaxBuffer     =  mAampAbrConfig->abrMaxBuffer;
+	mAbrConfig.abrMinBuffer     =  mAampAbrConfig->abrMinBuffer;
+	mAbrConfig.abrCacheOutlier  =  mAampAbrConfig->abrCacheOutlier;
+	mAbrConfig.abrBufferCounter =  mAampAbrConfig->abrBufferCounter;
+	mAbrConfig.bandwidthEstimatorType = mAampAbrConfig->bandwidthEstimatorType;
 	
 	//Logging Level
 	
-	eAAMPAbrConfig.infologging     =  mAampAbrConfig->infologging;
-	eAAMPAbrConfig.debuglogging    = mAampAbrConfig->debuglogging;
-	eAAMPAbrConfig.tracelogging    = mAampAbrConfig->tracelogging;
-	eAAMPAbrConfig.warnlogging     = mAampAbrConfig->warnlogging;
-	AAMPLOG_MIL("ABRCacheLife %d, ABRCacheLength %d, ABRSkipDuration %d, ABRNwConsistency %d, ABRThresholdSize %d, ABRMaxBuffer %d, ABRMinBuffer %d ABRCacheOutlier %d ABRBufferCounter %d ABRBandwidthEstimator %d",eAAMPAbrConfig.abrCacheLife,eAAMPAbrConfig.abrCacheLength,eAAMPAbrConfig.abrSkipDuration,eAAMPAbrConfig.abrNwConsistency,eAAMPAbrConfig.abrThresholdSize,eAAMPAbrConfig.abrMaxBuffer,eAAMPAbrConfig.abrMinBuffer,eAAMPAbrConfig.abrCacheOutlier,eAAMPAbrConfig.abrBufferCounter,eAAMPAbrConfig.bandwidthEstimatorType);
+	mAbrConfig.infologging     =  mAampAbrConfig->infologging;
+	mAbrConfig.debuglogging    = mAampAbrConfig->debuglogging;
+	mAbrConfig.tracelogging    = mAampAbrConfig->tracelogging;
+	mAbrConfig.warnlogging     = mAampAbrConfig->warnlogging;
+	AAMPLOG_MIL("ABRCacheLife %d, ABRCacheLength %d, ABRSkipDuration %d, ABRNwConsistency %d, ABRThresholdSize %d, ABRMaxBuffer %d, ABRMinBuffer %d ABRCacheOutlier %d ABRBufferCounter %d ABRBandwidthEstimator %d",mAbrConfig.abrCacheLife,mAbrConfig.abrCacheLength,mAbrConfig.abrSkipDuration,mAbrConfig.abrNwConsistency,mAbrConfig.abrThresholdSize,mAbrConfig.abrMaxBuffer,mAbrConfig.abrMinBuffer,mAbrConfig.abrCacheOutlier,mAbrConfig.abrBufferCounter,mAbrConfig.bandwidthEstimatorType);
 
-	if (eAAMPAbrConfig.bandwidthEstimatorType < BANDWIDTH_ESTIMATION_ALGORITHM_MAX)
+	if (mAbrConfig.bandwidthEstimatorType < BANDWIDTH_ESTIMATION_ALGORITHM_MAX)
 	{
 		const auto ConfigureEstimator = [&]()
 		{
 			if(mBandwidthEstimator)
 			{
 				BandwidthEstimatorConfig config;
-				config.mAbrCacheLife = eAAMPAbrConfig.abrCacheLife;
-				config.mAbrCacheLength = eAAMPAbrConfig.abrCacheLength;
-				config.mAbrCacheOutlier = eAAMPAbrConfig.abrCacheOutlier;
+				config.mAbrCacheLife = mAbrConfig.abrCacheLife;
+				config.mAbrCacheLength = mAbrConfig.abrCacheLength;
+				config.mAbrCacheOutlier = mAbrConfig.abrCacheOutlier;
 				config.mLowLatencyCacheLength = DEFAULT_ABR_CHUNK_CACHE_LENGTH;
 				mBandwidthEstimator->SetConfig(config);
 			}
 		};
 
-		const auto newEstimatorType = static_cast<BandwidthEstimationAlgorithm>(eAAMPAbrConfig.bandwidthEstimatorType);
+		const auto newEstimatorType = static_cast<BandwidthEstimationAlgorithm>(mAbrConfig.bandwidthEstimatorType);
 		bool needNewEstimator = false;
 		{
 			std::lock_guard<std::mutex> lock(mBandwidthEstimatorLock);
@@ -962,7 +960,7 @@ bool ABRManager::CheckProfileChange(double totalFetchedDuration, int currProfile
 	bool checkProfileChange = true;
 	BitsPerSecond currBW = getBandwidthOfProfile(currProfileIndex);
 	//Avoid doing ABR during initial buffering which will affect tune times adversely
-	if ( totalFetchedDuration > 0 && totalFetchedDuration < eAAMPAbrConfig.abrSkipDuration)
+	if ( totalFetchedDuration > 0 && totalFetchedDuration < mAbrConfig.abrSkipDuration)
 	{
 		AAMPLOG_TRACE("TotalFetchedDuration %lf ", totalFetchedDuration);
 		//For initial fragment downloads, check available bw is less than default bw
@@ -996,7 +994,7 @@ void ABRManager::GetDesiredProfileOnBuffer(int currProfileIndex,int &newProfileI
 		{
 			// Rampup attempt . check if buffer availability is good before profile change
 			// else retain current profile
-			if(bufferValue < eAAMPAbrConfig.abrMaxBuffer)
+			if(bufferValue < mAbrConfig.abrMaxBuffer)
 				newProfileIndex = currProfileIndex;
 		}
 		else if (! GetLowLatencyServiceConfigured())
@@ -1032,7 +1030,7 @@ void ABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfile
 	{
 		AAMPLOG_WARN("attempted rampup from steady state currProfileIndex %d newProfileIndex %d bufferValue %lf threshold %d", currProfileIndex, newProfileIndex, bufferValue, abrThreshold);
 		mRampupFromSteadyStateLoop = (++mRampupFromSteadyStateLoop >4)?1:mRampupFromSteadyStateLoop;
-		mMaxBufferCountCheck =  pow(eAAMPAbrConfig.abrBufferCounter,mRampupFromSteadyStateLoop);
+		mMaxBufferCountCheck =  pow(mAbrConfig.abrBufferCounter,mRampupFromSteadyStateLoop);
 		mhBitrateReason = eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL;
 	}
 }
@@ -1043,7 +1041,7 @@ void ABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfile
 void ABRManager::CheckRampdownFromSteadyState(int currProfileIndex, int &newProfileIndex,BitrateChangeReason &mBitrateReason,int mABRLowBufferCounter,const std::string& periodId)
 {
 	AAMPLOG_INFO("currProfileIndex %d newProfileIndex %d mABRLowBufferCounter %d", currProfileIndex, newProfileIndex, mABRLowBufferCounter);
-	if(mABRLowBufferCounter >= eAAMPAbrConfig.abrBufferCounter)
+	if(mABRLowBufferCounter >= mAbrConfig.abrBufferCounter)
 	{
 		newProfileIndex = getRampedDownProfileIndex(currProfileIndex,periodId);
 		if(newProfileIndex  != currProfileIndex)
@@ -1141,7 +1139,7 @@ void ABRManager::CheckLLDashABRSpeedStoreSize(struct SpeedCache *speedcache,Bits
  */
 BitsPerSecond ABRManager::FragmentfailureRampdown(int currentBuffer, int currentProfileIndex)
 {
-	double bufferPercentage = ((double)currentBuffer / eAAMPAbrConfig.abrMaxBuffer) * 100;
+	double bufferPercentage = ((double)currentBuffer / mAbrConfig.abrMaxBuffer) * 100;
 	BitsPerSecond desiredProfilebw = 0;
 	BitsPerSecond currentbw = getBandwidthOfProfile(currentProfileIndex);
 	std::vector<ProfileInfo> availableProfiles = mProfiles;

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -514,6 +514,12 @@ public:
 	 */
 	BitsPerSecond FragmentfailureRampdown(int currentBuffer,int currentProfileIndex);
 	
+	/**
+	 * @brief Get the current ABR configuration (read-only)
+	 * @return const reference to the per-instance ABR configuration
+	 */
+	const AampAbrConfig& getAbrConfig() const { return mAbrConfig; }
+	
 private:
 	bool bLowLatencyStartABR;             /**<Low Latency ABR Start Status */
 	bool bLowLatencyServiceConfigured;    /**<Low Latency Service Configuration Status */
@@ -580,6 +586,11 @@ private:
 	 * @brief Default iframe bitrate
 	 */
 	BitsPerSecond mDefaultIframeBitrate = 0;
+	/**
+	 * @brief Per-instance ABR configuration
+	 */
+	AampAbrConfig mAbrConfig{};
+
 	/**
 	 * @brief Default init bitrate value.
 	 */

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -54,12 +54,10 @@
 	} while (0)
 
 
-#define AAMPABRLOG_TRACE(FORMAT, ...) AAMPABRLOG(eAAMPAbrConfig.tracelogging,"TRACE",FORMAT, ##__VA_ARGS__)
-#define AAMPABRLOG_INFO(FORMAT, ...)  AAMPABRLOG(eAAMPAbrConfig.infologging,"INFO",FORMAT, ##__VA_ARGS__)
-#define AAMPABRLOG_WARN(FORMAT, ...)  AAMPABRLOG(eAAMPAbrConfig.warnlogging,"WARN",FORMAT, ##__VA_ARGS__)
-#define AAMPABRLOG_ERR(FORMAT, ...)   AAMPABRLOG(eAAMPAbrConfig.debuglogging,"ERROR",FORMAT, ##__VA_ARGS__)
-
-HybridABRManager::AampAbrConfig eAAMPAbrConfig;
+#define AAMPABRLOG_TRACE(FORMAT, ...) AAMPABRLOG(mAbrConfig.tracelogging,"TRACE",FORMAT, ##__VA_ARGS__)
+#define AAMPABRLOG_INFO(FORMAT, ...)  AAMPABRLOG(mAbrConfig.infologging,"INFO",FORMAT, ##__VA_ARGS__)
+#define AAMPABRLOG_WARN(FORMAT, ...)  AAMPABRLOG(mAbrConfig.warnlogging,"WARN",FORMAT, ##__VA_ARGS__)
+#define AAMPABRLOG_ERR(FORMAT, ...)   AAMPABRLOG(mAbrConfig.debuglogging,"ERROR",FORMAT, ##__VA_ARGS__)
 
 /**
  * @struct SpeedCache
@@ -90,23 +88,23 @@ struct SpeedCache
  */
 void HybridABRManager::ReadPlayerConfig(AampAbrConfig *mAampAbrConfig)
 {
-	eAAMPAbrConfig.abrCacheLife     =  mAampAbrConfig->abrCacheLife;
-	eAAMPAbrConfig.abrCacheLength   =  mAampAbrConfig->abrCacheLength;
-	eAAMPAbrConfig.abrSkipDuration  =  mAampAbrConfig->abrSkipDuration;
-	eAAMPAbrConfig.abrNwConsistency =  mAampAbrConfig->abrNwConsistency;
-	eAAMPAbrConfig.abrThresholdSize =  mAampAbrConfig->abrThresholdSize;
-	eAAMPAbrConfig.abrMaxBuffer     =  mAampAbrConfig->abrMaxBuffer;
-	eAAMPAbrConfig.abrMinBuffer     =  mAampAbrConfig->abrMinBuffer;
-	eAAMPAbrConfig.abrCacheOutlier  =  mAampAbrConfig->abrCacheOutlier;
-	eAAMPAbrConfig.abrBufferCounter =  mAampAbrConfig->abrBufferCounter;
+	mAbrConfig.abrCacheLife     =  mAampAbrConfig->abrCacheLife;
+	mAbrConfig.abrCacheLength   =  mAampAbrConfig->abrCacheLength;
+	mAbrConfig.abrSkipDuration  =  mAampAbrConfig->abrSkipDuration;
+	mAbrConfig.abrNwConsistency =  mAampAbrConfig->abrNwConsistency;
+	mAbrConfig.abrThresholdSize =  mAampAbrConfig->abrThresholdSize;
+	mAbrConfig.abrMaxBuffer     =  mAampAbrConfig->abrMaxBuffer;
+	mAbrConfig.abrMinBuffer     =  mAampAbrConfig->abrMinBuffer;
+	mAbrConfig.abrCacheOutlier  =  mAampAbrConfig->abrCacheOutlier;
+	mAbrConfig.abrBufferCounter =  mAampAbrConfig->abrBufferCounter;
 
 	//Logging Level 
 
-	eAAMPAbrConfig.infologging     =  mAampAbrConfig->infologging;
-	eAAMPAbrConfig.debuglogging    = mAampAbrConfig->debuglogging;
-	eAAMPAbrConfig.tracelogging    = mAampAbrConfig->tracelogging;
-	eAAMPAbrConfig.warnlogging     = mAampAbrConfig->warnlogging;
-	logprintf("[%s][%d]PlayerConfig : ABRCacheLife %d ,ABRCacheLength %d ,ABRSkipDuration %d , ABRNwConsistency %d ,ABRThresholdSize %d ,ABRMaxBuffer %d ,ABRMinBuffer %d ABRCacheOutlier %d ABRBufferCounter %d ",__FUNCTION__,__LINE__,eAAMPAbrConfig.abrCacheLife,eAAMPAbrConfig.abrCacheLength,eAAMPAbrConfig.abrSkipDuration,eAAMPAbrConfig.abrNwConsistency,eAAMPAbrConfig.abrThresholdSize,eAAMPAbrConfig.abrMaxBuffer,eAAMPAbrConfig.abrMinBuffer,eAAMPAbrConfig.abrCacheOutlier,eAAMPAbrConfig.abrBufferCounter);
+	mAbrConfig.infologging     =  mAampAbrConfig->infologging;
+	mAbrConfig.debuglogging    = mAampAbrConfig->debuglogging;
+	mAbrConfig.tracelogging    = mAampAbrConfig->tracelogging;
+	mAbrConfig.warnlogging     = mAampAbrConfig->warnlogging;
+	logprintf("[%s][%d]PlayerConfig : ABRCacheLife %d ,ABRCacheLength %d ,ABRSkipDuration %d , ABRNwConsistency %d ,ABRThresholdSize %d ,ABRMaxBuffer %d ,ABRMinBuffer %d ABRCacheOutlier %d ABRBufferCounter %d ",__FUNCTION__,__LINE__,mAbrConfig.abrCacheLife,mAbrConfig.abrCacheLength,mAbrConfig.abrSkipDuration,mAbrConfig.abrNwConsistency,mAbrConfig.abrThresholdSize,mAbrConfig.abrMaxBuffer,mAbrConfig.abrMinBuffer,mAbrConfig.abrCacheOutlier,mAbrConfig.abrBufferCounter);
 }
 
 
@@ -143,7 +141,7 @@ void HybridABRManager::UpdateABRBitrateDataBasedOnCacheLength(std::vector < std:
 	}
 	else
 	{
-		if(mAbrBitrateData.size() > eAAMPAbrConfig.abrCacheLength)
+		if(mAbrBitrateData.size() > mAbrConfig.abrCacheLength)
 			mAbrBitrateData.erase(mAbrBitrateData.begin());
 	}
 }
@@ -159,7 +157,7 @@ void HybridABRManager::UpdateABRBitrateDataBasedOnCacheLife(std::vector < std::p
 	for (bitrateIter = mAbrBitrateData.begin(); bitrateIter != mAbrBitrateData.end();)
 	{
 		//AAMPLOG_WARN("Sz[%d] TimeCheck Pre[%lld] Sto[%lld] diff[%lld] bw[%ld] ",mAbrBitrateData.size(),presentTime,(*bitrateIter).first,(presentTime - (*bitrateIter).first),(long)(*bitrateIter).second);
-		if ((bitrateIter->first <= 0) || (presentTime - bitrateIter->first > eAAMPAbrConfig.abrCacheLife))
+		if ((bitrateIter->first <= 0) || (presentTime - bitrateIter->first > mAbrConfig.abrCacheLife))
 		{
 			bitrateIter = mAbrBitrateData.erase(bitrateIter);
 		}
@@ -198,7 +196,7 @@ long HybridABRManager::UpdateABRBitrateDataBasedOnCacheOutlier(std::vector< long
 
 	long diffOutlier = 0;
 	avg = 0;
-	abrOutlierDiffBytes = eAAMPAbrConfig.abrCacheOutlier ;
+	abrOutlierDiffBytes = mAbrConfig.abrCacheOutlier ;
 	for (tmpDataIter = tmpData.begin();tmpDataIter != tmpData.end();)
 	{
 		diffOutlier = (*tmpDataIter) > medianbps ? (*tmpDataIter) - medianbps : medianbps - (*tmpDataIter);
@@ -238,7 +236,7 @@ bool HybridABRManager::CheckProfileChange(double totalFetchedDuration ,int currP
 	bool checkProfileChange = true;
 	long currBW = getBandwidthOfProfile(currProfileIndex);
 	//Avoid doing ABR during initial buffering which will affect tune times adversely
-	if ( totalFetchedDuration > 0 && totalFetchedDuration < eAAMPAbrConfig.abrSkipDuration)
+	if ( totalFetchedDuration > 0 && totalFetchedDuration < mAbrConfig.abrSkipDuration)
 	{
 		AAMPABRLOG_TRACE("[%s][%d] TotalFetchedDuration %lf ",__FUNCTION__,__LINE__,totalFetchedDuration);
 		//For initial fragment downloads, check available bw is less than default bw
@@ -273,7 +271,7 @@ void HybridABRManager::GetDesiredProfileOnBuffer(int currProfileIndex,int &newPr
 		{
 			// Rampup attempt . check if buffer availability is good before profile change
 			// else retain current profile
-			if(bufferValue < eAAMPAbrConfig.abrMaxBuffer)
+			if(bufferValue < mAbrConfig.abrMaxBuffer)
 				newProfileIndex = currProfileIndex;
 		}
 		else if (! GetLowLatencyServiceConfigured())
@@ -310,7 +308,7 @@ void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newP
 		AAMPABRLOG_WARN("Attempted rampup from steady state ->currProf:%d newProf:%d bufferValue:%lf threshold:%d(30)",
 				currProfileIndex,newProfileIndex,bufferValue,abrThreshold);
 		mRampupFromSteadyStateLoop = (++mRampupFromSteadyStateLoop >4)?1:mRampupFromSteadyStateLoop;
-		mMaxBufferCountCheck =  pow(eAAMPAbrConfig.abrBufferCounter,mRampupFromSteadyStateLoop);
+		mMaxBufferCountCheck =  pow(mAbrConfig.abrBufferCounter,mRampupFromSteadyStateLoop);
 		mhBitrateReason = eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL;
 	}
 }
@@ -322,7 +320,7 @@ void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newP
 void HybridABRManager::CheckRampdownFromSteadyState(int currProfileIndex, int &newProfileIndex,BitrateChangeReason &mBitrateReason,int mABRLowBufferCounter,const std::string& periodId)
 {
 	AAMPABRLOG_INFO("[%s][%d] currProfileIndex %d ,newProfileIndex %d, mABRLowBufferCounter %d",__FUNCTION__,__LINE__,currProfileIndex,newProfileIndex,mABRLowBufferCounter);
-	if(mABRLowBufferCounter >= eAAMPAbrConfig.abrBufferCounter)
+	if(mABRLowBufferCounter >= mAbrConfig.abrBufferCounter)
 	{
 		newProfileIndex = getRampedDownProfileIndex(currProfileIndex,periodId);
 		if(newProfileIndex  != currProfileIndex)
@@ -426,7 +424,7 @@ void HybridABRManager::CheckLLDashABRSpeedStoreSize(struct SpeedCache *speedcach
  */
 long HybridABRManager::FragmentfailureRampdown(int currentBuffer, int currentProfileIndex)
 {
-	double bufferPercentage = ((double)currentBuffer / eAAMPAbrConfig.abrMaxBuffer) * 100;
+	double bufferPercentage = ((double)currentBuffer / mAbrConfig.abrMaxBuffer) * 100;
 	long desiredProfilebw = 0;
 	long currentbw = getBandwidthOfProfile(currentProfileIndex);
 	std::vector<ProfileInfo> availableProfiles = getProfileInfo();

--- a/support/aampabr/HybridABRManager.h
+++ b/support/aampabr/HybridABRManager.h
@@ -123,6 +123,7 @@ class HybridABRManager:public ABRManager
 		int mABRHighBufferCounter;	    /**< ABR High buffer counter */
 		int mABRLowBufferCounter;	    /**< ABR Low Buffer counter */
 		int mRampupFromSteadyStateLoop{1};	/**< Per-instance exponential backoff counter for steady-state rampup */
+		AampAbrConfig mAbrConfig{};	    /**< Per-instance ABR configuration */
 
 		/**
 		 * @brief Different reasons for bitrate change

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -32,23 +32,28 @@ using ::testing::_;
 
 AampConfig *gpGlobalConfig{nullptr};
 
-extern ABRManager::AampAbrConfig eAAMPAbrConfig;
+static ABRManager::AampAbrConfig MakeDefaultTestConfig()
+{
+	ABRManager::AampAbrConfig cfg{};
+	// Cache life is interpreted as milliseconds by the estimator.
+	// Use a large value to avoid timing-related flakes in unit tests.
+	cfg.abrCacheLife = 600000;
+	cfg.abrCacheLength = 3;
+	cfg.abrCacheOutlier = 1000000;
+	cfg.bandwidthEstimatorType = BANDWIDTH_ESTIMATION_ALGORITHM_ROLLING_MEDIAN_OUTLIER;
+	return cfg;
+}
 
 class AbrTests : public ::testing::Test
 {
 protected:
+	ABRManager::AampAbrConfig mTestConfig;
+
 	void SetUp() override
 	{
 		ABRManager::mPersistBandwidth = 0;
 		ABRManager::mPersistBandwidthUpdatedTime = 0;
-
-		eAAMPAbrConfig = ABRManager::AampAbrConfig();
-		// Cache life is interpreted as milliseconds by the estimator.
-		// Use a large value to avoid timing-related flakes in unit tests.
-		eAAMPAbrConfig.abrCacheLife = 600000;
-		eAAMPAbrConfig.abrCacheLength = 3;
-		eAAMPAbrConfig.abrCacheOutlier = 1000000;
-		eAAMPAbrConfig.bandwidthEstimatorType =	BANDWIDTH_ESTIMATION_ALGORITHM_ROLLING_MEDIAN_OUTLIER;
+		mTestConfig = MakeDefaultTestConfig();
 	}
 };
 
@@ -107,16 +112,17 @@ TEST_F(AampAbrConfigTests, LoadAampAbrConfig)
 
 	aamp->LoadAampAbrConfig();
 
-	EXPECT_EQ(eAAMPAbrConfig.abrCacheLife, 3);
-	EXPECT_EQ(eAAMPAbrConfig.abrCacheLength, 2);
-	EXPECT_EQ(eAAMPAbrConfig.abrSkipDuration, 6);
-	EXPECT_EQ(eAAMPAbrConfig.abrNwConsistency, 2);
-	EXPECT_EQ(eAAMPAbrConfig.abrThresholdSize, 3);
-	EXPECT_EQ(eAAMPAbrConfig.abrMaxBuffer, 15);
-	EXPECT_EQ(eAAMPAbrConfig.abrMinBuffer, 10);
-	EXPECT_EQ(eAAMPAbrConfig.abrCacheOutlier, 10000);
-	EXPECT_EQ(eAAMPAbrConfig.abrBufferCounter, 4);
-	EXPECT_EQ(eAAMPAbrConfig.bandwidthEstimatorType, BANDWIDTH_ESTIMATION_ALGORITHM_HARMONIC_EWMA);
+	const auto &cfg = aamp->mhAbrManager.getAbrConfig();
+	EXPECT_EQ(cfg.abrCacheLife, 3);
+	EXPECT_EQ(cfg.abrCacheLength, 2);
+	EXPECT_EQ(cfg.abrSkipDuration, 6);
+	EXPECT_EQ(cfg.abrNwConsistency, 2);
+	EXPECT_EQ(cfg.abrThresholdSize, 3);
+	EXPECT_EQ(cfg.abrMaxBuffer, 15);
+	EXPECT_EQ(cfg.abrMinBuffer, 10);
+	EXPECT_EQ(cfg.abrCacheOutlier, 10000);
+	EXPECT_EQ(cfg.abrBufferCounter, 4);
+	EXPECT_EQ(cfg.bandwidthEstimatorType, BANDWIDTH_ESTIMATION_ALGORITHM_HARMONIC_EWMA);
 }
 
 /**
@@ -137,11 +143,11 @@ TEST_F(AbrTests, DefaultEstimatorIsRMOAndUnavailableInitially)
  */
 TEST_F(AbrTests, RMOAveragesSamplesWithConfiguredCacheLength)
 {
-	eAAMPAbrConfig.abrCacheLength = 3;
-	eAAMPAbrConfig.abrCacheOutlier = 1000000;
+	mTestConfig.abrCacheLength = 3;
+	mTestConfig.abrCacheOutlier = 1000000;
 
 	ABRManager abrManager;
-	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	abrManager.ReadPlayerConfig(&mTestConfig);
 	abrManager.AddBandwidthSample(1000, false);
 	abrManager.AddBandwidthSample(2000, false);
 	abrManager.AddBandwidthSample(3000, false);
@@ -154,11 +160,11 @@ TEST_F(AbrTests, RMOAveragesSamplesWithConfiguredCacheLength)
  */
 TEST_F(AbrTests, RMOTrimsSamplesToConfiguredCacheLength)
 {
-	eAAMPAbrConfig.abrCacheLength = 2;
-	eAAMPAbrConfig.abrCacheOutlier = 1000000;
+	mTestConfig.abrCacheLength = 2;
+	mTestConfig.abrCacheOutlier = 1000000;
 
 	ABRManager abrManager;
-	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	abrManager.ReadPlayerConfig(&mTestConfig);
 	abrManager.AddBandwidthSample(1000, false);
 	abrManager.AddBandwidthSample(2000, false);
 	abrManager.AddBandwidthSample(3000, false);
@@ -171,11 +177,11 @@ TEST_F(AbrTests, RMOTrimsSamplesToConfiguredCacheLength)
  */
 TEST_F(AbrTests, RMORejectsOutlierSamplesBeyondConfiguredThreshold)
 {
-	eAAMPAbrConfig.abrCacheLength = 10;
-	eAAMPAbrConfig.abrCacheOutlier = 5000;
+	mTestConfig.abrCacheLength = 10;
+	mTestConfig.abrCacheOutlier = 5000;
 
 	ABRManager abrManager;
-	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	abrManager.ReadPlayerConfig(&mTestConfig);
 	abrManager.AddBandwidthSample(1000, false);
 	abrManager.AddBandwidthSample(1100, false);
 	abrManager.AddBandwidthSample(100000, false); // Gets rejected
@@ -188,14 +194,14 @@ TEST_F(AbrTests, RMORejectsOutlierSamplesBeyondConfiguredThreshold)
  */
 TEST_F(AbrTests, RMORejectsHigherOutlierWhen2SamplesPresent)
 {
-	eAAMPAbrConfig.abrCacheLength = 10;
-	eAAMPAbrConfig.abrCacheOutlier = 5000;
+	mTestConfig.abrCacheLength = 10;
+	mTestConfig.abrCacheOutlier = 5000;
 
 	// Previously both samples would get rejected and bandwidth would be unavailable (-1).
 	// Now with the fix to reject only samples greater than the outlier threshold, the bandwidth
 	// should be available and calculated from the remaining sample.
 	ABRManager abrManager;
-	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	abrManager.ReadPlayerConfig(&mTestConfig);
 	abrManager.AddBandwidthSample(1000, false);
 	abrManager.AddBandwidthSample(100000, false); // Gets rejected as outlier
 
@@ -229,11 +235,11 @@ TEST_F(AbrTests, HarmonicEWMAComputesBandwidthFromDownloadMetrics)
  */
 TEST_F(AbrTests, SwitchingEstimatorsUsesNewEstimatorState)
 {
-	eAAMPAbrConfig.abrCacheLength = 3;
-	eAAMPAbrConfig.abrCacheOutlier = 1000000;
+	mTestConfig.abrCacheLength = 3;
+	mTestConfig.abrCacheOutlier = 1000000;
 
 	ABRManager abrManager;
-	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	abrManager.ReadPlayerConfig(&mTestConfig);
 	abrManager.AddBandwidthSample(1000, false);
 	EXPECT_EQ(abrManager.GetCurrentlyAvailableBandwidth(), 1000);
 
@@ -256,6 +262,7 @@ TEST_F(AbrTests, SwitchingEstimatorsUsesNewEstimatorState)
 }
 
 /**
+<<<<<<< HEAD
  * @brief Helper to add video profiles to an ABRManager for rampup tests.
  */
 static void AddTestProfiles(ABRManager &mgr)
@@ -434,3 +441,46 @@ TEST_F(AbrTests, UpdateProfile_DefaultIframeBitrate_SelectsBelowDefault)
 	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 2);
 }
 
+/**
+ * @brief Test that ReadPlayerConfig is per-instance, not global.
+ *
+ * Two ABRManager instances configured with different abrSkipDuration values
+ * must exhibit independent CheckProfileChange behavior.
+ */
+TEST_F(AbrTests, ReadPlayerConfig_IsPerInstance)
+{
+	ABRManager mgr1;
+	ABRManager mgr2;
+
+	// Give both managers a video profile so getBandwidthOfProfile works
+	ABRManager::ProfileInfo profile{};
+	profile.isIframeTrack = false;
+	profile.bandwidthBitsPerSecond = 5000000;
+	profile.width = 1920;
+	profile.height = 1080;
+	mgr1.addProfile(profile);
+	mgr2.addProfile(profile);
+
+	// Configure mgr1 with abrSkipDuration = 100 (skip ABR for first 100s)
+	ABRManager::AampAbrConfig cfg1 = MakeDefaultTestConfig();
+	cfg1.abrSkipDuration = 100;
+	mgr1.ReadPlayerConfig(&cfg1);
+
+	// Configure mgr2 with abrSkipDuration = 0 (never skip ABR)
+	ABRManager::AampAbrConfig cfg2 = MakeDefaultTestConfig();
+	cfg2.abrSkipDuration = 0;
+	mgr2.ReadPlayerConfig(&cfg2);
+
+	// Verify configs are independent
+	EXPECT_EQ(mgr1.getAbrConfig().abrSkipDuration, 100);
+	EXPECT_EQ(mgr2.getAbrConfig().abrSkipDuration, 0);
+
+	// With totalFetchedDuration=50 (< 100), mgr1 should skip profile change
+	// (returns false because availBW > currBW won't trigger rampdown)
+	bool mgr1Change = mgr1.CheckProfileChange(50.0, 0, 6000000);
+	EXPECT_FALSE(mgr1Change);
+
+	// With totalFetchedDuration=50 (> 0 = skipDuration), mgr2 should allow change
+	bool mgr2Change = mgr2.CheckProfileChange(50.0, 0, 6000000);
+	EXPECT_TRUE(mgr2Change);
+}


### PR DESCRIPTION
- eAAMPAbrConfig was a file-scope global in both ABR implementations, shared across all ABRManager/HybridABRManager instances. Multiple player instances would overwrite each other's ABR configuration.
- Add mAbrConfig as a per-instance member in ABRManager (abr/abr.h) and HybridABRManager (HybridABRManager.h).
- Remove file-scope global declarations from abr.cpp and HybridABRManager.cpp.
- Replace all 51 references to eAAMPAbrConfig with mAbrConfig.
- Add public getAbrConfig() const accessor to ABRManager.
- Add ReadPlayerConfig_IsPerInstance test verifying two ABRManager instances maintain independent configuration.