### PR TITLE
Replace CachedFragment::Copy with std::move in CacheTsbFragment

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -628,8 +628,8 @@ bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment> fragme
 		}
 		if(!cachedFragment->fragment.empty())
 		{
-			// If following log is coming, possible memory leak. Need to clear the data first before slot reuse.
-			AAMPLOG_WARN("Fetch buffer has junk data, Need to free this up");
+			// Slot was not cleared after previous use; the assignment below will overwrite and release the old data.
+			AAMPLOG_WARN("Fetch buffer has junk data; previous slot was not cleared after use");
 		}
 		*cachedFragment = std::move(*fragment);
 		if(!cachedFragment->fragment.empty())

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -612,7 +612,7 @@ int MediaStreamContext::GetDefaultDurationBetweenPlaylistUpdates()
  * @param fragment TSB fragment pointer
  * @retval true on success
  */
-bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment> fragment)
+bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment>&& fragment)
 {
 	// FN_TRACE_F_MPD( __FUNCTION__ );
 	std::lock_guard<std::mutex> lock(fetchChunkBufferMutex);

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -621,12 +621,17 @@ bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment> fragme
 	{
 		AAMPLOG_TRACE("Type[%s] fragmentTime %f discontinuity %d duration %f initFragment:%d", name, fragment->position, fragment->discontinuity, fragment->duration, fragment->initFragment);
 		CachedFragment* cachedFragment = GetFetchChunkBuffer(true);
+		if(!cachedFragment)
+		{
+			AAMPLOG_ERR("[%s] GetFetchChunkBuffer returned null", name);
+			return false;
+		}
 		if(!cachedFragment->fragment.empty())
 		{
 			// If following log is coming, possible memory leak. Need to clear the data first before slot reuse.
 			AAMPLOG_WARN("Fetch buffer has junk data, Need to free this up");
 		}
-		cachedFragment->Copy(*fragment);
+		*cachedFragment = std::move(*fragment);
 		if(!cachedFragment->fragment.empty())
 		{
 			ret = true;
@@ -730,7 +735,8 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 			// If reader is at EOS, inject the last data in AAMP TSB
 			if (aamp->GetLLDashChunkMode())
 			{
-				CacheTsbFragment(fragmentToTsbSessionMgr);
+				auto fragmentForChunkCache = std::make_shared<CachedFragment>(*fragmentToTsbSessionMgr);
+				CacheTsbFragment(std::move(fragmentForChunkCache));
 			}
 			SetLocalTSBInjection(false);
 			// If all of the active media contexts are no longer injecting from TSB, update the AAMP flag
@@ -741,7 +747,8 @@ void MediaStreamContext::OnFragmentDownloadSuccess(DownloadInfoPtr dlInfo)
 			// In chunk mode, media segments are added to the chunk cache in the SSL callback, but init segments are added here
 			if (aamp->GetLLDashChunkMode())
 			{
-				CacheTsbFragment(fragmentToTsbSessionMgr);
+				auto fragmentForChunkCache = std::make_shared<CachedFragment>(*fragmentToTsbSessionMgr);
+				CacheTsbFragment(std::move(fragmentForChunkCache));
 			}
 		}
 		tsbSessionManager->EnqueueWrite(std::move(dlInfo->url), std::move(fragmentToTsbSessionMgr), context->GetPeriod()->GetId());

--- a/MediaStreamContext.h
+++ b/MediaStreamContext.h
@@ -146,10 +146,10 @@ bool CacheFragment(std::string fragmentUrl, unsigned int curlInstance, double po
 
 /**
  * @fn CacheTsbFragment
- * @param[in] fragment TSB fragment pointer
+ * @param[in] fragment TSB fragment pointer (must be passed with std::move)
  * @retval true on success
  */
-bool CacheTsbFragment(std::shared_ptr<CachedFragment> fragment);
+bool CacheTsbFragment(std::shared_ptr<CachedFragment>&& fragment);
 
 /**
  * @fn CacheFragmentChunk

--- a/test/utests/fakes/FakeMediaStreamContext.cpp
+++ b/test/utests/fakes/FakeMediaStreamContext.cpp
@@ -108,11 +108,11 @@ void MediaStreamContext::abortWaitForVideoPTS()
 {
 }
 
-bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment> fragment)
+bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment>&& fragment)
 {
 	if (g_mockMediaStreamContext != nullptr)
 	{
-		return g_mockMediaStreamContext->CacheTsbFragment(fragment);
+		return g_mockMediaStreamContext->CacheTsbFragment(std::move(fragment));
 	}
 	else
 	{

--- a/test/utests/mocks/MockMediaStreamContext.h
+++ b/test/utests/mocks/MockMediaStreamContext.h
@@ -27,7 +27,7 @@ class MockMediaStreamContext
 {
 public:
 	MOCK_METHOD(bool, CacheFragment, (std::string fragmentUrl, unsigned int curlInstance, double position, double duration, const char *range, bool initSegment, bool discontinuity, bool playingAd, uint32_t scale));
-	MOCK_METHOD(bool, CacheTsbFragment, (std::shared_ptr<CachedFragment> fragment));
+	MOCK_METHOD(bool, CacheTsbFragment, (std::shared_ptr<CachedFragment>&& fragment));
 	MOCK_METHOD(bool, CacheFragmentChunk, (AampMediaType actualType, const uint8_t *ptr, size_t size, std::string remoteUrl, uint64_t dnldStartTime, uint64_t durationInTicks));
 	MOCK_METHOD(bool, IsLocalTSBInjection, ());
 };

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -767,8 +767,13 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
  * @brief Verify that CacheTsbFragment uses move semantics to transfer
  *        fragment data into the ring buffer slot, avoiding a deep copy.
  *
- * After the call the destination (ring buffer slot) must own the data
- * and the source fragment must be left in a moved-from (empty) state.
+ * The source shared_ptr is passed by value (not moved at the call site) so
+ * that sourceFragment still points to the same CachedFragment object after
+ * the call.  The move assignment inside CacheTsbFragment empties that object,
+ * which is then observable through sourceFragment.  If the implementation
+ * were changed to Copy() instead of move, sourceFragment->fragment would
+ * still hold the original data and the source-empty assertions below would
+ * fail, catching the regression.
  */
 TEST_F(FragmentDownloadTests, CacheTsbFragment_MoveSemantics_TransfersOwnership)
 {
@@ -792,17 +797,28 @@ TEST_F(FragmentDownloadTests, CacheTsbFragment_MoveSemantics_TransfersOwnership)
 	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch());
 
 	// --- Act ---
-	bool result = mMediaStreamContext->CacheTsbFragment(std::move(sourceFragment));
+	// Pass sourceFragment by value (shared_ptr copy) — NOT std::move — so that
+	// sourceFragment still aliases the same CachedFragment after the call and
+	// we can assert the underlying object was moved-from (not copied).
+	bool result = mMediaStreamContext->CacheTsbFragment(sourceFragment);
 
 	// --- Assert ---
 	EXPECT_TRUE(result);
 
-	// Destination should now own the fragment data and metadata.
+	// Destination ring buffer slot must own the data.
 	EXPECT_EQ(ringBufferSlot->fragment.size(), testPayload.size());
-	EXPECT_EQ(ringBufferSlot->position, 42.0);
-	EXPECT_EQ(ringBufferSlot->duration, 2.0);
+	EXPECT_DOUBLE_EQ(ringBufferSlot->position, 42.0);
+	EXPECT_DOUBLE_EQ(ringBufferSlot->duration, 2.0);
 	EXPECT_TRUE(ringBufferSlot->initFragment);
 	EXPECT_TRUE(ringBufferSlot->discontinuity);
+
+	// Source CachedFragment must be in a moved-from (empty) state, proving
+	// that a move — not a copy — transferred the payload.
+	EXPECT_TRUE(sourceFragment->fragment.empty());
+	EXPECT_DOUBLE_EQ(sourceFragment->position, 0.0);
+	EXPECT_DOUBLE_EQ(sourceFragment->duration, 0.0);
+	EXPECT_FALSE(sourceFragment->initFragment);
+	EXPECT_FALSE(sourceFragment->discontinuity);
 }
 
 // ---------------------------------------------------------------------------

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -797,10 +797,11 @@ TEST_F(FragmentDownloadTests, CacheTsbFragment_MoveSemantics_TransfersOwnership)
 	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch());
 
 	// --- Act ---
-	// Pass sourceFragment by value (shared_ptr copy) — NOT std::move — so that
-	// sourceFragment still aliases the same CachedFragment after the call and
-	// we can assert the underlying object was moved-from (not copied).
-	bool result = mMediaStreamContext->CacheTsbFragment(sourceFragment);
+	// std::move transfers the shared_ptr into the && parameter without
+	// decrementing the ref count, so sourceFragment still aliases the same
+	// CachedFragment after the call.  The move assignment inside
+	// CacheTsbFragment empties that object, observable through sourceFragment.
+	bool result = mMediaStreamContext->CacheTsbFragment(std::move(sourceFragment));
 
 	// --- Assert ---
 	EXPECT_TRUE(result);

--- a/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
+++ b/test/utests/tests/MediaStreamContextTests/FragmentDownloadTests.cpp
@@ -760,6 +760,52 @@ TEST_F(FragmentDownloadTests, OnFragmentDownloadSuccess_CheckEos_PausedDueToUnde
 }
 
 // ---------------------------------------------------------------------------
+// CacheTsbFragment: move semantics transfer data without copying
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Verify that CacheTsbFragment uses move semantics to transfer
+ *        fragment data into the ring buffer slot, avoiding a deep copy.
+ *
+ * After the call the destination (ring buffer slot) must own the data
+ * and the source fragment must be left in a moved-from (empty) state.
+ */
+TEST_F(FragmentDownloadTests, CacheTsbFragment_MoveSemantics_TransfersOwnership)
+{
+	// --- Arrange ---
+	constexpr std::string_view testPayload{"MOVE_SEMANTICS_TEST_DATA"};
+	auto sourceFragment = std::make_shared<CachedFragment>();
+	sourceFragment->fragment.assign(
+		reinterpret_cast<const uint8_t*>(testPayload.data()),
+		reinterpret_cast<const uint8_t*>(testPayload.data()) + testPayload.size());
+	sourceFragment->position = 42.0;
+	sourceFragment->duration = 2.0;
+	sourceFragment->initFragment = true;
+	sourceFragment->discontinuity = true;
+
+	// The ring buffer slot that GetFetchChunkBuffer will return.
+	auto ringBufferSlot = std::make_shared<CachedFragment>();
+
+	// WaitForCachedFragmentChunkInjected is handled by the fake (always returns true).
+	EXPECT_CALL(*g_mockMediaTrack, GetFetchChunkBuffer(true))
+		.WillOnce(Return(ringBufferSlot.get()));
+	EXPECT_CALL(*g_mockMediaTrack, UpdateTSAfterChunkFetch());
+
+	// --- Act ---
+	bool result = mMediaStreamContext->CacheTsbFragment(std::move(sourceFragment));
+
+	// --- Assert ---
+	EXPECT_TRUE(result);
+
+	// Destination should now own the fragment data and metadata.
+	EXPECT_EQ(ringBufferSlot->fragment.size(), testPayload.size());
+	EXPECT_EQ(ringBufferSlot->position, 42.0);
+	EXPECT_EQ(ringBufferSlot->duration, 2.0);
+	EXPECT_TRUE(ringBufferSlot->initFragment);
+	EXPECT_TRUE(ringBufferSlot->discontinuity);
+}
+
+// ---------------------------------------------------------------------------
 // Regression: wasUnderFlowActive guard prevents discarding the recovery fragment
 // ---------------------------------------------------------------------------
 // The hook defined in FakeStreamAbstractionAamp.cpp is called inside


### PR DESCRIPTION
Eliminate unnecessary deep copy of fragment data (2-7 MB for UHD) in CacheTsbFragment by using move assignment instead of Copy(). The move assignment operator already exists on CachedFragment.

Also add null guard for GetFetchChunkBuffer return value to prevent potential null pointer dereference. (bug discovered while doing above)

LL-DASH chunk mode callers that need the fragment for both CacheTsbFragment and EnqueueWrite now create a separate copy before moving into the cache.

Add unit test validating move semantics transfer ownership correctly.