### PR TITLE
VPAAMP-193 - iframe tracks can be selected as rampdown target in legacy and new abr

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1122,6 +1122,10 @@ BitsPerSecond ABRManager::FragmentfailureRampdown(int currentBuffer, int current
 	BitsPerSecond desiredProfilebw = 0;
 	BitsPerSecond currentbw = getBandwidthOfProfile(currentProfileIndex);
 	std::vector<ProfileInfo> availableProfiles = mProfiles;
+	availableProfiles.erase(
+		std::remove_if(availableProfiles.begin(), availableProfiles.end(),
+			[](const ProfileInfo &p) { return p.isIframeTrack; }),
+		availableProfiles.end());
 	int i = (int)availableProfiles.size();
 	if( i>0 )
 	{

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -96,7 +96,7 @@ long HybridABRManager::CheckAbrThresholdSize(int bufferlen, int downloadTimeMs ,
 	long downloadbps = 0;
 	if (downloadTimeMs > 0)
 	{
-		downloadbps = static_cast<long>((static_cast<long long>(bufferlen) * 8000LL) / downloadTimeMs);
+		downloadbps = static_cast<long>((static_cast<long long>(bufferlen) * 8000LL) /downloadTimeMs);
 	}
 	// extra coding to avoid picking lower profile
 	// Avoid this reset for Low bandwidth timeout cases

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -410,6 +410,10 @@ long HybridABRManager::FragmentfailureRampdown(int currentBuffer, int currentPro
 	long desiredProfilebw = 0;
 	long currentbw = getBandwidthOfProfile(currentProfileIndex);
 	std::vector<ProfileInfo> availableProfiles = getProfileInfo();
+	availableProfiles.erase(
+		std::remove_if(availableProfiles.begin(), availableProfiles.end(),
+			[](const ProfileInfo &p) { return p.isIframeTrack; }),
+		availableProfiles.end());
 	int len = (int)availableProfiles.size() - 1;
 	std::sort(availableProfiles.begin(), availableProfiles.end(), [](const ProfileInfo& a, const ProfileInfo& b) {
         return a.bandwidthBitsPerSecond < b.bandwidthBitsPerSecond;

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -96,9 +96,7 @@ long HybridABRManager::CheckAbrThresholdSize(int bufferlen, int downloadTimeMs ,
 	long downloadbps = 0;
 	if (downloadTimeMs > 0)
 	{
-		downloadbps = static_cast<long>(
-			(static_cast<long long>(bufferlen) * 8000LL) /
-			downloadTimeMs);
+		downloadbps = static_cast<long>((static_cast<long long>(bufferlen) * 8000LL) / downloadTimeMs);
 	}
 	// extra coding to avoid picking lower profile
 	// Avoid this reset for Low bandwidth timeout cases

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -96,7 +96,9 @@ long HybridABRManager::CheckAbrThresholdSize(int bufferlen, int downloadTimeMs ,
 	long downloadbps = 0;
 	if (downloadTimeMs > 0)
 	{
-		downloadbps = static_cast<long>((static_cast<long long>(bufferlen) * 8000LL) /downloadTimeMs);
+		downloadbps = static_cast<long>(
+			(static_cast<long long>(bufferlen) * 8000LL) /
+			downloadTimeMs);
 	}
 	// extra coding to avoid picking lower profile
 	// Avoid this reset for Low bandwidth timeout cases

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -434,3 +434,109 @@ TEST_F(AbrTests, UpdateProfile_DefaultIframeBitrate_SelectsBelowDefault)
 	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 2);
 }
 
+/**
+ * @brief Bug #11: FragmentfailureRampdown must skip iframe tracks when
+ *        selecting a rampdown target, matching every other ABR function.
+ */
+TEST_F(AbrTests, FragmentfailureRampdown_SkipsIframeTrack)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 30;
+
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	// Profile 0: 500 kbps video
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 500000;
+	p.width = 320; p.height = 240;
+	abrManager.addProfile(p);
+
+	// Profile 1: 800 kbps iframe — should be skipped
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 800000;
+	p.width = 640; p.height = 360;
+	abrManager.addProfile(p);
+
+	// Profile 2: 1 Mbps video
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	abrManager.addProfile(p);
+
+	// Profile 3: 2 Mbps video (current)
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	abrManager.addProfile(p);
+
+	// Buffer at 15/30 = 50%.  Sorted video BWs: 500k, 1M, 2M.
+	// Profile percentages (relative to max 2M): 25%, 50%, 100%.
+	// Iterating descending: 100% !< 50% skip, 50% !< 50% skip, 25% < 50% → 500k.
+	BitsPerSecond result = abrManager.FragmentfailureRampdown(15, 3);
+	EXPECT_EQ(result, 500000);
+}
+
+TEST_F(AbrTests, FragmentfailureRampdown_NoIframes_NormalBehavior)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 30;
+
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	p.bandwidthBitsPerSecond = 500000;
+	p.width = 320; p.height = 240;
+	abrManager.addProfile(p);
+
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	abrManager.addProfile(p);
+
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	abrManager.addProfile(p);
+
+	// Buffer 21/30 = 70%.  Profile percentages: 25%, 50%, 100%.
+	// Descending: 100% !< 70%, 50% < 70% AND 1M < 2M → 1M.
+	BitsPerSecond result = abrManager.FragmentfailureRampdown(21, 2);
+	EXPECT_EQ(result, 1000000);
+}
+
+TEST_F(AbrTests, FragmentfailureRampdown_FallbackLowestIsNotIframe)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 30;
+
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Profile 0: 200 kbps iframe — lowest BW overall but should be excluded
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 200000;
+	p.width = 160; p.height = 120;
+	abrManager.addProfile(p);
+
+	// Profile 1: 500 kbps video — lowest video profile
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 500000;
+	p.width = 320; p.height = 240;
+	abrManager.addProfile(p);
+
+	// Profile 2: 2 Mbps video (current)
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	abrManager.addProfile(p);
+
+	// Buffer 1/30 ≈ 3.3%.  Sorted video BWs: 500k, 2M.
+	// Profile percentages: 25%, 100%.  Both ≥ 3.3%, but only 500k < currentbw.
+	// 25% < 3.3% is false, so no profile matches → fallback to lowest.
+	// Without the fix, fallback would return 200k (the iframe track).
+	BitsPerSecond result = abrManager.FragmentfailureRampdown(1, 2);
+	EXPECT_EQ(result, 500000);
+}
+

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -23,6 +23,32 @@
 // SpeedCache is provided by AampSpeedCache.h, included (or defined inline as
 // a fallback) by HybridABRManager.h above.
 
+/**
+ * @brief Local definition of SpeedCache for test use.
+ *        The production definition lives in priv_aamp.h, which cannot be
+ *        included here because it transitively pulls in abr/abr.h and
+ *        redefines ABRManager, conflicting with the legacy ABRManager
+ *        from support/aampabr/.
+ */
+struct SpeedCache
+{
+	long last_sample_time_val;
+	long prev_dlnow;
+	long prevSampleTotalDownloaded;
+	long totalDownloaded;
+	long speed_now;
+	long start_val;
+	bool bStart;
+
+	double totalWeight;
+	double weightedBitsPerSecond;
+	std::vector< std::pair<double,long> > mChunkSpeedData;
+
+	SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false) , totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
+	{
+	}
+};
+
 extern HybridABRManager::AampAbrConfig eAAMPAbrConfig;
 
 class HybridAbrTests : public ::testing::Test

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -23,32 +23,6 @@
 // SpeedCache is provided by AampSpeedCache.h, included (or defined inline as
 // a fallback) by HybridABRManager.h above.
 
-/**
- * @brief Local definition of SpeedCache for test use.
- *        The production definition lives in priv_aamp.h, which cannot be
- *        included here because it transitively pulls in abr/abr.h and
- *        redefines ABRManager, conflicting with the legacy ABRManager
- *        from support/aampabr/.
- */
-struct SpeedCache
-{
-	long last_sample_time_val;
-	long prev_dlnow;
-	long prevSampleTotalDownloaded;
-	long totalDownloaded;
-	long speed_now;
-	long start_val;
-	bool bStart;
-
-	double totalWeight;
-	double weightedBitsPerSecond;
-	std::vector< std::pair<double,long> > mChunkSpeedData;
-
-	SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false) , totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
-	{
-	}
-};
-
 extern HybridABRManager::AampAbrConfig eAAMPAbrConfig;
 
 class HybridAbrTests : public ::testing::Test

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -190,3 +190,111 @@ TEST_F(HybridAbrTests, CheckLLDashABRSpeedStoreSize_LargeChunk_Correct)
 	abrManager.CheckLLDashABRSpeedStoreSize(&sc, bps, 1000, 10000, 500, 10000);
 	EXPECT_EQ(sc.speed_now, 160000);
 }
+
+/**
+ * @brief Bug #11: FragmentfailureRampdown must skip iframe tracks when
+ *        selecting a rampdown target, matching every other ABR function.
+ */
+TEST_F(HybridAbrTests, FragmentfailureRampdown_SkipsIframeTrack)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 30;
+
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	// Profile 0: 500 kbps video
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 500000;
+	p.width = 320; p.height = 240;
+	mgr.addProfile(p);
+
+	// Profile 1: 800 kbps iframe — should be skipped
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 800000;
+	p.width = 640; p.height = 360;
+	mgr.addProfile(p);
+
+	// Profile 2: 1 Mbps video
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	mgr.addProfile(p);
+
+	// Profile 3: 2 Mbps video (current)
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	mgr.addProfile(p);
+
+	// Buffer at 15/30 = 50%.  Sorted video BWs: 500k, 1M, 2M.
+	// Profile percentages (relative to max 2M): 25%, 50%, 100%.
+	// Iterating descending: 100% !< 50% skip, 50% !< 50% skip, 25% < 50% → 500k.
+	// Without the fix the iframe 800k (40%) would also be in the list and could
+	// be selected as the rampdown target.
+	long result = mgr.FragmentfailureRampdown(15, 3);
+	EXPECT_EQ(result, 500000);
+}
+
+TEST_F(HybridAbrTests, FragmentfailureRampdown_NoIframes_NormalBehavior)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 30;
+
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	p.bandwidthBitsPerSecond = 500000;
+	p.width = 320; p.height = 240;
+	mgr.addProfile(p);
+
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	mgr.addProfile(p);
+
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	mgr.addProfile(p);
+
+	// Buffer 21/30 = 70%.  Profile percentages: 25%, 50%, 100%.
+	// Descending: 100% !< 70%, 50% < 70% AND 1M < 2M → 1M.
+	long result = mgr.FragmentfailureRampdown(21, 2);
+	EXPECT_EQ(result, 1000000);
+}
+
+TEST_F(HybridAbrTests, FragmentfailureRampdown_FallbackLowestIsNotIframe)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 30;
+
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Profile 0: 200 kbps iframe — lowest BW overall but should be excluded
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 200000;
+	p.width = 160; p.height = 120;
+	mgr.addProfile(p);
+
+	// Profile 1: 500 kbps video — lowest video profile
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 500000;
+	p.width = 320; p.height = 240;
+	mgr.addProfile(p);
+
+	// Profile 2: 2 Mbps video (current)
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	mgr.addProfile(p);
+
+	// Buffer 1/30 ≈ 3.3%.  Sorted video BWs: 500k, 2M.
+	// Profile percentages: 25%, 100%.  Both ≥ 3.3%, but only 500k < currentbw.
+	// 25% < 3.3% is false, so no profile matches → fallback to lowest.
+	// Without the fix, fallback would return 200k (the iframe track).
+	long result = mgr.FragmentfailureRampdown(1, 2);
+	EXPECT_EQ(result, 500000);
+}


### PR DESCRIPTION
FragmentfailureRampdown in abr.cpp and HybridABRManager.cpp don't filter out iframe tracks (unlike other abr-related methods). An iframe track bandwidth could be selected as the desired rampdown target, which doesn't correspond to any regular video profile. The caller then passes this bandwidth to GetProfileIndexForBandwidth which may not find a match. I think this currently works by accident for most Comcast live manifests because the iframe track bandwidths are the same as the track from which the iframes are derived.