### PR TITLE
Revert "VPAAMP-369: Remove EAS StreamSink stop on End of stream"

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -3959,6 +3959,14 @@ void PrivateInstanceAAMP::NotifyEOSReached()
 		{
 			SetState(eSTATE_COMPLETE);
 			SendEvent(std::make_shared<AAMPEventObject>(AAMP_EVENT_EOS, GetSessionId()),AAMP_EVENT_ASYNC_MODE);
+			if (ContentType_EAS == mContentType)
+			{
+				StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
+				if (sink)
+				{
+					sink->Stop(false);
+				}
+			}
 			SendAnomalyEvent(ANOMALY_TRACE, "Generating EOS event");
 			trickStartUTCMS = -1;
 			return;


### PR DESCRIPTION
Reverts rdkcentral/aamp#1471

We don't think this patch is needed, with alternate proper fix available in https://github.com/rdkcentral/aamp/pull/1452