### PR TITLE
RDKEMW-18590: Disable pre-tune(faketune) in RDK-E 8.4 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,11 +51,6 @@ pkg_check_modules(OPENSSL REQUIRED openssl)
 pkg_check_modules(LIBCJSON REQUIRED libcjson)
 pkg_check_modules(UUID REQUIRED uuid)
 
-if(CMAKE_PREINIT_DECODER)
-       message("CMAKE_PREINIT_DECODER Set")
-       set(LIBAAMP_DEFINES "${LIBAAMP_DEFINES} -DUSE_PREINIT_DECODING=1")
-       set(LIBAAMPJSBINDINGS_DEFINES "${LIBAAMPJSBINDINGS_DEFINES} -DUSE_PREINIT_DECODING=1")
-endif()
 
 if(APPLE)
 	# libcurl < 8.5 exhibits memory leaks. On Ubuntu 22.04 can't update beyond 7.81.0-1ubuntu1.16 without building from source


### PR DESCRIPTION
Reason for Change: disabled pre-tune

Test procedure: upon deep sleep fake tune should be disabled

Risks : Low