### PR TITLE
VPAAMP-246 config rename to eAAMPConfig_EnableLiveLatencyRateCorrection for clarity

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -298,7 +298,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false,"useMatchingBaseUrl",eAAMPConfig_MatchBaseUrl,false},
 	{false,"wifiCurlHeader",eAAMPConfig_WifiCurlHeader,false},
 	{false,"enableSeekableRange",eAAMPConfig_EnableSeekRange,false},
-	{false,"enableLiveLatencyCorrection",eAAMPConfig_EnableLiveLatencyCorrection,true},
+	{false,"enableLiveLatencyCorrection",eAAMPConfig_EnableLiveLatencyRateCorrection,true},
 	{true,"dashParallelFragDownload",eAAMPConfig_DashParallelFragDownload,false},
 	{false,"persistBitrateOverSeek",eAAMPConfig_PersistentBitRateOverSeek,true},
 	{true,"setLicenseCaching",eAAMPConfig_SetLicenseCaching,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -143,7 +143,7 @@ typedef enum
 	eAAMPConfig_MatchBaseUrl,						/**< Enable host of main url will be matched with host of base url*/
 	eAAMPConfig_WifiCurlHeader,
 	eAAMPConfig_EnableSeekRange,						/**< Enable seekable range reporting via progress events */
-	eAAMPConfig_EnableLiveLatencyCorrection,            /**< Enable the live latency (drift) correction by adjusting the playback speed */
+	eAAMPConfig_EnableLiveLatencyRateCorrection,            /**< Enable the live latency (drift) correction by adjusting the playback speed */
 	eAAMPConfig_DashParallelFragDownload,					/**< Enable dash fragment parallel download*/
 	eAAMPConfig_PersistentBitRateOverSeek,					/**< ABR profile persistence during Seek/Trickplay/Audio switching*/
 	eAAMPConfig_SetLicenseCaching,						/**< License caching*/

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -143,7 +143,7 @@ typedef enum
 	eAAMPConfig_MatchBaseUrl,						/**< Enable host of main url will be matched with host of base url*/
 	eAAMPConfig_WifiCurlHeader,
 	eAAMPConfig_EnableSeekRange,						/**< Enable seekable range reporting via progress events */
-	eAAMPConfig_EnableLiveLatencyRateCorrection,            /**< Enable the live latency (drift) correction by adjusting the playback speed (renamed from eAAMPConfig_EnableLiveLatencyCorrection in VPAAMP-246) */
+	eAAMPConfig_EnableLiveLatencyRateCorrection,            /**< Enable the live latency (drift) correction by adjusting the playback speed (renamed from eAAMPConfig_EnableLiveLatencyCorrection) */
 	eAAMPConfig_DashParallelFragDownload,					/**< Enable dash fragment parallel download*/
 	eAAMPConfig_PersistentBitRateOverSeek,					/**< ABR profile persistence during Seek/Trickplay/Audio switching*/
 	eAAMPConfig_SetLicenseCaching,						/**< License caching*/

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -143,7 +143,7 @@ typedef enum
 	eAAMPConfig_MatchBaseUrl,						/**< Enable host of main url will be matched with host of base url*/
 	eAAMPConfig_WifiCurlHeader,
 	eAAMPConfig_EnableSeekRange,						/**< Enable seekable range reporting via progress events */
-	eAAMPConfig_EnableLiveLatencyRateCorrection,            /**< Enable the live latency (drift) correction by adjusting the playback speed */
+	eAAMPConfig_EnableLiveLatencyRateCorrection,            /**< Enable the live latency (drift) correction by adjusting the playback speed (renamed from eAAMPConfig_EnableLiveLatencyCorrection in VPAAMP-246) */
 	eAAMPConfig_DashParallelFragDownload,					/**< Enable dash fragment parallel download*/
 	eAAMPConfig_PersistentBitRateOverSeek,					/**< ABR profile persistence during Seek/Trickplay/Audio switching*/
 	eAAMPConfig_SetLicenseCaching,						/**< License caching*/

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -463,7 +463,7 @@ static void HandleBufferingTimeoutCb(bool isBufferingTimeoutConditionMet, bool i
 			if(isRateCorrectionDefaultOnPlaying)
 			{
 				// Setting first fractional rate as DEFAULT_INITIAL_RATE_CORRECTION_SPEED right away on PLAYING to avoid audio drop
-				if (aamp->mConfig->IsConfigSet(eAAMPConfig_EnableLiveLatencyCorrection) && aamp->IsLive())
+				if (aamp->mConfig->IsConfigSet(eAAMPConfig_EnableLiveLatencyRateCorrection) && aamp->IsLive())
 				{
 					AAMPLOG_WARN("Setting first fractional rate %.6f right after moving to PLAYING", DEFAULT_INITIAL_RATE_CORRECTION_SPEED);
 					_this->SetPlayBackRate(DEFAULT_INITIAL_RATE_CORRECTION_SPEED);
@@ -840,7 +840,7 @@ void AAMPGstPlayer::Configure(StreamOutputFormat format, StreamOutputFormat audi
 	PipelinePriority = envVal ? atoi(envVal) : -1;
 
 	bool FirstFrameFlag = aamp->IsFirstVideoFrameDisplayedRequired();
-	bool isLiveRateCorrection = aamp->mConfig->IsConfigSet(eAAMPConfig_EnableLiveLatencyCorrection) && aamp->IsLive();
+	bool isLiveRateCorrection = aamp->mConfig->IsConfigSet(eAAMPConfig_EnableLiveLatencyRateCorrection) && aamp->IsLive();
 	/*Configure and create the pipeline*/
 	playerInstance->ConfigurePipeline(static_cast<int>(format),static_cast<int>(audioFormat),static_cast<int>(subFormat),
 									  bESChangeStatus,setReadyAfterPipelineCreation,

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6822,7 +6822,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	//temporary hack
 	if (strcasestr(mAppName.c_str(), "peacock"))
 	{
-		// Enable PTS Restamping
+		// Enable live latency rate correction, PTS Restamping and other app-specific configurations
 		if(SocUtils::EnableLiveLatencyCorrection())
 		{
 			SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnableLiveLatencyRateCorrection, true);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2565,7 +2565,7 @@ void PrivateInstanceAAMP::RateCorrectionWorkerThread(void)
 	}
 	else
 	{
-		AAMPLOG_WARN("Rate Correction Ignored Due to Rate Correction disabled from config;  EnableLiveLatencyCorrection [%d]",
+		AAMPLOG_WARN("Rate Correction Ignored Due to Rate Correction disabled from config;  EnableLiveLatencyRateCorrection [%d]",
 		ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection));
 	}
 }

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2423,7 +2423,7 @@ void PrivateInstanceAAMP::StartRateCorrectionWorkerThread(void)
 	try
 	{
 		bool newTune = IsNewTune();
-		bool enabled = ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection);
+		bool enabled = ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection);
 		/** Spawn the rate Correction thread if it is live, new tune, thread not started yet, and rate correction enabled **/
 		if(IsLive() && newTune && !mRateCorrectionThread.joinable() && enabled )
 		{
@@ -2444,7 +2444,7 @@ void PrivateInstanceAAMP::StartRateCorrectionWorkerThread(void)
  */
 void PrivateInstanceAAMP::RateCorrectionWorkerThread(void)
 {
-	if(ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection))
+	if(ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection))
 	{
 		int latencyMonitorInterval = GETCONFIGVALUE_PRIV(eAAMPConfig_LatencyMonitorIntervalMs);
 		double normalPlaybackRate = GETCONFIGVALUE_PRIV(eAAMPConfig_NormalLatencyCorrectionPlaybackRate);
@@ -2566,7 +2566,7 @@ void PrivateInstanceAAMP::RateCorrectionWorkerThread(void)
 	else
 	{
 		AAMPLOG_WARN("Rate Correction Ignored Due to Rate Correction disabled from config;  EnableLiveLatencyCorrection [%d]",
-		ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection));
+		ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection));
 	}
 }
 
@@ -2758,7 +2758,7 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 		{
 			currentRate = mLatencyMonitor->GetCurrentRate();
 		}
-		else if (!mAampLLDashServiceData.lowLatencyMode && ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection) )
+		else if (!mAampLLDashServiceData.lowLatencyMode && ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection) )
 		{
 			currentRate = mCorrectionRate;
 		}
@@ -3811,7 +3811,7 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 			mpStreamAbstractionAAMP->ResetESChangeStatus();
 			mpStreamAbstractionAAMP->ReSetPipelineFlushStatus();
 
-			bool isRateCorrectionEnabled = ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection);
+			bool isRateCorrectionEnabled = ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection);
 			int  disableRateCorrectionTimeInSeconds = GETCONFIGVALUE_PRIV(eAAMPConfig_RateCorrectionDelay);
 			if( disableRateCorrectionTimeInSeconds > 0  && isRateCorrectionEnabled )
 			{
@@ -6406,7 +6406,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			mMediaFormat = eMEDIAFORMAT_HLS_MP4;
 		}
 
-		if (ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyCorrection))
+		if (ISCONFIGSET_PRIV(eAAMPConfig_EnableLiveLatencyRateCorrection))
 		{
 			StartRateCorrectionWorkerThread();
 		}
@@ -6825,7 +6825,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 		// Enable PTS Restamping
 		if(SocUtils::EnableLiveLatencyCorrection())
 		{
-			SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnableLiveLatencyCorrection, true);
+			SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnableLiveLatencyRateCorrection, true);
 		}
 		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_EnablePTSReStamp, SocUtils::EnablePTSRestamp());
 		SETCONFIGVALUE_PRIV(AAMP_DEFAULT_SETTING, eAAMPConfig_DisableWebVTT, true);

--- a/simnet/README.md
+++ b/simnet/README.md
@@ -1,4 +1,4 @@
-# Network Persona Fitter (VPAAMP-129)
+# Network Persona Fitter
 
 Automatic generation of a simnet **network persona JSON** directly from a live AAMP
 playback session — no external Python tool or post-processing step required.

--- a/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
+++ b/test/utests/tests/AampAbrTests/HybridAbrTests.cpp
@@ -53,7 +53,7 @@ TEST_F(HybridAbrTests, UpdateABRBitrateDataBasedOnCacheOutlierEven)
 /**
  * @brief Two HybridABRManager instances must have independent rampup loop
  *        counters. Verifies the per-instance mRampupFromSteadyStateLoop fix
- *        in HybridABRManager (VPAAMP-173).
+ *        in HybridABRManager.
  */
 TEST_F(HybridAbrTests, CheckRampupFromSteadyState_LoopIsPerInstance)
 {


### PR DESCRIPTION
Reason for Change: Looking to help make code more consistent and self documenting.
- Two variables that read this flag in the codebase are already named isLiveRateCorrection (aampgstplayer.cpp:843) and isRateCorrectionEnabled (priv_aamp.cpp:3814), showing the intent is specifically rate-based.
- The current name EnableLiveLatencyCorrection is ambiguous — "latency correction" could mean a seek, an ABR switch, a buffer drain, or a rate change. Adding "Rate" removes that ambiguity.