### PR TITLE
VPAAMP-239 Change the CURLOPT_DNS_CACHE_TIMEOUT config

### DIFF
--- a/downloader/AampCurlStore.cpp
+++ b/downloader/AampCurlStore.cpp
@@ -362,7 +362,7 @@ CURL* CurlStore::CurlEasyInitWithOpt ( PrivateInstanceAAMP *aamp, const std::str
 	CURL_EASY_SETOPT_STRING(curlEasyhdl, CURLOPT_ACCEPT_ENCODING, "");//Enable all the encoding formats supported by client
 	CURL_EASY_SETOPT_FUNC(curlEasyhdl, CURLOPT_SSL_CTX_FUNCTION, ssl_callback); //Check for downloads disabled in btw ssl handshake
 	CURL_EASY_SETOPT_POINTER(curlEasyhdl, CURLOPT_SSL_CTX_DATA, aamp);
-	long dns_cache_timeout = 3*60;
+	long dns_cache_timeout = GETCONFIGVALUE(eAAMPConfig_Dns_CacheTimeout);
 	CURL_EASY_SETOPT_LONG(curlEasyhdl, CURLOPT_DNS_CACHE_TIMEOUT, dns_cache_timeout);
 	CURL_EASY_SETOPT_POINTER(curlEasyhdl, CURLOPT_SHARE, aamp->mCurlShared);
 


### PR DESCRIPTION
Reason for Change: Change the CURLOPT_DNS_CACHE_TIMEOUT config to be updated from config not as default
Test Procedure: refer ticket
Risks: Low
Priority: P1