### PR TITLE
VPAAMP-207: Fix Ethan log double newline in VIPA logging (#1368)

### DIFF
--- a/aamplogging.cpp
+++ b/aamplogging.cpp
@@ -154,6 +154,7 @@ void logprintf(AAMP_LogLevel logLevelIndex, const char* func, int line, const ch
 						ethanLogLevel = ETHAN_LOG_MILESTONE;
 						break;
 				}
+				format_ptr[format_bytes-1] = 0x00; // strip explicit newline, since Ethan logger will add one and we don't want it doubled
 				vethanlog(ethanLogLevel,NULL,NULL,-1,format_ptr, args);
 			}
 			else

--- a/middleware/playerLogManager/PlayerLogManager.cpp
+++ b/middleware/playerLogManager/PlayerLogManager.cpp
@@ -157,6 +157,7 @@ void logprintf(MW_LogLevel logLevelIndex, const char* func, int line, const char
 					    ethanLogLevel = ETHAN_LOG_MILESTONE;
 					    break;
 			    }
+			    format_ptr[format_bytes-1] = 0x00; // strip explicit newline, since Ethen logger will add one and we don't want it doubled
 			    vethanlog(ethanLogLevel,NULL,NULL,-1,format_ptr, args);
 		    }
 		    else


### PR DESCRIPTION
* VPAAMP-207: Fix Ethan log double newline in VIPA logging

Reason for change:
This change resolves blank lines seen in VIPA logs when Ethan logging is enabled. The log formatter was adding a trailing newline, and Ethan logging was also applying line termination, resulting in double spacing between entries. The fix strips the trailing newline only on the Ethan redirection path, while keeping CLI and journal logging behavior unchanged.

Test Procedure:  check vipa logs

Priority: P2

Risks:Low



---------





(cherry picked from commit 154ccb238051f863fc5881445f6ecd1fa5294c4e)