### PR TITLE
VPAAMP-369: Remove EAS StreamSink stop on EOS

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3351,14 +3351,6 @@ void PrivateInstanceAAMP::NotifyEOSReached()
 		{
 			SetState(eSTATE_COMPLETE);
 			SendEvent(std::make_shared<AAMPEventObject>(AAMP_EVENT_EOS, GetSessionId()),AAMP_EVENT_ASYNC_MODE);
-			if (ContentType_EAS == mContentType)
-			{
-				StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-				if (sink)
-				{
-					sink->Stop(false);
-				}
-			}
 			SendAnomalyEvent(ANOMALY_TRACE, "Generating EOS event");
 			trickStartUTCMS = -1;
 			return;


### PR DESCRIPTION
Reason for change:
Revert DELI A-25590 behavior that stops StreamSink when EAS content reaches end-of-stream. This causes crashes in VIPA when app pauses at EOS during concurrent stop operations. The original fix ( calling stop)  was specific to XRE X1 platforms and is not required for VIPA.

Test Procedure:

Priority: P2

Risks:Low
(cherry picked from commit aa012a1d0a7bc57c91e188332640bb39065de89d)