### PR TITLE
Revert "Revert "VPAAMP-201 Move SpeedCache to common AampSpeedCache.h header""

### DIFF
--- a/AampSpeedCache.h
+++ b/AampSpeedCache.h
@@ -1,0 +1,57 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2018 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**
+ * @file AampSpeedCache.h
+ * @brief SpeedCache struct used by low-latency DASH ABR speed estimation
+ *
+ * Shared by priv_aamp.h, abr/abr.cpp and support/aampabr/HybridABRManager.cpp
+ * to avoid duplicate definitions and the need to pull in priv_aamp.h for ABR-only users.
+ */
+
+#ifndef AAMP_SPEED_CACHE_H
+#define AAMP_SPEED_CACHE_H
+
+#include <vector>
+#include <utility>
+
+/**
+ * @struct SpeedCache
+ * @brief Stores the information for cache speed
+ */
+struct SpeedCache
+{
+	long last_sample_time_val;
+	long prev_dlnow;
+	long prevSampleTotalDownloaded;
+	long totalDownloaded;
+	long speed_now;
+	long start_val;
+	bool bStart;
+
+	double totalWeight;
+	double weightedBitsPerSecond;
+	std::vector< std::pair<double,long> > mChunkSpeedData;
+
+	SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false), totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
+	{
+	}
+};
+
+#endif /* AAMP_SPEED_CACHE_H */

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -707,6 +707,7 @@ install(FILES
 	abr/RollingMedianOutlierEstimator.h
 	abr/HarmonicEwmaEstimator.h
 	abr/BandwidthEstimatorBase.h
+	AampSpeedCache.h
 	DESTINATION include
 )
 

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -33,6 +33,7 @@
 #include <sys/time.h>
 #include <algorithm>
 #include "AampLogManager.h"
+#include "AampSpeedCache.h"
 
 //#define DEBUG_ENABLED
 
@@ -836,30 +837,6 @@ int ABRManager::getClosestProfileIndexByBandwidth( BitsPerSecond inputBandwidth 
 		return 0;
 	}
 }
-
-/**
- * @struct SpeedCache
- * @brief Stores the information for cache speed
- */
-
-struct SpeedCache
-{
-	long last_sample_time_val;
-	long prev_dlnow;
-	long prevSampleTotalDownloaded;
-	long totalDownloaded;
-	long speed_now;
-	long start_val;
-	bool bStart;
-	
-	double totalWeight;
-	double weightedBitsPerSecond;
-	std::vector< std::pair<double,long> > mChunkSpeedData;
-	
-	SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false), totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
-	{
-	}
-};
 
 /** @brief Read Config values
  *  @return none

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -32,6 +32,7 @@
 #include "AampMediaType.h"
 #include "BandwidthEstimatorBase.h"
 #include "AampCurlDefine.h"
+#include "AampSpeedCache.h"
 
 enum BandwidthEstimationAlgorithm
 {

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -30,7 +30,7 @@
 #include "AampScheduler.h"
 #include "StreamSink.h"
 #include "TimedMetadata.h"
-
+#include "AampSpeedCache.h"
 #include "AampProfiler.h"
 #include "DrmHelper.h"
 #include "DrmMediaFormat.h"
@@ -409,30 +409,6 @@ struct ThumbnailData {
 	int x;    /**< x coordinate of thumbnail within tile */
 	int y;    /**< y coordinate of Thumbnail within tile */
 };
-
-/**
- * @struct SpeedCache
- * @brief Stores the information for cache speed
- */
-struct SpeedCache
-{
-    long last_sample_time_val;
-    long prev_dlnow;
-    long prevSampleTotalDownloaded;
-    long totalDownloaded;
-    long speed_now;
-    long start_val;
-    bool bStart;
-
-    double totalWeight;
-    double weightedBitsPerSecond;
-    std::vector< std::pair<double,long> > mChunkSpeedData;
-
-    SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false) , totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
-    {
-    }
-};
-
 
 /**
  * @brief To store video rectangle properties

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -39,7 +39,6 @@
 #endif
 #include <sys/time.h>
 #include <algorithm>
-#include "AampSpeedCache.h"
 
 #define MAX_DEBUG_LOG_BUFF_SIZE 1024
 #define DEFAULT_ABR_CHUNK_CACHE_LENGTH	10					/**< Default ABR chunk cache length */

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -39,6 +39,7 @@
 #endif
 #include <sys/time.h>
 #include <algorithm>
+#include "AampSpeedCache.h"
 
 #define MAX_DEBUG_LOG_BUFF_SIZE 1024
 #define DEFAULT_ABR_CHUNK_CACHE_LENGTH	10					/**< Default ABR chunk cache length */
@@ -60,30 +61,6 @@
 #define AAMPABRLOG_ERR(FORMAT, ...)   AAMPABRLOG(eAAMPAbrConfig.debuglogging,"ERROR",FORMAT, ##__VA_ARGS__)
 
 HybridABRManager::AampAbrConfig eAAMPAbrConfig;
-
-/**
- * @struct SpeedCache
- * @brief Stores the information for cache speed
- */
-
-struct SpeedCache
-{
-	long last_sample_time_val;
-	long prev_dlnow;
-	long prevSampleTotalDownloaded;
-	long totalDownloaded;
-	long speed_now;
-	long start_val;
-	bool bStart;
-
-	double totalWeight;
-	double weightedBitsPerSecond;
-	std::vector< std::pair<double,long> > mChunkSpeedData;
-
-	SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false) , totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
-	{
-	}
-};
 
 /** @brief Read Config values
  *  @return none

--- a/support/aampabr/HybridABRManager.h
+++ b/support/aampabr/HybridABRManager.h
@@ -27,7 +27,39 @@
 #include <string>
 #include <cstdio>
 #include "ABRManager.h"
-#include "AampSpeedCache.h"
+
+// Include AampSpeedCache.h if available (AAMP build); otherwise define SpeedCache inline
+// so that consumers like FOG, which install only HybridABRManager.h remain buildable without needing AampSpeedCache.h as a separate installed header.
+#ifdef __has_include
+#  if __has_include("AampSpeedCache.h")
+#    include "AampSpeedCache.h"
+#  endif
+#else
+#  include "AampSpeedCache.h"
+#endif
+
+#ifndef AAMP_SPEED_CACHE_H
+#define AAMP_SPEED_CACHE_H
+#include <utility>
+struct SpeedCache
+{
+	long last_sample_time_val;
+	long prev_dlnow;
+	long prevSampleTotalDownloaded;
+	long totalDownloaded;
+	long speed_now;
+	long start_val;
+	bool bStart;
+
+	double totalWeight;
+	double weightedBitsPerSecond;
+	std::vector< std::pair<double,long> > mChunkSpeedData;
+
+	SpeedCache() : last_sample_time_val(0), prev_dlnow(0), prevSampleTotalDownloaded(0), totalDownloaded(0), speed_now(0), start_val(0), bStart(false), totalWeight(0), weightedBitsPerSecond(0), mChunkSpeedData()
+	{
+	}
+};
+#endif /* AAMP_SPEED_CACHE_H */
 
 class HybridABRManager:public ABRManager
 {

--- a/support/aampabr/HybridABRManager.h
+++ b/support/aampabr/HybridABRManager.h
@@ -34,8 +34,6 @@
 #  if __has_include("AampSpeedCache.h")
 #    include "AampSpeedCache.h"
 #  endif
-#else
-#  include "AampSpeedCache.h"
 #endif
 
 #ifndef AAMP_SPEED_CACHE_H

--- a/support/aampabr/HybridABRManager.h
+++ b/support/aampabr/HybridABRManager.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <cstdio>
 #include "ABRManager.h"
+#include "AampSpeedCache.h"
 
 class HybridABRManager:public ABRManager
 {


### PR DESCRIPTION
Reverts rdkcentral/aamp#1361

Reason for Change: preparing for reintroduction.