### PR TITLE
VPLAY-13151 [LLD channel]: Trickplay not functioning correctly when useMp4Demux=true

### DIFF
--- a/AampDemuxDataTypes.h
+++ b/AampDemuxDataTypes.h
@@ -46,6 +46,7 @@ struct AampMediaSample
 	double mPts{0.0};                        /**< Presentation timestamp in seconds */
 	double mDts{0.0};                        /**< Decode timestamp in seconds */
 	double mDuration{0.0};                   /**< Sample duration in seconds */
+	bool mIsKeyFrame{false};                 /**< True if this sample is a sync/key frame (I-frame) */
 	MediaDrmMetadata mDrmMetadata{}; /**< DRM metadata for encrypted samples */
 
 	// Move constructor and move assignment (allow efficient transfers)

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2193,6 +2193,9 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 				pMediaStreamContext->fragmentTime -= offset;
 			}
 		}
+		// Compute once: skip mFirstPTS update when using mp4demux during trickplay,
+		// as mp4demux restamps PTS starting from 0.0. Used in both timeline and segment-template paths below.
+		bool skipFirstPtsUpdate = ISCONFIGSET(eAAMPConfig_UseMp4Demux) && (aamp->rate != AAMP_NORMAL_PLAY_RATE);
 		do
 		{
 			if (segmentTimeline)
@@ -2364,15 +2367,10 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 							//If we land at the mid of a segment, the position reminder is added to fragment time. This corrects the epoch value to its original segment start time
 							pMediaStreamContext->fragmentTime += mVideoPosRemainder;
 							/*Keep the lower PTS */
-							// Skip mFirstPTS update when using mp4demux during trickplay, as mp4demux restamps PTS starting from 0.0
-							bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux);
-							bool isTrickplay = (aamp->rate != AAMP_NORMAL_PLAY_RATE);
-							bool skipFirstPtsUpdate = (useMp4Demux && isTrickplay);
-							
 							if (skipFirstPtsUpdate && pMediaStreamContext->type == eTRACK_VIDEO)
 							{
-								AAMPLOG_INFO("[%s] Skipping mFirstPTS update (useMp4Demux=%d, rate=%.2f) - mp4demux will restamp PTS from 0.0", 
-											 pMediaStreamContext->name, useMp4Demux, aamp->rate);
+								AAMPLOG_INFO("[%s] Skipping mFirstPTS update (rate=%.2f) - mp4demux will restamp PTS from 0.0", 
+											 pMediaStreamContext->name, aamp->rate);
 							}
 							else if ( ((mFirstPTS == 0) || (firstPTS < mFirstPTS)) && (pMediaStreamContext->type == eTRACK_VIDEO))
 							{
@@ -2468,11 +2466,6 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 
 					if(!aamp->IsLive())
 					{
-						// Skip mFirstPTS update when using mp4demux during trickplay, as mp4demux restamps PTS starting from 0.0
-						bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux);
-						bool isTrickplay = (aamp->rate != AAMP_NORMAL_PLAY_RATE);
-						bool skipFirstPtsUpdate = (useMp4Demux && isTrickplay);
-						
 						if (!skipFirstPtsUpdate)
 						{
 							if( timeScale )
@@ -2489,8 +2482,8 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 						}
 						else
 						{
-							AAMPLOG_INFO("Type[%d] Skipping mFirstPTS update (useMp4Demux=%d, rate=%.2f) - mp4demux will restamp PTS from 0.0",
-										 pMediaStreamContext->type, useMp4Demux, aamp->rate);
+							AAMPLOG_INFO("Type[%d] Skipping mFirstPTS update (rate=%.2f) - mp4demux will restamp PTS from 0.0",
+										 pMediaStreamContext->type, aamp->rate);
 						}
 					}
 					if (skipTime >= segmentDuration)
@@ -14414,7 +14407,7 @@ bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate)
 	/* Determine if early stream sink flush is needed based on configuration and playback state
 	 * Do flush to PTS position from manifest when:
 	 * 1. EnableMediaProcessor is disabled or EnableMediaProcessor enabled but segment timeline enabled (media processor will not flush in this case), AND
-	 * 2. EnablePTSReStamp is disabled, or play rate is normal (AAMP_NORMAL_PLAY_RATE). Here, we are using the flush(0) that occurs else where, AND
+	 * 2. EnablePTSReStamp is disabled, or play rate is normal (AAMP_NORMAL_PLAY_RATE). Here, we are using the flush(0) that occurs elsewhere, AND
 	 * 3. Skip early flush when using mp4demux with PTS restamping disabled during trickplay (flush(0) will be used)
 	 */
 	bool enableMediaProcessor = ISCONFIGSET(eAAMPConfig_EnableMediaProcessor);

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -11208,6 +11208,14 @@ double StreamAbstractionAAMP_MPD::GetFirstPTS()
 			ptsOffset = mPTSOffset;
 		}
 	}
+    // AampMp4Demuxer restamps ALL trickplay PTS starting from 0.0 — applies to both TSB and
+    // non-TSB paths. Override firstPTS (and clear any PTS offset) after both paths above.
+    if (ISCONFIGSET(eAAMPConfig_UseMp4Demux) && (aamp->rate != AAMP_NORMAL_PLAY_RATE))
+    {
+        firstPTS = 0.0;
+        ptsOffset = {};
+		AAMPLOG_INFO("Mp4demux trickplay: overriding firstPTS to 0.0 (restamped by AampMp4Demuxer, rate=%.2f)", aamp->rate);
+    }
 
 	restampedPTS = firstPTS + ptsOffset.inSeconds();
 	AAMPLOG_INFO("Restamped first pts:%lf, firstPTS:%lf, ptsOffsetSec:%lf", restampedPTS, firstPTS, ptsOffset.inSeconds());

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -2364,7 +2364,17 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 							//If we land at the mid of a segment, the position reminder is added to fragment time. This corrects the epoch value to its original segment start time
 							pMediaStreamContext->fragmentTime += mVideoPosRemainder;
 							/*Keep the lower PTS */
-							if ( ((mFirstPTS == 0) || (firstPTS < mFirstPTS)) && (pMediaStreamContext->type == eTRACK_VIDEO))
+							// Skip mFirstPTS update when using mp4demux during trickplay, as mp4demux restamps PTS starting from 0.0
+							bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux);
+							bool isTrickplay = (aamp->rate != AAMP_NORMAL_PLAY_RATE);
+							bool skipFirstPtsUpdate = (useMp4Demux && isTrickplay);
+							
+							if (skipFirstPtsUpdate && pMediaStreamContext->type == eTRACK_VIDEO)
+							{
+								AAMPLOG_INFO("[%s] Skipping mFirstPTS update (useMp4Demux=%d, rate=%.2f) - mp4demux will restamp PTS from 0.0", 
+											 pMediaStreamContext->name, useMp4Demux, aamp->rate);
+							}
+							else if ( ((mFirstPTS == 0) || (firstPTS < mFirstPTS)) && (pMediaStreamContext->type == eTRACK_VIDEO))
 							{
 								AAMPLOG_INFO("[%s] mFirstPTS %f -> %f ", pMediaStreamContext->name, mFirstPTS, firstPTS);
 								mFirstPTS = firstPTS;
@@ -2458,16 +2468,29 @@ double StreamAbstractionAAMP_MPD::SkipFragments( MediaStreamContext *pMediaStrea
 
 					if(!aamp->IsLive())
 					{
-						if( timeScale )
+						// Skip mFirstPTS update when using mp4demux during trickplay, as mp4demux restamps PTS starting from 0.0
+						bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux);
+						bool isTrickplay = (aamp->rate != AAMP_NORMAL_PLAY_RATE);
+						bool skipFirstPtsUpdate = (useMp4Demux && isTrickplay);
+						
+						if (!skipFirstPtsUpdate)
 						{
-							mFirstPTS = (double)segmentTemplates.GetPresentationTimeOffset() / (double)timeScale;
+							if( timeScale )
+							{
+								mFirstPTS = (double)segmentTemplates.GetPresentationTimeOffset() / (double)timeScale;
+							}
+							if( updateFirstPTS )
+							{
+								mFirstPTS += skipTime;
+								// Here, PTO is known from manifest, so set it as final PTS
+								mIsFinalFirstPTS = true;
+								AAMPLOG_DEBUG("Type[%d] updateFirstPTS: %f SkipTime: %f",pMediaStreamContext->type, mFirstPTS, skipTime);
+							}
 						}
-						if( updateFirstPTS )
+						else
 						{
-							mFirstPTS += skipTime;
-							// Here, PTO is known from manifest, so set it as final PTS
-							mIsFinalFirstPTS = true;
-							AAMPLOG_DEBUG("Type[%d] updateFirstPTS: %f SkipTime: %f",pMediaStreamContext->type, mFirstPTS, skipTime);
+							AAMPLOG_INFO("Type[%d] Skipping mFirstPTS update (useMp4Demux=%d, rate=%.2f) - mp4demux will restamp PTS from 0.0",
+										 pMediaStreamContext->type, useMp4Demux, aamp->rate);
 						}
 					}
 					if (skipTime >= segmentDuration)
@@ -14390,14 +14413,18 @@ bool StreamAbstractionAAMP_MPD::DoEarlyStreamSinkFlush(bool newTune, float rate)
 {
 	/* Determine if early stream sink flush is needed based on configuration and playback state
 	 * Do flush to PTS position from manifest when:
-	 * 1. EnableMediaProcessor is disabled or EnableMediaProcessor enabled but segment timeline enabled (media processor will not flush in this case), OR
-	 * 2. EnablePTSReStamp is disabled, or play rate is normal (AAMP_NORMAL_PLAY_RATE). Here, we are using the flush(0) that occurs else where
+	 * 1. EnableMediaProcessor is disabled or EnableMediaProcessor enabled but segment timeline enabled (media processor will not flush in this case), AND
+	 * 2. EnablePTSReStamp is disabled, or play rate is normal (AAMP_NORMAL_PLAY_RATE). Here, we are using the flush(0) that occurs else where, AND
+	 * 3. Skip early flush when using mp4demux with PTS restamping disabled during trickplay (flush(0) will be used)
 	 */
 	bool enableMediaProcessor = ISCONFIGSET(eAAMPConfig_EnableMediaProcessor);
 	bool enablePTSReStamp = ISCONFIGSET(eAAMPConfig_EnablePTSReStamp);
+	
 	bool doFlush = ((!enableMediaProcessor || mIsSegmentTimelineEnabled) &&
 					(!enablePTSReStamp || rate == AAMP_NORMAL_PLAY_RATE));
-	AAMPLOG_INFO("doFlush=%d, newTune=%d, rate=%f", doFlush, newTune, rate);
+	
+	AAMPLOG_INFO("doFlush=%d, newTune=%d, rate=%f, enablePTSReStamp=%d", 
+				 doFlush, newTune, rate, enablePTSReStamp);
 	return doFlush;
 }
 

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -62,9 +62,14 @@ void AampMp4Demuxer::setFrameRateForTM(int frameRate)
  */
 void AampMp4Demuxer::setRate(double rate, PlayMode mode)
 {
+	if (mRate != rate)
+	{
+		// Rate changed - reset to UNDEF so the next init fragment drives the state machine
+		mTrickPhase = Mp4TrickPhase::UNDEF;
+	}
 	mRate = rate;
 	mIsTrickMode = (rate > AAMP_NORMAL_PLAY_RATE) || (rate < 0);
-	AAMPLOG_INFO("Rate set to %.2f, trickmode: %s for media type %s", 
+	AAMPLOG_INFO("Rate set to %.2f, trickmode: %s for media type %s",
 		rate, mIsTrickMode ? "enabled" : "disabled", GetMediaTypeName(mMediaType));
 }
 
@@ -116,18 +121,18 @@ void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duratio
        double fragmentPtsDelta = 0.0;
        double restampedDuration = 0.0;
 
+       // Pure computation only — state transitions are handled exclusively by sendSegment().
+       // By the time this function is called, mTrickPhase is always FIRST_SAMPLE or STEADY.
        switch (mTrickPhase)
        {
 	       case Mp4TrickPhase::FIRST_SAMPLE:
-		   		// First sample: estimate duration based on rate and trickPlayFPS
+				// First sample: estimate duration based on rate and trickPlayFPS
 				// Use MAX to avoid too small a number (minimum 0.25 seconds)
-
 		       restampedDuration = MAX(duration / std::fabs(mRate), 1.0 / mTrickPlayFPS);
 		       mRestampedPts = 0.0;
-		       mTrickPhase = Mp4TrickPhase::STEADY;
 		       break;
 	       case Mp4TrickPhase::STEADY:
-		   		// Calculate the duration between the current sample and the previous sample
+				// Calculate the duration between the current sample and the previous sample
 				// and divide it by the rate to determine the restamped duration
 		       fragmentPtsDelta = fabs(sample.mPts - mLastSamplePts);
 		       restampedDuration = fragmentPtsDelta / std::fabs(mRate);
@@ -135,12 +140,12 @@ void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duratio
 		       break;
 	       case Mp4TrickPhase::UNDEF:
 	       default:
-		       AAMPLOG_WARN("[%s] Unexpected trickmode state %d in trickmode", 
+		       // Safety net: treat as first sample if state machine was not driven correctly
+		       AAMPLOG_WARN("[%s] Unexpected trickmode state %d, treating as FIRST_SAMPLE",
 			       GetMediaTypeName(mMediaType),
 			       static_cast<int>(mTrickPhase));
 		       restampedDuration = MAX(duration / std::fabs(mRate), 1.0 / mTrickPlayFPS);
 		       mRestampedPts = 0.0;
-		       mTrickPhase = Mp4TrickPhase::STEADY;
 		       break;
        }
 
@@ -194,15 +199,35 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 		auto segment = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
 		AAMPLOG_INFO("Processing segment with type:%d position: %f, duration: %f, isInit: %d", mMediaType, position, duration, isInit);
 		
-		// Combine trickmode rate change and init fragment handling for state reset
-		if (mIsTrickMode && ((mRate != mLastTrickRate && isInit) || mTrickPhase == Mp4TrickPhase::UNDEF))
+		// State machine transitions — all owned here in sendSegment():
+		//   UNDEF       → INIT         on init fragment arrival (normal path)
+		//   UNDEF       → FIRST_SAMPLE on data fragment arrival without prior init (edge case)
+		//   INIT        → FIRST_SAMPLE on first data fragment arrival
+		//   FIRST_SAMPLE→ STEADY       after the first key frame sample is processed
+		if (mIsTrickMode)
 		{
-			mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
-			mRestampedPts = 0.0;
-			mLastSamplePts = 0.0;
-			mLastTrickRate = mRate;
-			
-			AAMPLOG_INFO("Trickmode state reset: rate=%.2f, isInit=%d, state set to FIRST_SAMPLE", mRate, (int)isInit);
+			if (mTrickPhase == Mp4TrickPhase::UNDEF && isInit)
+			{
+				mTrickPhase = Mp4TrickPhase::INIT;
+				mLastTrickRate = mRate;
+				mRestampedPts = 0.0;
+				mLastSamplePts = 0.0;
+				AAMPLOG_INFO("Trickmode UNDEF->INIT: rate=%.2f", mRate);
+			}
+			else if (mTrickPhase == Mp4TrickPhase::UNDEF && !isInit)
+			{
+				// Edge case: data segment arrived before init segment (e.g. init reused from
+				// normal playback on rate change). Skip INIT and go directly to FIRST_SAMPLE.
+				mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
+				mRestampedPts = 0.0;
+				mLastSamplePts = 0.0;
+				AAMPLOG_WARN("Trickmode UNDEF->FIRST_SAMPLE (no init segment received): rate=%.2f", mRate);
+			}
+			else if (mTrickPhase == Mp4TrickPhase::INIT && !isInit)
+			{
+				mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
+				AAMPLOG_INFO("Trickmode INIT->FIRST_SAMPLE: rate=%.2f", mRate);
+			}
 		}		
 	
 		ret = mMp4Demux->Parse(std::move(segment));
@@ -220,21 +245,29 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 				{
 					for (auto& sample : samples)
 					{
-						
-						// Apply trickmode PTS restamping to the sample. This modifies the sample timestamps to create a smooth trickplay experience, 
-						// especially for fast-forward and rewind modes. The restamping logic is based on a state machine that handles the first sample differently to establish a baseline for subsequent samples.
-						TrickmodePtsRestamp(sample, duration);						
-						// Send the sample to the pipeline
+						// In trickmode, only I-frames (key frames) should be sent to the sink.
+						// This mirrors the upstream ConvertToKeyFrame filtering done in the TSB path
+						// and the iframe-track selection in the non-TSB path.
+						if (!sample.mIsKeyFrame)
+						{
+							AAMPLOG_TRACE("[%s] Skipping non-key frame sample in trickmode (pts=%.3f)",
+								GetMediaTypeName(mMediaType), sample.mPts);
+							continue;
+						}
+						TrickmodePtsRestamp(sample, duration);
+						// FIRST_SAMPLE -> STEADY after the first key frame is processed
+						if (mTrickPhase == Mp4TrickPhase::FIRST_SAMPLE)
+						{
+							mTrickPhase = Mp4TrickPhase::STEADY;
+							AAMPLOG_INFO("Trickmode FIRST_SAMPLE->STEADY: rate=%.2f", mRate);
+						}
 						mAamp->SendStreamTransfer(mMediaType, std::move(sample));
 					}
 				}
 				else
 				{
-					// Normal playback mode - reset trickmode state
-					mTrickPhase = Mp4TrickPhase::UNDEF;
-					mRestampedPts = 0.0;
-					mLastSamplePts = 0.0;
-					mLastTrickRate = mRate;
+					// Normal playback mode - reset trickmode state via reset()
+					reset();
 					for (auto& sample : samples)
 					{
 						// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -64,8 +64,12 @@ void AampMp4Demuxer::setRate(double rate, PlayMode mode)
 {
 	if (mRate != rate)
 	{
-		// Rate changed - reset to UNDEF so the next init fragment drives the state machine
-		mTrickPhase = Mp4TrickPhase::UNDEF;
+		// Rate changed - reset to FIRST_SAMPLE and clear PTS state so the
+		// next keyframe starts a fresh restamp sequence from 0.
+		mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
+		mRestampedPts = 0.0;
+		mLastSamplePts = 0.0;
+		mLastTrickRate = rate;
 	}
 	mRate = rate;
 	mIsTrickMode = (rate > AAMP_NORMAL_PLAY_RATE) || (rate < 0);
@@ -78,7 +82,7 @@ void AampMp4Demuxer::setRate(double rate, PlayMode mode)
  */
 void AampMp4Demuxer::abort()
 {
-	mTrickPhase = Mp4TrickPhase::UNDEF;
+	mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
 	mLastSamplePts = 0.0;
 	mRestampedPts = 0.0;
 	mLastTrickRate = 0.0;
@@ -90,7 +94,17 @@ void AampMp4Demuxer::abort()
  */
 void AampMp4Demuxer::reset()
 {
-	mTrickPhase = Mp4TrickPhase::UNDEF;
+	resetTrickMode();
+}
+
+/**
+ * @brief Reset only trickmode-specific state variables.
+ * Separated from reset() so future additions to the public reset() API
+ * do not inadvertently affect the trickmode path in sendSegment().
+ */
+void AampMp4Demuxer::resetTrickMode()
+{
+	mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
 	mLastSamplePts = 0.0;
 	mRestampedPts = 0.0;
 	mLastTrickRate = 0.0;
@@ -121,8 +135,7 @@ void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duratio
        double fragmentPtsDelta = 0.0;
        double restampedDuration = 0.0;
 
-       // Pure computation only — state transitions are handled exclusively by sendSegment().
-       // By the time this function is called, mTrickPhase is always FIRST_SAMPLE or STEADY.
+       // FIRST_SAMPLE→STEADY transition is owned here; all other transitions remain in sendSegment().
        switch (mTrickPhase)
        {
 	       case Mp4TrickPhase::FIRST_SAMPLE:
@@ -130,6 +143,9 @@ void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duratio
 				// Use MAX to avoid too small a number (minimum 0.25 seconds)
 		       restampedDuration = MAX(duration / std::fabs(mRate), 1.0 / mTrickPlayFPS);
 		       mRestampedPts = 0.0;
+		       // Advance to STEADY so subsequent keyframes use delta-based duration
+		       mTrickPhase = Mp4TrickPhase::STEADY;
+		       AAMPLOG_INFO("Trickmode FIRST_SAMPLE->STEADY: rate=%.2f", mRate);
 		       break;
 	       case Mp4TrickPhase::STEADY:
 				// Calculate the duration between the current sample and the previous sample
@@ -138,18 +154,9 @@ void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duratio
 		       restampedDuration = fragmentPtsDelta / std::fabs(mRate);
 		       mRestampedPts += restampedDuration;
 		       break;
-	       case Mp4TrickPhase::UNDEF:
-	       default:
-		       // Safety net: treat as first sample if state machine was not driven correctly
-		       AAMPLOG_WARN("[%s] Unexpected trickmode state %d, treating as FIRST_SAMPLE",
-			       GetMediaTypeName(mMediaType),
-			       static_cast<int>(mTrickPhase));
-		       restampedDuration = MAX(duration / std::fabs(mRate), 1.0 / mTrickPlayFPS);
-		       mRestampedPts = 0.0;
-		       break;
-       }
+       } // end switch
 
-       // Store the current sample PTS for next iteration
+       // Store the current sample PTS before overwriting it
        mLastSamplePts = sample.mPts;
 
        // Apply restamped PTS and duration to the sample
@@ -199,36 +206,6 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 		auto segment = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
 		AAMPLOG_INFO("Processing segment with type:%d position: %f, duration: %f, isInit: %d", mMediaType, position, duration, isInit);
 		
-		// State machine transitions — all owned here in sendSegment():
-		//   UNDEF       → INIT         on init fragment arrival (normal path)
-		//   UNDEF       → FIRST_SAMPLE on data fragment arrival without prior init (edge case)
-		//   INIT        → FIRST_SAMPLE on first data fragment arrival
-		//   FIRST_SAMPLE→ STEADY       after the first key frame sample is processed
-		if (mIsTrickMode)
-		{
-			if (mTrickPhase == Mp4TrickPhase::UNDEF && isInit)
-			{
-				mTrickPhase = Mp4TrickPhase::INIT;
-				mLastTrickRate = mRate;
-				mRestampedPts = 0.0;
-				mLastSamplePts = 0.0;
-				AAMPLOG_INFO("Trickmode UNDEF->INIT: rate=%.2f", mRate);
-			}
-			else if (mTrickPhase == Mp4TrickPhase::UNDEF && !isInit)
-			{
-				// Edge case: data segment arrived before init segment (e.g. init reused from
-				// normal playback on rate change). Skip INIT and go directly to FIRST_SAMPLE.
-				mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
-				mRestampedPts = 0.0;
-				mLastSamplePts = 0.0;
-				AAMPLOG_WARN("Trickmode UNDEF->FIRST_SAMPLE (no init segment received): rate=%.2f", mRate);
-			}
-			else if (mTrickPhase == Mp4TrickPhase::INIT && !isInit)
-			{
-				mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
-				AAMPLOG_INFO("Trickmode INIT->FIRST_SAMPLE: rate=%.2f", mRate);
-			}
-		}		
 	
 		ret = mMp4Demux->Parse(std::move(segment));
 		
@@ -255,19 +232,14 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 							continue;
 						}
 						TrickmodePtsRestamp(sample, duration);
-						// FIRST_SAMPLE -> STEADY after the first key frame is processed
-						if (mTrickPhase == Mp4TrickPhase::FIRST_SAMPLE)
-						{
-							mTrickPhase = Mp4TrickPhase::STEADY;
-							AAMPLOG_INFO("Trickmode FIRST_SAMPLE->STEADY: rate=%.2f", mRate);
-						}
+
 						mAamp->SendStreamTransfer(mMediaType, std::move(sample));
 					}
 				}
 				else
 				{
-					// Normal playback mode - reset trickmode state via reset()
-					reset();
+					// Normal playback mode - reset only trickmode state
+					resetTrickMode();
 					for (auto& sample : samples)
 					{
 						// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -25,6 +25,8 @@
 #include "AampMp4Demuxer.h"
 #include "AampLogManager.h"
 #include "AampUtils.h"
+#include "AampConfig.h"
+#include <cmath>
 
 
 /**
@@ -40,6 +42,54 @@ AampMp4Demuxer::AampMp4Demuxer(PrivateInstanceAAMP* aamp, AampMediaType type, bo
 	// TODO: Should we limit the media types here to only video/audio?
 	// Make restamp logging configurable as it might cause log flooding, since logs will come for each demuxed frames per fragment
 	mEnablePtsRestampLogging = mAamp->mConfig->IsConfigSet(eAAMPConfig_EnablePTSReStampLogging);
+	// mTrickPlayFPS should be set via setFrameRateForTM()
+}
+
+/**
+ * @brief Set frame rate for trickmode
+ * @param[in] frameRate - rate per second
+ */
+void AampMp4Demuxer::setFrameRateForTM(int frameRate)
+{
+	mTrickPlayFPS = frameRate;
+	AAMPLOG_INFO("TrickPlay FPS set to %d for media type %s", frameRate, GetMediaTypeName(mMediaType));
+}
+
+/**
+ * @brief Set playback rate
+ * @param[in] rate - playback rate
+ * @param[in] mode - playback mode
+ */
+void AampMp4Demuxer::setRate(double rate, PlayMode mode)
+{
+	mRate = rate;
+	mIsTrickMode = (rate > AAMP_NORMAL_PLAY_RATE) || (rate < 0);
+	AAMPLOG_INFO("Rate set to %.2f, trickmode: %s for media type %s", 
+		rate, mIsTrickMode ? "enabled" : "disabled", GetMediaTypeName(mMediaType));
+}
+
+/**
+ * @brief Abort all operations and reset trickmode state
+ */
+void AampMp4Demuxer::abort()
+{
+	mTrickPhase = Mp4TrickPhase::UNDEF;
+	mLastSamplePts = 0.0;
+	mRestampedPts = 0.0;
+	mLastTrickRate = 0.0;
+	AAMPLOG_INFO("Abort: Reset trickmode state for media type %s", GetMediaTypeName(mMediaType));
+}
+
+/**
+ * @brief Reset all trickmode state variables
+ */
+void AampMp4Demuxer::reset()
+{
+	mTrickPhase = Mp4TrickPhase::UNDEF;
+	mLastSamplePts = 0.0;
+	mRestampedPts = 0.0;
+	mLastTrickRate = 0.0;
+	AAMPLOG_INFO("Reset trickmode state for media type %s", GetMediaTypeName(mMediaType));
 }
 
 /**
@@ -51,6 +101,71 @@ AampMp4Demuxer::~AampMp4Demuxer()
 	// std::unique_ptr automatically handles cleanup
 }
 
+/**
+ * @brief Apply trickmode PTS restamping to a sample, dynamically adjusting duration based on rate and frame rate
+ * Similar to qtdemux approach but with dynamic duration calculation for smoother trickmode playback
+ * @param[in,out] sample - Sample to restamp
+ * @param[in] duration - Fragment duration
+ */
+void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duration)
+{
+       // Store original values for logging
+       double originalPts = sample.mPts;
+       double originalDts = sample.mDts;
+       double originalDuration = sample.mDuration;
+       double fragmentPtsDelta = 0.0;
+       double restampedDuration = 0.0;
+
+       switch (mTrickPhase)
+       {
+	       case Mp4TrickPhase::FIRST_SAMPLE:
+		   		// First sample: estimate duration based on rate and trickPlayFPS
+				// Use MAX to avoid too small a number (minimum 0.25 seconds)
+
+		       restampedDuration = MAX(duration / std::fabs(mRate), 1.0 / mTrickPlayFPS);
+		       mRestampedPts = 0.0;
+		       mTrickPhase = Mp4TrickPhase::STEADY;
+		       break;
+	       case Mp4TrickPhase::STEADY:
+		   		// Calculate the duration between the current sample and the previous sample
+				// and divide it by the rate to determine the restamped duration
+		       fragmentPtsDelta = fabs(sample.mPts - mLastSamplePts);
+		       restampedDuration = fragmentPtsDelta / std::fabs(mRate);
+		       mRestampedPts += restampedDuration;
+		       break;
+	       case Mp4TrickPhase::UNDEF:
+	       default:
+		       AAMPLOG_WARN("[%s] Unexpected trickmode state %d in trickmode", 
+			       GetMediaTypeName(mMediaType),
+			       static_cast<int>(mTrickPhase));
+		       restampedDuration = MAX(duration / std::fabs(mRate), 1.0 / mTrickPlayFPS);
+		       mRestampedPts = 0.0;
+		       mTrickPhase = Mp4TrickPhase::STEADY;
+		       break;
+       }
+
+       // Store the current sample PTS for next iteration
+       mLastSamplePts = sample.mPts;
+
+       // Apply restamped PTS and duration to the sample
+       sample.mPts = mRestampedPts;
+       sample.mDts = mRestampedPts;
+       sample.mDuration = restampedDuration;
+
+       // Single comprehensive log line
+       AAMPLOG_INFO("state %d rate %.2f trickPlayFPS %d origPTS %.6f origDTS %.6f origDur %.6f restampedPTS %.6f restampedDTS %.6f restampedDur %.6f lastSamplePTS %.6f inputDuration %.6f",
+	       static_cast<int>(mTrickPhase),
+	       mRate,
+	       mTrickPlayFPS,
+	       originalPts,
+	       originalDts,
+	       originalDuration,
+	       sample.mPts,
+	       sample.mDts,
+	       sample.mDuration,
+	       mLastSamplePts,
+	       duration);
+}
 /**
  * @fn sendSegment
  *
@@ -67,7 +182,7 @@ AampMp4Demuxer::~AampMp4Demuxer()
  * @return true if fragment was sent, false otherwise
  */
 bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous,
-								bool isInit, process_fcn_t processor, bool &ptsError)
+				bool isInit, process_fcn_t processor, bool &ptsError)
 {
 	bool ret = true;
 	(void) processor;
@@ -78,7 +193,20 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 		// so each sample keeps the segment buffer alive for its lifetime.
 		auto segment = std::make_shared<std::vector<uint8_t>>(std::move(buffer));
 		AAMPLOG_INFO("Processing segment with type:%d position: %f, duration: %f, isInit: %d", mMediaType, position, duration, isInit);
+		
+		// Combine trickmode rate change and init fragment handling for state reset
+		if (mIsTrickMode && ((mRate != mLastTrickRate && isInit) || mTrickPhase == Mp4TrickPhase::UNDEF))
+		{
+			mTrickPhase = Mp4TrickPhase::FIRST_SAMPLE;
+			mRestampedPts = 0.0;
+			mLastSamplePts = 0.0;
+			mLastTrickRate = mRate;
+			
+			AAMPLOG_INFO("Trickmode state reset: rate=%.2f, isInit=%d, state set to FIRST_SAMPLE", mRate, (int)isInit);
+		}		
+	
 		ret = mMp4Demux->Parse(std::move(segment));
+		
 		if (!ret)
 		{
 			AAMPLOG_ERR("Failed to parse MP4 segment [err:%d] for type:%d position: %f, duration: %f, isInit: %d", mMp4Demux->GetLastError(), mMediaType, position, duration, isInit);
@@ -88,27 +216,47 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 			auto samples = mMp4Demux->GetSamples();
 			if (!samples.empty())
 			{
-				for (auto&& sample : samples)
+				if (mIsTrickMode)
 				{
-					// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.
-					if (mEnablePtsRestamp)
+					for (auto& sample : samples)
 					{
-						double beforeDTS = sample.mDts;
-						sample.mPts += fragmentPTSoffset;
-						sample.mDts += fragmentPTSoffset;
-						// Log the restamping if enabled. This can be helpful for debugging and verifying correct behavior, but may cause log flooding for large segments.
-						if (mEnablePtsRestampLogging)
-						{
-							uint32_t timeScale = mMp4Demux->GetTimeScale();
-							AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
-							GetMediaTypeName(mMediaType),
-							timeScale,
-							beforeDTS * timeScale,
-							sample.mDts * timeScale,
-							sample.mDuration * timeScale);
-						}
+						
+						// Apply trickmode PTS restamping to the sample. This modifies the sample timestamps to create a smooth trickplay experience, 
+						// especially for fast-forward and rewind modes. The restamping logic is based on a state machine that handles the first sample differently to establish a baseline for subsequent samples.
+						TrickmodePtsRestamp(sample, duration);						
+						// Send the sample to the pipeline
+						mAamp->SendStreamTransfer(mMediaType, std::move(sample));
 					}
-					mAamp->SendStreamTransfer(mMediaType, std::move(sample));
+				}
+				else
+				{
+					// Normal playback mode - reset trickmode state
+					mTrickPhase = Mp4TrickPhase::UNDEF;
+					mRestampedPts = 0.0;
+					mLastSamplePts = 0.0;
+					mLastTrickRate = mRate;
+					for (auto& sample : samples)
+					{
+						// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.
+						if (mEnablePtsRestamp)
+						{
+							double beforeDTS = sample.mDts;
+							sample.mPts += fragmentPTSoffset;
+							sample.mDts += fragmentPTSoffset;
+							// Log the restamping if enabled. This can be helpful for debugging and verifying correct behavior, but may cause log flooding for large segments.
+							if (mEnablePtsRestampLogging)
+							{
+								uint32_t timeScale = mMp4Demux->GetTimeScale();
+								AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
+								GetMediaTypeName(mMediaType),
+								timeScale,
+								beforeDTS * timeScale,
+								sample.mDts * timeScale,
+								sample.mDuration * timeScale);
+							}
+						}
+						mAamp->SendStreamTransfer(mMediaType, std::move(sample));
+					}
 				}
 			}
 			else

--- a/mp4demux/AampMp4Demuxer.h
+++ b/mp4demux/AampMp4Demuxer.h
@@ -139,10 +139,8 @@ public:
 private:
 	enum class Mp4TrickPhase
 	{
-		UNDEF,// Initial state before any samples are processed
-		INIT,// After processing an init fragment in trickmode, waiting for the first sample to establish timing
-		FIRST_SAMPLE,// After processing the first sample in trickmode, used to calculate restamp offset
-		STEADY// After processing subsequent samples in trickmode, normal restamping applies
+		FIRST_SAMPLE,// Initial/reset state: timestamps the first keyframe and seeds mRestampedPts = 0
+		STEADY       // Steady state: computes PTS delta from previous sample
 	};
 
 	/**
@@ -151,6 +149,14 @@ private:
 	 * @param[in] duration - Fragment duration
 	 */
 	void TrickmodePtsRestamp(AampMediaSample& sample, double duration);
+
+	/**
+	 * @brief Reset only trickmode state variables.
+	 * Called internally whenever trickmode state must be cleared (e.g. on
+	 * transition back to normal play). Intentionally separate from the public
+	 * reset() API so future additions to reset() do not affect this path.
+	 */
+	void resetTrickMode();
 
 	std::unique_ptr<Mp4Demux> mMp4Demux;
 	PrivateInstanceAAMP* mAamp;
@@ -166,7 +172,7 @@ private:
 	double mLastSamplePts {0.0};			/**< PTS of the previous sample, used in trick modes */
 	double mRestampedPts {0.0};				/**< Restamped PTS of the sample, used in trick modes */
 		
-	Mp4TrickPhase mTrickPhase {Mp4TrickPhase::UNDEF}; /**< Current trick mode state */
+	Mp4TrickPhase mTrickPhase {Mp4TrickPhase::FIRST_SAMPLE}; /**< Current trick mode state */
 	double mLastTrickRate {0.0}; /**< Last used trickplay rate for state reset */
 };
 

--- a/mp4demux/AampMp4Demuxer.h
+++ b/mp4demux/AampMp4Demuxer.h
@@ -72,7 +72,7 @@ public:
 	 * @return true if fragment was sent, false otherwise
 	 */
 	bool sendSegment(std::vector<uint8_t>&& buffer, double position, double duration, double fragmentPTSoffset, bool discontinuous,
-						bool isInit, process_fcn_t processor, bool &ptsError) override;
+					bool isInit, process_fcn_t processor, bool &ptsError) override;
 
 	/**
 	 * @brief Set playback rate
@@ -81,7 +81,7 @@ public:
 	 * @param[in] mode - playback mode
 	 * @return void
 	 */
-	void setRate(double rate, PlayMode mode) override { };
+	void setRate(double rate, PlayMode mode) override;
 
 	/**
 	 * @brief Enable or disable throttle
@@ -97,21 +97,21 @@ public:
 	 * @param[in] frameRate - rate per second
 	 * @return void
 	 */
-	void setFrameRateForTM (int frameRate) override { }
+	void setFrameRateForTM (int frameRate) override;
 
 	/**
 	 * @brief Abort all operations
 	 *
 	 * @return void
 	 */
-	void abort() override { }
+	void abort() override;
 
 	/**
 	 * @brief Reset all variables
 	 *
 	 * @return void
 	 */
-	void reset() override { }
+	void reset() override;
 
 	/**
 	 * @brief Function to abort wait for injecting the segment
@@ -137,12 +137,37 @@ public:
 	bool getPTSRestampStatus() const override;
 
 private:
+	enum class Mp4TrickPhase
+	{
+		UNDEF,// Initial state before any samples are processed
+		INIT,// After processing an init fragment in trickmode, waiting for the first sample to establish timing
+		FIRST_SAMPLE,// After processing the first sample in trickmode, used to calculate restamp offset
+		STEADY// After processing subsequent samples in trickmode, normal restamping applies
+	};
+
+	/**
+	 * @brief Apply trickmode PTS restamping to a sample
+	 * @param[in,out] sample - Sample to restamp
+	 * @param[in] duration - Fragment duration
+	 */
+	void TrickmodePtsRestamp(AampMediaSample& sample, double duration);
+
 	std::unique_ptr<Mp4Demux> mMp4Demux;
 	PrivateInstanceAAMP* mAamp;
 	AampMediaType mMediaType;
 	bool mEnablePtsRestamp; // Flag to enable PTS restamping
 	// A separate flag to enable logging for PTS restamping for better control.
 	bool mEnablePtsRestampLogging {false}; // Flag to enable logging for PTS restamping
+	
+	// Trickmode state variables
+	int mTrickPlayFPS {0};					/**< Trickplay frames per second */
+	double mRate {1.0};						/**< Current playback rate */
+	bool mIsTrickMode {false};				/**< True if in trickmode (rate != 1.0) */
+	double mLastSamplePts {0.0};			/**< PTS of the previous sample, used in trick modes */
+	double mRestampedPts {0.0};				/**< Restamped PTS of the sample, used in trick modes */
+		
+	Mp4TrickPhase mTrickPhase {Mp4TrickPhase::UNDEF}; /**< Current trick mode state */
+	double mLastTrickRate {0.0}; /**< Last used trickplay rate for state reset */
 };
 
 #endif /* __AAMPMP4DEMUXER_H__ */

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -712,11 +712,12 @@ void Mp4Demux::ParseTrackRun()
 		int32_t dataOffset = ReadI32();
 		dataPtr += dataOffset;
 	}
-	uint32_t sampleFlags = 0;
+	// ISO 14496-12: TRUN_FIRST_SAMPLE_FLAGS_PRESENT overrides the first sample only;
+	// TRUN_SAMPLE_FLAGS_PRESENT provides per-sample flags; otherwise use defaultSampleFlags.
+	uint32_t firstSampleFlags = 0;
 	if (flags & TRUN_FIRST_SAMPLE_FLAGS_PRESENT)
 	{
-		sampleFlags = ReadU32();
-		(void)sampleFlags;
+		firstSampleFlags = ReadU32();
 	}
 	uint64_t dts = baseMediaDecodeTime;
 	for (auto i = 0u; i < sampleCount; i++)
@@ -732,11 +733,18 @@ void Mp4Demux::ParseTrackRun()
 		{
 			sampleLen = ReadU32();
 		}
+		uint32_t effectiveSampleFlags = defaultSampleFlags;
 		if (flags & TRUN_SAMPLE_FLAGS_PRESENT)
-		{ // rarely present?
-			sampleFlags = ReadU32();
-			(void)sampleFlags;
+		{ // per-sample flags present in TRUN
+			effectiveSampleFlags = ReadU32();
 		}
+		else if (i == 0 && (flags & TRUN_FIRST_SAMPLE_FLAGS_PRESENT))
+		{ // first-sample-only override (mutually exclusive with TRUN_SAMPLE_FLAGS_PRESENT)
+			effectiveSampleFlags = firstSampleFlags;
+		}
+		// ISO 14496-12 sample_flags bit 16: sample_is_non_sync_sample
+		// 0 = sync/key frame (I-frame), 1 = non-sync sample
+		bool isKeyFrame = (effectiveSampleFlags & 0x00010000) == 0;
 		int32_t sampleCompositionTimeOffset = 0;
 		if (flags & TRUN_SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT)
 		{ // for samples where pts and dts differ (overriding 'trex')
@@ -751,13 +759,10 @@ void Mp4Demux::ParseTrackRun()
 		pendingSample.mDts      = dts / (double)timeScale;
 		pendingSample.mPts      = (dts + sampleCompositionTimeOffset) / (double)timeScale;
 		pendingSample.mDuration = sampleDuration / (double)timeScale;
+		pendingSample.mIsKeyFrame = isKeyFrame;
 		mSampleInfo.emplace_back(pendingSample);
 		dataPtr += sampleLen;
 		dts += sampleDuration;
-
-		AAMPLOG_INFO("Parsed sample %zu: dataPtr=%p, len=%u, dts=%.3f, pts=%.3f, duration=%.3f",
-				samples.size() - 1, pendingSample.dataPtr, pendingSample.sampleLen,
-				pendingSample.mDts, pendingSample.mPts, pendingSample.mDuration);
 	}
 }
 
@@ -792,11 +797,12 @@ void Mp4Demux::ProcessSamples()
 		AampMediaSample& s = samples[pending.sampleIdx];
 		// Aliasing constructor: mData shares mCurrentSegment's refcount but
 		// points directly at the sample payload within that buffer.
-		s.mData     = std::shared_ptr<const uint8_t>(mCurrentSegment, dataPtr);
-		s.mDataSize = sampleLen;
-		s.mDts      = pending.mDts;
-		s.mPts      = pending.mPts;
-		s.mDuration = pending.mDuration;
+		s.mData       = std::shared_ptr<const uint8_t>(mCurrentSegment, dataPtr);
+		s.mDataSize   = sampleLen;
+		s.mDts        = pending.mDts;
+		s.mPts        = pending.mPts;
+		s.mDuration   = pending.mDuration;
+		s.mIsKeyFrame = pending.mIsKeyFrame;
 	}
 	mSampleInfo.clear();
 }

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -754,6 +754,10 @@ void Mp4Demux::ParseTrackRun()
 		mSampleInfo.emplace_back(pendingSample);
 		dataPtr += sampleLen;
 		dts += sampleDuration;
+
+		AAMPLOG_INFO("Parsed sample %zu: dataPtr=%p, len=%u, dts=%.3f, pts=%.3f, duration=%.3f",
+				samples.size() - 1, pendingSample.dataPtr, pendingSample.sampleLen,
+				pendingSample.mDts, pendingSample.mPts, pendingSample.mDuration);
 	}
 }
 

--- a/mp4demux/MP4Demux.h
+++ b/mp4demux/MP4Demux.h
@@ -236,6 +236,7 @@ private:
 		double mDts;            /**< Decode timestamp in seconds */
 		double mPts;            /**< Presentation timestamp in seconds */
 		double mDuration;       /**< Sample duration in seconds */
+		bool mIsKeyFrame{false}; /**< True if this is a sync/key frame (I-frame) */
 	};
 	std::vector<PendingSamplePayload> mSampleInfo; /**< sample payloads awaiting mdat bounds */
 	MediaCodecInfo codecInfo; /**< Codec information */

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4185,6 +4185,16 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 				}
 			}
 		}
+		else if (track && track->enabled && track->playContext != nullptr)
+		{
+			// playContext already exists (subsequent trickplay/rate-change requests) - update rate and FPS
+			track->playContext->setRate(aamp->rate, PlayMode_normal);
+			if (ISCONFIGSET(eAAMPConfig_UseMp4Demux) && i != eMEDIATYPE_SUBTITLE)
+			{
+				int trickPlayFPS = aamp->mConfig->GetConfigValue(eAAMPConfig_VODTrickPlayFPS);
+				track->playContext->setFrameRateForTM(trickPlayFPS);
+			}
+		}
 	}
 }
 

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -936,7 +936,7 @@ bool MediaTrack::ProcessFragmentChunk()
 	}
 	if(cachedFragment->initFragment)
 	{
-		if ((pContext) && ISCONFIGSET(eAAMPConfig_EnablePTSReStamp))
+		if ((pContext) && ISCONFIGSET(eAAMPConfig_EnablePTSReStamp) && (!ISCONFIGSET(eAAMPConfig_UseMp4Demux)))
 		{
 			if (pContext->trickplayMode)
 			{
@@ -1048,7 +1048,7 @@ bool MediaTrack::ProcessFragmentChunk()
 		parsedBufferChunk.insert(parsedBufferChunk.end(),
 				unparsedBufferChunk.data(),
 				unparsedBufferChunk.data() + parsedBufferSize);
-		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp))
+		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp) && (!ISCONFIGSET(eAAMPConfig_UseMp4Demux)))
 		{
 			if (pContext && pContext->trickplayMode)
 			{
@@ -1058,13 +1058,10 @@ bool MediaTrack::ProcessFragmentChunk()
 			}
 			else
 			{
-				if (!ISCONFIGSET(eAAMPConfig_UseMp4Demux))
-				{
-					int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
-					(void)mIsoBmffHelper->RestampPts(parsedBufferChunk, ptsOffset, cachedFragment->uri,
-												 name, cachedFragment->timeScale);
-					fpts += cachedFragment->PTSOffsetSec;
-				}
+				int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
+				(void)mIsoBmffHelper->RestampPts(parsedBufferChunk, ptsOffset, cachedFragment->uri,
+												name, cachedFragment->timeScale);
+				fpts += cachedFragment->PTSOffsetSec;
 			}
 		}
 
@@ -1339,7 +1336,11 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 	else
 	{
 		// Restamp 2.0 only for DASH streams
-		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp) && (eMEDIAFORMAT_DASH == aamp->mMediaFormat))
+		/*
+		* Ignore restamping for mp4demux here(both Trickplay and normal playback) as the restamping will be done in the mp4demux
+		* after parsing the segment before sending to gstreamer.
+		*/
+		if (ISCONFIGSET(eAAMPConfig_EnablePTSReStamp) && (eMEDIAFORMAT_DASH == aamp->mMediaFormat) && (!ISCONFIGSET(eAAMPConfig_UseMp4Demux)))
 		{
 			if ((pContext && pContext->trickplayMode))
 			{
@@ -1347,26 +1348,19 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 			}
 			else
 			{
-				/*
-				 * Ignore restamping for mp4demux here as the restamping will be done in the mp4demux
-				 * after parsing the segment before sending to gstreamer.
-				 */
-				if (!ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+				if (!cachedFragment->initFragment)
 				{
-					if (!cachedFragment->initFragment)
-					{
-						// We could skip RestampPts when PTSOffsetSec==0 but the RestampPts log line
-						// would then be missing and it is important for l2 tests
-						int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
+					// We could skip RestampPts when PTSOffsetSec==0 but the RestampPts log line
+					// would then be missing and it is important for l2 tests
+					int64_t ptsOffset = cachedFragment->PTSOffsetSec * cachedFragment->timeScale;
 
-						(void)mIsoBmffHelper->RestampPts(cachedFragment->fragment, ptsOffset,
-														cachedFragment->uri, name,
-														cachedFragment->timeScale);
-					}
-					else
-					{
-						ClearMediaHeaderDuration(cachedFragment);
-					}
+					(void)mIsoBmffHelper->RestampPts(cachedFragment->fragment, ptsOffset,
+													cachedFragment->uri, name,
+													cachedFragment->timeScale);
+				}
+				else
+				{
+					ClearMediaHeaderDuration(cachedFragment);
 				}
 			}
 		}
@@ -4176,6 +4170,14 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 				if (i != eMEDIATYPE_SUBTITLE)
 				{
 					track->playContext = std::make_shared<AampMp4Demuxer>(aamp, (AampMediaType)i, ISCONFIGSET(eAAMPConfig_EnablePTSReStamp));
+					
+					// Set playback rate
+					track->playContext->setRate(aamp->rate, PlayMode_normal);
+					
+					// Set trickplay FPS for the demuxer
+					int trickPlayFPS = aamp->mConfig->GetConfigValue(eAAMPConfig_VODTrickPlayFPS);
+					
+					track->playContext->setFrameRateForTM(trickPlayFPS);
 				}
 				else
 				{

--- a/test/utests/fakes/FakeAampMp4Demuxer.cpp
+++ b/test/utests/fakes/FakeAampMp4Demuxer.cpp
@@ -63,3 +63,19 @@ bool AampMp4Demuxer::getPTSRestampStatus() const
 	}
 	return false;
 }
+
+void AampMp4Demuxer::setRate(double rate, PlayMode mode)
+{
+}
+
+void AampMp4Demuxer::setFrameRateForTM(int frameRate)
+{
+}
+
+void AampMp4Demuxer::abort()
+{
+}
+
+void AampMp4Demuxer::reset()
+{
+}

--- a/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
@@ -108,7 +108,7 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithSamples)
 		.WillOnce(Return(true));
 
 	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
-		.WillOnce(Invoke([]() {
+		.WillOnce([]() {
 			std::vector<AampMediaSample> mockSamples;
 			AampMediaSample sample1, sample2;
 
@@ -123,7 +123,7 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithSamples)
 			mockSamples.push_back(std::move(sample2));
 
 			return mockSamples;
-		}));
+		});
 
 	// Set expectations for PrivateInstanceAAMP mock
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_VIDEO, _))
@@ -184,7 +184,7 @@ TEST_F(AampMp4DemuxerTests, SendSegmentDifferentMediaTypes)
 
 	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
 	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
-		.WillOnce(Invoke([]() {
+		.WillOnce([]() {
 			std::vector<AampMediaSample> samples;
 			AampMediaSample sample;
 			const char* audioSample = "audio_sample";
@@ -193,7 +193,7 @@ TEST_F(AampMp4DemuxerTests, SendSegmentDifferentMediaTypes)
 			sample.mDataSize = seg->size();
 			samples.push_back(std::move(sample));
 			return samples;
-		}));
+		});
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_AUDIO, _));
 	bool ptsError = false;
 	bool result = audDemuxer->sendSegment(std::move(buffer), 2.0, 1.5, 0.0, false, false, nullptr, ptsError);
@@ -214,15 +214,15 @@ TEST_F(AampMp4DemuxerTests, SendInitSegmentWithValidCodecInfo)
 
 	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
 	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
-		.WillOnce(Invoke([]() {
+		.WillOnce([]() {
 			return std::vector<AampMediaSample>(); // No samples
-		}));
+		});
 	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
-		.WillOnce(Invoke([]() {
+		.WillOnce([]() {
 			MediaCodecInfo codecInfo;
 			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
 			return codecInfo;
-		})); // Return codec info
+		}); // Return codec info
 	// No SendStreamTransfer calls expected for init segment
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(eMEDIATYPE_VIDEO, _)).Times(1); // Should set stream caps
@@ -244,16 +244,16 @@ TEST_F(AampMp4DemuxerTests, SendInitSegmentWithInvalidCodecInfo)
 
 	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
 	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
-		.WillOnce(Invoke([]() {
+		.WillOnce([]() {
 			return std::vector<AampMediaSample>(); // No samples
-		}));
+		});
 	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
-		.WillOnce(Invoke([]() {
+		.WillOnce([]() {
 			MediaCodecInfo codecInfo;
 			codecInfo.mCodecFormat = GST_FORMAT_INVALID;
 			codecInfo.mIsEncrypted = false;
 			return codecInfo;
-		})); // Return explicit invalid codec info
+		}); // Return explicit invalid codec info
 	// No SendStreamTransfer and SetStreamCaps calls expected for init segment
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(eMEDIATYPE_VIDEO, _)).Times(0); // Should set stream caps
@@ -323,20 +323,20 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithPtsRestampEnabled)
 	//	EXPECT_CALL(*g_mockMp4Demux, GetTimeScale())
 	//		.WillOnce(Return(90000));
 	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
-		.WillOnce(Invoke([=]() {
+		.WillOnce([]() {
 			std::vector<AampMediaSample> mockSamples;
 			AampMediaSample sample;
-			sample.mPts = kBasePts;
-			sample.mDts = kBaseDts;
+			sample.mPts = 10.0;
+			sample.mDts = 9.5;
 			mockSamples.push_back(std::move(sample));
 			return mockSamples;
-		}));
+		});
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_VIDEO, _))
-		.WillOnce(Invoke([=](AampMediaType /*mediaType*/, AampMediaSample&& sample) {
-			EXPECT_DOUBLE_EQ(sample.mPts, kBasePts + kFragmentPtsOffset);
-			EXPECT_DOUBLE_EQ(sample.mDts, kBaseDts + kFragmentPtsOffset);
-		}));
+		.WillOnce([kFragmentPtsOffset](AampMediaType /*mediaType*/, AampMediaSample&& sample) {
+			EXPECT_DOUBLE_EQ(sample.mPts, 10.0 + kFragmentPtsOffset);
+			EXPECT_DOUBLE_EQ(sample.mDts, 9.5 + kFragmentPtsOffset);
+		});
 
 	bool ptsError = false;
 	bool result = restampDemuxer.sendSegment(std::move(buffer), 10.0, 5.0, kFragmentPtsOffset,
@@ -344,4 +344,421 @@ TEST_F(AampMp4DemuxerTests, SendSegmentWithPtsRestampEnabled)
 
 	EXPECT_TRUE(result);
 	EXPECT_FALSE(ptsError);
+}
+
+/**
+ * @brief Test trickplay PTS restamping - Initial state reset on first init fragment at trickplay rate
+ * 
+ * Validates that when entering trickplay mode with an init fragment:
+ * - Trickmode state transitions to FIRST_SAMPLE
+ * - mRestampedPts is reset to 0.0
+ * - mLastTrickRate is updated with current rate
+ */
+TEST_F(AampMp4DemuxerTests, TrickplayPtsRestamp_InitFragmentStateReset)
+{
+	// Set trickplay rate (4x fast forward)
+	mPrivateInstanceAAMP->rate = 4.0;
+	mDemuxer->setRate(4.0, PlayMode_normal);
+	mDemuxer->setFrameRateForTM(4);
+	
+	// Create init fragment buffer
+	const char* initData = "init_fragment";
+	std::vector<uint8_t> initBuffer(initData, initData + strlen(initData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			return std::vector<AampMediaSample>(); // Init has no samples
+		});
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			return codecInfo;
+		});
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(eMEDIATYPE_VIDEO, _)).Times(1);
+	
+	bool ptsError = false;
+	bool result = mDemuxer->sendSegment(std::move(initBuffer), 0.0, 0.0, 0.0, false, true, nullptr, ptsError);
+	
+	EXPECT_TRUE(result);
+	EXPECT_FALSE(ptsError);
+}
+
+/**
+ * @brief Test trickplay PTS restamping - First media fragment after init
+ * 
+ * Validates FIRST_SAMPLE state behavior:
+ * - First sample PTS is restamped to 0.0
+ * - Duration is calculated based on fragment duration and rate
+ * - State transitions to STEADY after first sample
+ */
+TEST_F(AampMp4DemuxerTests, TrickplayPtsRestamp_FirstMediaFragment)
+{
+	// Set trickplay rate (4x fast forward)
+	mPrivateInstanceAAMP->rate = 4.0;
+	mDemuxer->setRate(4.0, PlayMode_normal);
+	mDemuxer->setFrameRateForTM(4);
+	
+	// First send init fragment to reset state
+	const char* initData = "init_fragment";
+	std::vector<uint8_t> initBuffer(initData, initData + strlen(initData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			return std::vector<AampMediaSample>();
+		});
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			return codecInfo;
+		});
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(eMEDIATYPE_VIDEO, _));
+	
+	bool ptsError = false;
+	mDemuxer->sendSegment(std::move(initBuffer), 0.0, 0.0, 0.0, false, true, nullptr, ptsError);
+	
+	// Now send first media fragment
+	const char* mediaData = "media_fragment";
+	std::vector<uint8_t> mediaBuffer(mediaData, mediaData + strlen(mediaData));
+	constexpr double kFragmentDuration = 2.0; // 2 seconds
+	constexpr double kOriginalPts = 1000.0;
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			std::vector<AampMediaSample> samples;
+			AampMediaSample sample;
+			sample.mPts = 1000.0;
+			sample.mDts = 1000.0;
+			sample.mDuration = 100.0;
+			samples.push_back(std::move(sample));
+			return samples;
+		});
+	
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_VIDEO, _))
+		.WillOnce([](AampMediaType /*mediaType*/, AampMediaSample&& sample) {
+			// First sample should be restamped to 0.0
+			EXPECT_DOUBLE_EQ(sample.mPts, 0.0);
+			EXPECT_DOUBLE_EQ(sample.mDts, 0.0);
+			// Duration should be fragment_duration / rate, but capped to reasonable value
+			EXPECT_GT(sample.mDuration, 0.0);
+		});
+	
+	bool result = mDemuxer->sendSegment(std::move(mediaBuffer), 0.0, kFragmentDuration, 0.0, false, false, nullptr, ptsError);
+	
+	EXPECT_TRUE(result);
+	EXPECT_FALSE(ptsError);
+}
+
+/**
+ * @brief Test trickplay PTS restamping - Rewind mode (negative rate)
+ * 
+ * Validates STEADY state behavior based on real-world logs:
+ * - Rate: -2.0 (rewind mode)
+ * - Fragment duration: 1.920 seconds
+ * - Expected PTS values: 0.0, 0.960, 1.920
+ * - Expected duration: 0.960 (fragment_duration / abs(rate) = 1.920 / 2.0)
+ * - PTS increases monotonically even in rewind
+ */
+TEST_F(AampMp4DemuxerTests, TrickplayPtsRestamp_RewindModeMultipleFragments)
+{
+	// Set rewind rate (-2x) as observed in logs
+	mPrivateInstanceAAMP->rate = -2.0;
+	mDemuxer->setRate(-2.0, PlayMode_reverse_GOP);
+	mDemuxer->setFrameRateForTM(4); // Set trickplay FPS to avoid division by zero
+	
+	// Send init fragment first
+	const char* initData = "init";
+	std::vector<uint8_t> initBuffer(initData, initData + strlen(initData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			return std::vector<AampMediaSample>();
+		});
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			return codecInfo;
+		});
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(_, _));
+	
+	bool ptsError = false;
+	mDemuxer->sendSegment(std::move(initBuffer), 0.0, 0.0, 0.0, false, true, nullptr, ptsError);
+	
+	// Expected values from logs
+	constexpr double kFragmentDuration = 1.920;
+	constexpr double kExpectedDuration = 0.960; // 1.920 / 2.0
+	const std::vector<double> kExpectedPts = {0.0, 0.960, 1.920};
+	const std::vector<double> kOriginalPts = {69762.803644, 69760.883644, 69758.963644};
+	
+	std::vector<double> actualPts;
+	
+	// Send 3 sequential media fragments (rewind: PTS decreases in source)
+	for (int i = 0; i < 3; i++)
+	{
+		const char* mediaData = "media";
+		std::vector<uint8_t> mediaBuffer(mediaData, mediaData + strlen(mediaData));
+		double originalPts = kOriginalPts[i];
+		
+		EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+		EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+			.WillOnce([originalPts, kFragmentDuration]() {
+				std::vector<AampMediaSample> samples;
+				AampMediaSample sample;
+				sample.mPts = originalPts;
+				sample.mDts = originalPts;
+				sample.mDuration = kFragmentDuration;
+				samples.push_back(std::move(sample));
+				return samples;
+			});
+		
+		EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(eMEDIATYPE_VIDEO, _))
+			.WillOnce([&actualPts, i, &kExpectedPts, kExpectedDuration](AampMediaType, AampMediaSample&& sample) {
+				actualPts.push_back(sample.mPts);
+				
+				// Verify expected PTS value (use NEAR for floating-point tolerance)
+				EXPECT_NEAR(sample.mPts, kExpectedPts[i], 0.001) 
+					<< "Fragment " << i << ": PTS mismatch";
+				
+				// Verify expected DTS value (should match PTS)
+				EXPECT_NEAR(sample.mDts, kExpectedPts[i], 0.001) 
+					<< "Fragment " << i << ": DTS mismatch";
+				
+				// Verify expected duration
+				EXPECT_NEAR(sample.mDuration, kExpectedDuration, 0.001) 
+					<< "Fragment " << i << ": Duration mismatch";
+			});
+		
+		mDemuxer->sendSegment(std::move(mediaBuffer), 0.0, kFragmentDuration, 0.0, false, false, nullptr, ptsError);
+	}
+	
+	// Verify PTS monotonicity - even in rewind, restamped PTS advances forward
+	ASSERT_EQ(actualPts.size(), 3);
+	for (size_t i = 1; i < actualPts.size(); i++)
+	{
+		EXPECT_GT(actualPts[i], actualPts[i-1]) 
+			<< "PTS should increase monotonically even in rewind mode";
+	}
+}
+/**
+ * @brief Test trickplay PTS restamping - Transition from normal to trickplay
+ * 
+ * Validates transition behavior:
+ * - Normal playback doesn't use trickmode restamping
+ * - Entering trickplay initializes state properly
+ * - Exiting trickplay clears state
+ */
+TEST_F(AampMp4DemuxerTests, TrickplayPtsRestamp_NormalToTrickplayTransition)
+{
+	// Start at normal rate
+	mPrivateInstanceAAMP->rate = 1.0;
+	
+	const char* mediaData = "media";
+	std::vector<uint8_t> mediaBuffer(mediaData, mediaData + strlen(mediaData));
+	
+	// Send normal playback fragment
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			std::vector<AampMediaSample> samples;
+			AampMediaSample sample;
+			sample.mPts = 1000.0;
+			sample.mDts = 1000.0;
+			sample.mDuration = 100.0;
+			samples.push_back(std::move(sample));
+			return samples;
+		});
+	
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _))
+		.WillOnce([](AampMediaType, AampMediaSample&& sample) {
+			// At normal rate, PTS should not be changed to 0
+			EXPECT_DOUBLE_EQ(sample.mPts, 1000.0);
+		});
+	
+	bool ptsError = false;
+	mDemuxer->sendSegment(std::move(mediaBuffer), 0.0, 2.0, 0.0, false, false, nullptr, ptsError);
+	
+	// Now enter trickplay mode
+	mPrivateInstanceAAMP->rate = 4.0;
+	mDemuxer->setRate(4.0, PlayMode_normal);
+	mDemuxer->setFrameRateForTM(4);
+	
+	// Send init to reset trickplay state
+	const char* initData = "init";
+	std::vector<uint8_t> initBuffer(initData, initData + strlen(initData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			return std::vector<AampMediaSample>();
+		});
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			return codecInfo;
+		});
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(_, _));
+	
+	mDemuxer->sendSegment(std::move(initBuffer), 0.0, 0.0, 0.0, false, true, nullptr, ptsError);
+	
+	// Send trickplay media fragment
+	std::vector<uint8_t> media2Buffer(mediaData, mediaData + strlen(mediaData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			std::vector<AampMediaSample> samples;
+			AampMediaSample sample;
+			sample.mPts = 3000.0;
+			sample.mDts = 3000.0;
+			sample.mDuration = 100.0;
+			samples.push_back(std::move(sample));
+			return samples;
+		});
+	
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _))
+		.WillOnce([](AampMediaType, AampMediaSample&& sample) {
+			// First trickplay sample should reset to 0
+			EXPECT_DOUBLE_EQ(sample.mPts, 0.0);
+			EXPECT_DOUBLE_EQ(sample.mDts, 0.0);
+		});
+	
+	mDemuxer->sendSegment(std::move(media2Buffer), 0.0, 2.0, 0.0, false, false, nullptr, ptsError);
+	
+	// Return to normal rate
+	mPrivateInstanceAAMP->rate = 1.0;
+	mDemuxer->setRate(1.0, PlayMode_normal);
+	
+	std::vector<uint8_t> media3Buffer(mediaData, mediaData + strlen(mediaData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			std::vector<AampMediaSample> samples;
+			AampMediaSample sample;
+			sample.mPts = 5000.0;
+			sample.mDts = 5000.0;
+			sample.mDuration = 100.0;
+			samples.push_back(std::move(sample));
+			return samples;
+		});
+	
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _))
+		.WillOnce([](AampMediaType, AampMediaSample&& sample) {
+			// Back to normal - should preserve original PTS
+			EXPECT_DOUBLE_EQ(sample.mPts, 5000.0);
+		});
+	
+	mDemuxer->sendSegment(std::move(media3Buffer), 0.0, 2.0, 0.0, false, false, nullptr, ptsError);
+}
+
+/**
+ * @brief Test trickplay PTS restamping - No duplicate init processing at same rate
+ * 
+ * This test specifically validates the fix for the TSB duplicate init issue:
+ * - First init at trickplay rate resets state
+ * - Subsequent inits at SAME rate do NOT reset state
+ * - State only resets when rate changes AND init is received
+ */
+TEST_F(AampMp4DemuxerTests, TrickplayPtsRestamp_NoDuplicateInitAtSameRate)
+{
+	// Set trickplay rate
+	mPrivateInstanceAAMP->rate = 4.0;
+	mDemuxer->setRate(4.0, PlayMode_normal);
+	mDemuxer->setFrameRateForTM(4);
+	
+	// Send first init - should reset state
+	const char* initData = "init";
+	std::vector<uint8_t> init1Buffer(initData, initData + strlen(initData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			return std::vector<AampMediaSample>();
+		});
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			return codecInfo;
+		});
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(_, _));
+	
+	bool ptsError = false;
+	mDemuxer->sendSegment(std::move(init1Buffer), 0.0, 0.0, 0.0, false, true, nullptr, ptsError);
+	
+	// Send media fragment
+	const char* media1 = "media1";
+	std::vector<uint8_t> media1Buffer(media1, media1 + strlen(media1));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			std::vector<AampMediaSample> samples;
+			AampMediaSample sample;
+			sample.mPts = 1000.0;
+			sample.mDts = 1000.0;
+			sample.mDuration = 100.0;
+			samples.push_back(std::move(sample));
+			return samples;
+		});
+	
+	double firstMediaPts = 0.0;
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _))
+		.WillOnce([&firstMediaPts](AampMediaType, AampMediaSample&& sample) {
+			firstMediaPts = sample.mPts;
+			EXPECT_DOUBLE_EQ(sample.mPts, 0.0); // First sample at 0
+		});
+	
+	mDemuxer->sendSegment(std::move(media1Buffer), 0.0, 2.0, 0.0, false, false, nullptr, ptsError);
+	
+	// Send second init AT THE SAME RATE - should NOT reset state
+	std::vector<uint8_t> init2Buffer(initData, initData + strlen(initData));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			return std::vector<AampMediaSample>();
+		});
+	EXPECT_CALL(*g_mockMp4Demux, GetCodecInfo())
+		.WillOnce([]() {
+			MediaCodecInfo codecInfo;
+			codecInfo.mCodecFormat = GST_FORMAT_VIDEO_ES_H264;
+			return codecInfo;
+		});
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetStreamCaps(_, _));
+	
+	// Rate is still 4.0 - no change
+	mDemuxer->sendSegment(std::move(init2Buffer), 0.0, 0.0, 0.0, false, true, nullptr, ptsError);
+	
+	// Send another media fragment - PTS should continue from previous, NOT reset to 0
+	const char* media2 = "media2";
+	std::vector<uint8_t> media2Buffer(media2, media2 + strlen(media2));
+	
+	EXPECT_CALL(*g_mockMp4Demux, Parse(_)).WillOnce(Return(true));
+	EXPECT_CALL(*g_mockMp4Demux, GetSamples())
+		.WillOnce([]() {
+			std::vector<AampMediaSample> samples;
+			AampMediaSample sample;
+			sample.mPts = 3000.0; // 2 seconds later
+			sample.mDts = 3000.0;
+			sample.mDuration = 100.0;
+			samples.push_back(std::move(sample));
+			return samples;
+		});
+	
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendStreamTransfer(_, _))
+		.WillOnce([&firstMediaPts](AampMediaType, AampMediaSample&& sample) {
+			// Should NOT be 0 - should continue from previous state
+			EXPECT_GT(sample.mPts, 0.0) << "PTS should continue, not reset after init at same rate";
+			EXPECT_GT(sample.mPts, firstMediaPts) << "PTS should advance from previous sample";
+		});
+	
+	mDemuxer->sendSegment(std::move(media2Buffer), 0.0, 2.0, 0.0, false, false, nullptr, ptsError);
 }

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -235,6 +235,8 @@ protected:
 
 		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_OverrideMediaHeaderDuration))
 			.WillRepeatedly(Return(false));
+		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
+			.WillRepeatedly(Return(false));
 		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
 			.WillRepeatedly(Return(false));
 		EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
@@ -308,6 +310,8 @@ TEST_P(MediaTrackDashPtsRestampNotConfiguredTests, PtsRestampNotConfiguredTest)
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
 		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
+		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentCached))
@@ -367,6 +371,8 @@ TEST_P(MediaTrackDashQtDemuxOverrideConfiguredTests, QtDemuxOverrideConfiguredTe
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
 		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
+		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentCached))
@@ -425,6 +431,8 @@ TEST_P(MediaTrackDashTrickModePtsRestampValidPlayRateTests, ValidPlayRateTest)
 	EXPECT_CALL(*g_mockIsoBmffHelper, RestampPts(_, _, _, _, _)).Times(0);
 
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
 		.WillRepeatedly(Return(true));
@@ -740,6 +748,8 @@ TEST_F(MediaTrackTests, DashTrickModePtsRestampDiscontinuityTest)
 	// There should be no PTS restamping for normal play rate media fragments in this test
 	EXPECT_CALL(*g_mockIsoBmffHelper, RestampPts(_, _, _, _, _)).Times(0);
 
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
+		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
@@ -866,6 +876,8 @@ TEST_F(MediaTrackTests, FlushFetchedFragmentsTest)
 	mStreamAbstractionAAMP_MPD->trickplayMode = true;
 
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_CurlThroughput))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
 		.WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
 		.WillRepeatedly(Return(true));


### PR DESCRIPTION
Reason for change: As the TrickmodeRestamp, is not handled for the Mp4segments, so sudden jumps in the pts value is noticed and the discontinuous segments injected to the pipeline causing trickplay failure. In order to resolve the above issue, handled TrickmodeRestamping accordingly for the Mp4segments
Risks: Low
Test Procedure: Refer jira ticket
Priority: P1
    