### PR TITLE
VPAAMP-129 fix: always compile ResetForTesting, remove AAMP_TEST_BUILD guard

### DIFF
--- a/simnet/net_persona_fitter.cpp
+++ b/simnet/net_persona_fitter.cpp
@@ -427,7 +427,6 @@ std::size_t NetPersonaFitter::GetBurstCount() const
 	return mBursts.size();
 }
 
-#ifdef AAMP_TEST_BUILD
 void NetPersonaFitter::ResetForTesting()
 {
 	std::lock_guard<std::mutex> lock{mMutex};
@@ -437,7 +436,6 @@ void NetPersonaFitter::ResetForTesting()
 	// with the C runtime and cannot be un-registered; re-registering on the next
 	// AddRequest() call would just add a duplicate entry.
 }
-#endif
 
 bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath) const
 {

--- a/simnet/net_persona_fitter.h
+++ b/simnet/net_persona_fitter.h
@@ -126,17 +126,14 @@ public:
 	 */
 	std::size_t GetBurstCount() const;
 
-#ifdef AAMP_TEST_BUILD
 	/**
 	 * @brief Reset all accumulated data to empty state.
 	 *
 	 * FOR TESTING ONLY. Allows each unit-test case to start from a clean
 	 * singleton state, preventing order-dependence under --gtest_shuffle
-	 * or when new tests are added.  Available only when AAMP_TEST_BUILD is
-	 * defined so the method is never present in production binaries.
+	 * or when new tests are added.
 	 */
 	void ResetForTesting();
-#endif
 
 private:
 	NetPersonaFitter() = default;


### PR DESCRIPTION
## Summary

Surgical follow-up to the VPAAMP-129 merge.

`NetPersonaFitter::ResetForTesting()` was guarded by `#ifdef AAMP_TEST_BUILD`, but the unit test build does not define that macro — causing a compile error in `NetPersonaFitterTestCases.cpp`.

### Change
Remove the `#ifdef` / `#endif` guards from both `net_persona_fitter.h` and `net_persona_fitter.cpp`. The method is test-only by convention; its presence in production builds is inert (it is never called outside test code).

### Files changed
- `simnet/net_persona_fitter.h` — remove `#ifdef AAMP_TEST_BUILD` guard
- `simnet/net_persona_fitter.cpp` — remove `#ifdef AAMP_TEST_BUILD` guard