### PR TITLE
VPAAMP-279: L1 failure fix

### DIFF
--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -3942,7 +3942,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 	MediaTrack *track = mStreamAbstractionAAMP_MPD->GetMediaTrack(eTRACK_VIDEO);
 	ASSERT_NE(track, nullptr);
 	MediaStreamContext *pMediaStreamContext = static_cast<MediaStreamContext *>(track);
-	//EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 
 	// Reset mFirstPTS before seek
 	mStreamAbstractionAAMP_MPD->clearFirstPTS();


### PR DESCRIPTION
Reason for change: g_mockPrivateInstanceAAMP is a StrictMock.With StrictMock, any call to a mocked method without a matching expectation causes a test failure. Test Procedure: see Jira ticket
Risks: Low
Priority: P1