### PR TITLE
VPAAMP-129  network persona generation optimizations

### DIFF
--- a/net_trace.h
+++ b/net_trace.h
@@ -309,7 +309,9 @@ private:
 	
 	// Meyer's singleton pattern for shared file state
 	struct FileState {
-		std::once_flag openOnce;			///< Ensures files are opened exactly once, race-free		std::mutex mutex;				///< Serializes stream writes and path mutations		std::string req_path = "/tmp/aamp_net_requests.csv";
+		std::once_flag openOnce;		///< Ensures files are opened exactly once, race-free
+		std::mutex mutex;				///< Serializes stream writes and path mutations
+		std::string req_path = "/tmp/aamp_net_requests.csv";
 		std::string burst_path = "/tmp/aamp_net_bursts.csv";
 		std::ofstream req_ofs;
 		std::ofstream burst_ofs;

--- a/net_trace.h
+++ b/net_trace.h
@@ -380,6 +380,9 @@ private:
 	 */
 	static void EnsureFilesOpen() {
 		auto& state = GetFileState();
+		// Fast path: skip mutex if both files are already open. Safe because
+		// once opened the streams are never closed before process exit.
+		if (state.req_ofs.is_open() && state.burst_ofs.is_open()) return;
 		std::lock_guard<std::mutex> g(state.mutex);
 		if (!state.req_ofs.is_open()) {
 			state.req_ofs.open(state.req_path, std::ios::app);

--- a/net_trace.h
+++ b/net_trace.h
@@ -309,8 +309,7 @@ private:
 	
 	// Meyer's singleton pattern for shared file state
 	struct FileState {
-		std::mutex mutex;
-		std::string req_path = "/tmp/aamp_net_requests.csv";
+		std::once_flag openOnce;			///< Ensures files are opened exactly once, race-free		std::mutex mutex;				///< Serializes stream writes and path mutations		std::string req_path = "/tmp/aamp_net_requests.csv";
 		std::string burst_path = "/tmp/aamp_net_bursts.csv";
 		std::ofstream req_ofs;
 		std::ofstream burst_ofs;
@@ -371,31 +370,26 @@ private:
 	
 	/**
 	 * @brief Open CSV output files if not already open
-	 * 
+	 *
 	 * Purpose: Lazily opens requests and bursts CSV files and writes headers if
-	 * files are new. Uses append mode to preserve existing data. Thread-safe via
-	 * mutex protection.
-	 * 
-	 * Thread Safety: Protected by FileState::mutex
+	 * files are new. Uses append mode to preserve existing data.
+	 *
+	 * Thread Safety: std::call_once guarantees the open+header-write block
+	 * executes exactly once across all threads, with no data race on the
+	 * stream state. Subsequent calls return immediately at the once_flag check.
 	 */
 	static void EnsureFilesOpen() {
 		auto& state = GetFileState();
-		// Fast path: skip mutex if both files are already open. Safe because
-		// once opened the streams are never closed before process exit.
-		if (state.req_ofs.is_open() && state.burst_ofs.is_open()) return;
-		std::lock_guard<std::mutex> g(state.mutex);
-		if (!state.req_ofs.is_open()) {
+		std::call_once(state.openOnce, [&state]() {
 			state.req_ofs.open(state.req_path, std::ios::app);
 			if (state.req_ofs.tellp() == 0) {
 				state.req_ofs << "req_id,when_start_s,url_path,media_type,bytes_total,http_code,conn_reused,primary_ip,local_port,ttfb_s,total_s,namelookup_s,connect_s,appconnect_s,pretransfer_s,redirect_s,chunked,gap_time_s,burst_time_s,burst_count,late_gap_count,avg_burst_rate_Bps\n";
 			}
-		}
-		if (!state.burst_ofs.is_open()) {
 			state.burst_ofs.open(state.burst_path, std::ios::app);
 			if (state.burst_ofs.tellp() == 0) {
 				state.burst_ofs << "req_id,burst_idx,t_start_s,duration_s,bytes,gap_before_s,class\n";
 			}
-		}
+		});
 	}
 	
 	// request identity

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4621,22 +4621,23 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 			}
 		}
 
-		// extract path component (after domain) from URL
+		// extract path component (after domain) from URL — lambda defined once as
+		// a static local; actual call and media-type string only evaluated when the
+		// tracer is enabled to avoid per-download work on the disabled hot path.
 		static const auto pathOnly = [](const std::string& u)->std::string {
 			size_t s = 0, p = u.find("://");
 			s = (p==std::string::npos) ? 0 : (p+3);
 			s = u.find('/', s);
 			return (s==std::string::npos) ? u : u.substr(s);
 		};
-		const char* mt_str =
-		(mediaType==eMEDIATYPE_VIDEO)    ? "video" :
-		(mediaType==eMEDIATYPE_AUDIO)    ? "audio" :
-		(mediaType==eMEDIATYPE_SUBTITLE) ? "text"  :
-		(mediaType==eMEDIATYPE_MANIFEST) ? "manifest" : "other";
-
 		static std::atomic<uint64_t> g_req_id{1};
 		std::unique_ptr<aamptrace::NetTrace> net_owner;
 		if (netTracerEnabled) {
+			const char* mt_str =
+			(mediaType==eMEDIATYPE_VIDEO)    ? "video" :
+			(mediaType==eMEDIATYPE_AUDIO)    ? "audio" :
+			(mediaType==eMEDIATYPE_SUBTITLE) ? "text"  :
+			(mediaType==eMEDIATYPE_MANIFEST) ? "manifest" : "other";
 			net_owner = std::make_unique<aamptrace::NetTrace>(
 				g_req_id.fetch_add(1), pathOnly(remoteUrl), mt_str,
 				/*chunked=*/false, kNetTraceBurstGapThresholdS, kNetTraceLateGapThresholdS);

--- a/simnet/net_persona_fitter.cpp
+++ b/simnet/net_persona_fitter.cpp
@@ -431,21 +431,26 @@ std::size_t NetPersonaFitter::GetBurstCount() const
 	return mBursts.size();
 }
 
-bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath) const
+bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath)
 {
 	std::vector<RequestRecord> requests;
 	std::vector<BurstRecord> bursts;
 
 	{
 		std::lock_guard<std::mutex> lock{mMutex};
+		if (mGenerated)
+		{
+			// Data was already consumed by a prior call (e.g., Stop() fired
+			// before the atexit safety-net). Silently skip rather than warn.
+			return false;
+		}
 		if (mRequests.empty() && mBursts.empty())
 		{
 			AAMPLOG_WARN("NetPersonaFitter: no data collected, skipping persona generation");
 			return false;
 		}
-		// Swap in O(1) so the mutex is held only for pointer exchanges, not
-		// for copying potentially thousands of records. mRequests/mBursts are
-		// declared mutable to permit this from a const method.
+		// Swap in O(1): hold the mutex only for pointer exchanges, then do
+		// the O(N) statistical fitting outside the lock.
 		requests.swap(mRequests);
 		bursts.swap(mBursts);
 	} // lock released before the O(N) statistical fitting
@@ -496,6 +501,11 @@ bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath) const
 		return false;
 	}
 	ofs.close();
+
+	{
+		std::lock_guard<std::mutex> lock{mMutex};
+		mGenerated = true;
+	}
 
 	AAMPLOG_MIL("NetPersonaFitter: wrote persona JSON to %s (%zu requests, %zu bursts)",
 				outputPath.c_str(), requests.size(), bursts.size());

--- a/simnet/net_persona_fitter.cpp
+++ b/simnet/net_persona_fitter.cpp
@@ -443,9 +443,12 @@ bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath) const
 			AAMPLOG_WARN("NetPersonaFitter: no data collected, skipping persona generation");
 			return false;
 		}
-		requests = mRequests;
-		bursts = mBursts;
-	}
+		// Swap in O(1) so the mutex is held only for pointer exchanges, not
+		// for copying potentially thousands of records. mRequests/mBursts are
+		// declared mutable to permit this from a const method.
+		requests.swap(mRequests);
+		bursts.swap(mBursts);
+	} // lock released before the O(N) statistical fitting
 
 	Persona persona;
 	FitRequests(requests, persona);
@@ -460,27 +463,31 @@ bool NetPersonaFitter::GeneratePersonaJson(const std::string& basePath) const
 		return false;
 	}
 
+	// JSON does not allow NaN or Inf; clamp any non-finite value to 0.0
+	// so the output is always valid JSON regardless of edge-case inputs.
+	auto jv = [](double v) -> double { return std::isfinite(v) ? v : 0.0; };
+
 	ofs << std::setprecision(15);
 	ofs << "{\n"
-		<< "\t\"base_rtt_ms\": "         << persona.baseRttMs         << ",\n"
-		<< "\t\"rtt_jitter_ms\": "       << persona.rttJitterMs        << ",\n"
-		<< "\t\"ttfb_spike_p\": "        << persona.ttfbSpikeP         << ",\n"
-		<< "\t\"ttfb_spike_ms\": "       << persona.ttfbSpikeMs        << ",\n"
-		<< "\t\"mean_thr_mbps\": "       << persona.meanThrMbps        << ",\n"
-		<< "\t\"thr_sigma_ln\": "        << persona.thrSigmaLn         << ",\n"
-		<< "\t\"thr_rho\": "             << persona.thrRho             << ",\n"
-		<< "\t\"bursts_per_segment\": "  << persona.burstsPerSegment   << ",\n"
-		<< "\t\"burst_bytes_cv\": "      << persona.burstBytesCv       << ",\n"
-		<< "\t\"cadence_ms\": "          << persona.cadenceMs          << ",\n"
-		<< "\t\"cadence_jitter_ms\": "   << persona.cadenceJitterMs    << ",\n"
-		<< "\t\"flush_jitter_ms\": "     << persona.flushJitterMs      << ",\n"
-		<< "\t\"late_chunk_p\": "        << persona.lateChunkP         << ",\n"
-		<< "\t\"late_chunk_extra_ms\": " << persona.lateChunkExtraMs   << ",\n"
-		<< "\t\"p_conn_reuse\": "        << persona.pConnReuse         << ",\n"
-		<< "\t\"new_conn_penalty_ms\": " << persona.newConnPenaltyMs   << ",\n"
-		<< "\t\"capacity_drop_p\": "     << persona.capacityDropP      << ",\n"
-		<< "\t\"capacity_drop_factor\": "<< persona.capacityDropFactor << ",\n"
-		<< "\t\"rtt_inflation_ms\": "    << persona.rttInflationMs     << "\n"
+		<< "\t\"base_rtt_ms\": "         << jv(persona.baseRttMs)         << ",\n"
+		<< "\t\"rtt_jitter_ms\": "       << jv(persona.rttJitterMs)        << ",\n"
+		<< "\t\"ttfb_spike_p\": "        << jv(persona.ttfbSpikeP)         << ",\n"
+		<< "\t\"ttfb_spike_ms\": "       << jv(persona.ttfbSpikeMs)        << ",\n"
+		<< "\t\"mean_thr_mbps\": "       << jv(persona.meanThrMbps)        << ",\n"
+		<< "\t\"thr_sigma_ln\": "        << jv(persona.thrSigmaLn)         << ",\n"
+		<< "\t\"thr_rho\": "             << jv(persona.thrRho)             << ",\n"
+		<< "\t\"bursts_per_segment\": "  << persona.burstsPerSegment        << ",\n"
+		<< "\t\"burst_bytes_cv\": "      << jv(persona.burstBytesCv)       << ",\n"
+		<< "\t\"cadence_ms\": "          << jv(persona.cadenceMs)          << ",\n"
+		<< "\t\"cadence_jitter_ms\": "   << jv(persona.cadenceJitterMs)    << ",\n"
+		<< "\t\"flush_jitter_ms\": "     << jv(persona.flushJitterMs)      << ",\n"
+		<< "\t\"late_chunk_p\": "        << jv(persona.lateChunkP)         << ",\n"
+		<< "\t\"late_chunk_extra_ms\": " << jv(persona.lateChunkExtraMs)   << ",\n"
+		<< "\t\"p_conn_reuse\": "        << jv(persona.pConnReuse)         << ",\n"
+		<< "\t\"new_conn_penalty_ms\": " << jv(persona.newConnPenaltyMs)   << ",\n"
+		<< "\t\"capacity_drop_p\": "     << jv(persona.capacityDropP)      << ",\n"
+		<< "\t\"capacity_drop_factor\": "<< jv(persona.capacityDropFactor) << ",\n"
+		<< "\t\"rtt_inflation_ms\": "    << jv(persona.rttInflationMs)     << "\n"
 		<< "}\n";
 
 	if (!ofs)

--- a/simnet/net_persona_fitter.h
+++ b/simnet/net_persona_fitter.h
@@ -108,11 +108,17 @@ public:
 	 * a 19-field persona JSON. The output filename is suffixed with the
 	 * process ID (e.g., /tmp/aamp_net_persona.json.12345).
 	 *
+	 * Note: This method is deliberately non-const. It swaps out (consumes)
+	 * the accumulated request/burst vectors in O(1) under the mutex, then
+	 * performs O(N) statistical fitting lock-free. After the first call the
+	 * vectors are empty; subsequent calls (e.g., the atexit safety-net) will
+	 * log nothing and return false without noisy warnings.
+	 *
 	 * @param[in] basePath Base output path (PID is appended)
 	 * @return true if JSON was written successfully, false on error or
 	 *         insufficient data
 	 */
-	bool GeneratePersonaJson(const std::string& basePath) const;
+	bool GeneratePersonaJson(const std::string& basePath);
 
 	/**
 	 * @brief Return the number of accumulated request records
@@ -138,10 +144,11 @@ private:
 	 */
 	static void AtExitHandler();
 
-	mutable std::mutex mMutex;						///< Protects mRequests and mBursts
-	mutable std::vector<RequestRecord> mRequests;	///< mutable to allow O(1) swap in const GeneratePersonaJson
-	mutable std::vector<BurstRecord> mBursts;		///< mutable to allow O(1) swap in const GeneratePersonaJson
-	bool mAtExitRegistered{false};		///< True after AtExit() has been called
+	mutable std::mutex mMutex;				///< Protects all mutable state below
+	std::vector<RequestRecord> mRequests;	///< Consumed (swapped out) on first GeneratePersonaJson call
+	std::vector<BurstRecord> mBursts;		///< Consumed (swapped out) on first GeneratePersonaJson call
+	bool mAtExitRegistered{false};			///< True after atexit() has been registered
+	bool mGenerated{false};					///< True after GeneratePersonaJson has successfully run once
 };
 
 } // namespace aamptrace

--- a/simnet/net_persona_fitter.h
+++ b/simnet/net_persona_fitter.h
@@ -138,9 +138,9 @@ private:
 	 */
 	static void AtExitHandler();
 
-	mutable std::mutex mMutex;			///< Protects mRequests and mBursts
-	std::vector<RequestRecord> mRequests;
-	std::vector<BurstRecord> mBursts;
+	mutable std::mutex mMutex;						///< Protects mRequests and mBursts
+	mutable std::vector<RequestRecord> mRequests;	///< mutable to allow O(1) swap in const GeneratePersonaJson
+	mutable std::vector<BurstRecord> mBursts;		///< mutable to allow O(1) swap in const GeneratePersonaJson
 	bool mAtExitRegistered{false};		///< True after AtExit() has been called
 };
 

--- a/simnet/simnet/persona.json
+++ b/simnet/simnet/persona.json
@@ -2,7 +2,7 @@
   "base_rtt_ms": 41.834500000000006,
   "burst_bytes_cv": 0.053355394585347396,
   "bursts_per_segment": 2,
-  "cadence_jitter_ms": NaN,
+  "cadence_jitter_ms": 0.0,
   "cadence_ms": 101.123,
   "capacity_drop_factor": 0.6,
   "capacity_drop_p": 0.0,


### PR DESCRIPTION
Reason for Change: deliver misc low priority optimizations
1. lambda and g_req_id.fetch_add run unconditionally
2. GeneratePersonaJson holds the mutex during the full vector copy 
3. EnsureFilesOpen() acquires FileState::mutex on every call
4. NaN in JSON output: std::ofstream will write nan (lowercase) for std::numeric_limits<double>::quiet_NaN()