### PR TITLE
VPLAY-13025 reduce required queued_frames to least common denominator 4 across all platforms

### DIFF
--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -28,7 +28,7 @@
 #include <gst/base/gstbasetransform.h>
 #include "PlayerLogManager.h"
 
-#define REQUIRED_QUEUED_FRAMES_DEFAULT (5+1)
+#define REQUIRED_QUEUED_FRAMES_DEFAULT 4 // reduced from 6 to 4 to satisfy least common denominator
 
 typedef gboolean (*AcceptCapsFunc)(GstBaseTransform *, GstPadDirection, GstCaps *);
 


### PR DESCRIPTION
Reason for Change: avoid rialto regression (surfacing in l3tests)
Test Guidance: rialto l3 tests working again
Risk: Low

Signed-off-by: Varatharajan_Narayanan<Varatharajan_Narayanan@comcast.com>