### PR TITLE
VPLAY-13506 : Ads are not played on cdvr asset

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -5457,7 +5457,7 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 				// time to set / adjust the event start and duration relative to the start time of the stream
 				if (eventInfo.presentationTime && (startOffsetMS > -1))
 				{
-					AAMPLOG_INFO("DEBUG-->CDAI event presentation time %" PRIu64 " ms, stream start offset %lld ms", eventInfo.presentationTime, startOffsetMS);
+					AAMPLOG_INFO("DEBUG-->CDAI event presentation time %" PRIu64 " ms, stream start offset %" PRId64 " ms", eventInfo.presentationTime, startOffsetMS);
 					// Adjust for stream start offset and check for pts wrap
 					eventStartTime = eventInfo.presentationTime;
 					if (eventStartTime < startOffsetMS)

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -3144,6 +3144,8 @@ void StreamAbstractionAAMP_MPD::ProcessMetadataFromManifest( ManifestDownloadRes
 		//If bulk metadata is enabled for live, all metadata should be reported as bulkmetadata event
 		//and player should not send the same  events again.
 		bool bMetadata		=	ISCONFIGSET(eAAMPConfig_BulkTimedMetaReport) || ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive);
+		
+		AAMPLOG_INFO("DEBUG-->Processing timed metadata from manifest");
 		FindTimedMetadata((dash::mpd::MPD *)tmpMPD, root, init, bMetadata);
 		if(!init)
 		{
@@ -5136,6 +5138,7 @@ void StreamAbstractionAAMP_MPD::FindTimedMetadata(MPD* mpd, Node* root, bool ini
 								if (processEventsInPeriod)
 								{
 									mCdaiObject->InsertToPeriodMap(period);	//Need to do it. Because the FulFill may finish quickly
+									AAMPLOG_WARN("Processing CDAI events for period %s", prdId.c_str());
 									ProcessEventStream(periodStartMS, firstSegmentStartTime, period, reportBulkMeta);
 									continue;
 								}
@@ -5454,11 +5457,13 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 				// time to set / adjust the event start and duration relative to the start time of the stream
 				if (eventInfo.presentationTime && (startOffsetMS > -1))
 				{
+					AAMPLOG_INFO("DEBUG-->CDAI event presentation time %" PRIu64 " ms, stream start offset %lld ms", eventInfo.presentationTime, startOffsetMS);
 					// Adjust for stream start offset and check for pts wrap
 					eventStartTime = eventInfo.presentationTime;
 					if (eventStartTime < startOffsetMS)
 					{
 						eventStartTime += (maxPTSTime - startOffsetMS);
+						AAMPLOG_INFO("DEBUG-->CDAI event start time after pts delta adjustment %" PRIu64 " ms", eventStartTime);
 
 						// If the difference is too large (>24hrs), assume this is not a pts wrap and the event is timed
 						// to occur before the start - set it to start immediately and adjust the duration accordingly
@@ -5487,21 +5492,23 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 				//for livestream send the timedMetadata only., because at init, control does not come here
 				if(mIsLiveManifest && ! ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive))
 				{
+					AAMPLOG_INFO("DEBUG-->Processing live manifest CDAI events");
 					// The current process relies on enabling eAAMPConfig_EnableClientDai and that may not be desirable
 					// for our requirements. We'll just skip this and use the VOD process to send events
 					bool modifySCTEProcessing = ISCONFIGSET(eAAMPConfig_EnableSCTE35PresentationTime);
-					if (modifySCTEProcessing)
+					if (modifySCTEProcessing && !aamp->mTuneCompleted && aamp->mFogTSBEnabled)
 					{
+						AAMPLOG_INFO("DEBUG-->Saving timedMetadata for live %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
 						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
+
 					}
-					else
-					{
 						aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
-					}
+				
 				}
 				else
 				{
 					//for vod, send TimedMetadata only when bulkmetadata is not enabled
+					AAMPLOG_INFO("DEBUG-->Processing VOD manifest CDAI events");
 					if(reportBulkMeta)
 					{
 						AAMPLOG_INFO("Saving timedMetadata for VOD %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -5498,7 +5498,7 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 					bool modifySCTEProcessing = ISCONFIGSET(eAAMPConfig_EnableSCTE35PresentationTime);
 					//SaveNewTimedMetadata is also invoked from FoundEventBreak, but only for events identified after tune completion. 
 					//To avoid duplicate execution of SaveNewTimedMetadata, an additional flag check has been introduced in below if loop.
-					if (modifySCTEProcessing && !aamp->mTuneCompleted && aamp->mFogTSBEnabled)
+					if (modifySCTEProcessing && !aamp->IsTuneCompleted() && aamp->mFogTSBEnabled)
 					{
 						AAMPLOG_INFO("DEBUG-->Saving timedMetadata for live %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
 						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -5496,12 +5496,15 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 					// The current process relies on enabling eAAMPConfig_EnableClientDai and that may not be desirable
 					// for our requirements. We'll just skip this and use the VOD process to send events
 					bool modifySCTEProcessing = ISCONFIGSET(eAAMPConfig_EnableSCTE35PresentationTime);
+					//SaveNewTimedMetadata is also invoked from FoundEventBreak, but only for events identified after tune completion. 
+					//To avoid duplicate execution of SaveNewTimedMetadata, an additional flag check has been introduced in below if loop.
 					if (modifySCTEProcessing && !aamp->mTuneCompleted && aamp->mFogTSBEnabled)
 					{
 						AAMPLOG_INFO("DEBUG-->Saving timedMetadata for live %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
 						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
 
 					}
+					        /*For CDVR CDAI, it is necessary to invoke FoundEventBreak to insert a placeholder when a CDAI event is present. Otherwise, only metadata will be saved, and when a CDAI ad request is made to AAMP, it will result in an eCDAI_ERROR_UNKNOWN being sent application, leading to ad playback failure.*/ 
 						aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
 				
 				}


### PR DESCRIPTION
Reason for change: CDAI events are not processed correctly when modifySCTCE config is not set 
Test Procedure : Check ticket
Priority : P1
Risks :Low