### PR TITLE
VPAAMP-211 Fix AAMPSTatusType typo in InvokeTsbReaders doc comments

### DIFF
--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -775,7 +775,7 @@ std::shared_ptr<AampTsbReader> AampTSBSessionManager::GetTsbReader(AampMediaType
  * @param[in] rate
  * @param[in] tuneType
  *
- * @return AAMPSTatusType - OK if success
+ * @return AAMPStatusType - OK if success
  */
 AAMPStatusType AampTSBSessionManager::InvokeTsbReaders(double &startPosSec, float rate, TuneType tuneType)
 {

--- a/AampTSBSessionManager.h
+++ b/AampTSBSessionManager.h
@@ -160,7 +160,7 @@ public:
 	 * @param[in] rate
 	 * @param[in] tuneType
 	 *
-	 * @return AAMPSTatusType - OK if success
+	 * @return AAMPStatusType - OK if success
 	 */
 	virtual AAMPStatusType InvokeTsbReaders(double &startPosSec, float rate, TuneType tuneType);
 	/**


### PR DESCRIPTION
Reason for Change: AAMPSTatusType -> AAMPStatusType in @return doc comments in AampTSBSessionManager.h and AampTSBSessionManager.cpp.