### PR TITLE
Fix updateProfile() 4K iframe selection bugs

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -310,19 +310,37 @@ void ABRManager::updateProfile()
 			}
 		} else {
 			if(is4K) {
-				// Get the default profile of 4k video, apply same bandwidth of video to iframe also
-				int desiredProfileIndexNonIframe = (int)profileCount / 2;
-				int desiredProfileNonIframeBW = (int)mProfiles[desiredProfileIndexNonIframe].bandwidthBitsPerSecond ;
-				mDesiredIframeProfile = mLowestIframeProfile = 0;
-				for (size_t cnt = 0; cnt < iframeTrackCount; cnt++) {
-					// if bandwidth matches, apply to both desired and lower ( for all speed of trick)
-					if(iframeTrackInfo[cnt].bandwidth == desiredProfileNonIframeBW) {
-						mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[cnt].idx;
+				// Get the middle video bandwidth (excluding iframe tracks) for 4K iframe selection.
+				// Use mSortedBWProfileList which only contains non-iframe profiles.
+				BitsPerSecond desiredProfileNonIframeBW = 0;
+				bool foundMiddleVideoBW = false;
+				for (const auto& periodEntry : mSortedBWProfileList)
+				{
+					const auto& bwMap = periodEntry.second;
+					if (!bwMap.empty())
+					{
+						auto it = bwMap.begin();
+						std::advance(it, static_cast<int>(bwMap.size() / 2));
+						desiredProfileNonIframeBW = it->first;
+						foundMiddleVideoBW = true;
 						break;
 					}
 				}
+				mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[0].idx;
+				bool foundMatchingIframe = false;
+				if (foundMiddleVideoBW)
+				{
+					for (size_t cnt = 0; cnt < iframeTrackCount; cnt++) {
+						// if bandwidth matches, apply to both desired and lower ( for all speed of trick)
+						if(iframeTrackInfo[cnt].bandwidth == desiredProfileNonIframeBW) {
+							mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[cnt].idx;
+							foundMatchingIframe = true;
+							break;
+						}
+					}
+				}
 				// if matching bandwidth not found with video, then pick the middle profile for iframe
-				if((!mDesiredIframeProfile) && (iframeTrackCount >= 1)) {
+				if(!foundMatchingIframe && (iframeTrackCount > 1)) {
 					int desiredTrackIdx = (int) (iframeTrackCount / 2) + (iframeTrackCount % 2);
 					mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[desiredTrackIdx].idx;
 				}

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -260,19 +260,37 @@ void ABRManager::updateProfile() {
       }
     } else {
       if(is4K) {
-        // Get the default profile of 4k video , apply same bandwidth of video to iframe also
-        int desiredProfileIndexNonIframe = profileCount / 2;
-        int desiredProfileNonIframeBW = (int)mProfiles[desiredProfileIndexNonIframe].bandwidthBitsPerSecond ;
-        mDesiredIframeProfile = mLowestIframeProfile = 0;
-        for (int cnt = 0; cnt <= iframeTrackIdx; cnt++) {
-          // if bandwidth matches , apply to both desired and lower ( for all speed of trick)
-          if(iframeTrackInfo[cnt].bandwidth == desiredProfileNonIframeBW) {
-            mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[cnt].idx;
-            break;
-          }
+        // Get the middle video bandwidth (excluding iframe tracks) for 4K iframe selection.
+        // Use mSortedBWProfileList which only contains non-iframe profiles.
+        long desiredProfileNonIframeBW = 0;
+        bool foundMiddleVideoBW = false;
+        for (const auto& periodEntry : mSortedBWProfileList)
+        {
+            const auto& bwMap = periodEntry.second;
+            if (!bwMap.empty())
+            {
+                auto it = bwMap.begin();
+                std::advance(it, static_cast<int>(bwMap.size() / 2));
+                desiredProfileNonIframeBW = it->first;
+                foundMiddleVideoBW = true;
+                break;
+            }
         }
-        // if matching bandwidth not found with video , then pick the middle profile for iframe
-        if((!mDesiredIframeProfile) && (iframeTrackIdx >= 1)) {
+        mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[0].idx;
+        bool foundMatchingIframe = false;
+        if (foundMiddleVideoBW)
+        {
+            for (int cnt = 0; cnt <= iframeTrackIdx; cnt++) {
+              // if bandwidth matches, apply to both desired and lower ( for all speed of trick)
+              if(iframeTrackInfo[cnt].bandwidth == desiredProfileNonIframeBW) {
+                mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[cnt].idx;
+                foundMatchingIframe = true;
+                break;
+              }
+            }
+        }
+        // if matching bandwidth not found with video, then pick the middle profile for iframe
+        if(!foundMatchingIframe && (iframeTrackIdx >= 1)) {
           int desiredTrackIdx = (int) (iframeTrackIdx / 2) + (iframeTrackIdx % 2);
           mDesiredIframeProfile = mLowestIframeProfile = iframeTrackInfo[desiredTrackIdx].idx;
         }

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -843,3 +843,41 @@ TEST_F(AbrTests, UpdateProfile_4K_IframeAtIndex0_NotTreatedAsNotFound)
 	EXPECT_EQ(abrManager.getLowestIframeProfile(), 0);
 }
 
+/**
+ * @brief Bug #14: updateProfile 4K fallback with a single iframe track must
+ *        not access out-of-bounds. The old formula count/2 + count%2 yields
+ *        index 1 when count == 1, which is past the end of a 1-element vector.
+ *        The fix guards the fallback with `> 1` instead of `>= 1`, keeping
+ *        mDesiredIframeProfile at the only available iframe track.
+ */
+TEST_F(AbrTests, UpdateProfile_4K_SingleIframeTrack_NoOutOfBounds)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Video profiles — bandwidth does not match the single iframe,
+	// exercising the fallback code path.
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 1920; p.height = 1080;
+	abrManager.addProfile(p); // index 0
+
+	p.bandwidthBitsPerSecond = 3000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 1
+
+	// Single 4K iframe track with a bandwidth that matches no video profile.
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 5000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 2
+
+	// Must not crash and must retain the only available iframe track.
+	abrManager.updateProfile();
+
+	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 2);
+	EXPECT_EQ(abrManager.getLowestIframeProfile(), 2);
+}
+

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -649,7 +649,7 @@ TEST_F(AbrTests, FragmentfailureRampdown_ZeroMaxBuffer_ReturnsZero)
  * @brief getBestMatchedProfileIndexByBandWidth returns exact match
  *        regardless of profile insertion order.
  */
-TEST_F(AbrTests, GetBestMatchedProfile_ExactMatch)
+TEST_F(AbrTests, GetBestMatchedProfile_ExactMatch_UnsortedProfiles)
 {
 	ABRManager abrManager;
 	ABRManager::ProfileInfo p{};
@@ -747,5 +747,99 @@ TEST_F(AbrTests, GetBestMatchedProfile_IframeOnly_ReturnsInvalid)
 
 	const int expected = ABRManager::INVALID_PROFILE;
 	EXPECT_EQ(abrManager.getBestMatchedProfileIndexByBandWidth(2000000), expected);
+}
+
+TEST_F(AbrTests, UpdateProfile_4K_MiddleIndex_ExcludesIframeTracks)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Video profiles
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1920; p.height = 1080;
+	abrManager.addProfile(p); // index 0
+
+	// Iframe interleaved in the middle
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 3000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 1
+
+	// More video
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 5000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 2
+
+	// Iframe tracks for 4K detection + selection
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 1920; p.height = 1080;
+	abrManager.addProfile(p); // index 3
+
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 5000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 4
+
+	abrManager.updateProfile();
+
+	// Video profiles in mSortedBWProfileList: {2M, 5M}. Middle = 5M.
+	// Iframe at 5M (index 4) should match.
+	// Old bug: profileCount/2 = 5/2 = 2 → mProfiles[2] = 5M video (lucky),
+	// but if order were different, it could land on an iframe.
+	// The fix uses mSortedBWProfileList which excludes iframes.
+	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 4);
+}
+
+/**
+ * @brief Bug #12: updateProfile 4K path must not treat iframe profile
+ *        index 0 as "not found". The old check `!mDesiredIframeProfile`
+ *        confuses index 0 with false.
+ */
+TEST_F(AbrTests, UpdateProfile_4K_IframeAtIndex0_NotTreatedAsNotFound)
+{
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Iframe at index 0 with bandwidth matching middle video
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 4000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 0
+
+	// Video profiles
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1920; p.height = 1080;
+	abrManager.addProfile(p); // index 1
+
+	p.bandwidthBitsPerSecond = 4000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 2
+
+	p.bandwidthBitsPerSecond = 8000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 3
+
+	// Another iframe for 4K detection
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 8000000;
+	p.width = 3840; p.height = 2160;
+	abrManager.addProfile(p); // index 4
+
+	abrManager.updateProfile();
+
+	// Video BWs in sorted map: {2M, 4M, 8M}. Middle = 4M.
+	// Iframe at index 0 has BW 4M → exact match.
+	// Old bug: mDesiredIframeProfile set to 0, then !0 == true → fallback
+	// overwrites with middle iframe. Fix uses bool flag instead.
+	EXPECT_EQ(abrManager.getDesiredIframeProfile(), 0);
+	EXPECT_EQ(abrManager.getLowestIframeProfile(), 0);
 }
 

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -451,3 +451,41 @@ TEST_F(HybridAbrTests, UpdateProfile_4K_IframeAtIndex0_NotTreatedAsNotFound)
 	EXPECT_EQ(mgr.getDesiredIframeProfile(), 0);
 	EXPECT_EQ(mgr.getLowestIframeProfile(), 0);
 }
+
+/**
+ * @brief Bug #14: updateProfile 4K fallback with a single iframe track
+ *        (legacy ABR) must not access out-of-bounds. The guard
+ *        `iframeTrackIdx >= 1` is false when iframeTrackIdx == 0 (only one
+ *        iframe exists), so the fallback is skipped and mDesiredIframeProfile
+ *        stays at the only available iframe track.
+ */
+TEST_F(HybridAbrTests, UpdateProfile_4K_SingleIframeTrack_NoOutOfBounds)
+{
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Video profiles — bandwidth does not match the single iframe,
+	// exercising the fallback code path.
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 1920; p.height = 1080;
+	mgr.addProfile(p); // index 0
+
+	p.bandwidthBitsPerSecond = 3000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 1
+
+	// Single 4K iframe track with a bandwidth that matches no video profile.
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 5000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 2
+
+	// Must not crash and must retain the only available iframe track.
+	mgr.updateProfile();
+
+	EXPECT_EQ(mgr.getDesiredIframeProfile(), 2);
+	EXPECT_EQ(mgr.getLowestIframeProfile(), 2);
+}

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -370,3 +370,84 @@ TEST_F(HybridAbrTests, GetBestMatchedProfile_IframeOnly_ReturnsInvalid)
 	const int expected = ABRManager::INVALID_PROFILE;
 	EXPECT_EQ(mgr.getBestMatchedProfileIndexByBandWidth(2000000), expected);
 }
+TEST_F(HybridAbrTests, UpdateProfile_4K_MiddleIndex_ExcludesIframeTracks)
+{
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	// Video profiles
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1920; p.height = 1080;
+	mgr.addProfile(p); // index 0
+
+	// Iframe interleaved
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 3000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 1
+
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 5000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 2
+
+	// Iframe tracks for 4K + selection
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 1920; p.height = 1080;
+	mgr.addProfile(p); // index 3
+
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 5000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 4
+
+	mgr.updateProfile();
+
+	// Video BWs: {2M, 5M}. Middle = 5M. Iframe at 5M = index 4.
+	EXPECT_EQ(mgr.getDesiredIframeProfile(), 4);
+}
+
+/**
+ * @brief Bug #12: updateProfile 4K must not treat iframe index 0 as
+ *        "not found" (legacy ABR).
+ */
+TEST_F(HybridAbrTests, UpdateProfile_4K_IframeAtIndex0_NotTreatedAsNotFound)
+{
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 4000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 0
+
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1920; p.height = 1080;
+	mgr.addProfile(p); // index 1
+
+	p.bandwidthBitsPerSecond = 4000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 2
+
+	p.bandwidthBitsPerSecond = 8000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 3
+
+	p.isIframeTrack = true;
+	p.bandwidthBitsPerSecond = 8000000;
+	p.width = 3840; p.height = 2160;
+	mgr.addProfile(p); // index 4
+
+	mgr.updateProfile();
+
+	// Middle video BW = 4M. Iframe at index 0 has 4M → match.
+	EXPECT_EQ(mgr.getDesiredIframeProfile(), 0);
+	EXPECT_EQ(mgr.getLowestIframeProfile(), 0);
+}


### PR DESCRIPTION
Issue: The 4K iframe selection path used `!mDesiredIframeProfile` to check whether a matching iframe was found. Since profile index 0 is a valid index, `!0` evaluates to true, causing the fallback to overwrite a correct match at index 0. Replace with an explicit `bool foundMatchingIframe` flag.

Issue: The middle video bandwidth was computed as
`mProfiles[profileCount / 2]`, which includes iframe tracks in the count and can land on an iframe profile. Use mSortedBWProfileList (which excludes iframes) to find the middle video bandwidth instead.

Issue: fix an out-of-bounds access in the fallback path: when iframeTrackCount == 1, the formula `count/2 + count%2` yields index 1, which is past the end of a 1-element vector. Initialize mDesiredIframeProfile to iframeTrackInfo[0].idx (lowest-BW iframe) and guard the fallback with `> 1` instead of `>= 1`.

Applied to both new ABR (abr/abr.cpp) and legacy ABR (support/aampabr/ABRManager.cpp). L1 tests added to AbrTests.cpp and HybridAbrTests.cpp covering all three bugs.
- GetBestMatchedProfile_ExactMatch_UnsortedProfiles (legacy)
- GetBestMatchedProfile_ClosestMatch_UnsortedProfiles (legacy)