### PR TITLE
RDKEMW-17690: Deprecating PluginScan to avoid Crash in plugin_loader_cleanup_child

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -395,7 +395,7 @@ AAMPGstPlayer::AAMPGstPlayer(PrivateInstanceAAMP *aamp, id3_callback_t id3Handle
 
 {
 	privateContext = new AAMPGstPlayerPriv();
-	playerInstance = new InterfacePlayerRDK();                                       // for time being to use across class and non-class members when progressive testing
+	playerInstance = new InterfacePlayerRDK(ISCONFIGSET(eAAMPConfig_useRialtoSink)); 
 	RegisterBusCb(this, playerInstance);
 	if(privateContext)
 	{

--- a/middleware/InterfacePlayerPriv.h
+++ b/middleware/InterfacePlayerPriv.h
@@ -262,7 +262,7 @@ class InterfacePlayerPriv
 	private:
 	protected:
 	public:
-		InterfacePlayerPriv();
+		InterfacePlayerPriv(bool isRialto);
 		~InterfacePlayerPriv();
 		GstPlayerPriv *gstPrivateContext;
 		std::shared_ptr<SocInterface> socInterface;

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -87,11 +87,11 @@ const char * CipherTypeToString(CipherType type)
 }
 
 /*InterfacePlayerRDK constructor*/
-InterfacePlayerRDK::InterfacePlayerRDK() :
+InterfacePlayerRDK::InterfacePlayerRDK(bool isRialto) :
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
 mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL), mDRMSessionManager(NULL)
 {
-	interfacePlayerPriv = new InterfacePlayerPriv();
+	interfacePlayerPriv = new InterfacePlayerPriv(isRialto);
 	MW_LOG_MIL("InterfacePlayerRDK constructed using built-in library");
 	m_gstConfigParam = new Configs();
 	m_gstConfigParam->framesToQueue = SocUtils::RequiredQueuedFrames();
@@ -121,10 +121,10 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	delete interfacePlayerPriv;
 }
 
-InterfacePlayerPriv::InterfacePlayerPriv():mPlayerName()
+InterfacePlayerPriv::InterfacePlayerPriv(bool isRialto):mPlayerName()
 {
 	gstPrivateContext = new GstPlayerPriv();
-	socInterface = SocInterface::CreateSocInterface();
+	socInterface = SocInterface::CreateSocInterface(isRialto);
 }
 
 InterfacePlayerPriv::~InterfacePlayerPriv()

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -166,7 +166,7 @@ class InterfacePlayerRDK
 		std::map<InterfaceCB, std::function<void(int)>> setupStreamCallbackMap;
         
 		PlayerScheduler mScheduler;
-        	InterfacePlayerRDK();
+		InterfacePlayerRDK(bool isRialto = false);
         	~InterfacePlayerRDK();
 		InterfacePlayerPriv* GetPrivatePlayer();
 		/**

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -29,6 +29,11 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
         std::shared_ptr<SocInterface> obj = std::make_shared<DefaultSocInterface>();
         return obj;
 }
+std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
+{
+        std::shared_ptr<SocInterface> obj = std::make_shared<DefaultSocInterface>();
+        return obj;
+}
 bool DefaultSocInterface::UseAppSrc()
 {
 #if defined (__APPLE__)

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -25,6 +25,8 @@
 #include "vendor/default/DefaultSocInterface.h"
 #include "vendor/mtk/MtkSocInterface.h"
 
+/**Initially re-sets the IsRialtoMode */
+bool SocInterface::mIsRialtoMode = false;
 /**
  * @brief Checks if the input string starts with the given prefix.
  *
@@ -151,6 +153,21 @@ SocPlatformType SocInterface::InferPlatformFromDeviceProperties( void )
 
 
 /**
+ * @brief Loads the instance with rialto mode or not 
+ *
+ * @return A pointer to the created SocInterface object, or nullptr on failure.
+ */
+std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
+{
+	if(isRialto == true)
+	{
+	    MW_LOG_MIL("Rialto is enabled and creating default soc");
+	}
+	mIsRialtoMode = isRialto;
+	return CreateSocInterface();
+}
+
+/**
  * @brief Creates an instance of the SoC-specific interface based on the detected platform.
  *
  * @return A pointer to the created SocInterface object, or nullptr on failure.
@@ -163,7 +180,11 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
 		SocPlatformType platformType = InferPlatformFromDeviceProperties();
 		if(platformType == SOC_PLATFORM_DEFAULT)
 		{
-			platformType = InferPlatformFromPluginScan();
+			if(!mIsRialtoMode)
+			{
+				MW_LOG_MIL("Performing InterfacePluginScan| Rialto-Disabled");
+				platformType = InferPlatformFromPluginScan();
+                        }
 		}
 		switch (platformType)
 		{

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -94,6 +94,11 @@ protected:
 public:
 	SocInterface() {}
 
+	/** 
+	 * @brief Set rialto mode or not
+	 * @return True when rialto is enabled 
+	 */
+	static bool mIsRialtoMode;
 	/**
 	 * @brief Sets the state of Westeros Sink usage.
 	 *
@@ -140,6 +145,11 @@ public:
 	 * @return A pointer to the created SocInterface object.
 	 */
 	static std::shared_ptr<SocInterface> CreateSocInterface();
+	/**
+	 * @brief Creates an instance of the SoC-specific interface with argument as rialtomode or not .
+	 * @return A pointer to the created SocInterface object.
+	 */
+	static std::shared_ptr<SocInterface> CreateSocInterface(bool isRialto);
 
 	/**
 	 * @brief Configure the accept caps


### PR DESCRIPTION

RDKEMW-17690:  [8.5] Deprecating PluginScan to avoid Crash in plugin_loader_cleanup_child
Reason for Change: Deprecation of InterfacePluginScan when rialto is enabled

Test Guidance: updated in ticket

Risk: Low