### PR TITLE
Revert "VPLAY-11838 Linear- Progress Bar Point jumping to the End/beg…

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -2441,7 +2441,7 @@ void InterfacePlayerPriv::SendGstEvents(int mediaType, GstClockTime pts, int ena
 
 	if(stream->pendingSeek)
 	{
-		if(gstPrivateContext->seekPosition >= 0)
+		if(gstPrivateContext->seekPosition > 0)
 		{
 			MW_LOG_MIL("gst_element_seek_simple! mediaType:%d pts:%" GST_TIME_FORMAT " seekPosition:%" GST_TIME_FORMAT,
 				mediaType, GST_TIME_ARGS(pts), GST_TIME_ARGS(gstPrivateContext->seekPosition * GST_SECOND));


### PR DESCRIPTION
…inning W…" (#1314)

This reverts commit 2624fb306d26c062758dcaace039509db1e54747.

Reason for Change: Reverting for now, as this change is increasing the random failure rate of 7001 L2 test.  Also the original issue is still randomly seen.

Risk: Low