### PR TITLE
mPersistBandwidth-related thread safety bugs in legacy and current ABR

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -42,8 +42,7 @@
 
 ABRManager::AampAbrConfig eAAMPAbrConfig;
 
-BitsPerSecond ABRManager::mPersistBandwidth = 0;
-long long ABRManager::mPersistBandwidthUpdatedTime = 0;
+std::atomic<ABRManager::PersistBandwidthData> ABRManager::mPersistBandwidthData{};
 
 ABRManager::ABRManager()
 	: bLowLatencyStartABR(false),

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -28,7 +28,9 @@
 #include <string>
 #include <cstdio>
 #include <memory>
+#include <cstdint>
 #include <mutex>
+#include <atomic>
 #include "AampMediaType.h"
 #include "BandwidthEstimatorBase.h"
 #include "AampCurlDefine.h"
@@ -99,15 +101,18 @@ public:
 	};
 	
 	/**
-	 * @brief Persist Network Bandwidth
+	 * @brief Atomically paired persist bandwidth and timestamp.
+	 *
+	 * Both fields are written together in UpdatePersistBandwidth() and
+	 * read together during manifest parsing. Using a single atomic
+	 * struct guarantees the reader always sees a consistent pair.
 	 */
-	static BitsPerSecond mPersistBandwidth;
-	
-	/**
-	 * @brief Persist Network Bandwidth Updated Time
-	 */
-	
-	static long long mPersistBandwidthUpdatedTime;
+	struct PersistBandwidthData
+	{
+		BitsPerSecond bandwidth{0};
+		int64_t updatedTimeMs{0};
+	};
+	static std::atomic<PersistBandwidthData> mPersistBandwidthData;
 	
 	
 	/**
@@ -291,13 +296,19 @@ public:
 	 *
 	 * @param network bitrate
 	 */
-	static void setPersistBandwidth(BitsPerSecond bitrate){mPersistBandwidth = bitrate;}
+	static void setPersistBandwidth(BitsPerSecond bitrate, int64_t timeMs)
+	{
+		mPersistBandwidthData.store({bitrate, timeMs}, std::memory_order_release);
+	}
 	/**
-	 * @brief Get Persisted Network Bandwidth
+	 * @brief Get the atomically paired persist bandwidth and timestamp.
 	 *
-	 * @return  bandwidth
+	 * @return PersistBandwidthData with bandwidth and updatedTimeMs
 	 */
-	static BitsPerSecond getPersistBandwidth() { return mPersistBandwidth;}
+	static PersistBandwidthData getPersistBandwidth()
+	{
+		return mPersistBandwidthData.load(std::memory_order_acquire);
+	}
 	
 	/*
 	 * @brief Configuration related to AampABR

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -143,7 +143,10 @@ public:
 	/**
 	 * @fn getBestMatchedProfileIndexByBandWidth
 	 * @param bandWidth  The given bandwidth
-	 * @return the best matched profile index
+	 * @return the best matched profile index, or INVALID_PROFILE (-1) if no
+	 *         non-iframe profiles are registered (e.g. profiles not yet added,
+	 *         or only iframe tracks present).  Callers must check for
+	 *         INVALID_PROFILE before using the result as a container index.
 	 */
 	int getBestMatchedProfileIndexByBandWidth(int bandwidth);
 	

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -3373,8 +3373,9 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 				// Set Default init bitrate according to last PersistBandwidth
 				if((ISCONFIGSET(eAAMPConfig_PersistLowNetworkBandwidth)|| ISCONFIGSET(eAAMPConfig_PersistHighNetworkBandwidth)) && !aamp->IsFogTSBSupported())
 				{
-					BitsPerSecond persistbandwidth = aamp->mhAbrManager.getPersistBandwidth();
-					long TimeGap   =  aamp_GetCurrentTimeMS() - ABRManager::mPersistBandwidthUpdatedTime;
+					const auto persistData = ABRManager::getPersistBandwidth();
+					BitsPerSecond persistbandwidth = persistData.bandwidth;
+					long TimeGap = aamp_GetCurrentTimeMS() - persistData.updatedTimeMs;
 					//If current Network bandwidth is lower than current default bitrate ,use persistbw as default bandwidth when persistLowNetworkConfig exist
 					if(ISCONFIGSET(eAAMPConfig_PersistLowNetworkBandwidth) && TimeGap < 10000 &&  persistbandwidth < aamp->GetDefaultBitrate() && persistbandwidth > 0)
 					{

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -3375,23 +3375,23 @@ AAMPStatusType StreamAbstractionAAMP_HLS::Init(TuneType tuneType)
 				{
 					const auto persistData = ABRManager::getPersistBandwidth();
 					BitsPerSecond persistbandwidth = persistData.bandwidth;
-					long TimeGap = aamp_GetCurrentTimeMS() - persistData.updatedTimeMs;
+					int64_t TimeGap = aamp_GetCurrentTimeMS() - persistData.updatedTimeMs;
 					//If current Network bandwidth is lower than current default bitrate ,use persistbw as default bandwidth when persistLowNetworkConfig exist
 					if(ISCONFIGSET(eAAMPConfig_PersistLowNetworkBandwidth) && TimeGap < 10000 &&  persistbandwidth < aamp->GetDefaultBitrate() && persistbandwidth > 0)
 					{
-						AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %ld",persistbandwidth,TimeGap);
+						AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %" PRId64,persistbandwidth,TimeGap);
 						aamp->mhAbrManager.setDefaultInitBitrate(persistbandwidth);
 					}
 					//If current Network bandwidth is higher than current default bitrate and if config for PersistHighBandwidth is true , then network bandwidth will be applied as default bitrate for tune
 					else if(ISCONFIGSET(eAAMPConfig_PersistHighNetworkBandwidth) && TimeGap < 10000 && persistbandwidth > 0)
 					{
-						AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %ld", persistbandwidth, TimeGap );
+						AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %" PRId64, persistbandwidth, TimeGap );
 						aamp->mhAbrManager.setDefaultInitBitrate(persistbandwidth);
 					}
 					//set default bitrate
 					else
 					{
-						AAMPLOG_MIL("Using defaultBitrate %" BITSPERSECOND_FORMAT " . PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %ld",
+						AAMPLOG_MIL("Using defaultBitrate %" BITSPERSECOND_FORMAT " . PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %" PRId64,
 									aamp->GetDefaultBitrate(), persistbandwidth, TimeGap);
 						aamp->mhAbrManager.setDefaultInitBitrate(aamp->GetDefaultBitrate());
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7749,8 +7749,9 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 						// Set Default init bitrate according to last PersistBandwidth
 						if((ISCONFIGSET(eAAMPConfig_PersistLowNetworkBandwidth)|| ISCONFIGSET(eAAMPConfig_PersistHighNetworkBandwidth)) && !aamp->IsFogTSBSupported())
 						{
-							BitsPerSecond persistbandwidth = aamp->mhAbrManager.getPersistBandwidth();
-							long TimeGap   =  aamp_GetCurrentTimeMS() - ABRManager::mPersistBandwidthUpdatedTime;
+							const auto persistData = ABRManager::getPersistBandwidth();
+							BitsPerSecond persistbandwidth = persistData.bandwidth;
+							long TimeGap = aamp_GetCurrentTimeMS() - persistData.updatedTimeMs;
 							//If current Network bandwidth is lower than current default bitrate ,use persistbw as default bandwidth when persistLowNetworkConfig exist
 							if(ISCONFIGSET(eAAMPConfig_PersistLowNetworkBandwidth) && TimeGap < 10000 &&  persistbandwidth < aamp->GetDefaultBitrate() && persistbandwidth > 0)
 							{

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7751,23 +7751,23 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 						{
 							const auto persistData = ABRManager::getPersistBandwidth();
 							BitsPerSecond persistbandwidth = persistData.bandwidth;
-							long TimeGap = aamp_GetCurrentTimeMS() - persistData.updatedTimeMs;
+							int64_t TimeGap = aamp_GetCurrentTimeMS() - persistData.updatedTimeMs;
 							//If current Network bandwidth is lower than current default bitrate ,use persistbw as default bandwidth when persistLowNetworkConfig exist
 							if(ISCONFIGSET(eAAMPConfig_PersistLowNetworkBandwidth) && TimeGap < 10000 &&  persistbandwidth < aamp->GetDefaultBitrate() && persistbandwidth > 0)
 							{
-								AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %ld", persistbandwidth, TimeGap);
+								AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %" PRId64, persistbandwidth, TimeGap);
 								aamp->mhAbrManager.setDefaultInitBitrate(persistbandwidth);
 							}
 							//If current Network bandwidth is higher than current default bitrate and if config for PersistHighBandwidth is true , then network bandwidth will be applied as default bitrate for tune
 							else if(ISCONFIGSET(eAAMPConfig_PersistHighNetworkBandwidth) && TimeGap < 10000 && persistbandwidth > 0)
 							{
-								AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %ld", persistbandwidth,TimeGap);
+								AAMPLOG_WARN("PersistBitrate used as defaultBitrate. PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %" PRId64, persistbandwidth,TimeGap);
 								aamp->mhAbrManager.setDefaultInitBitrate(persistbandwidth);
 							}
 							// Set default init bitrate
 							else
 							{
-								AAMPLOG_MIL("Using defaultBitrate %" BITSPERSECOND_FORMAT " . PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %ld", aamp->GetDefaultBitrate(),persistbandwidth,TimeGap);
+								AAMPLOG_MIL("Using defaultBitrate %" BITSPERSECOND_FORMAT " . PersistBandwidth : %" BITSPERSECOND_FORMAT " TimeGap : %" PRId64, aamp->GetDefaultBitrate(),persistbandwidth,TimeGap);
 								aamp->mhAbrManager.setDefaultInitBitrate(aamp->GetDefaultBitrate());
 
 							}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -620,8 +620,7 @@ void PrivateInstanceAAMP::UpdatePersistBandwidth(BitsPerSecond bandwidth)
 		return;
 	}
 
-	ABRManager::setPersistBandwidth(bandwidth);
-	ABRManager::mPersistBandwidthUpdatedTime = aamp_GetCurrentTimeMS();
+	ABRManager::setPersistBandwidth(bandwidth, aamp_GetCurrentTimeMS());
 }
 
 /**

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -139,8 +139,7 @@ void ABRLogger(const char* levelstr,const char* file, int line,const char *fmt, 
 #endif
 }
 
-long ABRManager::mPersistBandwidth = 0;
-long long ABRManager::mPersistBandwidthUpdatedTime = 0;
+std::atomic<ABRManager::PersistBandwidthData> ABRManager::mPersistBandwidthData{};
 /**
  * @brief Constructor of ABRManager
  */

--- a/support/aampabr/ABRManager.h
+++ b/support/aampabr/ABRManager.h
@@ -26,7 +26,9 @@
 #include <map>
 #include <string>
 #include <cstdio>
+#include <cstdint>
 #include <mutex>
+#include <atomic>
 
 typedef long BitsPerSecond;
 #define BITSPERSECOND_FORMAT "ld"
@@ -77,15 +79,18 @@ public:
   };
 
   /**
-   * @brief Persist Network Bandwidth 
+   * @brief Atomically paired persist bandwidth and timestamp.
+   *
+   * Both fields are written together in UpdatePersistBandwidth() and
+   * read together during manifest parsing. Using a single atomic
+   * struct guarantees the reader always sees a consistent pair.
    */
-  static long mPersistBandwidth;
-
-  /**
-   * @brief Persist Network Bandwidth Updated Time
-   */
-
-  static long long mPersistBandwidthUpdatedTime;
+  struct PersistBandwidthData
+  {
+      BitsPerSecond bandwidth{0};
+      int64_t updatedTimeMs{0};
+  };
+  static std::atomic<PersistBandwidthData> mPersistBandwidthData;
 public:
   /**
    * @fn ABRManager
@@ -272,13 +277,19 @@ public:
     *
     * @param network bitrate
     */
-   static void setPersistBandwidth(long bitrate){mPersistBandwidth = bitrate;}
+   static void setPersistBandwidth(long bitrate, int64_t timeMs)
+   {
+       mPersistBandwidthData.store({bitrate, timeMs}, std::memory_order_release);
+   }
    /**
-    * @brief Get Persisted Network Bandwidth
+    * @brief Get the atomically paired persist bandwidth and timestamp.
     *
-    * @return  bandwidth
+    * @return PersistBandwidthData with bandwidth and updatedTimeMs
     */
-   static long getPersistBandwidth() { return mPersistBandwidth;}
+   static PersistBandwidthData getPersistBandwidth()
+   {
+       return mPersistBandwidthData.load(std::memory_order_acquire);
+   }
    
    /**
     * @brief Get the available profiles

--- a/support/aampabr/ABRManager.h
+++ b/support/aampabr/ABRManager.h
@@ -85,10 +85,9 @@ public:
    * read together during manifest parsing. Using a single atomic
    * struct guarantees the reader always sees a consistent pair.
    */
-  struct PersistBandwidthData
-  {
-      BitsPerSecond bandwidth{0};
-      int64_t updatedTimeMs{0};
+  struct PersistBandwidthData {
+    BitsPerSecond bandwidth{0};
+    int64_t updatedTimeMs{0};
   };
   static std::atomic<PersistBandwidthData> mPersistBandwidthData;
 public:

--- a/support/aampabr/ABRManager.h
+++ b/support/aampabr/ABRManager.h
@@ -118,7 +118,10 @@ public:
   /**
    * @fn getBestMatchedProfileIndexByBandWidth
    * @param bandWidth  The given bandwidth
-   * @return the best matched profile index
+   * @return the best matched profile index, or INVALID_PROFILE (-1) if no
+   *         non-iframe profiles are registered (e.g. profiles not yet added,
+   *         or only iframe tracks present).  Callers must check for
+   *         INVALID_PROFILE before using the result as a container index.
    */
   int getBestMatchedProfileIndexByBandWidth(int bandwidth);
 

--- a/support/aampabr/CMakeLists.txt
+++ b/support/aampabr/CMakeLists.txt
@@ -29,6 +29,12 @@ if(CMAKE_SYSTEMD_JOURNAL)
 	target_link_libraries (abr "-lsystemd")
 endif()
 
+# On Linux/x86_64, std::atomic<16-byte struct> requires the atomic library for
+# __atomic_load_16 / __atomic_store_16 (ARM64 handles them natively).
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	target_link_libraries(abr PUBLIC atomic)
+endif()
+
 set_target_properties(abr PROPERTIES PUBLIC_HEADER "ABRManager.h;HybridABRManager.h")
 install(TARGETS abr
 		DESTINATION lib

--- a/test/utests/drm/mocks/FakeABRManager.cpp
+++ b/test/utests/drm/mocks/FakeABRManager.cpp
@@ -19,8 +19,7 @@
 
 #include "abr.h"
 
-long ABRManager::mPersistBandwidth = 0;
-long long ABRManager::mPersistBandwidthUpdatedTime = 0;
+std::atomic<ABRManager::PersistBandwidthData> ABRManager::mPersistBandwidthData{};
 
 int ABRManager::getProfileCount()
 {

--- a/test/utests/fakes/FakeABR.cpp
+++ b/test/utests/fakes/FakeABR.cpp
@@ -20,8 +20,7 @@
 #include "abr.h"
 #include "MockABRManager.h"
 
-BitsPerSecond ABRManager::mPersistBandwidth = 0;
-long long ABRManager::mPersistBandwidthUpdatedTime = 0;
+std::atomic<ABRManager::PersistBandwidthData> ABRManager::mPersistBandwidthData{};
 
 MockABRManager *g_mockABRManager = nullptr;
 

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -21,6 +21,9 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include <cstddef>
+#include <thread>
+#include <atomic>
+#include <vector>
 #include "priv_aamp.h"
 #include "AampConfig.h"
 #include "MockAampConfig.h"
@@ -39,8 +42,7 @@ class AbrTests : public ::testing::Test
 protected:
 	void SetUp() override
 	{
-		ABRManager::mPersistBandwidth = 0;
-		ABRManager::mPersistBandwidthUpdatedTime = 0;
+		ABRManager::setPersistBandwidth(0, 0);
 
 		eAAMPAbrConfig = ABRManager::AampAbrConfig();
 		// Cache life is interpreted as milliseconds by the estimator.
@@ -538,5 +540,88 @@ TEST_F(AbrTests, FragmentfailureRampdown_FallbackLowestIsNotIframe)
 	// Without the fix, fallback would return 200k (the iframe track).
 	BitsPerSecond result = abrManager.FragmentfailureRampdown(1, 2);
 	EXPECT_EQ(result, 500000);
+}
+
+/**
+ * @brief setPersistBandwidth round-trips bandwidth and timestamp correctly.
+ */
+TEST_F(AbrTests, PersistBandwidth_SetGetRoundTrip)
+{
+	ABRManager::setPersistBandwidth(5000000, 12345);
+	auto data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 5000000);
+	EXPECT_EQ(data.updatedTimeMs, 12345);
+
+	ABRManager::setPersistBandwidth(0, 0);
+	data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 0);
+	EXPECT_EQ(data.updatedTimeMs, 0);
+}
+
+/**
+ * @brief Large 64-bit timestamp values round-trip correctly, covering
+ *        values that would produce torn reads on ARM without atomics.
+ */
+TEST_F(AbrTests, PersistBandwidthUpdatedTime_LargeValueRoundTrip)
+{
+	constexpr int64_t largeTime = INT64_C(0x1234567890ABCDEF);
+	ABRManager::setPersistBandwidth(42, largeTime);
+	auto data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 42);
+	EXPECT_EQ(data.updatedTimeMs, largeTime);
+}
+
+/**
+ * @brief Concurrent writers and readers must always observe a consistent
+ *        (bandwidth, timestamp) pair — never a mix of two different writes.
+ *
+ * Writers alternate between two distinct pairs. Readers verify every
+ * observation matches one of those pairs. A torn or unpaired read would
+ * produce a combination from two different writes, failing the test.
+ * This is the primary regression test for abr-bugs.md #4.
+ */
+TEST_F(AbrTests, PersistBandwidthData_ConcurrentAccessConsistentPair)
+{
+	constexpr BitsPerSecond kBwA = 1000000;
+	constexpr int64_t kTimeA = INT64_C(0x00000000FFFFFFFF);
+	constexpr BitsPerSecond kBwB = 9000000;
+	constexpr int64_t kTimeB = INT64_C(0xFFFFFFFF00000000);
+	constexpr int kIterations = 100000;
+
+	std::atomic<bool> stop{false};
+	std::atomic<bool> failure{false};
+
+	// Writer thread: alternates between two known pairs
+	std::thread writer([&]() {
+		for (int i = 0; i < kIterations; ++i)
+		{
+			if (i % 2 == 0)
+				ABRManager::setPersistBandwidth(kBwA, kTimeA);
+			else
+				ABRManager::setPersistBandwidth(kBwB, kTimeB);
+		}
+		stop.store(true, std::memory_order_release);
+	});
+
+	// Reader thread: verifies consistent pairing
+	std::thread reader([&]() {
+		while (!stop.load(std::memory_order_acquire))
+		{
+			auto data = ABRManager::getPersistBandwidth();
+			bool isZero = (data.bandwidth == 0 && data.updatedTimeMs == 0);
+			bool isPairA = (data.bandwidth == kBwA && data.updatedTimeMs == kTimeA);
+			bool isPairB = (data.bandwidth == kBwB && data.updatedTimeMs == kTimeB);
+			if (!isZero && !isPairA && !isPairB)
+			{
+				failure.store(true, std::memory_order_release);
+				break;
+			}
+		}
+	});
+
+	writer.join();
+	reader.join();
+
+	EXPECT_FALSE(failure.load());
 }
 

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <thread>
 #include <atomic>
-#include <vector>
 #include "priv_aamp.h"
 #include "AampConfig.h"
 #include "MockAampConfig.h"

--- a/test/utests/tests/AampAbrTests/CMakeLists.txt
+++ b/test/utests/tests/AampAbrTests/CMakeLists.txt
@@ -57,5 +57,5 @@ add_executable(HybridAbrTests HybridAbrTests.cpp
 	../../../../support/aampabr/HybridABRManager.cpp
 	../../../../support/aampabr/ABRManager.cpp
 )
-target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main)
+target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:atomic>)
 aamp_utest_run_add(HybridAbrTests)

--- a/test/utests/tests/CommonTestIncludes.cmake
+++ b/test/utests/tests/CommonTestIncludes.cmake
@@ -55,3 +55,10 @@ include_directories(${AAMP_ROOT}/middleware
                     ${AAMP_ROOT}/middleware/baseConversion
                     ${AAMP_ROOT}/middleware/playerLogManager
                     ${AAMP_ROOT}/middleware/vendor)
+
+# On Linux/x86_64, std::atomic<16-byte struct> (e.g. ABRManager::PersistBandwidthData)
+# emits __atomic_load_16 / __atomic_store_16 which live in libatomic.  ARM64 (macOS)
+# handles them with native instructions and needs no extra library.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(OS_LD_FLAGS ${OS_LD_FLAGS} -latomic)
+endif()

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -5737,8 +5737,7 @@ struct GetStreamFormatTestParams {
  */
 TEST_F(PrivAampTests, UpdatePersistBandwidth_ConfigEnabledAndPlayEnabled_UpdatesAbrStatics)
 {
-	ABRManager::mPersistBandwidth = 0;
-	ABRManager::mPersistBandwidthUpdatedTime = 0;
+	ABRManager::setPersistBandwidth(0, 0);
 
 	ON_CALL(*g_mockAampConfig, IsConfigSet(_)).WillByDefault(Return(false));
 	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_PersistLowNetworkBandwidth))
@@ -5750,8 +5749,9 @@ TEST_F(PrivAampTests, UpdatePersistBandwidth_ConfigEnabledAndPlayEnabled_Updates
 	p_aamp->mbPlayEnabled = true;
 	p_aamp->UpdatePersistBandwidth(5000);
 
-	EXPECT_EQ(ABRManager::getPersistBandwidth(), 5000);
-	EXPECT_EQ(ABRManager::mPersistBandwidthUpdatedTime, 1234);
+	auto data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 5000);
+	EXPECT_EQ(data.updatedTimeMs, 1234);
 }
 
 /**
@@ -5759,8 +5759,7 @@ TEST_F(PrivAampTests, UpdatePersistBandwidth_ConfigEnabledAndPlayEnabled_Updates
  */
 TEST_F(PrivAampTests, UpdatePersistBandwidth_ConfigDisabled_DoesNotUpdateAbrStatics)
 {
-	ABRManager::mPersistBandwidth = 123;
-	ABRManager::mPersistBandwidthUpdatedTime = 999;
+	ABRManager::setPersistBandwidth(123, 999);
 
 	ON_CALL(*g_mockAampConfig, IsConfigSet(_)).WillByDefault(Return(false));
 	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_PersistLowNetworkBandwidth))
@@ -5773,8 +5772,9 @@ TEST_F(PrivAampTests, UpdatePersistBandwidth_ConfigDisabled_DoesNotUpdateAbrStat
 	p_aamp->mbPlayEnabled = true;
 	p_aamp->UpdatePersistBandwidth(5000);
 
-	EXPECT_EQ(ABRManager::getPersistBandwidth(), 123);
-	EXPECT_EQ(ABRManager::mPersistBandwidthUpdatedTime, 999);
+	auto data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 123);
+	EXPECT_EQ(data.updatedTimeMs, 999);
 }
 
 /**
@@ -5782,8 +5782,7 @@ TEST_F(PrivAampTests, UpdatePersistBandwidth_ConfigDisabled_DoesNotUpdateAbrStat
  */
 TEST_F(PrivAampTests, UpdatePersistBandwidth_PlaybackDisabled_DoesNotUpdateAbrStatics)
 {
-	ABRManager::mPersistBandwidth = 123;
-	ABRManager::mPersistBandwidthUpdatedTime = 999;
+	ABRManager::setPersistBandwidth(123, 999);
 
 	ON_CALL(*g_mockAampConfig, IsConfigSet(_)).WillByDefault(Return(false));
 	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_PersistLowNetworkBandwidth))
@@ -5794,8 +5793,9 @@ TEST_F(PrivAampTests, UpdatePersistBandwidth_PlaybackDisabled_DoesNotUpdateAbrSt
 	p_aamp->mbPlayEnabled = false;
 	p_aamp->UpdatePersistBandwidth(5000);
 
-	EXPECT_EQ(ABRManager::getPersistBandwidth(), 123);
-	EXPECT_EQ(ABRManager::mPersistBandwidthUpdatedTime, 999);
+	auto data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 123);
+	EXPECT_EQ(data.updatedTimeMs, 999);
 }
 
 /**
@@ -5821,8 +5821,7 @@ TEST_F(PrivAampTests, DetachFlushesAndBlocksAsyncEvents)
  */
 TEST_F(PrivAampTests, UpdatePersistBandwidth_ZeroBandwidth_DoesNotUpdateAbrStatics)
 {
-	ABRManager::mPersistBandwidth = 123;
-	ABRManager::mPersistBandwidthUpdatedTime = 999;
+	ABRManager::setPersistBandwidth(123, 999);
 
 	ON_CALL(*g_mockAampConfig, IsConfigSet(_)).WillByDefault(Return(false));
 	ON_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_PersistLowNetworkBandwidth))
@@ -5833,8 +5832,9 @@ TEST_F(PrivAampTests, UpdatePersistBandwidth_ZeroBandwidth_DoesNotUpdateAbrStati
 	p_aamp->mbPlayEnabled = true;
 	p_aamp->UpdatePersistBandwidth(0);
 
-	EXPECT_EQ(ABRManager::getPersistBandwidth(), 123);
-	EXPECT_EQ(ABRManager::mPersistBandwidthUpdatedTime, 999);
+	auto data = ABRManager::getPersistBandwidth();
+	EXPECT_EQ(data.bandwidth, 123);
+	EXPECT_EQ(data.updatedTimeMs, 999);
 }
 
 // This function is used by Google Test to print the parameter value.


### PR DESCRIPTION
Fix torn reads on mPersistBandwidth/mPersistBandwidthUpdatedTime in both legacy and new ABR algorithms. Switch from old style C types (long long) to explicit width types (int64_t).

Replace two unsynchronized static members with a single std::atomic<PersistBandwidthData> struct so readers always observe a consistent (bandwidth, timestamp) pair. Eliminates undefined behavior from torn 64-bit reads on ARM.

Changes:
- abr/abr.h, support/aampabr/ABRManager.h: Add PersistBandwidthData struct with BitsPerSecond + int64_t fields; single atomic member replaces two separate statics; paired set/get accessors with acquire/release ordering.
- abr/abr.cpp, support/aampabr/ABRManager.cpp: Update static definitions.
- priv_aamp.cpp: Single setPersistBandwidth(bw, time) call replaces two separate stores.
- fragmentcollector_mpd.cpp, fragmentcollector_hls.cpp: Load consistent pair via getPersistBandwidth() returning struct.
- test/utests: Update FakeABR, FakeABRManager, AbrTests (3 new tests including concurrent pairing test), PrivAampTests (4 updated tests).
