### PR TITLE
Fix FragmentfailureRampdown thread safety and divide-by-zero

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1117,10 +1117,20 @@ void ABRManager::CheckLLDashABRSpeedStoreSize(struct SpeedCache *speedcache,Bits
  */
 BitsPerSecond ABRManager::FragmentfailureRampdown(int currentBuffer, int currentProfileIndex)
 {
+	if (eAAMPAbrConfig.abrMaxBuffer <= 0)
+	{
+		AAMPLOG_ERR("abrMaxBuffer is %d, cannot compute buffer percentage",
+			eAAMPAbrConfig.abrMaxBuffer);
+		return 0;
+	}
 	double bufferPercentage = ((double)currentBuffer / eAAMPAbrConfig.abrMaxBuffer) * 100;
 	BitsPerSecond desiredProfilebw = 0;
 	BitsPerSecond currentbw = getBandwidthOfProfile(currentProfileIndex);
-	std::vector<ProfileInfo> availableProfiles = mProfiles;
+	std::vector<ProfileInfo> availableProfiles;
+	{
+		std::lock_guard<std::mutex> lock(mProfileLock);
+		availableProfiles = mProfiles;
+	}
 	availableProfiles.erase(
 		std::remove_if(availableProfiles.begin(), availableProfiles.end(),
 			[](const ProfileInfo &p) { return p.isIframeTrack; }),

--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1113,13 +1113,14 @@ void ABRManager::CheckLLDashABRSpeedStoreSize(struct SpeedCache *speedcache,Bits
 /**
  * @brief - Fn to rampdown during fragment download failure based on buffer
  * @param - current available buffer
- * @return - desired profile based on buffer
+ * @return - desired profile based on buffer, or 0 if abrMaxBuffer <= 0
+ *           (misconfiguration sentinel — caller must treat 0 as a rampdown failure)
  */
 BitsPerSecond ABRManager::FragmentfailureRampdown(int currentBuffer, int currentProfileIndex)
 {
 	if (eAAMPAbrConfig.abrMaxBuffer <= 0)
 	{
-		AAMPLOG_ERR("abrMaxBuffer is %d, cannot compute buffer percentage",
+		AAMPLOG_WARN("abrMaxBuffer is %d, cannot compute buffer percentage",
 			eAAMPAbrConfig.abrMaxBuffer);
 		return 0;
 	}

--- a/support/aampabr/ABRManager.cpp
+++ b/support/aampabr/ABRManager.cpp
@@ -688,6 +688,14 @@ int ABRManager::removeProfiles(std::vector<long> profileBPS, int currentProfileI
 }
 
 /**
+ *  @brief Get a thread-safe copy of the profile list
+ */
+std::vector<ABRManager::ProfileInfo> ABRManager::getProfileInfoLocked() {
+  std::lock_guard<std::mutex> lock(mProfileLock);
+  return mProfiles;
+}
+
+/**
  *  @brief Clear profiles
  */
 void ABRManager::clearProfiles() {

--- a/support/aampabr/ABRManager.h
+++ b/support/aampabr/ABRManager.h
@@ -294,6 +294,12 @@ protected:
 	 */
 	static void logprintf( const char *fmt, ... ) __attribute__ ((format (printf, 1, 2)));
 
+	/**
+	 * @brief Get a thread-safe copy of the profile list
+	 * @return Copy of mProfiles taken under mProfileLock
+	 */
+	std::vector<ProfileInfo> getProfileInfoLocked();
+
 private:
   /**
    * @fn getProfileCountUnlocked

--- a/support/aampabr/ABRManager.h
+++ b/support/aampabr/ABRManager.h
@@ -283,11 +283,6 @@ public:
     */
    static long getPersistBandwidth() { return mPersistBandwidth;}
    
-   /**
-    * @brief Get the available profiles
-    */
-   std::vector<ProfileInfo> getProfileInfo() { return mProfiles;}
-
 protected:
 	/**
 	 * @brief Logger

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -406,10 +406,16 @@ void HybridABRManager::CheckLLDashABRSpeedStoreSize(struct SpeedCache *speedcach
  */
 long HybridABRManager::FragmentfailureRampdown(int currentBuffer, int currentProfileIndex)
 {
+	if (eAAMPAbrConfig.abrMaxBuffer <= 0)
+	{
+		logprintf("%s:%d abrMaxBuffer is %d, cannot compute buffer percentage",
+			__FUNCTION__, __LINE__, eAAMPAbrConfig.abrMaxBuffer);
+		return 0;
+	}
 	double bufferPercentage = ((double)currentBuffer / eAAMPAbrConfig.abrMaxBuffer) * 100;
 	long desiredProfilebw = 0;
 	long currentbw = getBandwidthOfProfile(currentProfileIndex);
-	std::vector<ProfileInfo> availableProfiles = getProfileInfo();
+	std::vector<ProfileInfo> availableProfiles = getProfileInfoLocked();
 	availableProfiles.erase(
 		std::remove_if(availableProfiles.begin(), availableProfiles.end(),
 			[](const ProfileInfo &p) { return p.isIframeTrack; }),

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -436,7 +436,7 @@ TEST_F(AbrTests, UpdateProfile_DefaultIframeBitrate_SelectsBelowDefault)
 }
 
 /**
- * @brief Bug #11: FragmentfailureRampdown must skip iframe tracks when
+ * @brief FragmentfailureRampdown must skip iframe tracks when
  *        selecting a rampdown target, matching every other ABR function.
  */
 TEST_F(AbrTests, FragmentfailureRampdown_SkipsIframeTrack)
@@ -622,5 +622,26 @@ TEST_F(AbrTests, PersistBandwidthData_ConcurrentAccessConsistentPair)
 	reader.join();
 
 	EXPECT_FALSE(failure.load());
+}
+
+/**
+ * @brief FragmentfailureRampdown must return 0 when abrMaxBuffer
+ *        is zero to avoid floating-point divide-by-zero.
+ */
+TEST_F(AbrTests, FragmentfailureRampdown_ZeroMaxBuffer_ReturnsZero)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 0;
+
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	abrManager.addProfile(p);
+
+	BitsPerSecond result = abrManager.FragmentfailureRampdown(5, 0);
+	EXPECT_EQ(result, 0);
 }
 

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -118,7 +118,7 @@ TEST_F(HybridAbrTests, UpdateABRBitrateDataBasedOnCacheOutlierOdd)
 }
 
 /**
- * @brief Bug #6: CheckAbrThresholdSize must multiply before dividing to
+ * @brief CheckAbrThresholdSize must multiply before dividing to
  *        avoid integer truncation when bufferlen < downloadTimeMs.
  */
 TEST_F(HybridAbrTests, CheckAbrThresholdSize_SmallFragment_NoTruncation)
@@ -143,7 +143,7 @@ TEST_F(HybridAbrTests, CheckAbrThresholdSize_LargeFragment_Correct)
 }
 
 /**
- * @brief Bug #17: CheckLLDashABRSpeedStoreSize must multiply before dividing
+ * @brief CheckLLDashABRSpeedStoreSize must multiply before dividing
  *        to avoid integer truncation when total_dl_diff < time_diff.
  */
 TEST_F(HybridAbrTests, CheckLLDashABRSpeedStoreSize_SmallChunk_NoTruncation)
@@ -166,7 +166,7 @@ TEST_F(HybridAbrTests, CheckLLDashABRSpeedStoreSize_LargeChunk_Correct)
 }
 
 /**
- * @brief Bug #11: FragmentfailureRampdown must skip iframe tracks when
+ * @brief FragmentfailureRampdown must skip iframe tracks when
  *        selecting a rampdown target, matching every other ABR function.
  */
 TEST_F(HybridAbrTests, FragmentfailureRampdown_SkipsIframeTrack)
@@ -271,4 +271,25 @@ TEST_F(HybridAbrTests, FragmentfailureRampdown_FallbackLowestIsNotIframe)
 	// Without the fix, fallback would return 200k (the iframe track).
 	long result = mgr.FragmentfailureRampdown(1, 2);
 	EXPECT_EQ(result, 500000);
+}
+
+/**
+ * @brief FragmentfailureRampdown must return 0 when abrMaxBuffer
+ *        is zero to avoid floating-point divide-by-zero (legacy ABR).
+ */
+TEST_F(HybridAbrTests, FragmentfailureRampdown_ZeroMaxBuffer_ReturnsZero)
+{
+	eAAMPAbrConfig.abrMaxBuffer = 0;
+
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	mgr.addProfile(p);
+
+	long result = mgr.FragmentfailureRampdown(5, 0);
+	EXPECT_EQ(result, 0);
 }


### PR DESCRIPTION
Add mProfileLock guard when copying mProfiles in
FragmentfailureRampdown. The vector was previously copied without holding the lock, which is undefined behavior if another thread calls clearProfiles()/addProfile() concurrently during a period transition.

Add early return when abrMaxBuffer <= 0 to prevent floating-point divide-by-zero when computing buffer percentage. The AampAbrConfig constructor initializes abrMaxBuffer to 0, so if ReadPlayerConfig has not been called, the division produces Inf.

For the legacy ABR, add a protected getProfileInfoLocked() helper to ABRManager so HybridABRManager can obtain a thread-safe copy of mProfiles without accessing private members directly.

These races are extremely unlikely to manifest, but are addressed here for reasons of code correctness and future proofing.

Applied to both new ABR (abr/abr.cpp) and legacy ABR (support/aampabr/HybridABRManager.cpp, ABRManager.h/cpp). L1 tests added for the abrMaxBuffer guard.