### PR TITLE
VPAAMP-53 Fix godspell: replace 'wakeups' with 'wake-ups' in comments

### DIFF
--- a/AampLatencyMonitor.cpp
+++ b/AampLatencyMonitor.cpp
@@ -558,7 +558,7 @@ void AampLatencyMonitor::UpdateDangerBufferState(double bufferMs)
  * - Below danger: wakes Run() early (once per episode) so the shift happens
  *   immediately rather than waiting for the next scheduled poll interval.
  *   Subsequent low-buffer fragments in the same episode are no-ops (episode
- *   guard mBelowDangerShifted suppresses redundant wakeups without a lock).
+	 *   guard mBelowDangerShifted suppresses redundant wake-ups without a lock).
  *
  * - Above danger: clears the episode guard so the next distinct dip will
  *   trigger a fresh wakeup and shift. Run() handles the restoration timer

--- a/AampLatencyMonitor.h
+++ b/AampLatencyMonitor.h
@@ -217,7 +217,7 @@ public:
 	 * early so it can apply the threshold shift on its next iteration rather
 	 * than waiting for the next scheduled poll interval.  Subsequent
 	 * notifications within the same episode are no-ops (the episode guard
-	 * suppresses redundant wakeups).
+	 * suppresses redundant wake-ups).
 	 *
 	 * When @p bufferMs is **at or above** dangerBufferMs and a danger episode
 	 * is active (mBelowDangerShifted is set), Run() is woken once so it can
@@ -364,7 +364,7 @@ private:
 	/// so the next distinct dip triggers a fresh shift.
 	///
 	/// OnBufferLevelUpdate() also reads this atomically (without holding mThresholdMutex)
-	/// to suppress redundant wakeups: once Run() has already shifted for the current
+	/// to suppress redundant wake-ups: once Run() has already shifted for the current
 	/// episode, further low-buffer fragment notifications do not re-signal the thread.
 	///
 	/// Atomic so that OnBufferLevelUpdate() can load it cheaply from the downloader


### PR DESCRIPTION
Reason for Change: spelling: "wakeups" -> "wake-ups"