### PR TITLE
VPAAMP-337 confusing/misleading log message, "Dash Manifest length [0]"

### DIFF
--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -669,11 +669,26 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 
 		case AAMP_EVENT_MANIFEST_REFRESH_NOTIFY:
 		{
-			std::string manifest;
 			ManifestRefreshEventPtr ev = std::dynamic_pointer_cast<ManifestRefreshEvent>(e);
 			AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
-			manifest = mAampcli.mSingleton->GetManifest();
-			AAMPCLI_PRINTF("[AAMPCLI] Dash  Manifest length [%zu]\n",manifest.length());
+			AAMPPlayerState state = mAampcli.mSingleton->GetState();
+			switch( state )
+			{
+				case eSTATE_ERROR:
+					AAMPCLI_PRINTF("[AAMPCLI] GetManifest skipped - player is in error state\n");
+					break;
+				case eSTATE_IDLE:
+				case eSTATE_RELEASED:
+				case eSTATE_STOPPED:
+					AAMPCLI_PRINTF("[AAMPCLI] GetManifest skipped - player is not active (state=%d)\n", static_cast<int>(state));
+					break;
+				default:
+				{
+					std::string manifest = mAampcli.mSingleton->GetManifest();
+					AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
+					break;
+				}
+			}
 			break;
 		}
 		case AAMP_EVENT_TUNE_TIME_METRICS:


### PR DESCRIPTION
Reason for Change: fix misleading zero-length manifest length log from aampcli when player in error state

eSTATE_ERROR gets its own explicit message: GetManifest skipped - player is in error state — directly explains the segment-404 scenario.

eSTATE_IDLE / eSTATE_RELEASED / eSTATE_STOPPED get a generic not-active message with the numeric state for completeness.

All other states call GetManifest() and print the actual length, which will always be non-zero since the player is in a healthy state when this path is reached.

The double-space typo in "Dash Manifest" was also cleaned up.

Risk: Low (aampcli only)
Test Guidance: refer ticket