### PR TITLE
VPAAMP-360 : Observed crash with “Technical Fault” error when toggling subtitles ON/OFFand then performing any actions

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12680,7 +12680,7 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 				SetClosedCaptionsFromTextTrack(track);
 			}
 		}
-		 ReleaseStreamLock();
+		ReleaseStreamLock();
 	}
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12671,7 +12671,6 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 
 					discardEnteringLiveEvt = false;
 				}
-				ReleaseStreamLock();
 			}
 			if (closedCaptionTrackId >= 0)
 			{
@@ -12681,6 +12680,7 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 				SetClosedCaptionsFromTextTrack(track);
 			}
 		}
+		 ReleaseStreamLock();
 	}
 }
 


### PR DESCRIPTION
Reason for change: Moving ReleaseStreamLock outside the else if loop. So that SetPreferredTextLanguage() won't hang if execution doesn't enter else loop.
Test Procedure: see Jira ticket
Risks: Low
Priority: P1

Signed-off-by: Abhi-jith-S abhijithssa7@gmail.com