### PR TITLE
VPAAMP-227 : Add AC4 CENC decryptor caps to GStreamer DRM plugins (#1382)

### DIFF
--- a/middleware/gst-plugins/drm/gst/gstclearkeydecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstclearkeydecryptor.cpp
@@ -48,7 +48,7 @@ GST_DEBUG_CATEGORY(gst_clearkeydecryptor_debug_category);
 
 static GstStaticPadTemplate gst_clearkeydecryptor_src_template =
 GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
-		GST_STATIC_CAPS("video/x-h264;audio/mpeg;video/x-h265;audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3"));
+		GST_STATIC_CAPS("video/x-h264;audio/mpeg;video/x-h265;audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-ac4"));
 
 static GstStaticPadTemplate gst_clearkeydecryptor_sink_template =
 GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
@@ -58,6 +58,7 @@ GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
 			"application/x-cenc, original-media-type=(string)audio/x-eac3, protection-system=(string)" CLEARKEY_PROTECTION_SYSTEM_ID "; "
 			"application/x-cenc, original-media-type=(string)audio/x-ac3, protection-system=(string)" CLEARKEY_PROTECTION_SYSTEM_ID "; "
 			"application/x-cenc, original-media-type=(string)audio/x-gst-fourcc-ec_3, protection-system=(string)" CLEARKEY_PROTECTION_SYSTEM_ID "; "
+			"application/x-cenc, original-media-type=(string)audio/x-ac4, protection-system=(string)" CLEARKEY_PROTECTION_SYSTEM_ID "; "
 			"application/x-cenc, original-media-type=(string)audio/mpeg, protection-system=(string)" CLEARKEY_PROTECTION_SYSTEM_ID));
 
 static GstStaticPadTemplate gst_clearkeydecryptor_dummy_sink_template =

--- a/middleware/gst-plugins/drm/gst/gstplayreadydecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstplayreadydecryptor.cpp
@@ -48,7 +48,7 @@ GST_DEBUG_CATEGORY(gst_playreadydecryptor_debug_category);
 
 static GstStaticPadTemplate gst_playreadydecryptor_src_template =
         GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
-        GST_STATIC_CAPS("video/x-h264;video/x-h264(memory:SecMem);audio/mpeg;video/x-h265;video/x-h265(memory:SecMem);audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3"));
+        GST_STATIC_CAPS("video/x-h264;video/x-h264(memory:SecMem);audio/mpeg;video/x-h265;video/x-h265(memory:SecMem);audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-ac4"));
  
 static GstStaticPadTemplate gst_playreadydecryptor_sink_template =
         GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
@@ -58,6 +58,7 @@ static GstStaticPadTemplate gst_playreadydecryptor_sink_template =
                         "application/x-cenc, original-media-type=(string)audio/x-eac3, protection-system=(string)" PLAYREADY_PROTECTION_SYSTEM_ID "; "
                         "application/x-cenc, original-media-type=(string)audio/x-ac3, protection-system=(string)" PLAYREADY_PROTECTION_SYSTEM_ID "; "
 			"application/x-cenc, original-media-type=(string)audio/x-gst-fourcc-ec_3, protection-system=(string)" PLAYREADY_PROTECTION_SYSTEM_ID "; "
+                        "application/x-cenc, original-media-type=(string)audio/x-ac4, protection-system=(string)" PLAYREADY_PROTECTION_SYSTEM_ID "; "
                         "application/x-cenc, original-media-type=(string)audio/mpeg, protection-system=(string)" PLAYREADY_PROTECTION_SYSTEM_ID));
 
 static GstStaticPadTemplate gst_playreadydecryptor_dummy_sink_template =

--- a/middleware/gst-plugins/drm/gst/gstverimatrixdecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstverimatrixdecryptor.cpp
@@ -44,7 +44,7 @@ GST_DEBUG_CATEGORY(gst_verimatrixdecryptor_debug_category);
 
 static GstStaticPadTemplate gst_verimatrixdecryptor_src_template =
         GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
-        GST_STATIC_CAPS("video/x-h264;audio/mpeg;video/x-h265;audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3"));
+        GST_STATIC_CAPS("video/x-h264;audio/mpeg;video/x-h265;audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-ac4"));
 
 static GstStaticPadTemplate gst_verimatrixdecryptor_sink_template =
         GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
@@ -54,6 +54,7 @@ static GstStaticPadTemplate gst_verimatrixdecryptor_sink_template =
                         "application/x-cenc, original-media-type=(string)audio/x-eac3, protection-system=(string)" VERIMATRIX_PROTECTION_SYSTEM_ID "; "
                         "application/x-cenc, original-media-type=(string)audio/x-ac3, protection-system=(string)" VERIMATRIX_PROTECTION_SYSTEM_ID "; "
 			"application/x-cenc, original-media-type=(string)audio/x-gst-fourcc-ec_3, protection-system=(string)" VERIMATRIX_PROTECTION_SYSTEM_ID "; "
+                        "application/x-cenc, original-media-type=(string)audio/x-ac4, protection-system=(string)" VERIMATRIX_PROTECTION_SYSTEM_ID "; "
                         "application/x-cenc, original-media-type=(string)audio/mpeg, protection-system=(string)" VERIMATRIX_PROTECTION_SYSTEM_ID));
 
 static GstStaticPadTemplate gst_verimatrixdecryptor_dummy_sink_template =

--- a/middleware/gst-plugins/drm/gst/gstwidevinedecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstwidevinedecryptor.cpp
@@ -47,7 +47,7 @@ GST_DEBUG_CATEGORY(gst_widevinedecryptor_debug_category);
 
 static GstStaticPadTemplate gst_widevinedecryptor_src_template =
         GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
-        GST_STATIC_CAPS("video/x-h264;video/x-h264(memory:SecMem);audio/mpeg;video/x-h265;video/x-h265(memory:SecMem);audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-opus"));
+        GST_STATIC_CAPS("video/x-h264;video/x-h264(memory:SecMem);audio/mpeg;video/x-h265;video/x-h265(memory:SecMem);audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-opus;audio/x-ac4"));
  
 static GstStaticPadTemplate gst_widevinedecryptor_sink_template =
         GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
@@ -58,6 +58,7 @@ static GstStaticPadTemplate gst_widevinedecryptor_sink_template =
                         "application/x-cenc, original-media-type=(string)audio/x-ac3, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
                         "application/x-cenc, original-media-type=(string)audio/x-opus, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
 			"application/x-cenc, original-media-type=(string)audio/x-gst-fourcc-ec_3, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
+                        "application/x-cenc, original-media-type=(string)audio/x-ac4, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
                         "application/x-cenc, original-media-type=(string)audio/mpeg, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID));
 
 static GstStaticPadTemplate gst_widevinedecryptor_dummy_sink_template =

--- a/test/qtdemuxAnalyzer/qtdemuxAnalyzer.cpp
+++ b/test/qtdemuxAnalyzer/qtdemuxAnalyzer.cpp
@@ -65,6 +65,7 @@ static GstStaticPadTemplate sink_template =
 		"application/x-cenc, original-media-type=(string)audio/x-eac3, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
 		"application/x-cenc, original-media-type=(string)audio/x-ac3, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
 		"application/x-cenc, original-media-type=(string)audio/x-opus, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
+		"application/x-cenc, original-media-type=(string)audio/x-ac4, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
 		"application/x-cenc, original-media-type=(string)audio/x-gst-fourcc-ec_3, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID "; "
 		"application/x-cenc, original-media-type=(string)audio/mpeg, protection-system=(string)" WIDEVINE_PROTECTION_SYSTEM_ID)
 	);
@@ -72,7 +73,7 @@ static GstStaticPadTemplate sink_template =
 
 static GstStaticPadTemplate src_template =
 		GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
-		GST_STATIC_CAPS("video/x-h264;video/x-h264(memory:SecMem);audio/mpeg;video/x-h265;video/x-h265(memory:SecMem);audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-opus")
+		GST_STATIC_CAPS("video/x-h264;video/x-h264(memory:SecMem);audio/mpeg;video/x-h265;video/x-h265(memory:SecMem);audio/x-eac3;audio/x-gst-fourcc-ec_3;audio/x-ac3;audio/x-opus;audio/x-ac4")
 	);
  
 


### PR DESCRIPTION
Reason for Change: This pull request extends the supported media caps of the in-tree GStreamer DRM decryptor elements to advertise AC-4 audio support for CENC-protected streams.

Add AC4 CENC decryptor caps to GStreamer DRM plugins

sync qtdemuxAnalyzer dummy Widevine decryptor caps with production

Add audio/x-ac4 to both sink_template and src_template of the dummy Widevine decryptor in qtdemuxAnalyzer.cpp to match the AC-4 caps added to the production gstwidevinedecryptor in middleware.

---------