### PR TITLE
VPAAMP-203 Link atomic library on Linux for 16-byte std::atomic support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,18 @@ if(CMAKE_SYSTEMD_JOURNAL)
 	set(LIBAAMPJSBINDINGS_DEPENDS ${LIBAAMPJSBINDINGS_DEPENDS} "-lsystemd")
 	set(LIBAAMPJSBINDINGS_DEFINES "${LIBAAMPJSBINDINGS_DEFINES} -DUSE_SYSTEMD_JOURNAL_PRINT=1 -DSD_JOURNAL_SUPPRESS_LOCATION=1")
 endif()
+# std::atomic<ABRManager::PersistBandwidthData> is 16 bytes.  On Linux/x86_64
+# GCC emits __atomic_load_16 / __atomic_store_16 which require the atomic
+# library.  ARM64 handles them natively so the library is not needed there,
+# but linking it is harmless when present.  Use find_library so that the build
+# does not fail on cross-compile toolchains (e.g. RDK) that do not ship it.
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	find_library(LIBATOMIC atomic)
+	if(LIBATOMIC)
+		set(LIBAAMP_DEPENDS ${LIBAAMP_DEPENDS} ${LIBATOMIC})
+		set(LIBAAMPJSBINDINGS_DEPENDS ${LIBAAMPJSBINDINGS_DEPENDS} ${LIBATOMIC})
+	endif()
+endif()
 #Enabling ethan log macro and lib
 if(CMAKE_USE_ETHAN_LOG)
 	message("DCMAKE_USE_ETHAN_LOG set")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,15 +278,10 @@ if(CMAKE_SYSTEMD_JOURNAL)
 endif()
 # std::atomic<ABRManager::PersistBandwidthData> is 16 bytes.  On Linux/x86_64
 # GCC emits __atomic_load_16 / __atomic_store_16 which require the atomic
-# library.  ARM64 handles them natively so the library is not needed there,
-# but linking it is harmless when present.  Use find_library so that the build
-# does not fail on cross-compile toolchains (e.g. RDK) that do not ship it.
+# support library shipped with GCC.  ARM64 handles them natively.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-	find_library(LIBATOMIC atomic)
-	if(LIBATOMIC)
-		set(LIBAAMP_DEPENDS ${LIBAAMP_DEPENDS} ${LIBATOMIC})
-		set(LIBAAMPJSBINDINGS_DEPENDS ${LIBAAMPJSBINDINGS_DEPENDS} ${LIBATOMIC})
-	endif()
+	set(LIBAAMP_DEPENDS ${LIBAAMP_DEPENDS} "-latomic")
+	set(LIBAAMPJSBINDINGS_DEPENDS ${LIBAAMPJSBINDINGS_DEPENDS} "-latomic")
 endif()
 #Enabling ethan log macro and lib
 if(CMAKE_USE_ETHAN_LOG)

--- a/support/aampabr/CMakeLists.txt
+++ b/support/aampabr/CMakeLists.txt
@@ -31,8 +31,12 @@ endif()
 
 # On Linux/x86_64, std::atomic<16-byte struct> requires the atomic library for
 # __atomic_load_16 / __atomic_store_16 (ARM64 handles them natively).
+# Use find_library so the build is safe on cross-compile toolchains that omit it.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-	target_link_libraries(abr PUBLIC atomic)
+	find_library(LIBATOMIC atomic)
+	if(LIBATOMIC)
+		target_link_libraries(abr PUBLIC ${LIBATOMIC})
+	endif()
 endif()
 
 set_target_properties(abr PROPERTIES PUBLIC_HEADER "ABRManager.h;HybridABRManager.h")

--- a/support/aampabr/CMakeLists.txt
+++ b/support/aampabr/CMakeLists.txt
@@ -29,14 +29,11 @@ if(CMAKE_SYSTEMD_JOURNAL)
 	target_link_libraries (abr "-lsystemd")
 endif()
 
-# On Linux/x86_64, std::atomic<16-byte struct> requires the atomic library for
-# __atomic_load_16 / __atomic_store_16 (ARM64 handles them natively).
-# Use find_library so the build is safe on cross-compile toolchains that omit it.
+# std::atomic<16-byte struct> requires the atomic support library on Linux/x86_64.
+# ARM64 handles 16-byte atomics natively; GCC always ships this library for
+# its target so it is safe to link unconditionally on Linux.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-	find_library(LIBATOMIC atomic)
-	if(LIBATOMIC)
-		target_link_libraries(abr PUBLIC ${LIBATOMIC})
-	endif()
+	target_link_libraries(abr PUBLIC "-latomic")
 endif()
 
 set_target_properties(abr PROPERTIES PUBLIC_HEADER "ABRManager.h;HybridABRManager.h")

--- a/test/utests/tests/AampAbrTests/CMakeLists.txt
+++ b/test/utests/tests/AampAbrTests/CMakeLists.txt
@@ -57,8 +57,8 @@ add_executable(HybridAbrTests HybridAbrTests.cpp
 	../../../../support/aampabr/HybridABRManager.cpp
 	../../../../support/aampabr/ABRManager.cpp
 )
-if(LIBATOMIC)
-	target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main ${LIBATOMIC})
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+	target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main "-latomic")
 else()
 	target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main)
 endif()

--- a/test/utests/tests/AampAbrTests/CMakeLists.txt
+++ b/test/utests/tests/AampAbrTests/CMakeLists.txt
@@ -57,5 +57,9 @@ add_executable(HybridAbrTests HybridAbrTests.cpp
 	../../../../support/aampabr/HybridABRManager.cpp
 	../../../../support/aampabr/ABRManager.cpp
 )
-target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:atomic>)
+if(LIBATOMIC)
+	target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main ${LIBATOMIC})
+else()
+	target_link_libraries(HybridAbrTests PRIVATE gtest gmock gtest_main)
+endif()
 aamp_utest_run_add(HybridAbrTests)

--- a/test/utests/tests/CommonTestIncludes.cmake
+++ b/test/utests/tests/CommonTestIncludes.cmake
@@ -57,11 +57,8 @@ include_directories(${AAMP_ROOT}/middleware
                     ${AAMP_ROOT}/middleware/vendor)
 
 # std::atomic<ABRManager::PersistBandwidthData> is 16 bytes.  On Linux/x86_64
-# GCC emits __atomic_load_16 / __atomic_store_16 which require the atomic
-# library.  Use find_library so the build is safe on cross-compile toolchains that omit it.
+# GCC emits __atomic_load_16 / __atomic_store_16 requiring the atomic support
+# library, which GCC always ships for its target arch.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    find_library(LIBATOMIC atomic)
-    if(LIBATOMIC)
-        set(OS_LD_FLAGS ${OS_LD_FLAGS} ${LIBATOMIC})
-    endif()
+    set(OS_LD_FLAGS ${OS_LD_FLAGS} "-latomic")
 endif()

--- a/test/utests/tests/CommonTestIncludes.cmake
+++ b/test/utests/tests/CommonTestIncludes.cmake
@@ -56,9 +56,12 @@ include_directories(${AAMP_ROOT}/middleware
                     ${AAMP_ROOT}/middleware/playerLogManager
                     ${AAMP_ROOT}/middleware/vendor)
 
-# On Linux/x86_64, std::atomic<16-byte struct> (e.g. ABRManager::PersistBandwidthData)
-# emits __atomic_load_16 / __atomic_store_16 which live in libatomic.  ARM64 (macOS)
-# handles them with native instructions and needs no extra library.
+# std::atomic<ABRManager::PersistBandwidthData> is 16 bytes.  On Linux/x86_64
+# GCC emits __atomic_load_16 / __atomic_store_16 which require the atomic
+# library.  Use find_library so the build is safe on cross-compile toolchains that omit it.
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(OS_LD_FLAGS ${OS_LD_FLAGS} -latomic)
+    find_library(LIBATOMIC atomic)
+    if(LIBATOMIC)
+        set(OS_LD_FLAGS ${OS_LD_FLAGS} ${LIBATOMIC})
+    endif()
 endif()


### PR DESCRIPTION
Reason for Change: address link failure on linux aamp build

std::atomic<ABRManager::PersistBandwidthData> is 16 bytes (BitsPerSecond
+ int64_t).  On Linux/x86_64, GCC emits __atomic_load_16/__atomic_store_16 which require the atomic library; ARM64 (macOS/RDK) handles them natively.

Use find_library(LIBATOMIC atomic) rather than hardcoding -latomic so that RDK cross-compile toolchains that do not ship the library do not fail the build (find_library returns empty and the if() guard skips the link step).

Four build systems updated:
- CMakeLists.txt         : libaamp.so and libaampjsbindings.so
- support/aampabr/CMakeLists.txt : standalone libabr.so used by FOG
- test/utests/tests/CommonTestIncludes.cmake : all L1 test targets via OS_LD_FLAGS
- test/utests/tests/AampAbrTests/CMakeLists.txt : HybridAbrTests (no OS_LD_FLAGS)