### PR TITLE
Fix getBestMatchedProfileIndexByBandWidth sorted-order assumption

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -349,7 +349,7 @@ void ABRManager::updateProfile()
  */
 int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth)
 {
-	int desiredProfileIndex = 0;
+	int desiredProfileIndex = INVALID_PROFILE;
 	std::lock_guard<std::mutex> lock(mProfileLock);
 	long bestDiff = LONG_MAX;
 
@@ -387,6 +387,10 @@ int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth)
 		}
 	}
 
+	if (desiredProfileIndex == INVALID_PROFILE)
+	{
+		AAMPLOG_WARN("getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)", bandwidth);
+	}
 #if defined(DEBUG_ENABLED)
 	size_t profileCount = mProfiles.size();
 	AAMPLOG_MIL("Get best matched profile index = %d bitrate = %" BITSPERSECOND_FORMAT,

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1,17 +1,22 @@
 /*
- *   Copyright 2022 RDK Management
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Copyright 2022 RDK Management
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /***************************************************

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -351,45 +351,50 @@ int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth)
 {
 	int desiredProfileIndex = INVALID_PROFILE;
 	std::lock_guard<std::mutex> lock(mProfileLock);
+
+	if (mSortedBWProfileList.empty())
+	{
+		AAMPLOG_WARN("getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)", bandwidth);
+		return INVALID_PROFILE;
+	}
+
+	if (mSortedBWProfileList.size() > 1)
+	{
+		AAMPLOG_WARN("getBestMatchedProfileIndexByBandWidth: unexpected multiple period maps (%zu), using first", mSortedBWProfileList.size());
+	}
+
+	// Use the first period's map, consistent with getClosestProfileIndexByBandwidth()
+	const auto& bwMap = mSortedBWProfileList.begin()->second;
+	if (bwMap.empty())
+	{
+		AAMPLOG_WARN("getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)", bandwidth);
+		return INVALID_PROFILE;
+	}
+
 	long bestDiff = LONG_MAX;
 
-	for (const auto& periodEntry : mSortedBWProfileList)
+	// lower_bound finds first entry with bandwidth >= target
+	auto it = bwMap.lower_bound(bandwidth);
+
+	if (it != bwMap.end())
 	{
-		const auto& bwMap = periodEntry.second;
-		if (bwMap.empty())
+		long diff = it->first - bandwidth;
+		if (diff < bestDiff)
 		{
-			continue;
-		}
-
-		// lower_bound finds first entry with bandwidth >= target
-		auto it = bwMap.lower_bound(bandwidth);
-
-		if (it != bwMap.end())
-		{
-			long diff = it->first - bandwidth;
-			if (diff < bestDiff)
-			{
-				bestDiff = diff;
-				desiredProfileIndex = it->second;
-			}
-		}
-
-		// Also check the entry just below target (if any) for a closer match
-		if (it != bwMap.begin())
-		{
-			--it;
-			long diff = bandwidth - it->first;
-			if (diff < bestDiff)
-			{
-				bestDiff = diff;
-				desiredProfileIndex = it->second;
-			}
+			bestDiff = diff;
+			desiredProfileIndex = it->second;
 		}
 	}
 
-	if (desiredProfileIndex == INVALID_PROFILE)
+	// Also check the entry just below target (if any) for a closer match
+	if (it != bwMap.begin())
 	{
-		AAMPLOG_WARN("getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)", bandwidth);
+		--it;
+		long diff = bandwidth - it->first;
+		if (diff < bestDiff)
+		{
+			desiredProfileIndex = it->second;
+		}
 	}
 #if defined(DEBUG_ENABLED)
 	size_t profileCount = mProfiles.size();

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <cstdio>
 #include <cmath>
+#include <climits>
 #include <chrono>
 #include <stdarg.h>
 #include <sys/time.h>
@@ -348,31 +349,46 @@ void ABRManager::updateProfile()
  */
 int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth)
 {
-	// a) Check if network bandwidth changed from starting bandwidth
-	// b) Check if netwwork bandwidth is different from persisted bandwidth( needed for first time reporting)
-	// find the profile for the newbandwidth
 	int desiredProfileIndex = 0;
 	std::lock_guard<std::mutex> lock(mProfileLock);
-	size_t profileCount = mProfiles.size();
-	for (int i = 0; i < (int)profileCount; i++) {
-		const ProfileInfo& profile = mProfiles[i];
-		if (!profile.isIframeTrack) {
-			if (profile.bandwidthBitsPerSecond == bandwidth) {
-				// Good case, most manifest url will have same bandwidth in fragment file with configured profile bandwidth
-				desiredProfileIndex = i;
-				break;
-			} else if (profile.bandwidthBitsPerSecond < bandwidth) {
-				// fragment file name bandwidth doesn't match the profile bandwidth, will be always less
-				if (static_cast<size_t>(i + 1) == profileCount) {
-					desiredProfileIndex = i;
-					break;
-				}
-				else
-					desiredProfileIndex = (i + 1);
+	long bestDiff = LONG_MAX;
+
+	for (const auto& periodEntry : mSortedBWProfileList)
+	{
+		const auto& bwMap = periodEntry.second;
+		if (bwMap.empty())
+		{
+			continue;
+		}
+
+		// lower_bound finds first entry with bandwidth >= target
+		auto it = bwMap.lower_bound(bandwidth);
+
+		if (it != bwMap.end())
+		{
+			long diff = it->first - bandwidth;
+			if (diff < bestDiff)
+			{
+				bestDiff = diff;
+				desiredProfileIndex = it->second;
+			}
+		}
+
+		// Also check the entry just below target (if any) for a closer match
+		if (it != bwMap.begin())
+		{
+			--it;
+			long diff = bandwidth - it->first;
+			if (diff < bestDiff)
+			{
+				bestDiff = diff;
+				desiredProfileIndex = it->second;
 			}
 		}
 	}
+
 #if defined(DEBUG_ENABLED)
+	size_t profileCount = mProfiles.size();
 	AAMPLOG_MIL("Get best matched profile index = %d bitrate = %" BITSPERSECOND_FORMAT,
 				desiredProfileIndex, (desiredProfileIndex != INVALID_PROFILE &&	static_cast<size_t>(desiredProfileIndex) < profileCount) ?
 				mProfiles[desiredProfileIndex].bandwidthBitsPerSecond : 0);

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -25,6 +25,7 @@
 #include <sys/time.h>
 #include <cstring>
 #include <algorithm>
+#include <climits>
 
 #if !defined(__APPLE__)
 #if defined(USE_SYSTEMD_JOURNAL_PRINT)
@@ -301,30 +302,45 @@ void ABRManager::updateProfile() {
 int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth) {
 
   std::lock_guard<std::mutex> lock(mProfileLock);
-  // a) Check if network bandwidth changed from starting bandwidth
-  // b) Check if netwwork bandwidth is different from persisted bandwidth( needed for first time reporting)
-  // find the profile for the newbandwidth
   int desiredProfileIndex = 0;
-  int profileCount = getProfileCountUnlocked();
-  for (int i = 0; i < profileCount; i++) {
-    const ProfileInfo& profile = mProfiles[i];
-    if (!profile.isIframeTrack) {
-        if (profile.bandwidthBitsPerSecond == bandwidth) {
-            // Good case ,most manifest url will have same bandwidth in fragment file with configured profile bandwidth
-            desiredProfileIndex = i;
-            break;
-        } else if (profile.bandwidthBitsPerSecond < bandwidth) {
-            // fragment file name bandwidth doesn't match the profile bandwidth, will be always less
-            if((i+1) == profileCount) {
-                desiredProfileIndex = i;
-                break;
-            }
-            else
-                desiredProfileIndex = (i + 1);
-        }
-    }
+  long bestDiff = LONG_MAX;
+
+  for (const auto& periodEntry : mSortedBWProfileList)
+  {
+      const auto& bwMap = periodEntry.second;
+      if (bwMap.empty())
+      {
+          continue;
+      }
+
+      // lower_bound finds first entry with bandwidth >= target
+      auto it = bwMap.lower_bound(bandwidth);
+
+      if (it != bwMap.end())
+      {
+          long diff = it->first - bandwidth;
+          if (diff < bestDiff)
+          {
+              bestDiff = diff;
+              desiredProfileIndex = it->second;
+          }
+      }
+
+      // Also check the entry just below target (if any) for a closer match
+      if (it != bwMap.begin())
+      {
+          --it;
+          long diff = bandwidth - it->first;
+          if (diff < bestDiff)
+          {
+              bestDiff = diff;
+              desiredProfileIndex = it->second;
+          }
+      }
   }
+
 #if defined(DEBUG_ENABLED)
+  int profileCount = getProfileCountUnlocked();
   logprintf("%s:%d Get best matched profile index = %d bitrate = %ld\n",
     __FUNCTION__, __LINE__, desiredProfileIndex,
     (profileCount > desiredProfileIndex && desiredProfileIndex != INVALID_PROFILE) ? mProfiles[desiredProfileIndex].bandwidthBitsPerSecond : 0);

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -303,46 +303,53 @@ int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth) {
 
   std::lock_guard<std::mutex> lock(mProfileLock);
   int desiredProfileIndex = INVALID_PROFILE;
-  long bestDiff = LONG_MAX;
 
-  for (const auto& periodEntry : mSortedBWProfileList)
-  {
-      const auto& bwMap = periodEntry.second;
-      if (bwMap.empty())
-      {
-          continue;
-      }
-
-      // lower_bound finds first entry with bandwidth >= target
-      auto it = bwMap.lower_bound(bandwidth);
-
-      if (it != bwMap.end())
-      {
-          long diff = it->first - bandwidth;
-          if (diff < bestDiff)
-          {
-              bestDiff = diff;
-              desiredProfileIndex = it->second;
-          }
-      }
-
-      // Also check the entry just below target (if any) for a closer match
-      if (it != bwMap.begin())
-      {
-          --it;
-          long diff = bandwidth - it->first;
-          if (diff < bestDiff)
-          {
-              bestDiff = diff;
-              desiredProfileIndex = it->second;
-          }
-      }
-  }
-
-  if (desiredProfileIndex == INVALID_PROFILE)
+  if (mSortedBWProfileList.empty())
   {
     logprintf("%s:%d getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)\n",
       __FUNCTION__, __LINE__, bandwidth);
+    return INVALID_PROFILE;
+  }
+
+  if (mSortedBWProfileList.size() > 1)
+  {
+    logprintf("%s:%d getBestMatchedProfileIndexByBandWidth: unexpected multiple period maps (%zu), using first\n",
+      __FUNCTION__, __LINE__, mSortedBWProfileList.size());
+  }
+
+  // Use the first period's map, consistent with getClosestProfileIndexByBandwidth()
+  const auto& bwMap = mSortedBWProfileList.begin()->second;
+  if (bwMap.empty())
+  {
+    logprintf("%s:%d getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)\n",
+      __FUNCTION__, __LINE__, bandwidth);
+    return INVALID_PROFILE;
+  }
+
+  long bestDiff = LONG_MAX;
+
+  // lower_bound finds first entry with bandwidth >= target
+  auto it = bwMap.lower_bound(bandwidth);
+
+  if (it != bwMap.end())
+  {
+      long diff = it->first - bandwidth;
+      if (diff < bestDiff)
+      {
+          bestDiff = diff;
+          desiredProfileIndex = it->second;
+      }
+  }
+
+  // Also check the entry just below target (if any) for a closer match
+  if (it != bwMap.begin())
+  {
+      --it;
+      long diff = bandwidth - it->first;
+      if (diff < bestDiff)
+      {
+          desiredProfileIndex = it->second;
+      }
   }
 #if defined(DEBUG_ENABLED)
   int profileCount = getProfileCountUnlocked();

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -1,18 +1,23 @@
 /*
- *   Copyright 2018 RDK Management
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
  *
- *   Licensed under the Apache License, Version 2.0 (the "License");
- *   you may not use this file except in compliance with the License.
- *   You may obtain a copy of the License at
+ * Copyright 2018 RDK Management
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *   Unless required by applicable law or agreed to in writing, software
- *   distributed under the License is distributed on an "AS IS" BASIS,
- *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *   See the License for the specific language governing permissions and
- *   limitations under the License.
-*/
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
 /***************************************************
  * @file ABRManager.cpp

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -302,7 +302,7 @@ void ABRManager::updateProfile() {
 int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth) {
 
   std::lock_guard<std::mutex> lock(mProfileLock);
-  int desiredProfileIndex = 0;
+  int desiredProfileIndex = INVALID_PROFILE;
   long bestDiff = LONG_MAX;
 
   for (const auto& periodEntry : mSortedBWProfileList)
@@ -339,6 +339,11 @@ int ABRManager::getBestMatchedProfileIndexByBandWidth(int bandwidth) {
       }
   }
 
+  if (desiredProfileIndex == INVALID_PROFILE)
+  {
+    logprintf("%s:%d getBestMatchedProfileIndexByBandWidth: no candidate found for bandwidth %d (sorted list empty or contains only iframe profiles)\n",
+      __FUNCTION__, __LINE__, bandwidth);
+  }
 #if defined(DEBUG_ENABLED)
   int profileCount = getProfileCountUnlocked();
   logprintf("%s:%d Get best matched profile index = %d bitrate = %ld\n",

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -645,3 +645,79 @@ TEST_F(AbrTests, FragmentfailureRampdown_ZeroMaxBuffer_ReturnsZero)
 	EXPECT_EQ(result, 0);
 }
 
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns exact match
+ *        regardless of profile insertion order.
+ */
+TEST_F(AbrTests, GetBestMatchedProfile_ExactMatch)
+{
+	ABRManager abrManager;
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	// Insert in descending order (unsorted)
+	p.bandwidthBitsPerSecond = 4000000;
+	abrManager.addProfile(p); // index 0
+	p.bandwidthBitsPerSecond = 2000000;
+	abrManager.addProfile(p); // index 1
+	p.bandwidthBitsPerSecond = 1000000;
+	abrManager.addProfile(p); // index 2
+
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2000000), 1);
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(4000000), 0);
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(1000000), 2);
+}
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns the closest profile
+ *        when no exact match exists, regardless of insertion order.
+ */
+TEST_F(AbrTests, GetBestMatchedProfile_ClosestMatch_UnsortedProfiles)
+{
+	ABRManager abrManager;
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	// Descending order
+	p.bandwidthBitsPerSecond = 4000000;
+	abrManager.addProfile(p); // index 0
+	p.bandwidthBitsPerSecond = 2000000;
+	abrManager.addProfile(p); // index 1
+	p.bandwidthBitsPerSecond = 1000000;
+	abrManager.addProfile(p); // index 2
+
+	// 3M is between 2M and 4M — closer to 4M? No, equidistant.
+	// 2.9M → closer to 2M (diff 900k) vs 4M (diff 1.1M) → index 1
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2900000), 1);
+	// 3.5M → closer to 4M (diff 500k) vs 2M (diff 1.5M) → index 0
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(3500000), 0);
+	// 500000 → below all, closest to 1M → index 2
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(500000), 2);
+	// 5000000 → above all, closest to 4M → index 0
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(5000000), 0);
+}
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth skips iframe tracks.
+ */
+TEST_F(AbrTests, GetBestMatchedProfile_SkipsIframeTracks)
+{
+	ABRManager abrManager;
+	ABRManager::ProfileInfo p{};
+
+	// iframe track at 2M
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 2000000;
+	abrManager.addProfile(p); // index 0
+
+	// video tracks
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	abrManager.addProfile(p); // index 1
+	p.bandwidthBitsPerSecond = 4000000;
+	abrManager.addProfile(p); // index 2
+
+	// 2M should match video tracks only — closest is 1M (index 1)
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2000000), 1);
+}
+

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -721,3 +721,31 @@ TEST_F(AbrTests, GetBestMatchedProfile_SkipsIframeTracks)
 	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2000000), 1);
 }
 
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns INVALID_PROFILE
+ *        when no profiles have been added.
+ */
+TEST_F(AbrTests, GetBestMatchedProfile_EmptyList_ReturnsInvalid)
+{
+	ABRManager abrManager;
+	const int expected = ABRManager::INVALID_PROFILE;
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2000000), expected);
+}
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns INVALID_PROFILE
+ *        when only iframe tracks are present (they are excluded from the
+ *        sorted list).
+ */
+TEST_F(AbrTests, GetBestMatchedProfile_IframeOnly_ReturnsInvalid)
+{
+	ABRManager abrManager;
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 2000000;
+	abrManager.addProfile(p);
+
+	const int expected = ABRManager::INVALID_PROFILE;
+	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2000000), expected);
+}
+

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -343,3 +343,30 @@ TEST_F(HybridAbrTests, GetBestMatchedProfile_ClosestMatch_UnsortedProfiles)
 	// Above all → closest to 4M → index 0
 	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(5000000), 0);
 }
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns INVALID_PROFILE
+ *        when no profiles have been added (legacy ABR).
+ */
+TEST_F(HybridAbrTests, GetBestMatchedProfile_EmptyList_ReturnsInvalid)
+{
+	HybridABRManager mgr;
+	const int expected = ABRManager::INVALID_PROFILE;
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(2000000), expected);
+}
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns INVALID_PROFILE
+ *        when only iframe tracks are present (legacy ABR).
+ */
+TEST_F(HybridAbrTests, GetBestMatchedProfile_IframeOnly_ReturnsInvalid)
+{
+	HybridABRManager mgr;
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 2000000;
+	mgr.addProfile(p);
+
+	const int expected = ABRManager::INVALID_PROFILE;
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(2000000), expected);
+}

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -293,3 +293,53 @@ TEST_F(HybridAbrTests, FragmentfailureRampdown_ZeroMaxBuffer_ReturnsZero)
 	long result = mgr.FragmentfailureRampdown(5, 0);
 	EXPECT_EQ(result, 0);
 }
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns exact match
+ *        regardless of profile insertion order (legacy ABR).
+ */
+TEST_F(HybridAbrTests, GetBestMatchedProfile_ExactMatch_UnsortedProfiles)
+{
+	HybridABRManager mgr;
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	// Insert in descending order
+	p.bandwidthBitsPerSecond = 4000000;
+	mgr.addProfile(p); // index 0
+	p.bandwidthBitsPerSecond = 2000000;
+	mgr.addProfile(p); // index 1
+	p.bandwidthBitsPerSecond = 1000000;
+	mgr.addProfile(p); // index 2
+
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(2000000), 1);
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(4000000), 0);
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(1000000), 2);
+}
+
+/**
+ * @brief getBestMatchedProfileIndexByBandWidth returns closest profile
+ *        when no exact match, regardless of insertion order (legacy ABR).
+ */
+TEST_F(HybridAbrTests, GetBestMatchedProfile_ClosestMatch_UnsortedProfiles)
+{
+	HybridABRManager mgr;
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+
+	p.bandwidthBitsPerSecond = 4000000;
+	mgr.addProfile(p); // index 0
+	p.bandwidthBitsPerSecond = 2000000;
+	mgr.addProfile(p); // index 1
+	p.bandwidthBitsPerSecond = 1000000;
+	mgr.addProfile(p); // index 2
+
+	// 2.9M → closer to 2M → index 1
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(2900000), 1);
+	// 3.5M → closer to 4M → index 0
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(3500000), 0);
+	// Below all → closest to 1M → index 2
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(500000), 2);
+	// Above all → closest to 4M → index 0
+	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(5000000), 0);
+}


### PR DESCRIPTION
The old implementation iterated mProfiles linearly, assuming profiles were sorted by ascending bandwidth. Because mProfiles is populated in manifest order (not necessarily sorted), the closest-match logic could return an incorrect profile index.

This assumption is largely correct for a MediaKind transcoder, CLO/Pillar linear segmenter, super8 packager origin stack, however the DASH specification does not require profiles to be in sorted order so this is a fragile assumption, and there may be cases where Super8 reorders things in the manifest that could cause subtle bugs here.

Replace the linear scan with a lookup into mSortedBWProfileList (a std::map keyed by bandwidth, already maintained in sorted order). Use std::map::lower_bound to find the closest bandwidth match, checking both the lower_bound entry and its predecessor to pick the nearest by absolute difference.

Applied to both ABR implementations:
- abr/abr.cpp (new ABR)
- support/aampabr/ABRManager.cpp (legacy ABR)

Added #include <climits> for LONG_MAX in both files.

L1 Tests added:
- GetBestMatchedProfile_ExactMatch
- GetBestMatchedProfile_ClosestMatch_UnsortedProfiles
- GetBestMatchedProfile_SkipsIframeTracks (new ABR only)
- GetBestMatchedProfile_ExactMatch_UnsortedProfiles (legacy)
- GetBestMatchedProfile_ClosestMatch_UnsortedProfiles (legacy)