### PR TITLE
VPLAY-13206 When rewinding to BoS, send position before start playback

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2125,8 +2125,9 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 		// If beginningOfStream is true or position < start, it means rewind has reached BoS
 		// Note: position could be = start immediately after tuning
 		else if (position < start || beginningOfStream)
-		{ // clamp start or handle BOS during rewind
-			AAMPLOG_TRACE("Reached start of TSB, position %fms < start %fms, beginningOfStream %d, rate %f",
+		{
+			// Reached the start of the stream (start of AAMP TSB, beginning of VoD asset...)
+			AAMPLOG_INFO("Reached start, position %fms < start %fms, beginningOfStream %d, rate %f",
 				position, start, beginningOfStream, rate);
 			position = start;
 			reachedStart = true;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2101,6 +2101,7 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 		double audioBufferedDuration = 0.0;
 		bool bProcessEvent = true;
 		double latency = 0;
+		bool reachedStart = false;
 
 
 		//Report Progress report position based on Availability Start Time
@@ -2128,18 +2129,10 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 			AAMPLOG_TRACE("Reached start of TSB, position %fms < start %fms, beginningOfStream %d, rate %f",
 				position, start, beginningOfStream, rate);
 			position = start;
+			reachedStart = true;
 		}
 		DeliverAdEvents(false, position); // use progress reporting as trigger to belatedly deliver ad events
 		ReportAdProgress(position);
-
-		if (position == start)
-		{
-			// Check the rate so that PlayFromTsbStart() is not called more than once
-			if (rate < AAMP_RATE_PAUSE)
-			{
-				PlayFromTsbStart();
-			}
-		}
 
 		if(ISCONFIGSET_PRIV(eAAMPConfig_ReportVideoPTS))
 		{
@@ -2325,6 +2318,15 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 			}
 
 			mReportProgressPosn = position;
+
+			if (reachedStart)
+			{
+				// Check the rate so that PlayFromTsbStart() is not called more than once
+				if (rate < AAMP_RATE_PAUSE)
+				{
+					PlayFromTsbStart();
+				}
+			}
 		}
 	}
 }

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2128,14 +2128,18 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 			AAMPLOG_TRACE("Reached start of TSB, position %fms < start %fms, beginningOfStream %d, rate %f",
 				position, start, beginningOfStream, rate);
 			position = start;
-			// Check the rate so that PlayFromTsbStart() is not called repeatedly
+		}
+		DeliverAdEvents(false, position); // use progress reporting as trigger to belatedly deliver ad events
+		ReportAdProgress(position);
+
+		if (position == start)
+		{
+			// Check the rate so that PlayFromTsbStart() is not called more than once
 			if (rate < AAMP_RATE_PAUSE)
 			{
 				PlayFromTsbStart();
 			}
 		}
-		DeliverAdEvents(false, position); // use progress reporting as trigger to belatedly deliver ad events
-		ReportAdProgress(position);
 
 		if(ISCONFIGSET_PRIV(eAAMPConfig_ReportVideoPTS))
 		{

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2318,14 +2318,14 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 			}
 
 			mReportProgressPosn = position;
+		}
 
-			if (reachedStart)
+		if (reachedStart)
+		{
+			// Check the rate so that PlayFromTsbStart() is not called more than once
+			if (rate < AAMP_RATE_PAUSE)
 			{
-				// Check the rate so that PlayFromTsbStart() is not called more than once
-				if (rate < AAMP_RATE_PAUSE)
-				{
-					PlayFromTsbStart();
-				}
+				PlayFromTsbStart();
 			}
 		}
 	}

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1195,8 +1195,8 @@ TEST_F(PrivAampTests, MonitorProgressRewindToBoS_ProgressBeforeSpeedChange)
 	p_aamp->culledSeconds = CULLED_SECONDS;
 	p_aamp->durationSeconds = DURATION_SECONDS;
 	p_aamp->mDownloadsEnabled = true;
-	p_aamp->mSinkPaused = false;
-	p_aamp->SetState(eSTATE_PLAYING, true);
+	p_aamp->pipeline_paused = false;
+	p_aamp->SetState(eSTATE_PLAYING);
 	p_aamp->SetLocalAAMPTsb(true);
 	p_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
 	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP_MPD;

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1177,6 +1177,66 @@ TEST_F(PrivAampTests, MonitorProgressBeginningOfTSBDetected)
 	EXPECT_DOUBLE_EQ(p_aamp->seek_pos_seconds, 0.0);
 }
 
+/**
+ * @brief Regression test for VPLAY-13206 / PR #1345.
+ *
+ * When rewinding reaches BoS during VoD ad playback, JSPP relies on the order
+ * of the events. This test guarantees that the order is not altered.
+ */
+TEST_F(PrivAampTests, MonitorProgressRewindToBoS_ProgressBeforeSpeedChange)
+{
+	constexpr double REWIND_RATE = -4.0;
+	constexpr double CULLED_SECONDS = 10.0;
+	constexpr double DURATION_SECONDS = 100.0;
+
+	// Setup: configure player for rewind scenario reaching BoS.
+	p_aamp->rate = REWIND_RATE;
+	p_aamp->seek_pos_seconds = 0.0;
+	p_aamp->culledSeconds = CULLED_SECONDS;
+	p_aamp->durationSeconds = DURATION_SECONDS;
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mSinkPaused = false;
+	p_aamp->SetState(eSTATE_PLAYING, true);
+	p_aamp->SetLocalAAMPTsb(true);
+	p_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP_MPD;
+
+	// Pretend a CDAI ad placement is in progress on this player. This is
+	// what makes ReportAdProgress() actually emit an
+	// AAMP_EVENT_AD_PLACEMENT_PROGRESS event; with an empty mAdProgressId
+	// it would early-return and the ordering bug would be invisible.
+	// trickStartUTCMS must be non-negative to enable ProgressEvent
+	// emission inside MonitorProgress(); without this the regular
+	// AAMP_EVENT_PROGRESS for this tick would be suppressed.
+	p_aamp->trickStartUTCMS = 1;
+	p_aamp->mAdProgressId = "ad-1";
+	p_aamp->mAdAbsoluteStartTime = 0;
+	p_aamp->mAdDuration = 1000;
+
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_))
+		.WillRepeatedly(Return(g_mockAampGstPlayer));
+
+	// Ordering assertion: in the BoS branch MonitorProgress() emits, in
+	// order, AAMP_EVENT_AD_PLACEMENT_PROGRESS (from ReportAdProgress),
+	// AAMP_EVENT_PROGRESS (the regular ProgressEvent for this tick), and
+	// finally AAMP_EVENT_SPEED_CHANGED (from PlayFromTsbStart resetting
+	// the rate). InSequence enforces the relative order.
+	testing::InSequence seq;
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(AnEventOfType(AAMP_EVENT_AD_PLACEMENT_PROGRESS), _)).Times(1);
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(AnEventOfType(AAMP_EVENT_PROGRESS), _)).Times(1);
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(SpeedChanged(AAMP_NORMAL_PLAY_RATE), _)).Times(1);
+
+	// Trigger BoS handling. position < start (culledSeconds*1000) ensures
+	// the reachedStart branch is taken in MonitorProgress().
+	p_aamp->MonitorProgress(true, false);
+}
+
 TEST_F(PrivAampTests,UpdateDurationTest)
 {
 	p_aamp->UpdateDuration(232.436);


### PR DESCRIPTION
Reason for Change: When rewinding over VoD ad, it was played momentarily

Summary of Changes:
* In MonitorProgress(), call ReportAdProgress before PlayFromTsbStart

Test Procedure: Rewind VoD asset over ads

Priority: P1

Risks: Medium