### PR TITLE
VPAAMP-262 FossID Detected License Issue

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -15,6 +15,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /**


### PR DESCRIPTION
Reason for Change: add SPDX-License-Identifier to fix FossID Apache-2.0 snippet false positive

Test Guidance: PRs no longer having FossID warnings

Risk: Low