### PR TITLE
VPAAMP-212: TuneTimeMetrics "tot" field is always 0

### DIFF
--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -313,7 +313,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 	unsigned int licenseAcqNWTime = bucketDuration(PROFILE_BUCKET_LA_NETWORK);
 	char tuneTimeStrPrefix[128];
 	memset(tuneTimeStrPrefix, '\0', sizeof(tuneTimeStrPrefix));
-	int mTotalTime;
+	int totalTuneTime = 0;
  	int mTimedMetadataStartTime = static_cast<int> (mTuneEndMetrics.mTimedMetadataStartTime - tuneStartMonotonicBase);
 
 	auto tFirstFrameStart = buckets[PROFILE_BUCKET_FIRST_FRAME].tStart;
@@ -330,12 +330,15 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 
 	if (mTuneEndMetrics.success > 0)
 	{
-		mTotalTime = playerPreBuffered ? tFirstFrameStart - tPreBufferStart : tFirstFrameStart;
+		totalTuneTime = playerPreBuffered ? tFirstFrameStart - tPreBufferStart : tFirstFrameStart;
 	}
 	else
 	{
-		mTotalTime = static_cast<int> (mTuneEndMetrics.mTotalTime - tuneStartMonotonicBase);
+		totalTuneTime = static_cast<int> (mTuneEndMetrics.mTotalTime - tuneStartMonotonicBase);
 	}
+	// Store the computed total tune time back in mTuneEndMetrics so
+	// TuneTimeMetricsData sees the updated value from this metrics struct.
+	mTuneEndMetrics.mTotalTime = totalTuneTime;
 	if (!appName.empty())
 	{
 		if (gpGlobalConfig && gpGlobalConfig->IsConfigSet(eAAMPConfig_UseFireboltSDK))
@@ -395,11 +398,14 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 
 		(playerPreBuffered && mTuneEndMetrics.success > 0) ? tFirstBufferStart - tPreBufferStart : tFirstBufferStart, // gstPlaying: offset in ms from tunestart when pipeline first fed data
 		(playerPreBuffered && mTuneEndMetrics.success > 0) ? tFirstFrameStart - tPreBufferStart : tFirstFrameStart,  // gstFirstFrame: offset in ms from tunestart when first frame of video is decoded/presented
-		mTuneEndMetrics.contentType,mTuneEndMetrics.streamType,mTuneEndMetrics.mFirstTune,
-		playerPreBuffered,playerPreBuffered ? tPreBufferStart : 0,
+		mTuneEndMetrics.contentType, mTuneEndMetrics.streamType, mTuneEndMetrics.mFirstTune,
+		playerPreBuffered,
+		playerPreBuffered ? tPreBufferStart : 0,
 		durationSeconds,interfaceWifi,
-		mTuneEndMetrics.mTuneAttempts, mTuneEndMetrics.success,failureReason.c_str(),appName.c_str(),
-		mTuneEndMetrics.mTimedMetadata,mTimedMetadataStartTime < 0 ? 0 : mTimedMetadataStartTime , mTuneEndMetrics.mTimedMetadataDuration,mTuneEndMetrics.mFogTSBEnabled,mTotalTime,mStopDurationMs,
+		mTuneEndMetrics.mTuneAttempts, mTuneEndMetrics.success, failureReason.c_str(), appName.c_str(),
+		mTuneEndMetrics.mTimedMetadata,
+		mTimedMetadataStartTime < 0 ? 0 : mTimedMetadataStartTime,
+		mTuneEndMetrics.mTimedMetadataDuration, mTuneEndMetrics.mFogTSBEnabled, totalTuneTime, mStopDurationMs,
 		tDecode // gstDecode: time taken to decode first frame, excluding decryption time. For clear streams, this will be the overall time spent in pipeline
 		);
 

--- a/test/utests/tests/AampProfilerTests/AampProfilerTests.cpp
+++ b/test/utests/tests/AampProfilerTests/AampProfilerTests.cpp
@@ -21,8 +21,10 @@
 #include "AampProfiler.h"
 #include "AampConfig.h"
 #include "MockAampConfig.h"
+#include "AampUtils.h" // for NOW_STEADY_TS_MS
 #include <cjson/cJSON.h>
 #include <algorithm>
+#include <thread>
 
 using namespace testing;
 AampConfig *gpGlobalConfig{nullptr};
@@ -456,6 +458,105 @@ TEST_F(AampProfilertests, TuneEndTest5)
     EXPECT_EQ(durationSeconds,3600);
     ASSERT_TRUE(interfaceWifi);         
 }
+
+// Test to verify that mTotalTime in TuneEndMetrics is updated correctly in success case when player is not pre-buffered.
+// Total time is calculated based on the start time of PROFILE_BUCKET_FIRST_FRAME.
+TEST_F(AampProfilertests, TuneEndTest6)
+{
+    TuneEndMetrics mTuneEndMetrics;
+    mTuneEndMetrics.success = 1;
+    mTuneEndMetrics.contentType = ContentType_VOD;
+    mTuneEndMetrics.streamType = 1;
+    mTuneEndMetrics.mFirstTune = true;
+    mTuneEndMetrics.mTimedMetadataStartTime = 12345;
+    mTuneEndMetrics.mTimedMetadataDuration = 500;
+    mTuneEndMetrics.mTuneAttempts = 0;
+    mTuneEndMetrics.mTotalTime = 0; // Initialize mTotalTime to 0
+    std::string appName = "Test6";
+    std::string playerActiveMode = "Active";
+    int playerId = 123;
+    bool playerPreBuffered = false;
+    unsigned int durationSeconds = 3600;
+    bool interfaceWifi = true;
+    std::string failureReason;
+    std::string tuneMetricData;
+    profileEvent->TuneBegin();
+    // Wait for 200ms to cause a delay and ensure buckets[PROFILE_BUCKET_FIRST_FRAME].tStart has a valid value.
+    // Total time is the start time for PROFILE_BUCKET_FIRST_FRAME.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    profileEvent->ProfileBegin(PROFILE_BUCKET_FIRST_FRAME);
+    profileEvent->ProfileEnd(PROFILE_BUCKET_FIRST_FRAME);
+    profileEvent->TuneEnd(mTuneEndMetrics, appName, playerActiveMode, playerId,
+                         playerPreBuffered, durationSeconds, interfaceWifi, failureReason, &tuneMetricData);
+    EXPECT_TRUE(mTuneEndMetrics.mTotalTime >= 200); // Check if mTotalTime is updated and is at least 200ms
+}
+
+// Test to verify that mTotalTime in TuneEndMetrics is updated correctly in success case when player is pre-buffered.
+// Total time is calculated based on the difference between the start time of PROFILE_BUCKET_FIRST_FRAME and
+// the start time of PROFILE_BUCKET_PLAYER_PRE_BUFFERED.
+TEST_F(AampProfilertests, TuneEndTest7)
+{
+    TuneEndMetrics mTuneEndMetrics;
+    mTuneEndMetrics.success = 1; // success case
+    mTuneEndMetrics.contentType = ContentType_VOD;
+    mTuneEndMetrics.streamType = 1;
+    mTuneEndMetrics.mFirstTune = true;
+    mTuneEndMetrics.mTimedMetadataStartTime = 12345;
+    mTuneEndMetrics.mTimedMetadataDuration = 500;
+    mTuneEndMetrics.mTuneAttempts = 0;
+    mTuneEndMetrics.mTotalTime = 0; // Initialize mTotalTime to 0
+    std::string appName = "Test7";
+    std::string playerActiveMode = "Active";
+    int playerId = 123;
+    bool playerPreBuffered = true;
+    unsigned int durationSeconds = 3600;
+    bool interfaceWifi = true;
+    std::string failureReason;
+    std::string tuneMetricData;
+    profileEvent->TuneBegin();
+    profileEvent->ProfileBegin(PROFILE_BUCKET_PLAYER_PRE_BUFFERED);
+    profileEvent->ProfileEnd(PROFILE_BUCKET_PLAYER_PRE_BUFFERED);
+    // Wait for 200ms to cause a delay and ensure buckets[PROFILE_BUCKET_FIRST_FRAME].tStart has a valid value.
+    // Total time is the buckets[PROFILE_BUCKET_FIRST_FRAME].tStart - buckets[PROFILE_BUCKET_PLAYER_PRE_BUFFERED].tStart.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    profileEvent->ProfileBegin(PROFILE_BUCKET_FIRST_FRAME);
+    profileEvent->ProfileEnd(PROFILE_BUCKET_FIRST_FRAME);
+    profileEvent->TuneEnd(mTuneEndMetrics, appName, playerActiveMode, playerId,
+                         playerPreBuffered, durationSeconds, interfaceWifi, failureReason, &tuneMetricData);
+    EXPECT_TRUE(mTuneEndMetrics.mTotalTime >= 200); // Check if mTotalTime is updated and is at least 200ms
+}
+
+// Test to verify that mTotalTime in TuneEndMetrics is updated correctly in failure case when player is not pre-buffered.
+// Total time for failure is the difference between the current time and the tunestart time.
+TEST_F(AampProfilertests, TuneEndTest8)
+{
+    TuneEndMetrics mTuneEndMetrics;
+    mTuneEndMetrics.success = 0; // failure case
+    mTuneEndMetrics.contentType = ContentType_VOD;
+    mTuneEndMetrics.streamType = 1;
+    mTuneEndMetrics.mFirstTune = true;
+    mTuneEndMetrics.mTimedMetadataStartTime = 12345;
+    mTuneEndMetrics.mTimedMetadataDuration = 500;
+    mTuneEndMetrics.mTuneAttempts = 0;
+    mTuneEndMetrics.mTotalTime = 0; // Initialize mTotalTime to 0
+    std::string appName = "Test8";
+    std::string playerActiveMode = "Active";
+    int playerId = 123;
+    bool playerPreBuffered = false;
+    unsigned int durationSeconds = 3600;
+    bool interfaceWifi = true;
+    std::string failureReason;
+    std::string tuneMetricData;
+    profileEvent->TuneBegin();
+    // Wait for 200ms to cause a delay and ensure mTuneEndMetrics.mTotalTime has a valid value.
+    // Total time for failure is based on the steady-clock delta from tuneStartMonotonicBase.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    mTuneEndMetrics.mTotalTime = NOW_STEADY_TS_MS;
+    profileEvent->TuneEnd(mTuneEndMetrics, appName, playerActiveMode, playerId,
+                         playerPreBuffered, durationSeconds, interfaceWifi, failureReason, &tuneMetricData);
+    EXPECT_TRUE(mTuneEndMetrics.mTotalTime >= 200); // Check if mTotalTime is updated and is at least 200ms
+}
+
 TEST_F(AampProfilertests, TestGetTuneEventsJSON22)
 {
     bool siblingEvent = false;


### PR DESCRIPTION
Reason for change: In TuneTimeMetrics event, the total tune time "tot" field is always returned as 0 for successful tunes. Fix this and validate with L1s.
Test Procedure: Validate "tot" is valid and same as tune time reported in IP_AAMP_TUNETIME log.
Risks: None