### PR TITLE
RDKEMW-17666: Playback stopped abruptly and going back to Asset info …

### DIFF
--- a/middleware/vendor/mtk/MtkSocInterface.cpp
+++ b/middleware/vendor/mtk/MtkSocInterface.cpp
@@ -103,7 +103,7 @@ bool MtkSocInterface::IsAudioOrVideoDecoder(const char* name)
     {
         AudioOrVideoDecoder = true;
     }
-
+	MW_LOG_WARN("InterfacePlayerRDK: AudioOrVideoDecoder check for element %s returns %d", name, AudioOrVideoDecoder);
     return AudioOrVideoDecoder;
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6650,7 +6650,10 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnablePTSReStamp, SocUtils::EnablePTSRestamp());
 		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_DisableWebVTT, true);
 		AAMPLOG_INFO("app name:%s disableWebVTT(%d)", mAppName.c_str(), GETCONFIGVALUE_PRIV(eAAMPConfig_DisableWebVTT));
+		
 	}
+	SETCONFIGVALUE_PRIV(AAMP_TUNE_SETTING, eAAMPConfig_UseWesterosSink, false);
+	AAMPLOG_INFO("app name:%s useWesterosSink(%d)", mAppName.c_str(), GETCONFIGVALUE_PRIV(eAAMPConfig_UseWesterosSink));
 
 	/* Reset counter in new tune */
 	mManifestRefreshCount = 0;


### PR DESCRIPTION
…page

Reason for change: disable westrosink for MTK platform
Risks: Low
Test Procedure: updated in the ticket
Priority: P0