### PR TITLE
VPAAMP-157 Spurious PlaybackSpeedChanged event

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1292,8 +1292,19 @@ void PlayerInstanceAAMP::SeekInternal(double secondsRelativeToTuneTime, bool kee
 
 			if (aamp->rate != AAMP_NORMAL_PLAY_RATE)
 			{
-				aamp->rate = AAMP_NORMAL_PLAY_RATE;
-				sentSpeedChangedEv = true;
+				if (tuneType == eTUNETYPE_SEEKTOLIVE || tuneType == eTUNETYPE_SEEKTOEND)
+				{
+					// Seeking to live/end during trickplay: reset to normal rate and notify
+					aamp->rate = AAMP_NORMAL_PLAY_RATE;
+					sentSpeedChangedEv = true;
+				}
+				else
+				{
+					// Seeking to a specific position during trickplay: preserve the trickplay
+					// rate to avoid sending a spurious speed=1 event. A subsequent SetRate
+					// call (already queued) will set the correct new rate.
+					AAMPLOG_INFO("Seek during trickplay at rate(%f) - maintaining rate, skipping speed-change notification", aamp->rate);
+				}
 			}
 
 			/**Set the flag true to indicate seeked **/

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1064,8 +1064,20 @@ static gboolean SeekAfterPrepared(gpointer ptr)
 	}
 	if (aamp->rate != AAMP_NORMAL_PLAY_RATE)
 	{
-		aamp->rate = AAMP_NORMAL_PLAY_RATE;
-		sentSpeedChangedEv = true;
+		if (tuneType == eTUNETYPE_SEEKTOLIVE || tuneType == eTUNETYPE_SEEKTOEND)
+		{
+			// Seeking to live/end during trickplay: reset to normal rate and notify
+			aamp->rate = AAMP_NORMAL_PLAY_RATE;
+			sentSpeedChangedEv = true;
+		}
+		else
+		{
+			// Seeking to a specific position during trickplay: preserve the current
+			// trickplay rate and avoid sending a spurious speed=1 event here.
+			// Callers that want to resume normal playback after the seek must
+			// explicitly call SetRate(AAMP_NORMAL_PLAY_RATE).
+			AAMPLOG_INFO("Seek during trickplay at rate(%f) - maintaining rate, skipping speed-change notification", aamp->rate);
+		}
 	}
 	if (aamp->mpStreamAbstractionAAMP)
 	{ // for seek while streaming

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1300,9 +1300,10 @@ void PlayerInstanceAAMP::SeekInternal(double secondsRelativeToTuneTime, bool kee
 				}
 				else
 				{
-					// Seeking to a specific position during trickplay: preserve the trickplay
-					// rate to avoid sending a spurious speed=1 event. A subsequent SetRate
-					// call (already queued) will set the correct new rate.
+					// Seeking to a specific position during trickplay: preserve the current
+					// trickplay rate and avoid sending a spurious speed=1 event here.
+					// Callers that want to resume normal playback after the seek must
+					// explicitly call SetRate(AAMP_NORMAL_PLAY_RATE).
 					AAMPLOG_INFO("Seek during trickplay at rate(%f) - maintaining rate, skipping speed-change notification", aamp->rate);
 				}
 			}

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -374,6 +374,7 @@ static int main_func(int argc, char **argv)
 
 	mAampcli.initPlayerLoop(0,NULL);
 	mAampcli.newPlayerInstance();
+	AAMPCLI_PRINTF("PID: %d\n", static_cast<int>(getpid())); //Used by L2 tests
 
 	// Read/create virtual channel map
 	const std::string cfgCSV("/opt/aampcli.csv");

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -134,6 +134,116 @@ TEST_F(PlayerInstanceAAMPTests,SeekInternalTest1)
 
 	mplayer->Seek_Internal(secondsRelativeToTuneTime,keepPaused);
 }
+
+/**
+ * @brief Test SeekInternal preserves trickplay rate for a positional seek.
+ *
+ * When aamp->rate != AAMP_NORMAL_PLAY_RATE and tuneType is eTUNETYPE_SEEK,
+ * SeekInternal must NOT reset the rate or fire a speed-change notification.
+ * The rate is preserved so the player resumes trickplay at the same speed
+ * after the seek completes.
+ */
+TEST_F(PlayerInstanceAAMPTests, SeekInternal_TrickplayPositionSeek_PreservesRateNoSpeedEvent)
+{
+	const float trickplayRate = 2.0f;
+	const double seekPosition = 30.0;
+
+	// Use active-playback state so SeekInternal takes the immediate seek path.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
+		.WillRepeatedly(Return(eSTATE_PLAYING));
+
+	mplayer->aamp->rate = trickplayRate;
+	mplayer->aamp->SetIsLive(false);        // VOD: avoids live-point checks
+	mplayer->aamp->pipeline_paused = false;
+	mplayer->aamp->mbPlayEnabled = true;
+	mplayer->aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	g_mockStreamAbstractionAAMP->mIsAtLivePoint = false;
+
+	// Key assertion: no speed-change notification for a positional seek during trickplay.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifySpeedChanged(_, _)).Times(0);
+
+	// Expected side-effects.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, false)).Times(1);
+
+	mplayer->Seek_Internal(seekPosition, false);
+
+	// Rate must be unchanged after a positional seek during trickplay.
+	EXPECT_FLOAT_EQ(mplayer->aamp->rate, trickplayRate);
+}
+
+/**
+ * @brief Test SeekInternal resets rate to normal and notifies on seek-to-live during trickplay.
+ *
+ * When aamp->rate != AAMP_NORMAL_PLAY_RATE and tuneType resolves to eTUNETYPE_SEEKTOLIVE
+ * (live stream, seek position == AAMP_SEEK_TO_LIVE_POSITION), SeekInternal must reset
+ * the rate to AAMP_NORMAL_PLAY_RATE and fire NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false).
+ */
+TEST_F(PlayerInstanceAAMPTests, SeekInternal_TrickplaySeekToLive_ResetsRateAndNotifies)
+{
+	const float trickplayRate = 2.0f;
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
+		.WillRepeatedly(Return(eSTATE_PLAYING));
+
+	mplayer->aamp->rate = trickplayRate;
+	mplayer->aamp->SetIsLive(true);         // Live stream -> eTUNETYPE_SEEKTOLIVE
+	mplayer->aamp->pipeline_paused = false;
+	mplayer->aamp->mbPlayEnabled = true;
+	mplayer->aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	g_mockStreamAbstractionAAMP->mIsAtLivePoint = false; // Not already at live edge
+
+	// Key assertions: rate is reset and a speed-change notification is emitted.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false)).Times(1);
+
+	// Expected side-effects.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEKTOLIVE, false)).Times(1);
+
+	mplayer->Seek_Internal(AAMP_SEEK_TO_LIVE_POSITION, false);
+
+	// Rate must be reset to normal after seek-to-live during trickplay.
+	EXPECT_FLOAT_EQ(mplayer->aamp->rate, AAMP_NORMAL_PLAY_RATE);
+}
+
+/**
+ * @brief Test SeekInternal resets rate to normal and notifies on seek-to-end during trickplay.
+ *
+ * When aamp->rate != AAMP_NORMAL_PLAY_RATE and tuneType resolves to eTUNETYPE_SEEKTOEND
+ * (VOD DASH content, seek position == AAMP_SEEK_TO_LIVE_POSITION == -1), SeekInternal must
+ * reset the rate to AAMP_NORMAL_PLAY_RATE and fire NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false).
+ */
+TEST_F(PlayerInstanceAAMPTests, SeekInternal_TrickplaySeekToEnd_ResetsRateAndNotifies)
+{
+	const float trickplayRate = 2.0f;
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
+		.WillRepeatedly(Return(eSTATE_PLAYING));
+
+	mplayer->aamp->rate = trickplayRate;
+	mplayer->aamp->SetIsLive(false);                    // VOD
+	mplayer->aamp->mMediaFormat = eMEDIAFORMAT_DASH;   // DASH VOD: seek(-1) -> SEEKTOEND
+	mplayer->aamp->pipeline_paused = false;
+	mplayer->aamp->mbPlayEnabled = true;
+	mplayer->aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	g_mockStreamAbstractionAAMP->mIsAtLivePoint = false;
+
+	// Key assertions: rate is reset and a speed-change notification is emitted.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false)).Times(1);
+
+	// Expected side-effects.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEKTOEND, false)).Times(1);
+
+	// seek(-1) on VOD DASH is interpreted as seek-to-end.
+	mplayer->Seek_Internal(AAMP_SEEK_TO_LIVE_POSITION, false);
+
+	// Rate must be reset to normal after seek-to-end during trickplay.
+	EXPECT_FLOAT_EQ(mplayer->aamp->rate, AAMP_NORMAL_PLAY_RATE);
+}
+
 TEST_F(PlayerInstanceAAMPTests, SetRateInternalTest)
 {
 	float rate = 2.2f;

--- a/test/utests/tests/TsProcessorTests/sendSegmentTests.cpp
+++ b/test/utests/tests/TsProcessorTests/sendSegmentTests.cpp
@@ -302,7 +302,7 @@ TEST_F(sendSegmentTests, CallsetBasePTSTest5)
 
 TEST_F(sendSegmentTests, CallsetBasePTSTest6)
 {
-    double position = LLONG_MAX;
+    double position = static_cast<double>(LLONG_MAX);
     long long pts = LLONG_MIN;
     mTSProcessor->CallsetBasePTS(position, pts);
 }


### PR DESCRIPTION
When rewinding Linear or Vod spurious speed (x1) events were being generated by AAMP.