### PR TITLE
RDKEMW-16382:Observed Video Freeze & Fast-Forward Effect After Channe…

### DIFF
--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -233,8 +233,9 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				{
 					if(numDownloadAttempts <= numRetriesAllowed)
 					{ //Attempt retry for partial downloads, which have a higher chance to succeed
-						if (httpRetVal == CURLE_COULDNT_CONNECT || IsCurlTimeoutFailure (httpRetVal) )
+						if (httpRetVal == CURLE_COULDNT_CONNECT || IsCurlTimeoutFailure (httpRetVal) || httpRetVal == CURLE_SEND_ERROR)
 						{
+							AAMPLOG_WARN("Download failed due to curl error %d numDownloadAttempts %d numRetriesAllowed %d",httpRetVal,numDownloadAttempts,numRetriesAllowed);
 							loopAgain = true;
 						}
 					}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4981,9 +4981,10 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						print_headerResponse(context.allResponseHeaders, mediaType);
 
 					}
-					if (res == CURLE_COULDNT_CONNECT || IsCurlTimeoutFailure(res) || (isDownloadStalled && (eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT != abortReason)))
+					if (res == CURLE_COULDNT_CONNECT || IsCurlTimeoutFailure(res) || (isDownloadStalled && (eCURL_ABORT_REASON_LOW_BANDWIDTH_TIMEDOUT != abortReason))|| res == CURLE_SEND_ERROR )
 					{
 
+						AAMPLOG_WARN("Download failed due to curl error %d numDownloadAttempts %d numRetriesAllowed %d",res,downloadAttempt,maxDownloadAttempt);
 						if(mpStreamAbstractionAAMP)
 						{
 							switch (mediaType)


### PR DESCRIPTION
…l Change

Reason for change: Added retry logic to AAMP downloads when curl returns error 55 (CURL_SEND_ERROR)
Risks: Low
Test Procedure: Refer jira ticket
Priority: P0