### PR TITLE
Revert "VPAAMP-129 fix: always compile ResetForTesting, remove AAMP_TEST_BUILD guard"

### DIFF
--- a/simnet/net_persona_fitter.cpp
+++ b/simnet/net_persona_fitter.cpp
@@ -427,6 +427,7 @@ std::size_t NetPersonaFitter::GetBurstCount() const
 	return mBursts.size();
 }
 
+#ifdef AAMP_TEST_BUILD
 void NetPersonaFitter::ResetForTesting()
 {
 	std::lock_guard<std::mutex> lock{mMutex};
@@ -436,6 +437,7 @@ void NetPersonaFitter::ResetForTesting()
 	// with the C runtime and cannot be un-registered; re-registering on the next
 	// AddRequest() call would just add a duplicate entry.
 }
+#endif
 
 bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath) const
 {

--- a/simnet/net_persona_fitter.h
+++ b/simnet/net_persona_fitter.h
@@ -126,14 +126,17 @@ public:
 	 */
 	std::size_t GetBurstCount() const;
 
+#ifdef AAMP_TEST_BUILD
 	/**
 	 * @brief Reset all accumulated data to empty state.
 	 *
 	 * FOR TESTING ONLY. Allows each unit-test case to start from a clean
 	 * singleton state, preventing order-dependence under --gtest_shuffle
-	 * or when new tests are added.
+	 * or when new tests are added.  Available only when AAMP_TEST_BUILD is
+	 * defined so the method is never present in production binaries.
 	 */
 	void ResetForTesting();
+#endif
 
 private:
 	NetPersonaFitter() = default;


### PR DESCRIPTION
Reverts rdkcentral/aamp#1349