### PR TITLE
VPAAMP-346 restore period state when UpdateTrackInfo fails in HandleS…

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7124,6 +7124,10 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 	for (int i = 0; i < mMaxTracks; i++)
 	{
 		class MediaStreamContext *pMediaStreamContext = mMediaStreamContext[i];
+		if (!pMediaStreamContext)
+		{
+			continue;
+		}
 		size_t numAdaptationSets = period->GetAdaptationSets().size();
 		int  selAdaptationSetIndex = -1;
 		int selRepresentationIndex = -1;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -1965,6 +1965,19 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 		return false;
 	}
 
+	// Snapshot period state before applying the switch.  UpdateTrackInfo may fail (e.g.
+	// malformed or codec-incompatible period discovered during a live manifest refresh).
+	// Without a rollback, the object is left in a partially-switched state: period index
+	// and id advanced to nextPeriodIdx while the track contexts still reflect the old
+	// period.  Subsequent fetcher-loop iterations would attempt to download fragments from
+	// a period that was never successfully initialised.
+	int         savedPeriodIdx       = mCurrentPeriodIdx;
+	IPeriod    *savedCurrentPeriod   = mCurrentPeriod;
+	std::string savedBasePeriodId    = mBasePeriodId;
+	double      savedPeriodStartTime = mPeriodStartTime;
+	double      savedPeriodDuration  = mPeriodDuration;
+	double      savedPeriodEndTime   = mPeriodEndTime;
+
 	mCurrentPeriodIdx = nextPeriodIdx;
 	mCurrentPeriod = mpd->GetPeriods().at(mCurrentPeriodIdx);
 	mBasePeriodId = mCurrentPeriod->GetId();
@@ -1977,7 +1990,13 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 	AAMPStatusType ret = UpdateTrackInfo(true, true);
 	if (ret != eAAMPSTATUS_OK)
 	{
-		AAMPLOG_WARN("SeekInPeriod: UpdateTrackInfo failed while switching to period %d", mCurrentPeriodIdx);
+		AAMPLOG_WARN("SeekInPeriod: UpdateTrackInfo failed switching to period %d; restoring previous period state", mCurrentPeriodIdx);
+		mCurrentPeriodIdx = savedPeriodIdx;
+		mCurrentPeriod    = savedCurrentPeriod;
+		mBasePeriodId     = savedBasePeriodId;
+		mPeriodStartTime  = savedPeriodStartTime;
+		mPeriodDuration   = savedPeriodDuration;
+		mPeriodEndTime    = savedPeriodEndTime;
 		return false;
 	}
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -1971,6 +1971,61 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 	// and id advanced to nextPeriodIdx while the track contexts still reflect the old
 	// period.  Subsequent fetcher-loop iterations would attempt to download fragments from
 	// a period that was never successfully initialised.
+	//
+	// StreamSelection() and UpdateTrackInfo() are not atomic: they iterate over tracks in
+	// order and mutate each context's adaptation/representation pointers, fragment number,
+	// eos flag, and timeline index one track at a time.  If UpdateTrackInfo() returns an
+	// error mid-way (e.g. a null context for a later track), earlier tracks already point
+	// at the new period's data while the period identity fields are about to be restored to
+	// the old period.  Snapshot and restore the full set of mutable per-track and ABR state
+	// so that a failed transition leaves the object in its pre-attempt state.
+	struct TrackSnapshot
+	{
+		bool                  enabled;
+		int                   adaptationSetIdx;
+		uint32_t              adaptationSetId;
+		int                   representationIndex;
+		bool                  profileChanged;
+		const IAdaptationSet  *adaptationSet;
+		const IRepresentation *representation;
+		BitsPerSecond         bandwidth;
+		uint64_t              number;
+		double                time;
+		bool                  eos;
+		int                   timeLineIndex;
+		int                   fragmentRepeatCount;
+		double                scaledPTO;
+	};
+	std::vector<TrackSnapshot> trackSnapshots(mMaxTracks);
+	for (int i = 0; i < mMaxTracks; i++)
+	{
+		if (mMediaStreamContext[i])
+		{
+			const auto *ctx = mMediaStreamContext[i];
+			trackSnapshots[i] = {
+				ctx->enabled,
+				ctx->adaptationSetIdx,
+				ctx->adaptationSetId,
+				ctx->representationIndex,
+				ctx->profileChanged,
+				ctx->adaptationSet,
+				ctx->representation,
+				ctx->fragmentDescriptor.Bandwidth,
+				ctx->fragmentDescriptor.Number,
+				ctx->fragmentDescriptor.Time,
+				ctx->eos,
+				ctx->timeLineIndex,
+				ctx->fragmentRepeatCount,
+				ctx->scaledPTO
+			};
+		}
+	}
+	int                        savedNumberOfTracks     = mNumberOfTracks;
+	bool                       savedUpdateStreamInfo   = mUpdateStreamInfo;
+	ABRMode                    savedABRMode             = mABRMode;
+	std::vector<StreamInfo>    savedStreamInfo          = mStreamInfo;
+	std::vector<BitsPerSecond> savedBitrateIndexVector  = mBitrateIndexVector;
+
 	int         savedPeriodIdx       = mCurrentPeriodIdx;
 	IPeriod    *savedCurrentPeriod   = mCurrentPeriod;
 	std::string savedBasePeriodId    = mBasePeriodId;
@@ -1991,12 +2046,39 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 	if (ret != eAAMPSTATUS_OK)
 	{
 		AAMPLOG_WARN("SeekInPeriod: UpdateTrackInfo failed switching to period %d; restoring previous period state", mCurrentPeriodIdx);
-		mCurrentPeriodIdx = savedPeriodIdx;
-		mCurrentPeriod    = savedCurrentPeriod;
-		mBasePeriodId     = savedBasePeriodId;
-		mPeriodStartTime  = savedPeriodStartTime;
-		mPeriodDuration   = savedPeriodDuration;
-		mPeriodEndTime    = savedPeriodEndTime;
+		mCurrentPeriodIdx   = savedPeriodIdx;
+		mCurrentPeriod      = savedCurrentPeriod;
+		mBasePeriodId       = savedBasePeriodId;
+		mPeriodStartTime    = savedPeriodStartTime;
+		mPeriodDuration     = savedPeriodDuration;
+		mPeriodEndTime      = savedPeriodEndTime;
+		mNumberOfTracks     = savedNumberOfTracks;
+		mUpdateStreamInfo   = savedUpdateStreamInfo;
+		mABRMode            = savedABRMode;
+		mStreamInfo         = std::move(savedStreamInfo);
+		mBitrateIndexVector = std::move(savedBitrateIndexVector);
+		for (int i = 0; i < mMaxTracks; i++)
+		{
+			if (mMediaStreamContext[i])
+			{
+				auto       *ctx  = mMediaStreamContext[i];
+				const auto &snap = trackSnapshots[i];
+				ctx->enabled             = snap.enabled;
+				ctx->adaptationSetIdx    = snap.adaptationSetIdx;
+				ctx->adaptationSetId     = snap.adaptationSetId;
+				ctx->representationIndex = snap.representationIndex;
+				ctx->profileChanged      = snap.profileChanged;
+				ctx->adaptationSet       = snap.adaptationSet;
+				ctx->representation      = snap.representation;
+				ctx->fragmentDescriptor.Bandwidth = snap.bandwidth;
+				ctx->fragmentDescriptor.Number    = snap.number;
+				ctx->fragmentDescriptor.Time      = snap.time;
+				ctx->eos                 = snap.eos;
+				ctx->timeLineIndex       = snap.timeLineIndex;
+				ctx->fragmentRepeatCount = snap.fragmentRepeatCount;
+				ctx->scaledPTO           = snap.scaledPTO;
+			}
+		}
 		return false;
 	}
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -52,6 +52,7 @@
 #include "AampMPDUtils.h"
 #include <chrono>
 #include "AampTSBSessionManager.h"
+#include "AampTelemetry2.hpp"
 #include "MediaSegmentDownloadJob.hpp"
 //#define DEBUG_TIMELINE
 #include "PlayerCCManager.h"
@@ -2045,7 +2046,15 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 	AAMPStatusType ret = UpdateTrackInfo(true, true);
 	if (ret != eAAMPSTATUS_OK)
 	{
-		AAMPLOG_WARN("SeekInPeriod: UpdateTrackInfo failed switching to period %d; restoring previous period state", mCurrentPeriodIdx);
+		AAMPLOG_ERR("HandleSeekEOSAndPeriodTransition: UpdateTrackInfo failed switching from period %d (%s) to period %d (%s); rolling back",
+				savedPeriodIdx, savedBasePeriodId.c_str(), mCurrentPeriodIdx, mBasePeriodId.c_str());
+#ifdef AAMP_TELEMETRY_SUPPORT
+		AAMPTelemetry2 at2(aamp->mAppName);
+		std::map<std::string, int> intData;
+		intData["from_period"] = savedPeriodIdx;
+		intData["to_period"]   = mCurrentPeriodIdx;
+		at2.send("PERIOD_SWITCH_FAILED", intData, {/*string data*/}, {/*float data*/});
+#endif // AAMP_TELEMETRY_SUPPORT
 		mCurrentPeriodIdx   = savedPeriodIdx;
 		mCurrentPeriod      = savedCurrentPeriod;
 		mBasePeriodId       = savedBasePeriodId;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2049,7 +2049,7 @@ bool StreamAbstractionAAMP_MPD::HandleSeekEOSAndPeriodTransition(double remainin
 		AAMPLOG_ERR("HandleSeekEOSAndPeriodTransition: UpdateTrackInfo failed switching from period %d (%s) to period %d (%s); rolling back",
 				savedPeriodIdx, savedBasePeriodId.c_str(), mCurrentPeriodIdx, mBasePeriodId.c_str());
 #ifdef AAMP_TELEMETRY_SUPPORT
-		AAMPTelemetry2 at2(aamp->mAppName);
+		AAMPTelemetry2 at2(aamp->GetAppName());
 		std::map<std::string, int> intData;
 		intData["from_period"] = savedPeriodIdx;
 		intData["to_period"]   = mCurrentPeriodIdx;

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -876,7 +876,7 @@ protected:
 	/**
 	 * @fn UpdateTrackInfo
 	 */
-	AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex = false, bool isInit = false);
+	virtual AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex = false, bool isInit = false);
 	/**
 	 * @fn SkipToEnd
 	 * @param pMediaStreamContext Track object pointer

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -343,3 +343,8 @@ uint32_t StreamAbstractionAAMP_MPD::GetManifestUpdateCounter()
 {
 	return 0;
 }
+
+AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex, bool isInit)
+{
+	return eAAMPSTATUS_OK;
+}

--- a/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP_MPD.h
@@ -42,6 +42,7 @@ public:
 	MOCK_METHOD(std::vector<AudioTrackInfo>&, GetAvailableAudioTracks, (bool allTrack), (override));
 	MOCK_METHOD(double, GetFirstPTS, (), (override));
 	MOCK_METHOD(double, GetBufferedDuration, (), (override));
+	MOCK_METHOD(AAMPStatusType, UpdateTrackInfo, (bool modifyDefaultBW, bool resetTimeLineIndex, bool isInit), (override));
 
   };
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -194,6 +194,26 @@ protected:
 		{
 			mMediaStreamContext[idx] = ctx;
 		}
+
+		std::string GetBasePeriodId() const
+		{
+			return mBasePeriodId;
+		}
+
+		double GetPeriodStartTime() const
+		{
+			return mPeriodStartTime;
+		}
+
+		double GetPeriodDuration() const
+		{
+			return mPeriodDuration;
+		}
+
+		double GetPeriodEndTime() const
+		{
+			return mPeriodEndTime;
+		}
 	};
 
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
@@ -2907,12 +2927,27 @@ TEST_F(FetcherLoopTests, HandleSeekEOS_UpdateTrackInfoFails_PeriodStateRestored)
 
 	int periodBefore = mTestableStreamAbstractionAAMP_MPD->GetCurrentPeriodIdx();
 
+	// Snapshot all period-identity and video-track state that the rollback is
+	// expected to restore.  These values characterise "in period 0 before the
+	// attempted switch" and must be identical after the failed transition.
+	dash::mpd::IPeriod *periodPtrBefore    = mTestableStreamAbstractionAAMP_MPD->GetCurrentPeriod();
+	std::string         basePeriodIdBefore = mTestableStreamAbstractionAAMP_MPD->GetBasePeriodId();
+	double              periodStartBefore  = mTestableStreamAbstractionAAMP_MPD->GetPeriodStartTime();
+	double              periodDurBefore    = mTestableStreamAbstractionAAMP_MPD->GetPeriodDuration();
+	double              periodEndBefore    = mTestableStreamAbstractionAAMP_MPD->GetPeriodEndTime();
+
 	// Set the video track eos=true (enabled should already be true after init) so the
 	// EOS check in HandleSeekEOSAndPeriodTransition fires for period 1.
 	MediaStreamContext *videoCtx = mTestableStreamAbstractionAAMP_MPD->GetMediaStreamContextAt(eMEDIATYPE_VIDEO);
 	ASSERT_NE(videoCtx, nullptr);
 	videoCtx->eos     = true;
 	videoCtx->enabled = true;
+
+	// Snapshot video-track fields that UpdateTrackInfo would mutate for period 1
+	// before they can be rolled back.
+	const IAdaptationSet  *videoAdaptSetBefore = videoCtx->adaptationSet;
+	const IRepresentation *videoRepBefore      = videoCtx->representation;
+	uint64_t               videoNumberBefore   = videoCtx->fragmentDescriptor.Number;
 
 	// Null out the audio context.  UpdateTrackInfo will encounter a null context and
 	// return eAAMPSTATUS_MANIFEST_CONTENT_ERROR, triggering the rollback path.
@@ -2926,5 +2961,25 @@ TEST_F(FetcherLoopTests, HandleSeekEOS_UpdateTrackInfoFails_PeriodStateRestored)
 
 	// UpdateTrackInfo failed: the period switch must have been rolled back.
 	EXPECT_FALSE(transitioned);
+
+	// Period-identity fields — any one of these left pointing at period 1 would cause
+	// the fetcher loop to download from the wrong period on the next iteration.
 	EXPECT_EQ(mTestableStreamAbstractionAAMP_MPD->GetCurrentPeriodIdx(), periodBefore);
+	EXPECT_EQ(mTestableStreamAbstractionAAMP_MPD->GetCurrentPeriod(),    periodPtrBefore);
+	EXPECT_EQ(mTestableStreamAbstractionAAMP_MPD->GetBasePeriodId(),     basePeriodIdBefore);
+	EXPECT_DOUBLE_EQ(mTestableStreamAbstractionAAMP_MPD->GetPeriodStartTime(), periodStartBefore);
+	EXPECT_DOUBLE_EQ(mTestableStreamAbstractionAAMP_MPD->GetPeriodDuration(),  periodDurBefore);
+	EXPECT_DOUBLE_EQ(mTestableStreamAbstractionAAMP_MPD->GetPeriodEndTime(),   periodEndBefore);
+
+	// Video track context — StreamSelection()/UpdateTrackInfo() switch adaptationSet and
+	// representation to period 1's objects before the null audio context causes a
+	// failure.  After rollback these must be restored to period 0's objects.
+	EXPECT_EQ(videoCtx->adaptationSet,            videoAdaptSetBefore);
+	EXPECT_EQ(videoCtx->representation,           videoRepBefore);
+	EXPECT_EQ(videoCtx->fragmentDescriptor.Number, videoNumberBefore);
+
+	// eos was set to true by the test (to trigger the period transition check) and
+	// must be preserved by the rollback rather than left at the false that
+	// UpdateTrackInfo writes for the new period.
+	EXPECT_TRUE(videoCtx->eos);
 }

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -195,6 +195,31 @@ protected:
 			mMediaStreamContext[idx] = ctx;
 		}
 
+		/**
+		 * When set, the UpdateTrackInfo override returns
+		 * eAAMPSTATUS_MANIFEST_CONTENT_ERROR immediately, simulating a
+		 * period whose tracks cannot be initialised (e.g. incompatible codec
+		 * or empty representation list).
+		 */
+		bool mForceUpdateTrackInfoFailure{false};
+
+		void SetForceUpdateTrackInfoFailure(bool v)
+		{
+			mForceUpdateTrackInfoFailure = v;
+		}
+
+		AAMPStatusType UpdateTrackInfo(bool modifyDefaultBW,
+									   bool resetTimeLineIndex = false,
+									   bool isInit = false) override
+		{
+			if (mForceUpdateTrackInfoFailure)
+			{
+				return eAAMPSTATUS_MANIFEST_CONTENT_ERROR;
+			}
+			return StreamAbstractionAAMP_MPD::UpdateTrackInfo(
+					modifyDefaultBW, resetTimeLineIndex, isInit);
+		}
+
 		std::string GetBasePeriodId() const
 		{
 			return mBasePeriodId;
@@ -2866,8 +2891,9 @@ TEST_F(FetcherLoopTests, SeekInPeriod_SubtitleResultNotUsedForPeriodTransition)
  * Scenario:
  *   - Init a 2-period video+audio manifest at period 0.
  *   - Mark the video track enabled and eos=true to trigger a forward period switch.
- *   - Null out the audio track context.  UpdateTrackInfo checks all track contexts and
- *     returns eAAMPSTATUS_MANIFEST_CONTENT_ERROR when it encounters a null context.
+ *   - Force UpdateTrackInfo to return eAAMPSTATUS_MANIFEST_CONTENT_ERROR via the
+ *     SetForceUpdateTrackInfoFailure flag, simulating a period whose tracks cannot
+ *     be initialised (e.g. incompatible codec, empty representation list).
  *   - Without the rollback, mCurrentPeriodIdx (and the other period members) remain
  *     set to period 1 even though the switch was not completed, leaving the object in
  *     a partially-switched state that will cause fragment-download failures on the
@@ -2943,21 +2969,18 @@ TEST_F(FetcherLoopTests, HandleSeekEOS_UpdateTrackInfoFails_PeriodStateRestored)
 	videoCtx->eos     = true;
 	videoCtx->enabled = true;
 
-	// Snapshot video-track fields that UpdateTrackInfo would mutate for period 1
-	// before they can be rolled back.
+	// Snapshot video-track fields that StreamSelection() will mutate when it sets
+	// up period 1 — the rollback must restore them to these period-0 values.
 	const IAdaptationSet  *videoAdaptSetBefore = videoCtx->adaptationSet;
 	const IRepresentation *videoRepBefore      = videoCtx->representation;
 	uint64_t               videoNumberBefore   = videoCtx->fragmentDescriptor.Number;
 
-	// Null out the audio context.  UpdateTrackInfo will encounter a null context and
-	// return eAAMPSTATUS_MANIFEST_CONTENT_ERROR, triggering the rollback path.
-	MediaStreamContext *audioCtx = mTestableStreamAbstractionAAMP_MPD->GetMediaStreamContextAt(eMEDIATYPE_AUDIO);
-	mTestableStreamAbstractionAAMP_MPD->SetMediaStreamContextAt(eMEDIATYPE_AUDIO, nullptr);
-
+	// Force UpdateTrackInfo to return MANIFEST_CONTENT_ERROR for the period-1
+	// switch attempt.  StreamSelection() runs first and is allowed to complete
+	// normally; only UpdateTrackInfo() signals failure, triggering the rollback.
+	mTestableStreamAbstractionAAMP_MPD->SetForceUpdateTrackInfoFailure(true);
 	bool transitioned = mTestableStreamAbstractionAAMP_MPD->InvokeHandleSeekEOSAndPeriodTransition(0.0, false);
-
-	// Restore audio context before any teardown path reads it.
-	mTestableStreamAbstractionAAMP_MPD->SetMediaStreamContextAt(eMEDIATYPE_AUDIO, audioCtx);
+	mTestableStreamAbstractionAAMP_MPD->SetForceUpdateTrackInfoFailure(false);
 
 	// UpdateTrackInfo failed: the period switch must have been rolled back.
 	EXPECT_FALSE(transitioned);
@@ -2971,9 +2994,8 @@ TEST_F(FetcherLoopTests, HandleSeekEOS_UpdateTrackInfoFails_PeriodStateRestored)
 	EXPECT_DOUBLE_EQ(mTestableStreamAbstractionAAMP_MPD->GetPeriodDuration(),  periodDurBefore);
 	EXPECT_DOUBLE_EQ(mTestableStreamAbstractionAAMP_MPD->GetPeriodEndTime(),   periodEndBefore);
 
-	// Video track context — StreamSelection()/UpdateTrackInfo() switch adaptationSet and
-	// representation to period 1's objects before the null audio context causes a
-	// failure.  After rollback these must be restored to period 0's objects.
+	// Video track context — StreamSelection() switches adaptationSet and
+	// representation to period 1's objects; rollback must restore period-0 values.
 	EXPECT_EQ(videoCtx->adaptationSet,            videoAdaptSetBefore);
 	EXPECT_EQ(videoCtx->representation,           videoRepBefore);
 	EXPECT_EQ(videoCtx->fragmentDescriptor.Number, videoNumberBefore);

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FetcherLoopTests.cpp
@@ -189,6 +189,11 @@ protected:
 			}
 			return mMediaStreamContext[idx];
 		}
+
+		void SetMediaStreamContextAt(int idx, MediaStreamContext *ctx)
+		{
+			mMediaStreamContext[idx] = ctx;
+		}
 	};
 
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
@@ -2832,4 +2837,94 @@ TEST_F(FetcherLoopTests, SeekInPeriod_SubtitleResultNotUsedForPeriodTransition)
 	ASSERT_NE(videoTrack, nullptr);
 	MediaStreamContext *pVideoContext = static_cast<MediaStreamContext *>(videoTrack);
 	EXPECT_EQ(pVideoContext->fragmentDescriptor.Number, 3);
+}
+
+/**
+ * @brief VPAAMP-346: HandleSeekEOSAndPeriodTransition must restore period state when
+ * UpdateTrackInfo fails after a period switch attempt.
+ *
+ * Scenario:
+ *   - Init a 2-period video+audio manifest at period 0.
+ *   - Mark the video track enabled and eos=true to trigger a forward period switch.
+ *   - Null out the audio track context.  UpdateTrackInfo checks all track contexts and
+ *     returns eAAMPSTATUS_MANIFEST_CONTENT_ERROR when it encounters a null context.
+ *   - Without the rollback, mCurrentPeriodIdx (and the other period members) remain
+ *     set to period 1 even though the switch was not completed, leaving the object in
+ *     a partially-switched state that will cause fragment-download failures on the
+ *     next fetcher-loop iteration.
+ *   - With the fix, all period members are restored to their pre-switch values.
+ */
+TEST_F(FetcherLoopTests, HandleSeekEOS_UpdateTrackInfoFails_PeriodStateRestored)
+{
+	AAMPStatusType status;
+
+	static const char *kTwoPeriodVideoAudioManifest = R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" maxSegmentDuration="PT2S" minBufferTime="PT4S"
+     profiles="urn:dvb:dash:profile:dvb-dash:2014" type="static">
+  <Period id="p0" start="PT0S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000">
+        <SegmentTemplate timescale="2500" initialization="video_p0_init.mp4"
+                         media="video_p0_$Number$.m4s" startNumber="1">
+          <SegmentTimeline><S t="0" d="5000" r="14"/></SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" contentType="audio" lang="eng">
+      <Representation id="0" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="128000">
+        <SegmentTemplate timescale="2500" initialization="audio_p0_init.mp4"
+                         media="audio_p0_$Number$.m4s" startNumber="1">
+          <SegmentTimeline><S t="0" d="5000" r="14"/></SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="p1" start="PT30S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4"
+                         media="video_p1_$Number$.m4s" startNumber="16">
+          <SegmentTimeline><S t="75000" d="5000" r="14"/></SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" contentType="audio" lang="eng">
+      <Representation id="0" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="128000">
+        <SegmentTemplate timescale="2500" initialization="audio_p1_init.mp4"
+                         media="audio_p1_$Number$.m4s" startNumber="16">
+          <SegmentTimeline><S t="75000" d="5000" r="14"/></SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>)";
+
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _))
+		.WillRepeatedly(Return(true));
+
+	status = InitializeMPD(kTwoPeriodVideoAudioManifest);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	int periodBefore = mTestableStreamAbstractionAAMP_MPD->GetCurrentPeriodIdx();
+
+	// Set the video track eos=true (enabled should already be true after init) so the
+	// EOS check in HandleSeekEOSAndPeriodTransition fires for period 1.
+	MediaStreamContext *videoCtx = mTestableStreamAbstractionAAMP_MPD->GetMediaStreamContextAt(eMEDIATYPE_VIDEO);
+	ASSERT_NE(videoCtx, nullptr);
+	videoCtx->eos     = true;
+	videoCtx->enabled = true;
+
+	// Null out the audio context.  UpdateTrackInfo will encounter a null context and
+	// return eAAMPSTATUS_MANIFEST_CONTENT_ERROR, triggering the rollback path.
+	MediaStreamContext *audioCtx = mTestableStreamAbstractionAAMP_MPD->GetMediaStreamContextAt(eMEDIATYPE_AUDIO);
+	mTestableStreamAbstractionAAMP_MPD->SetMediaStreamContextAt(eMEDIATYPE_AUDIO, nullptr);
+
+	bool transitioned = mTestableStreamAbstractionAAMP_MPD->InvokeHandleSeekEOSAndPeriodTransition(0.0, false);
+
+	// Restore audio context before any teardown path reads it.
+	mTestableStreamAbstractionAAMP_MPD->SetMediaStreamContextAt(eMEDIATYPE_AUDIO, audioCtx);
+
+	// UpdateTrackInfo failed: the period switch must have been rolled back.
+	EXPECT_FALSE(transitioned);
+	EXPECT_EQ(mTestableStreamAbstractionAAMP_MPD->GetCurrentPeriodIdx(), periodBefore);
 }


### PR DESCRIPTION
…eekEOSAndPeriodTransition

HandleSeekEOSAndPeriodTransition updates six period-identity members (mCurrentPeriodIdx, mCurrentPeriod, mBasePeriodId, mPeriodStartTime, mPeriodDuration, mPeriodEndTime) before calling UpdateTrackInfo.  If UpdateTrackInfo returns failure (malformed period, no codec-compatible representation, null track context after live manifest refresh), the function returned false but left all six members pointing at the new, uninitialised period.  The next fetcher-loop iteration would read mCurrentPeriodIdx as the new value and attempt to download fragments from a period whose tracks were never set up, producing download errors or incorrect init-segment selection.

Fix: snapshot all six members before the switch.  On UpdateTrackInfo failure, restore them and return false so the caller sees a clean no-op.

Unit test: HandleSeekEOS_UpdateTrackInfoFails_PeriodStateRestored forces UpdateTrackInfo to fail by nulling the audio track context (UpdateTrackInfo returns MANIFEST_CONTENT_ERROR on a null context) and verifies that mCurrentPeriodIdx is restored to its pre-switch value.