### PR TITLE
VPAAMP-31: Fix VOD CDAI issue with mp4demux

### DIFF
--- a/File.txt
+++ b/File.txt
@@ -1,3 +1,0 @@
-
-pkg_check_modules(LIBCJSON REQUIRED libcjson)
-link_directories(${LIBCJSON_LIBRARY_DIRS})

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -808,6 +808,8 @@ public:
 	int noMDATCount;                    /**< MDAT Chunk Not Found count continuously while chunk buffer processing*/
 	double m_totalDurationForPtsRestamping;
 	std::shared_ptr<MediaProcessor> playContext;		/**< state for s/w demuxer / pts/pcr restamper module */
+	std::string mContentInitFragmentUrl;			/**< URL of most-recent non-ad init fragment; used to
+								     prime encrypted pipeline before a pre-roll ad plays */
 	bool seamlessAudioSwitchInProgress; /**< Flag to indicate seamless audio track switch in progress */
 	bool seamlessSubtitleSwitchInProgress;
 	bool mCheckForRampdown;		        /**< flag to indicate if the track is undergoing rampdown or not */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -283,7 +283,6 @@ static bool IsAtmosAudio(const IMPDElement *nodePtr)
 			}
 		}
 	}
-
 	return isAtmos;
 }
 
@@ -4033,10 +4032,15 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			else
 			{
 				// Check if single pipeline has a main asset that has
-				// encrypted content whose init header urls have been saved
+				// encrypted content whose init header urls have been saved.
+				// In a CDAI pre-roll scenario the headers were consumed by the
+				// previous session so the "already injected" flag may be set;
+				// reset it so the stored headers can be used again.
+				AampStreamSinkManager::GetInstance().ReinjectEncryptedHeaders();
 				AampStreamSinkManager::GetInstance().GetEncryptedHeaders(headers);
 				if (!headers.empty())
 				{
+					AAMPLOG_MIL("[CDAI] Re-using stored encrypted headers to prime pipeline before pre-roll ad");
 					PushEncryptedHeaders(headers);
 					aamp->mPipelineIsClear = false;
 					aamp->mEncryptedPeriodFound = false;
@@ -9375,7 +9379,7 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 							MediaTrack *audio = GetMediaTrack(eTRACK_AUDIO);
 							audio->UpdateInjectedDuration((double)mAudioSurplus);
 							mAudioSurplus = 0;
-						}else if ( mVideoSurplus != 0 )
+						}
 						{
 							MediaTrack *video = GetMediaTrack(eTRACK_VIDEO);
 							video->UpdateInjectedDuration((double)mVideoSurplus);
@@ -9533,6 +9537,87 @@ bool StreamAbstractionAAMP_MPD::IndexSelectedPeriod(bool periodChanged, bool adS
 		}
 	}
 	return true;
+}
+
+/**
+ * @fn InjectContentInitBeforeAd
+ * @brief For a pre-roll ad (clear) following encrypted content, send the cached
+ *        content init fragment through each track's demuxer before the ad init
+ *        arrives.  This causes SetStreamCaps(encrypted) to fire first so that
+ *        AampMp4Demuxer's mEncryptedCapsPrimed guard suppresses the subsequent
+ *        clear caps call, keeping the GStreamer pipeline in encrypted mode for
+ *        the content that resumes after the ad.
+ */
+void StreamAbstractionAAMP_MPD::InjectContentInitBeforeAd()
+{
+	AAMPLOG_MIL("[CDAI] Injecting content init fragments to prime encrypted pipeline "
+		"before pre-roll ad (basePeriodId:%s)", mBasePeriodId.c_str());
+
+	for (int i = 0; i < mNumberOfTracks; i++)
+	{
+		MediaStreamContext *ctx = mMediaStreamContext[i];
+		if (!ctx->enabled)
+		{
+			AAMPLOG_INFO("[CDAI] Track %d disabled, skipping content init prime", i);
+			continue;
+		}
+		if (ctx->mContentInitFragmentUrl.empty())
+		{
+			AAMPLOG_WARN("[CDAI] No cached content init URL for track %d (%s) - "
+				"encrypted pipeline may not be established correctly",
+				i, GetMediaTypeName(ctx->mediaType));
+			continue;
+		}
+		if (!ctx->playContext)
+		{
+			AAMPLOG_WARN("[CDAI] No playContext for track %d (%s), cannot inject content init",
+				i, GetMediaTypeName(ctx->mediaType));
+			continue;
+		}
+
+		std::vector<uint8_t> buffer;
+		std::string effectiveUrl;
+		bool found = aamp->getAampCacheHandler()->RetrieveFromInitFragmentCache(
+			ctx->mContentInitFragmentUrl, buffer, effectiveUrl);
+		if (!found || buffer.empty())
+		{
+			AAMPLOG_WARN("[CDAI] Content init not in cache for track %d (%s) url:%s - "
+				"skipping pipeline prime",
+				i, GetMediaTypeName(ctx->mediaType),
+				ctx->mContentInitFragmentUrl.c_str());
+			continue;
+		}
+
+		AAMPLOG_INFO("[CDAI] Sending content init to demuxer for track %d (%s) "
+			"url:%s size:%zu - will set encrypted caps before ad init arrives",
+			i, GetMediaTypeName(ctx->mediaType),
+			ctx->mContentInitFragmentUrl.c_str(), buffer.size());
+
+		MediaProcessor::process_fcn_t processor =
+			[](AampMediaType, SegmentInfo_t, std::vector<uint8_t>) {};
+		bool ptsErr = false;
+		bool sent = ctx->playContext->sendSegment(
+			std::move(buffer),
+			0.0  /*position*/,
+			0.0  /*duration*/,
+			0.0  /*PTSoffset*/,
+			false /*discontinuity*/,
+			true  /*isInit*/,
+			std::move(processor),
+			ptsErr);
+
+		if (sent)
+		{
+			AAMPLOG_MIL("[CDAI] Encrypted pipeline primed for track %d (%s)",
+				i, GetMediaTypeName(ctx->mediaType));
+		}
+		else
+		{
+			AAMPLOG_ERR("[CDAI] sendSegment returned false for content init on track %d (%s) - "
+				"encrypted pipeline prime failed",
+				i, GetMediaTypeName(ctx->mediaType));
+		}
+	}
 }
 
 /**

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -818,6 +818,15 @@ protected:
 	void FetchAndInjectInitialization(int trackIdx, bool discontinuity = false);
 	/**
 	 * @fn RefreshTrack
+	/**
+	 * @fn InjectContentInitBeforeAd
+	 * @brief Retrieve the cached content-period init fragment for each enabled track and
+	 *        send it through the demuxer so that an encrypted GStreamer pipeline is
+	 *        established before the pre-roll ad's clear init fragment arrives.
+	 */
+	void InjectContentInitBeforeAd();
+	/**
+	 * @fn RefreshTrack
 	 * @param type media type
 	 * @return void
 	 */

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -117,13 +117,29 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 				if (codecInfo.mCodecFormat != GST_FORMAT_INVALID &&
 					codecInfo.mCodecFormat != GST_FORMAT_UNKNOWN)
 				{
-					// Invoke SetStreamCaps for proper codec info
-					AAMPLOG_INFO("Updating codecInfo with format:%d", codecInfo.mCodecFormat);
-					mAamp->SetStreamCaps(mMediaType, std::move(codecInfo));
+					// Suppress clear caps if an encrypted init has already been
+					// processed first (pre-roll ad scenario: content init sent
+					// before the ad to establish an encrypted GStreamer pipeline).
+					if (mEncryptedCapsPrimed && !codecInfo.mIsEncrypted)
+					{
+						AAMPLOG_INFO("Suppressing clear caps for type:%d - encrypted pipeline already set",
+							mMediaType);
+					}
+					else
+					{
+						if (codecInfo.mIsEncrypted)
+						{
+							mEncryptedCapsPrimed = true;
+						}
+						AAMPLOG_INFO("Updating codecInfo with format:%d encrypted:%d for type:%d",
+							codecInfo.mCodecFormat, codecInfo.mIsEncrypted, mMediaType);
+						mAamp->SetStreamCaps(mMediaType, std::move(codecInfo));
+					}
 				}
 				else
 				{
-					AAMPLOG_ERR("No samples for type:%d and invalid codec format:%d", mMediaType, codecInfo.mCodecFormat);
+					AAMPLOG_ERR("No samples for type:%d and invalid codec format:%d",
+						mMediaType, codecInfo.mCodecFormat);
 					ret = false;
 				}
 			}

--- a/mp4demux/AampMp4Demuxer.h
+++ b/mp4demux/AampMp4Demuxer.h
@@ -111,7 +111,7 @@ public:
 	 *
 	 * @return void
 	 */
-	void reset() override { }
+	void reset() override { mEncryptedCapsPrimed = false; }
 
 	/**
 	 * @brief Function to abort wait for injecting the segment
@@ -143,6 +143,7 @@ private:
 	bool mEnablePtsRestamp; // Flag to enable PTS restamping
 	// A separate flag to enable logging for PTS restamping for better control.
 	bool mEnablePtsRestampLogging {false}; // Flag to enable logging for PTS restamping
+	bool mEncryptedCapsPrimed {false}; // True once an encrypted init has set caps
 };
 
 #endif /* __AAMPMP4DEMUXER_H__ */

--- a/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
@@ -265,6 +265,133 @@ TEST_F(AampMp4DemuxerTests, SendInitSegmentWithInvalidCodecInfo)
 }
 
 /**
+ * @brief Test that sending an encrypted init via normal sendSegment sets mEncryptedCapsPrimed
+ *        and subsequent clear init does not overwrite the encrypted pipeline caps.
+ *        This covers the pre-roll ad VOD scenario where the content init is fed first
+ *        so GStreamer creates an encrypted pipeline before the clear ad init arrives.
+ */
+TEST_F(AampMp4DemuxerTests, EncryptedInitFollowedByClearInitSuppressesClearCaps)
+{
+	const char* encInitData = "encrypted_init";
+	std::vector<uint8_t> encInitBuffer(encInitData, encInitData + strlen(encInitData));
+	const char* clearInitData = "clear_init";
+	std::vector<uint8_t> clearInitBuffer(clearInitData, clearInitData + strlen(clearInitData));
+
+	// First call: encrypted content init (sent before pre-roll ad starts)
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_))
+		.WillOnce(Return(true))   // encrypted init
+		.WillOnce(Return(true));  // clear ad init
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce(Invoke([]() { return std::vector<AampMediaSample>(); }))
+		.WillOnce(Invoke([]() { return std::vector<AampMediaSample>(); }));
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce(Invoke([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			codecInfo.mIsEncrypted = true;
+			return codecInfo;
+		}))
+		.WillOnce(Invoke([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			codecInfo.mIsEncrypted = false;
+			return codecInfo;
+		}));
+	// SetStreamCaps must be called exactly once (for the encrypted init only)
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		SetStreamCaps(eMEDIATYPE_VIDEO, _)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _)).Times(0);
+
+	bool ptsError = false;
+	// Content init arrives first via CacheFragment path
+	EXPECT_TRUE(mDemuxer->sendSegment(std::move(encInitBuffer), 0.0, 0.0, 0.0,
+		false, true, nullptr, ptsError));
+	EXPECT_FALSE(ptsError);
+
+	// Ad init arrives — clear caps must be suppressed
+	EXPECT_TRUE(mDemuxer->sendSegment(std::move(clearInitBuffer), 0.0, 0.0, 0.0,
+		false, true, nullptr, ptsError));
+	EXPECT_FALSE(ptsError);
+}
+
+/**
+ * @brief Test that reset() clears the encrypted caps primed flag so a subsequent
+ *        init can update the pipeline normally (content restart after ad).
+ */
+TEST_F(AampMp4DemuxerTests, ResetClearsEncryptedCapsPrimedFlag)
+{
+	const char* encInitData = "encrypted_init";
+	std::vector<uint8_t> encInitBuffer(encInitData, encInitData + strlen(encInitData));
+	const char* contentInitData = "content_init_restart";
+	std::vector<uint8_t> contentRestartBuffer(
+		contentInitData, contentInitData + strlen(contentInitData));
+
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_))
+		.WillOnce(Return(true))   // encrypted init
+		.WillOnce(Return(true));  // content init after reset
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce(Invoke([]() { return std::vector<AampMediaSample>(); }))
+		.WillOnce(Invoke([]() { return std::vector<AampMediaSample>(); }));
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce(Invoke([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			codecInfo.mIsEncrypted = true;
+			return codecInfo;
+		}))
+		.WillOnce(Invoke([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			codecInfo.mIsEncrypted = true;
+			return codecInfo;
+		}));
+	// SetStreamCaps called for both: first priming, then content restart after reset
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		SetStreamCaps(eMEDIATYPE_VIDEO, _)).Times(2);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _)).Times(0);
+
+	bool ptsError = false;
+	EXPECT_TRUE(mDemuxer->sendSegment(std::move(encInitBuffer), 0.0, 0.0, 0.0,
+		false, true, nullptr, ptsError));
+
+	// reset() is called when content playback is restarted (ad ends)
+	mDemuxer->reset();
+
+	// Content init re-sent by fragment collector — must not be suppressed
+	EXPECT_TRUE(mDemuxer->sendSegment(std::move(contentRestartBuffer), 0.0, 0.0, 0.0,
+		false, true, nullptr, ptsError));
+	EXPECT_FALSE(ptsError);
+}
+
+/**
+ * @brief Test that a clear init sent without prior encrypted init proceeds normally.
+ */
+TEST_F(AampMp4DemuxerTests, ClearInitWithoutPriorEncryptedInitSetsClearCaps)
+{
+	const char* clearInitData = "clear_init";
+	std::vector<uint8_t> clearInitBuffer(clearInitData, clearInitData + strlen(clearInitData));
+
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce(Invoke([]() { return std::vector<AampMediaSample>(); }));
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce(Invoke([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			codecInfo.mIsEncrypted = false;
+			return codecInfo;
+		}));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		SetStreamCaps(eMEDIATYPE_VIDEO, _)).Times(1);
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _)).Times(0);
+
+	bool ptsError = false;
+	EXPECT_TRUE(mDemuxer->sendSegment(std::move(clearInitBuffer), 0.0, 0.0, 0.0,
+		false, true, nullptr, ptsError));
+	EXPECT_FALSE(ptsError);
+}
+
+/**
  * @brief Test sendSegment with parse failure
  */
 TEST_F(AampMp4DemuxerTests, SendSegmentWithParseFailure)


### PR DESCRIPTION
Reason for change: Consturct an encrypted
pipeline before ad starts
Test Procedure: updated in ticket
Risks: Medium