### PR TITLE
Fix CheckRampupFromSteadyState blocking rampup on negative threshold

### DIFF
--- a/abr/abr.cpp
+++ b/abr/abr.cpp
@@ -1050,7 +1050,7 @@ void ABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newProfile
 	AAMPLOG_INFO("currProfileIndex %d newProfileIndex %d nwBandwidth %" BITSPERSECOND_FORMAT " bufferValue %lf newBandwidth %" BITSPERSECOND_FORMAT " threshold %d", currProfileIndex, newProfileIndex, nwBandwidth, bufferValue, newBandwidth, abrThreshold);
 	int nProfileIdx = getRampedUpProfileIndex(currProfileIndex,periodId);
 	// switch to new profile only on bitrate difference is less than 30 percentage
-	if(abrThreshold >= 0 && abrThreshold <= 30)
+	if(abrThreshold <= 30)
 		newProfileIndex = nProfileIdx;
 	if(newProfileIndex  != currProfileIndex)
 	{

--- a/support/aampabr/HybridABRManager.cpp
+++ b/support/aampabr/HybridABRManager.cpp
@@ -283,7 +283,7 @@ void HybridABRManager::CheckRampupFromSteadyState(int currProfileIndex,int &newP
 	AAMPABRLOG_INFO("[%s][%d]  currProfileIndex %d, newProfileIndex %d ,nwBandwidth %ld ,bufferValue %lf ,newBandwidth %ld threshold %d(30)",__FUNCTION__,__LINE__,currProfileIndex,newProfileIndex,nwBandwidth,bufferValue,newBandwidth, abrThreshold);
 	int nProfileIdx = getRampedUpProfileIndex(currProfileIndex,periodId);
 	// switch to new profile only on bitrate difference is less than 30 percentage
-	if(abrThreshold >= 0 && abrThreshold <= 30)
+	if(abrThreshold <= 30)
 		newProfileIndex = nProfileIdx;
 	if(newProfileIndex  != currProfileIndex)
 	{

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -358,6 +358,36 @@ TEST_F(AbrTests, CheckRampupFromSteadyState_ValidBandwidth_RampsUp)
 }
 
 /**
+ * @brief CheckRampupFromSteadyState allows rampup when newBandwidth is below
+ *        nwBandwidth (negative threshold) but within 30%.
+ */
+TEST_F(AbrTests, CheckRampupFromSteadyState_NegativeThreshold_RampsUp)
+{
+	eAAMPAbrConfig.abrBufferCounter = 2;
+
+	ABRManager abrManager;
+	abrManager.ReadPlayerConfig(&eAAMPAbrConfig);
+	AddTestProfiles(abrManager);
+
+	int currProfileIndex = 0;
+	int newProfileIndex = currProfileIndex;
+	BitsPerSecond nwBandwidth = 2000000;
+	double bufferValue = 20.0;
+	// newBandwidth 1800000 is ~-10% below nwBandwidth, within the <=30 threshold
+	BitsPerSecond newBandwidth = 1800000;
+	ABRManager::BitrateChangeReason reason = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBufferCountCheck = 1;
+
+	abrManager.CheckRampupFromSteadyState(
+		currProfileIndex, newProfileIndex, nwBandwidth, bufferValue,
+		newBandwidth, reason, maxBufferCountCheck);
+
+	// Should ramp up to the next profile (index 1)
+	EXPECT_EQ(newProfileIndex, 1);
+	EXPECT_EQ(reason, ABRManager::eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL);
+}
+
+/**
  * @brief updateProfile correctly selects the desired iframe profile
  *        from a set of mixed video + iframe profiles.
  */

--- a/test/utests/tests/AampAbrTests/AbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/AbrTests.cpp
@@ -371,10 +371,12 @@ TEST_F(AbrTests, CheckRampupFromSteadyState_NegativeThreshold_RampsUp)
 
 	int currProfileIndex = 0;
 	int newProfileIndex = currProfileIndex;
-	BitsPerSecond nwBandwidth = 2000000;
+	BitsPerSecond nwBandwidth = 2200000;
 	double bufferValue = 20.0;
-	// newBandwidth 1800000 is ~-10% below nwBandwidth, within the <=30 threshold
-	BitsPerSecond newBandwidth = 1800000;
+	// newBandwidth matches target profile index 1 (2 Mbps); nwBandwidth is
+	// higher so threshold = (2M - 2.2M) / 2.2M ≈ -9%, which is negative
+	// but within the <=30% allowed range → rampup should proceed.
+	BitsPerSecond newBandwidth = 2000000;
 	ABRManager::BitrateChangeReason reason = ABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
 	int maxBufferCountCheck = 1;
 

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -107,6 +107,48 @@ TEST_F(HybridAbrTests, CheckRampupFromSteadyState_LoopIsPerInstance)
 	EXPECT_EQ(maxBuf1, 16);
 }
 
+/**
+ * @brief CheckRampupFromSteadyState allows ramp-up when newBandwidth (target
+ *        profile bitrate) is slightly below nwBandwidth, producing a negative
+ *        abrThreshold that is still within the 30% limit.
+ *        Regression for the VPAAMP-175 fix: the old code blocked rampup
+ *        whenever abrThreshold was negative.
+ */
+TEST_F(HybridAbrTests, CheckRampupFromSteadyState_NegativeThreshold_RampsUp)
+{
+	eAAMPAbrConfig.abrBufferCounter = 2;
+
+	HybridABRManager mgr;
+	mgr.ReadPlayerConfig(&eAAMPAbrConfig);
+
+	ABRManager::ProfileInfo p{};
+	p.isIframeTrack = false;
+	p.bandwidthBitsPerSecond = 1000000;
+	p.width = 640; p.height = 360;
+	mgr.addProfile(p); // index 0
+
+	p.bandwidthBitsPerSecond = 2000000;
+	p.width = 1280; p.height = 720;
+	mgr.addProfile(p); // index 1
+
+	int currProfileIndex = 0;
+	int newProfileIndex = currProfileIndex;
+	// nwBandwidth is 2.2 Mbps; newBandwidth matches target profile (2 Mbps).
+	// threshold = (2M - 2.2M) / 2.2M ≈ -9% — negative but within <=30 limit.
+	long nwBandwidth = 2200000;
+	long newBandwidth = 2000000;
+	double bufferValue = 20.0;
+	HybridABRManager::BitrateChangeReason reason = HybridABRManager::eAAMP_BITRATE_CHANGE_BY_ABR;
+	int maxBufferCountCheck = 1;
+
+	mgr.CheckRampupFromSteadyState(
+		currProfileIndex, newProfileIndex, nwBandwidth, bufferValue,
+		newBandwidth, reason, maxBufferCountCheck);
+
+	EXPECT_EQ(newProfileIndex, 1);
+	EXPECT_EQ(reason, HybridABRManager::eAAMP_BITRATE_CHANGE_BY_BUFFER_FULL);
+}
+
 TEST_F(HybridAbrTests, UpdateABRBitrateDataBasedOnCacheOutlierOdd)
 {
 	std::vector<long> tmpData = {100, 200, 300, 400, 500};


### PR DESCRIPTION
Remove the >= 0 guard from the abrThreshold check in CheckRampupFromSteadyState. The condition incorrectly prevented rampup when newBandwidth was below nwBandwidth but still within the 30% threshold. Add test for negative threshold rampup scenario.