### PR TITLE
VPAAMP-157: Bring dev_sprint_25_2 to parity with support/2.11.1_8.4_vipa

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1071,6 +1071,42 @@ void PlayerInstanceAAMP::PauseAtInternal(double position)
 	}
 }
 
+/**
+ * @brief Applies trickplay-rate handling for a seek operation.
+ *
+ * When the player is currently in trickplay (rate != AAMP_NORMAL_PLAY_RATE):
+ *  - SeekToLive / SeekToEnd: resets rate to normal and flags a speed-change
+ *    notification so the app knows playback has returned to 1x.
+ *  - Positional seek: preserves the trickplay rate.  The caller is responsible
+ *    for calling SetRate(AAMP_NORMAL_PLAY_RATE) if normal speed is desired after
+ *    the seek.
+ *
+ * @param[in]  aamp              The private AAMP instance.
+ * @param[in]  tuneType          Resolved tune type for this seek.
+ * @param[out] sentSpeedChangedEv Set to true if a speed-change notification
+ *                                should be fired after the seek completes.
+ */
+static void ApplyTrickplayRateOnSeek(PrivateInstanceAAMP* aamp, TuneType tuneType, bool& sentSpeedChangedEv)
+{
+	if (aamp->rate != AAMP_NORMAL_PLAY_RATE)
+	{
+		if (tuneType == eTUNETYPE_SEEKTOLIVE || tuneType == eTUNETYPE_SEEKTOEND)
+		{
+			// Seeking to live/end during trickplay: reset to normal rate and notify
+			aamp->rate = AAMP_NORMAL_PLAY_RATE;
+			sentSpeedChangedEv = true;
+		}
+		else
+		{
+			// Seeking to a specific position during trickplay: preserve the current
+			// trickplay rate and avoid sending a spurious speed=1 event here.
+			// Callers that want to resume normal playback after the seek must
+			// explicitly call SetRate(AAMP_NORMAL_PLAY_RATE).
+			AAMPLOG_INFO("Seek during trickplay at rate(%f) - maintaining rate, skipping speed-change notification", aamp->rate);
+		}
+	}
+}
+
 static gboolean SeekAfterPrepared(gpointer ptr)
 {
 	PrivateInstanceAAMP* aamp = (PrivateInstanceAAMP*) ptr;
@@ -1127,11 +1163,7 @@ static gboolean SeekAfterPrepared(gpointer ptr)
 	{
 		AAMPLOG_WARN("tune type is SEEK");
 	}
-	if (aamp->rate != AAMP_NORMAL_PLAY_RATE)
-	{
-		aamp->rate = AAMP_NORMAL_PLAY_RATE;
-		sentSpeedChangedEv = true;
-	}
+	ApplyTrickplayRateOnSeek(aamp, tuneType, sentSpeedChangedEv);
 	if (aamp->mpStreamAbstractionAAMP)
 	{ // for seek while streaming
 
@@ -1351,22 +1383,7 @@ void PlayerInstanceAAMP::SeekInternal(double secondsRelativeToTuneTime, bool kee
 				aamp->seek_pos_seconds = -1;
 			}
 
-			if (aamp->rate != AAMP_NORMAL_PLAY_RATE)
-			{
-				if (tuneType == eTUNETYPE_SEEKTOLIVE || tuneType == eTUNETYPE_SEEKTOEND)
-				{
-					// Seeking to live/end during trickplay: reset to normal rate and notify
-					aamp->rate = AAMP_NORMAL_PLAY_RATE;
-					sentSpeedChangedEv = true;
-				}
-				else
-				{
-					/*
-					* Seeking to a specific position during trickplay: preserve the trickplay
-					* rate to avoid sending a spurious speed=1 event. */
-					AAMPLOG_INFO("Seek during trickplay at rate(%f) - maintaining rate, skipping speed-change notification", aamp->rate);
-				}
-			}
+			ApplyTrickplayRateOnSeek(aamp, tuneType, sentSpeedChangedEv);
 
 			/**Set the flag true to indicate seeked **/
 			aamp->mbSeeked = true;

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -134,6 +134,116 @@ TEST_F(PlayerInstanceAAMPTests,SeekInternalTest1)
 
 	mplayer->Seek_Internal(secondsRelativeToTuneTime,keepPaused);
 }
+
+/**
+ * @brief Test SeekInternal preserves trickplay rate for a positional seek.
+ *
+ * When aamp->rate != AAMP_NORMAL_PLAY_RATE and tuneType is eTUNETYPE_SEEK,
+ * SeekInternal must NOT reset the rate or fire a speed-change notification.
+ * The rate is preserved so the player resumes trickplay at the same speed
+ * after the seek completes.
+ */
+TEST_F(PlayerInstanceAAMPTests, SeekInternal_TrickplayPositionSeek_PreservesRateNoSpeedEvent)
+{
+	const float trickplayRate = 2.0f;
+	const double seekPosition = 30.0;
+
+	// Use active-playback state so SeekInternal takes the immediate seek path.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
+		.WillRepeatedly(Return(eSTATE_PLAYING));
+
+	mplayer->aamp->rate = trickplayRate;
+	mplayer->aamp->SetIsLive(false); // VOD: avoids live-point checks
+	mplayer->aamp->mSinkPaused = false;
+	mplayer->aamp->mbPlayEnabled = true;
+	mplayer->aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	g_mockStreamAbstractionAAMP->mIsAtLivePoint = false;
+
+	// Key assertion: no speed-change notification for a positional seek during trickplay.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, NotifySpeedChanged(_, _)).Times(0);
+
+	// Expected side-effects.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING, true)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEK, false)).Times(1);
+
+	mplayer->Seek_Internal(seekPosition, false);
+
+	// Rate must be unchanged after a positional seek during trickplay.
+	EXPECT_FLOAT_EQ(mplayer->aamp->rate, trickplayRate);
+}
+
+/**
+ * @brief Test SeekInternal resets rate to normal and notifies on seek-to-live during trickplay.
+ *
+ * When aamp->rate != AAMP_NORMAL_PLAY_RATE and tuneType resolves to eTUNETYPE_SEEKTOLIVE
+ * (live stream, seek position == AAMP_SEEK_TO_LIVE_POSITION), SeekInternal must reset
+ * the rate to AAMP_NORMAL_PLAY_RATE and fire NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false).
+ */
+TEST_F(PlayerInstanceAAMPTests, SeekInternal_TrickplaySeekToLive_ResetsRateAndNotifies)
+{
+	const float trickplayRate = 2.0f;
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
+		.WillRepeatedly(Return(eSTATE_PLAYING));
+
+	mplayer->aamp->rate = trickplayRate;
+	mplayer->aamp->SetIsLive(true); // Live stream -> eTUNETYPE_SEEKTOLIVE
+	mplayer->aamp->mSinkPaused = false;
+	mplayer->aamp->mbPlayEnabled = true;
+	mplayer->aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	g_mockStreamAbstractionAAMP->mIsAtLivePoint = false; // Not already at live edge
+
+	// Key assertions: rate is reset and a speed-change notification is emitted.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false)).Times(1);
+
+	// Expected side-effects.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING, true)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEKTOLIVE, false)).Times(1);
+
+	mplayer->Seek_Internal(AAMP_SEEK_TO_LIVE_POSITION, false);
+
+	// Rate must be reset to normal after seek-to-live during trickplay.
+	EXPECT_FLOAT_EQ(mplayer->aamp->rate, AAMP_NORMAL_PLAY_RATE);
+}
+
+/**
+ * @brief Test SeekInternal resets rate to normal and notifies on seek-to-end during trickplay.
+ *
+ * When aamp->rate != AAMP_NORMAL_PLAY_RATE and tuneType resolves to eTUNETYPE_SEEKTOEND
+ * (VOD DASH content, seek position == AAMP_SEEK_TO_LIVE_POSITION == -1), SeekInternal must
+ * reset the rate to AAMP_NORMAL_PLAY_RATE and fire NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false).
+ */
+TEST_F(PlayerInstanceAAMPTests, SeekInternal_TrickplaySeekToEnd_ResetsRateAndNotifies)
+{
+	const float trickplayRate = 2.0f;
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetState())
+		.WillRepeatedly(Return(eSTATE_PLAYING));
+
+	mplayer->aamp->rate = trickplayRate;
+	mplayer->aamp->SetIsLive(false); // VOD
+	mplayer->aamp->mMediaFormat = eMEDIAFORMAT_DASH; // DASH VOD: seek(-1) -> SEEKTOEND
+	mplayer->aamp->mSinkPaused = false;
+	mplayer->aamp->mbPlayEnabled = true;
+	mplayer->aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP;
+	g_mockStreamAbstractionAAMP->mIsAtLivePoint = false;
+
+	// Key assertions: rate is reset and a speed-change notification is emitted.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		NotifySpeedChanged(AAMP_NORMAL_PLAY_RATE, false)).Times(1);
+
+	// Expected side-effects.
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetState(eSTATE_SEEKING, true)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, TuneHelper(eTUNETYPE_SEEKTOEND, false)).Times(1);
+
+	// seek(-1) on VOD DASH is interpreted as seek-to-end.
+	mplayer->Seek_Internal(AAMP_SEEK_TO_LIVE_POSITION, false);
+
+	// Rate must be reset to normal after seek-to-end during trickplay.
+	EXPECT_FLOAT_EQ(mplayer->aamp->rate, AAMP_NORMAL_PLAY_RATE);
+}
+
 TEST_F(PlayerInstanceAAMPTests, SetRateInternalTest)
 {
 	float rate = 2.2f;


### PR DESCRIPTION
Reason for Change: Apply the same trickplay-seek rate fix to SeekAfterPrepared() that was already applied to SeekInternal() in PR #1351. When the deferred seek path is taken (eSTATE_INITIALIZED / eSTATE_PREPARING), positional seeks now preserve the trickplay rate and skip the spurious speed=1 notification, consistent with the SeekInternal() behaviour.

- Add three unit tests covering the trickplay seek scenarios:
    * SeekInternal_TrickplayPositionSeek_PreservesRateNoSpeedEvent
    * SeekInternal_TrickplaySeekToLive_ResetsRateAndNotifies
    * SeekInternal_TrickplaySeekToEnd_ResetsRateAndNotifies