### PR TITLE
VPAAMP-391 - AAMP errors with HLS manifest attribute len > 10

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -99,7 +99,7 @@ static const ProfilerBucketType mediaTrackDecryptBucketTypes[AAMP_DRM_CURL_COUNT
 static void ParseKeyAttributeCallback(lstring attrName, lstring valuePtr, void* arg)
 {
 	TrackState *ts = (TrackState *)arg;
-	if (attrName.equal("METHOD"))
+	if (attrName.equalsCString("METHOD"))
 	{
 		if (valuePtr.SubStringMatch("NONE"))
 		{ // used by DAI
@@ -165,7 +165,7 @@ static void ParseKeyAttributeCallback(lstring attrName, lstring valuePtr, void* 
 			AAMPLOG_ERR("unsupported METHOD");
 		}
 	}
-	else if (attrName.equal("KEYFORMAT"))
+	else if (attrName.equalsCString("KEYFORMAT"))
 	{
 		std::string keyFormat = valuePtr.GetAttributeValueString();
 		ts->mDrmInfo.keyFormat = keyFormat;
@@ -175,10 +175,10 @@ static void ParseKeyAttributeCallback(lstring attrName, lstring valuePtr, void* 
 			ts->mDrmInfo.systemUUID = keyFormat.substr(9);
 		}
 	}
-	else if (attrName.equal("URI"))
+	else if (attrName.equalsCString("URI"))
 	{
 		std::string uri;
-		if( !valuePtr.startswith(CHAR_QUOTE) && !valuePtr.equal("NONE") )
+		if( !valuePtr.startswith(CHAR_QUOTE) && !valuePtr.equalsCString("NONE") )
 		{
 			// Handling keys with relative URIs
 			// This condition is used to extract key URI from unquoted / NONE strings
@@ -194,7 +194,7 @@ static void ParseKeyAttributeCallback(lstring attrName, lstring valuePtr, void* 
 			ts->mDrmInfo.keyURI = std::move(uri);
 		}
 	}
-	else if (attrName.equal("IV"))
+	else if (attrName.equalsCString("IV"))
 	{ // 16 bytes
 		if( valuePtr.removePrefix("0x") || valuePtr.removePrefix("0X") )
 		{
@@ -203,7 +203,7 @@ static void ParseKeyAttributeCallback(lstring attrName, lstring valuePtr, void* 
 			ts->mDrmInfo.bUseMediaSequenceIV = false;
 		}
 	}
-	else if (attrName.equal("CMSha1Hash"))
+	else if (attrName.equalsCString("CMSha1Hash"))
 	{ // 20 bytes; Metadata Hash.
 		if( valuePtr.removePrefix("0x") || valuePtr.removePrefix("0X") )
 		{
@@ -227,12 +227,12 @@ static void ParseTileInfCallback(lstring attrName, lstring valuePtr, void* arg)
 {
 	// #EXT-X-TILES:RESOLUTION=416x234,LAYOUT=9x17,DURATION=2.002
 	TileLayout *var = (TileLayout *)arg;
-	if (attrName.equal("LAYOUT"))
+	if (attrName.equalsCString("LAYOUT"))
 	{
 		std::string temp = valuePtr.tostring();
 		sscanf(temp.c_str(), "%dx%d", &var->numCols, &var->numRows);
 	}
-	else if (attrName.equal("DURATION"))
+	else if (attrName.equalsCString("DURATION"))
 	{
 		var->posterDuration = valuePtr.atof();
 	}
@@ -251,11 +251,11 @@ static void ParseTileInfCallback(lstring attrName, lstring valuePtr, void* arg)
 static void ParseXStartAttributeCallback(lstring attrName, lstring valuePtr, void* arg)
 {
 	HLSXStart *var = (HLSXStart *)arg;
-	if (attrName.equal("TIME-OFFSET"))
+	if (attrName.equalsCString("TIME-OFFSET"))
 	{
 		var->offset = valuePtr.atof();
 	}
-	else if (attrName.equal("PRECISE"))
+	else if (attrName.equalsCString("PRECISE"))
 	{
 		// Precise attribute is not considered . By default NO option is selected
 		var->precise = false;
@@ -276,45 +276,45 @@ static void ParseStreamInfCallback( lstring attrName, lstring valuePtr, void* ar
 {
 	StreamAbstractionAAMP_HLS *context = (StreamAbstractionAAMP_HLS *) arg;
 	HlsStreamInfo &streamInfo = context->streamInfoStore[context->GetTotalProfileCount()];
-	if (attrName.equal("URI"))
+	if (attrName.equalsCString("URI"))
 	{
 		streamInfo.uri = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("BANDWIDTH"))
+	else if (attrName.equalsCString("BANDWIDTH"))
 	{
 		streamInfo.bandwidthBitsPerSecond = valuePtr.atol();
 	}
-	else if (attrName.equal("PROGRAM-ID"))
+	else if (attrName.equalsCString("PROGRAM-ID"))
 	{
 		streamInfo.program_id = valuePtr.atol();
 	}
-	else if (attrName.equal("AUDIO"))
+	else if (attrName.equalsCString("AUDIO"))
 	{
 		streamInfo.audio = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("CODECS"))
+	else if (attrName.equalsCString("CODECS"))
 	{
 		streamInfo.codecs = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("RESOLUTION"))
+	else if (attrName.equalsCString("RESOLUTION"))
 	{
 		std::string temp = valuePtr.tostring();
 		sscanf(temp.c_str(), "%dx%d", &streamInfo.resolution.width, &streamInfo.resolution.height);
 	}
 	// following are rarely present
-	else if (attrName.equal("AVERAGE-BANDWIDTH"))
+	else if (attrName.equalsCString("AVERAGE-BANDWIDTH"))
 	{
 		streamInfo.averageBandwidth = valuePtr.atol();
 	}
-	else if (attrName.equal("FRAME-RATE"))
+	else if (attrName.equalsCString("FRAME-RATE"))
 	{
 		streamInfo.resolution.framerate = valuePtr.atof();
 	}
-	else if (attrName.equal("CLOSED-CAPTIONS"))
+	else if (attrName.equalsCString("CLOSED-CAPTIONS"))
 	{
 		streamInfo.closedCaptions = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("SUBTITLES"))
+	else if (attrName.equalsCString("SUBTITLES"))
 	{
 		streamInfo.subtitles = valuePtr.GetAttributeValueString();
 	}
@@ -342,7 +342,7 @@ static void ParseMediaAttributeCallback( lstring attrName, lstring valuePtr, voi
 	#EXT - X - MEDIA:TYPE = AUDIO, GROUP - ID = "g117600", NAME = "English", LANGUAGE = "en", DEFAULT = YES, AUTOSELECT = YES
 	#EXT - X - MEDIA:TYPE = AUDIO, GROUP - ID = "g117600", NAME = "Spanish", LANGUAGE = "es", URI = "HBOHD_HD_NAT_15152_0_5939026565177792163/format-hls-track-sap-bandwidth-117600-repid-root_audio103.m3u8"
 	*/
-	if (attrName.equal("TYPE"))
+	if (attrName.equalsCString("TYPE"))
 	{
 		if (valuePtr.SubStringMatch("AUDIO"))
 		{
@@ -362,26 +362,26 @@ static void ParseMediaAttributeCallback( lstring attrName, lstring valuePtr, voi
 			mediaInfo.isCC = true;
 		}
 	}
-	else if (attrName.equal("GROUP-ID"))
+	else if (attrName.equalsCString("GROUP-ID"))
 	{
 		mediaInfo.group_id = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("NAME"))
+	else if (attrName.equalsCString("NAME"))
 	{
 		mediaInfo.name = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("LANGUAGE"))
+	else if (attrName.equalsCString("LANGUAGE"))
 	{
 		mediaInfo.language = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("AUTOSELECT"))
+	else if (attrName.equalsCString("AUTOSELECT"))
 	{
 		if (valuePtr.SubStringMatch("YES"))
 		{
 			mediaInfo.autoselect = true;
 		}
 	}
-	else if (attrName.equal("DEFAULT"))
+	else if (attrName.equalsCString("DEFAULT"))
 	{
 		if (valuePtr.SubStringMatch("YES"))
 		{
@@ -392,26 +392,26 @@ static void ParseMediaAttributeCallback( lstring attrName, lstring valuePtr, voi
 			mediaInfo.isDefault = false;
 		}
 	}
-	else if (attrName.equal("URI"))
+	else if (attrName.equalsCString("URI"))
 	{
 		mediaInfo.uri = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("CHANNELS"))
+	else if (attrName.equalsCString("CHANNELS"))
 	{
 		mediaInfo.channels = valuePtr.atoi();
 	}
-	else if (attrName.equal("INSTREAM-ID"))
+	else if (attrName.equalsCString("INSTREAM-ID"))
 	{
 		mediaInfo.instreamID = valuePtr.GetAttributeValueString();
 	}
-	else if (attrName.equal("FORCED"))
+	else if (attrName.equalsCString("FORCED"))
 	{
 		if (valuePtr.SubStringMatch("YES"))
 		{
 			mediaInfo.forced = true;
 		}
 	}
-	else if (attrName.equal("CHARACTERISTICS"))
+	else if (attrName.equalsCString("CHARACTERISTICS"))
 	{
 		mediaInfo.characteristics = valuePtr.GetAttributeValueString();
 	}
@@ -768,7 +768,7 @@ lstring TrackState::GetIframeFragmentUriFromIndex(bool &bSegmentRepeated)
 		{
 			// For Fragmented MP4 check if initFragment injection is required
 			if ( !idxNode->initFragmentPtr.empty() &&
-				(mInitFragmentInfo.empty() || !mInitFragmentInfo.equal(idxNode->initFragmentPtr)) )
+				(mInitFragmentInfo.empty() || !mInitFragmentInfo.isSameView(idxNode->initFragmentPtr)) )
 			{
 				mInitFragmentInfo = idxNode->initFragmentPtr;
 				mInjectInitFragment = true;
@@ -949,7 +949,7 @@ lstring TrackState::GetNextFragmentUriFromPlaylist(bool& reloadUri, bool ignoreD
 				}
 				else if(ptr.removePrefix("-X-MAP:"))
 				{
-					if( !mInitFragmentInfo.equal(ptr) )
+					if( !mInitFragmentInfo.isSameView(ptr) )
 					{
 						mInitFragmentInfo = ptr;
 						mInjectInitFragment = true;
@@ -1948,7 +1948,7 @@ void TrackState::IndexPlaylist(bool IsRefresh, AampTime &culledSec)
 	lstring iter = lstring(reinterpret_cast<const char*>(playlist.data()),playlist.size());
 	if( !iter.empty() ){
 		lstring ptr = iter.mystrpbrk();
-		if( !ptr.equal("#EXTM3U") )
+		if( !ptr.equalsCString("#EXTM3U") )
 		{
 			int numChars = iter.getLen();
 			if( numChars>MANIFEST_TEMP_DATA_LENGTH ) numChars = MANIFEST_TEMP_DATA_LENGTH;
@@ -2651,23 +2651,23 @@ StreamOutputFormat GetFormatFromFragmentExtension( const std::vector<uint8_t> &p
                             break;
                         }
                     }
-                    if( ptr.equal("ts") )
+                    if( ptr.equalsCString("ts") )
                     {
                         format = FORMAT_MPEGTS;
                     }
-                    else if ( ptr.equal("aac") )
+                    else if ( ptr.equalsCString("aac") )
                     {
                         format = FORMAT_AUDIO_ES_AAC;
                     }
-                    else if ( ptr.equal("ac3") )
+                    else if ( ptr.equalsCString("ac3") )
                     {
                         format = FORMAT_AUDIO_ES_AC3;
                     }
-                    else if ( ptr.equal("ec3") )
+                    else if ( ptr.equalsCString("ec3") )
                     {
                         format = FORMAT_AUDIO_ES_EC3;
                     }
-                    else if( ptr.equal("vtt") || ptr.equal("webvtt") )
+                    else if( ptr.equalsCString("vtt") || ptr.equalsCString("webvtt") )
                     {
                         format = FORMAT_SUBTITLE_WEBVTT;
                     }

--- a/lstring.cpp
+++ b/lstring.cpp
@@ -19,154 +19,141 @@
 
 /**
  * @file lstring.cpp
- * @brief Implementation file for lightweight trivially‑copiable string utilities.
+ * @brief Implementation file for lightweight string-view utilities.
  *
- * This file contains the out‑of‑line definition of lstring::atof().  
- * All other lstring methods remain header‑only for performance and inlining.
+ * This file contains the out-of-line definition of lstring::atof().
+ * All other lstring methods remain header-only for performance and inlining.
  *
  * @note atof() is implemented here (instead of in lstring.hpp) to avoid pulling
  *       in heavy dependencies through AampLogManager.h. Including that header
- *       inside lstring.hpp would force every consumer of lstring.hpp
- *       (notably fragmentcollector_hls.h) to indirectly include large modules
- *       such as curl, increasing compile‑time coupling and reducing the
- *       lightweight, reusable nature of the lstring abstraction.
+ *       inside lstring.hpp would force every consumer of lstring.hpp to
+ *       indirectly include large modules, increasing compile-time coupling and
+ *       reducing the lightweight, reusable nature of the lstring abstraction.
  *
  * @note lstring represents a simple (ptr, length) view similar to
  *       std::basic_string_view from <string_view>.
  */
 
 #include <cctype>
-#include <stdexcept>
+#include <climits>
+
 #include "lstring.hpp"
 #include "AampLogManager.h"
 
 /**
- * @brief Converts a character buffer to a floating‑point value with robust,
- *        fault‑tolerant parsing tailored for HLS playlist fields.
+ * @brief Converts the view to a floating-point value with robust, fault-tolerant
+ *        parsing tailored for HLS playlist fields.
  *
- * This function is designed for scenarios where malformed or unexpected input
- * is common (e.g., EXTINF durations in HLS playlists) and strict failure is
- * undesirable. It extracts a best‑effort numeric value while still providing
- * strong diagnostics for debugging malformed playlist data.
+ * This parser is designed for scenarios where malformed or unexpected input is
+ * common (e.g., EXTINF durations in HLS playlists) and strict failure is
+ * undesirable. It extracts a best-effort numeric value and stops cleanly at the
+ * first non-numeric character.
  *
- * Compared to std::atof() or std::strtod(), this parser:
- *   - Accepts partial numbers and stops cleanly at the first non‑numeric
- *     character (e.g., "3.25e-5" → 3.25, "12.5abc" → 12.5).
- *   - Rejects malformed formats that may indicate real authoring errors,
- *     such as multiple decimal points ("12.34.56") or a sign with no digits
- *     ("+", "-", "+  ").
- *   - Handles leading whitespace and an optional sign.
- *   - Avoids undefined behavior by safely casting characters before calling
- *     std::isspace() or std::isdigit().
- *   - Logs detailed error messages—including the failure reason, offending
- *     character, and input buffer—without throwing exceptions to the caller.
+ * Parsing behavior:
+ *   - Skips leading whitespace.
+ *   - Accepts an optional leading '+' or '-' sign.
+ *   - Parses digits and at most one '.' decimal point.
+ *   - Requires at least one digit somewhere (either before or after '.').
+ *   - Stops at the first character that is not a digit or '.'.
+ *   - If a second '.' is encountered, parsing stops (best-effort) rather than
+ *     failing the entire conversion.
+ *   - Does not parse exponent notation (e.g. "3.25e-5" parses as 3.25 and stops
+ *     at 'e').
  *
- * @return The parsed floating‑point value, or a best‑effort approximation if
- *         the input is partially valid.
+ * Safety / robustness:
+ *   - Never reads past @c len.
+ *   - Avoids undefined behavior from signed integer overflow by accumulating
+ *     directly into @c double.
+ *   - Uses safe casting when calling std::isspace() / std::isdigit().
+ *   - Logs a diagnostic message on failure (no digits found, null/empty input).
+ *
+ * @return Parsed floating-point value on success; 0.0 on failure.
  */
 double lstring::atof() const
 {
-    try
-    {
-        if (ptr == nullptr)
-            throw std::runtime_error("null pointer input");
+	if (ptr == nullptr || len == 0)
+	{
+		AAMPLOG_ERR("lstring::atof invalid input | ptr=%p len=%zu", ptr, (size_t)len);
+		return 0.0;
+	}
 
-        if (len == 0)
-            throw std::runtime_error("empty string at index 0");
+	size_t i = 0;
 
-        size_t i = 0;
+	// Skip leading whitespace
+	while (i < len && std::isspace(static_cast<unsigned char>(ptr[i])))
+	{
+		i++;
+	}
 
-        // Skip leading whitespace
-        while (i < len && std::isspace(static_cast<unsigned char>(ptr[i])))
-            i++;
+	// Whitespace-only input
+	if (i >= len)
+	{
+		AAMPLOG_ERR("lstring::atof whitespace-only input | len=%zu", (size_t)len);
+		return 0.0;
+	}
 
-        // If we reached the end, the string was only whitespace
-        if (i >= len)
-            throw std::runtime_error("empty string at index 0");
+	// Optional sign
+	double sign = 1.0;
+	if (ptr[i] == '+' || ptr[i] == '-')
+	{
+		if (ptr[i] == '-')
+		{
+			sign = -1.0;
+		}
+		i++;
+	}
 
-        // Optional sign
-        int sign = 1;
-        if (ptr[i] == '-' || ptr[i] == '+')
-        {
-            if (ptr[i] == '-')
-                sign = -1;
-            i++;
-        }
+	// Parse digits and optional decimal point. Require at least one digit.
+	bool sawDigit = false;
+	bool sawDot   = false;
 
-        // First meaningful character must be digit or '.'
-        if (i >= len)
-        {
-            throw std::runtime_error(
-                std::string("unexpected end of string while expecting digit or '.' at index ") + std::to_string(i)
-            );
-        }
+	double value     = 0.0;
+	double fracScale = 0.1;
 
-        // After optional sign, the first character MUST be digit or '.'
-        if (!(std::isdigit(static_cast<unsigned char>(ptr[i])) || ptr[i] == '.'))
-        {
-            throw std::runtime_error( std::string("unexpected character '") + ptr[i] + "' at index " + std::to_string(i) );
-        }
+	for (; i < len; i++)
+	{
+		char c = ptr[i];
 
-        long long ival = 0;     // integer part
-        long long frac = 0;     // fractional part
-        long long fracDiv = 1;  // divisor for fractional digits
-        bool afterDecimal = false;
+		if (c >= '0' && c <= '9')
+		{
+			sawDigit = true;
+			int d = c - '0';
 
-        // Main parsing loop
-        for (; i < len; i++)
-        {
-            char c = ptr[i];
+			if (!sawDot)
+			{
+				// Accumulate integer part (in double; no signed-integer overflow UB)
+				value = value * 10.0 + (double)d;
+			}
+			else
+			{
+				// Accumulate fractional part
+				value += (double)d * fracScale;
+				fracScale *= 0.1;
+			}
+		}
+		else if (c == '.')
+		{
+			if (sawDot)
+			{
+				// Best-effort: stop on second decimal point rather than failing
+				break;
+			}
+			sawDot = true;
+		}
+		else
+		{
+			// Stop parsing on any other character
+			break;
+		}
+	}
 
-            if (c >= '0' && c <= '9')
-            {
-                if (!afterDecimal)
-                    ival = ival * 10 + (c - '0');
-                else
-                {
-                    frac = frac * 10 + (c - '0');
-                    fracDiv *= 10;
-                }
-            }
-            else if (c == '.')
-            {
-                if (afterDecimal)
-                {
-                    throw std::runtime_error( "multiple decimal points at index " + std::to_string(i) );
-                }
-                afterDecimal = true;
-            }
-            else
-            {
-                // Stop parsing on any non-numeric character
-                break;
-            }
-        }
+	if (!sawDigit)
+	{
+		// Log a bounded preview of the input (does not require null termination)
+		int n = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
+		AAMPLOG_ERR("lstring::atof no digits | input:\"%.*s\" len:%zu", n, ptr, (size_t)len);
+		return 0.0;
+	}
 
-        double result = (double)ival + (double)frac / (double)fracDiv;
-        return sign * result;
-    }
-    catch (const std::exception& e)
-    {
-        if (ptr != nullptr && len > 0)
-        {
-            AAMPLOG_ERR( "exception %s | input: \"%.*s\" len: %zu", e.what(), (int)len, ptr, (size_t)len );
-        }
-        else
-        {
-            AAMPLOG_ERR( "unknown exception | len: %zu", (size_t)len );
-        }
-        return 0.0;
-    }
-    catch (...)
-    {
-        if (ptr != nullptr && len > 0)
-        {
-            AAMPLOG_ERR( "unknown exception | input: \"%.*s\" len: %zu", (int)len, ptr, (size_t)len );
-        }
-        else
-        {
-            AAMPLOG_ERR( "unknown exception | len: %zu", (size_t)len );
-        }
-        return 0.0;
-    }
+	return sign * value;
 }

--- a/lstring.hpp
+++ b/lstring.hpp
@@ -18,107 +18,233 @@
 */
 
 /**
-* @file lstring.h
-* @brief abstract data type for a lightweight trivially-copiable string defined by (ptr,length)
-* @note includes HLS-friendly parsing convenience methods, i.e. ParseAttrList
-* @note similar to std::basic_string_view from <string_view>
-*/
-#ifndef __LSTRING_H__
-#define __LSTRING_H__
+ * @file lstring.hpp
+ * @brief Lightweight, trivially-copyable string view defined by (pointer, length).
+ *
+ * lstring is a non-owning string view similar to std::basic_string_view. It
+ * holds a pointer into an existing character buffer and a byte count; it never
+ * allocates or frees memory. Copying an lstring copies only (ptr,len).
+ *
+ * Primary use-case is HLS manifest parsing inside AAMP:
+ *   - ParseAttrList() walks a comma-separated attribute list and fires a
+ *     callback for every (name, value) pair.
+ *   - mystrpbrk() consumes the next LF-delimited line, stripping any trailing
+ *     CR so callers see a clean token regardless of CRLF / LF line endings.
+ *
+ * @note This type is *trivially copyable* (trivial copy/move/dtor), but is not
+ *       required to be trivially constructible.
+ * @note All methods that do not mutate the view are marked @c const.
+ * @note Invariant expectation: if @c len > 0 then @c ptr is non-null and points
+ *       to at least @c len bytes. Debug builds assert this where practical.
+ */
 
-#include <stddef.h>
-#include <assert.h>
+#ifndef LSTRING_HPP
+#define LSTRING_HPP
+
+#include <cstddef>
+#include <cassert>
+#include <cstring>
+#include <climits>
 #include <string>
 
-const char CHAR_CR = '\r'; // 0x0d
-const char CHAR_LF = '\n'; // 0x0a
-const char CHAR_QUOTE = '\"'; // 0x22
+/**
+ * @def LSTRING_ENABLE_LEGACY_EQUAL
+ * @brief Enables legacy wrapper overloads named equal(...).
+ *
+ * When enabled, lstring provides:
+ *   - bool equal(const char*)  -> calls equalsCString(const char*)
+ *   - bool equal(const lstring&) -> calls isSameView(const lstring&)
+ *
+ * These wrappers help preserve older call sites. Disable if you want to force
+ * updated naming everywhere.
+ */
+#ifndef LSTRING_ENABLE_LEGACY_EQUAL
+#define LSTRING_ENABLE_LEGACY_EQUAL 1
+#endif
 
+/**
+ * @def LSTRING_EMPTY_PTR_NULL
+ * @brief Forces ptr to become nullptr when the view becomes empty via removePrefix(n>=len).
+ *
+ * Default is 0 (string_view-like): empty means len==0, ptr may retain its prior value.
+ * Enabling (1) makes empty consistently ptr==nullptr, which can be simpler, but may
+ * subtly change behavior for code that uses pointer identity on empty views.
+ */
+#ifndef LSTRING_EMPTY_PTR_NULL
+#define LSTRING_EMPTY_PTR_NULL 0
+#endif
+
+/**
+ * @def LSTRING_SUBSTR_ALLOW_ENDPOS
+ * @brief Controls substr(len) behavior.
+ *
+ * Default is 0 (backward-compatible with prior header): substr(offset>=len) returns empty().
+ * If set to 1, substr(len) returns an empty view at end (ptr+len, 0), matching string_view.
+ */
+#ifndef LSTRING_SUBSTR_ALLOW_ENDPOS
+#define LSTRING_SUBSTR_ALLOW_ENDPOS 0
+#endif
+
+/// Common ASCII characters used by HLS parsing helpers.
+inline constexpr char CHAR_CR    = '\r'; // 0x0d
+inline constexpr char CHAR_LF    = '\n'; // 0x0a
+inline constexpr char CHAR_QUOTE = '"';  // 0x22
+
+/**
+ * @class lstring
+ * @brief Non-owning, trivially-copyable string view (pointer + length).
+ *
+ * The pointed-to buffer is never owned and must remain valid for the lifetime
+ * of the lstring object.
+ */
 class lstring
 {
 private:
-	const char *ptr;
-	size_t len;
-	
+	const char *ptr = nullptr; /**< Pointer into backing buffer; may be NULL when len == 0. */
+	size_t      len = 0;       /**< Number of bytes in the view; excludes any null terminator. */
+
+	inline void assertInvariant() const
+	{
+		assert(ptr != nullptr || len == 0);
+	}
+
 public:
-	lstring()
+	/**
+	 * @brief Constructs an empty lstring (ptr == NULL, len == 0).
+	 */
+	constexpr lstring() noexcept = default;
+
+	/**
+	 * @brief Constructs an lstring view over an existing buffer.
+	 * @param cstring Pointer to the first character of the backing buffer.
+	 * @param sz      Number of bytes in the view (must not exceed buffer size).
+	 */
+	constexpr lstring(const char *cstring, size_t sz) noexcept
+		: ptr(cstring), len(sz)
 	{
-		ptr = NULL;
-		len = 0;
+		// Debug-time invariant: non-empty views must have a valid pointer.
+		assertInvariant();
 	}
-	
-	lstring( const char *cstring, size_t sz )
+
+	/**
+	 * @brief Copy constructor — copies (pointer, length); no heap allocation.
+	 */
+	constexpr lstring(const lstring &) noexcept = default;
+
+	/**
+	 * @brief Copy assignment — copies (pointer, length); no heap allocation.
+	 */
+	constexpr lstring &operator=(const lstring &) noexcept = default;
+
+	/**
+	 * @brief Destructor — no-op; lstring does not own its backing buffer.
+	 */
+	~lstring() = default;
+
+	/**
+	 * @brief Returns the number of bytes in the view.
+	 * @return Byte count (0 for empty).
+	 */
+	constexpr size_t length() const noexcept { return len; }
+
+	/**
+	 * @brief Returns the length as an int for use with printf "%.*s".
+	 *
+	 * Example: @code printf("%.*s", ls.getLen(), ls.getPtr()); @endcode
+	 * @return Length clamped to INT_MAX to avoid truncation UB in printf width.
+	 */
+	int getLen() const noexcept
 	{
-		ptr = cstring;
-		len = sz;
+		return (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
 	}
-	
-	lstring( const lstring &other )
+
+	/**
+	 * @brief Returns a pointer to the first byte of the view.
+	 * @return Pointer into the backing buffer; may be NULL if empty.
+	 */
+	constexpr const char *getPtr() const noexcept { return ptr; }
+
+	/**
+	 * @brief Convenience alias for getPtr().
+	 */
+	constexpr const char *data() const noexcept { return ptr; }
+
+	/**
+	 * @brief Resets to empty state (ptr = NULL, len = 0).
+	 */
+	constexpr void clear() noexcept
 	{
-		ptr = other.ptr;
-		len = other.len;
-	}
-	
-	~lstring()
-	{
-	}
-	
-	size_t length( void ) const
-	{
-		return len;
-	}
-	
-	int getLen( void ) const
-	{ // for use with printf( "%.*s", lstring.getLen(), lstring.getPtr ); format option
-		return (int)len;
-	}
-	
-	const char *getPtr( void ) const
-	{
-		return ptr;
-	}
-	
-	void clear(void)
-	{ // reset back to empty string
-		ptr = NULL;
+		ptr = nullptr;
 		len = 0;
 	}
 
 	/**
- 	* @brief Converts the internal character buffer to a double.
- 	*
-	* @return The parsed double value.
- 	*/
+	 * @brief Parses the view as a floating-point number.
+	 *
+	 * Implemented in lstring.cpp to avoid pulling AampLogManager.h into this header.
+	 * Parsing is HLS-tolerant; see implementation for details.
+	 *
+	 * @return Parsed double value, or 0.0 on failure.
+	 */
 	double atof() const;
 
-	size_t find( char c ) const
-	{ // returns offset to first occurrence of character, or length if not found
-		size_t rc;
-		for( rc=0; rc<len; rc++ )
+	/**
+	 * @brief Finds first occurrence of character @p c within the view.
+	 * @param c Character to search for.
+	 * @return Offset of first occurrence, or @c length() if not found.
+	 */
+	size_t find(char c) const noexcept
+	{
+		assertInvariant();
+		for (size_t rc = 0; rc < len; rc++)
 		{
-			if( ptr[rc]==c )
+			if (ptr[rc] == c)
 			{
-				break;
+				return rc;
 			}
 		}
-		return rc;
+		return len;
 	}
-	
-	lstring mystrpbrk( void )
-	{ // extract next LF-delimited substring
-        size_t delim = find(CHAR_LF);
-        lstring token = lstring(ptr,delim);
-		while( token.peekLastChar() == CHAR_CR)
-		{ // trim any final CR characters
+
+	/**
+	 * @brief Extracts and returns the next LF-delimited line from the view.
+	 *
+	 * Advances this view past the line and its terminating LF (if present).
+	 * Strips trailing CR characters from the returned token so callers see a
+	 * clean line regardless of CRLF or LF line endings.
+	 *
+	 * If no LF is found, the entire remaining content is returned and this view
+	 * is set to empty.
+	 *
+	 * @return lstring view of the next line, with trailing CR stripped.
+	 */
+	lstring mystrpbrk() noexcept
+	{
+		assertInvariant();
+		size_t delim = find(CHAR_LF);
+		lstring token(ptr, delim);
+
+		while (token.peekLastChar() == CHAR_CR)
+		{ // trim any trailing CR characters (handles CRLF line endings)
 			token.len--;
 		}
-		removePrefix(delim+1);
+
+		// Consume the token plus LF if present.
+		removePrefix(delim + 1);
 		return token;
 	}
-	
-	void removePrefix( size_t n = 1 )
+
+	/**
+	 * @brief Removes the first @p n bytes from the front of the view.
+	 *
+	 * If @p n >= len the view becomes empty.
+	 *
+	 * @param n Number of bytes to remove (default 1).
+	 */
+	void removePrefix(size_t n = 1) noexcept
 	{
-		if( n<len )
+		assertInvariant();
+		if (n < len)
 		{
 			ptr += n;
 			len -= n;
@@ -126,81 +252,168 @@ public:
 		else
 		{
 			len = 0;
+#if LSTRING_EMPTY_PTR_NULL
+			ptr = nullptr;
+#endif
 		}
 	}
-	
-	bool equal( const char *cstring )
+
+	/**
+	 * @brief Strict content equality with a null-terminated C string.
+	 *
+	 * Returns true iff:
+	 *   - the view has the same byte count as strlen(cstring), and
+	 *   - all characters match.
+	 *
+	 * The comparison never reads past @p cstring's null terminator.
+	 *
+	 * @param cstring Null-terminated string to compare against (must be non-null).
+	 * @return true if equal, false otherwise (including null input).
+	 */
+	bool equalsCString(const char *cstring) const noexcept
 	{
-		size_t n = 0;
-		while( n < len )
+		assertInvariant();
+		if (!cstring) return false;
+
+		for (size_t n = 0; n < len; n++)
 		{
-			char c = *cstring++;
-			if( ptr[n++] != c )
+			if (cstring[n] == '\0')
+			{ // cstring ended before view did
+				return false;
+			}
+			if (ptr[n] != cstring[n])
 			{
-				break;
+				return false;
 			}
 		}
-		return *cstring<' ';// == 0x00;
+		// All len chars matched; cstring must end here too
+		return cstring[len] == '\0';
 	}
-	
-	bool SubStringMatch( const char *cstring ) const
+
+	/**
+	 * @brief Tests whether @p cstring is a prefix of this view.
+	 *
+	 * @param cstring Null-terminated prefix to match (must be non-null).
+	 * @return true if this view starts with cstring, false otherwise.
+	 */
+	bool SubStringMatch(const char *cstring) const noexcept
 	{
-		size_t n = 0;
-		for (;;)
+		assertInvariant();
+		if (!cstring) return false;
+
+		for (size_t n = 0;; n++)
 		{
-			char c = *cstring++;
-			if (c == 0)
+			char c = cstring[n];
+			if (c == '\0')
 			{
 				return true;
 			}
-			if( ptr[n++] != c)
+			if (n >= len)
+			{
+				return false;
+			}
+			if (ptr[n] != c)
 			{
 				return false;
 			}
 		}
 	}
-	
-	bool startswith( char c ) const
+
+	/**
+	 * @brief Tests whether the first character of the view equals @p c.
+	 * @param c Character to test.
+	 * @return true if non-empty and begins with c.
+	 */
+	bool startswith(char c) const noexcept
 	{
-		return len>0 && *ptr == c;
+		assertInvariant();
+		return (len > 0 && ptr[0] == c);
 	}
-	
-	bool removePrefix( const char *prefix )
+
+	/**
+	 * @brief If @p prefix matches start of view, removes it and returns true.
+	 *
+	 * @param prefix Null-terminated prefix to match and consume (must be non-null).
+	 * @return true if prefix matched and was removed; false otherwise.
+	 */
+	bool removePrefix(const char *prefix) noexcept
 	{
-		size_t n = 0;
-		for (;;)
+		assertInvariant();
+		if (!prefix) return false;
+
+		for (size_t n = 0;; n++)
 		{
-			char c = *prefix++;
-			if (c == 0)
+			char c = prefix[n];
+			if (c == '\0')
 			{
 				removePrefix(n);
 				return true;
 			}
-			if( ptr[n++] != c)
+			if (n >= len)
+			{
+				return false;
+			}
+			if (ptr[n] != c)
 			{
 				return false;
 			}
 		}
 	}
-	
-	lstring substr( int offset ) const
+
+	/**
+	 * @brief Returns a sub-view starting at byte offset @p offset.
+	 *
+	 * If @p offset is negative or out of range, returns an empty view.
+	 *
+	 * @param offset Start position within the view.
+	 * @return Sub-view, or empty if out of range.
+	 */
+	lstring substr(int offset) const noexcept
 	{
-		lstring rc;
-		rc.ptr = ptr+offset;
-		rc.len = len-offset;
-		return rc;
+		assertInvariant();
+		if (offset < 0)
+		{
+			return lstring();
+		}
+		size_t off = (size_t)offset;
+
+#if LSTRING_SUBSTR_ALLOW_ENDPOS
+		if (off > len)
+		{
+			return lstring();
+		}
+		return lstring(ptr + off, len - off);
+#else
+		// Backward-compatible: offset >= len -> empty()
+		if (off >= len)
+		{
+			return lstring();
+		}
+		return lstring(ptr + off, len - off);
+#endif
 	}
-	
-	long long atoll() const
+
+	/**
+	 * @brief Parses the view as a non-negative decimal integer (long long).
+	 *
+	 * Scans digits until a non-digit is found. Does not parse sign.
+	 *
+	 * @return Parsed value, or 0 if empty or begins with non-digit.
+	 *
+	 * @note This function does not attempt to detect overflow; extremely long
+	 *       inputs may overflow long long and invoke undefined behavior.
+	 *       If that is a concern for your inputs, ask and we can harden it.
+	 */
+	long long atoll() const noexcept
 	{
+		assertInvariant();
 		long long rc = 0;
-		for( int i=0; i<len; i++ )
+		for (size_t i = 0; i < len; i++)
 		{
 			char c = ptr[i];
-			if( c>='0' && c<='9' )
+			if (c >= '0' && c <= '9')
 			{
-				rc *= 10;
-				rc += (c-'0');
+				rc = rc * 10 + (c - '0');
 			}
 			else
 			{
@@ -209,121 +422,206 @@ public:
 		}
 		return rc;
 	}
-	
-	long atol() const
+
+	/**
+	 * @brief Parses the view as a non-negative decimal integer (long).
+	 */
+	long atol() const noexcept { return (long)atoll(); }
+
+	/**
+	 * @brief Parses the view as a non-negative decimal integer (int).
+	 */
+	int atoi() const noexcept { return (int)atoll(); }
+
+	/**
+	 * @brief Tests whether the view has zero length.
+	 */
+	constexpr bool empty() const noexcept { return (len == 0); }
+
+	/**
+	 * @brief Converts the view to a std::string (allocates).
+	 *
+	 * @return std::string with same content as the view.
+	 */
+	std::string tostring() const
 	{
-		return (long)atoll();
-	}
-	
-	int atoi() const
-	{
-		return (int)atoll();
+		assertInvariant();
+		if (len == 0)
+		{
+			return std::string();
+		}
+		return std::string(ptr, len);
 	}
 
-	bool empty( void ) const
+	/**
+	 * @brief Extracts the unquoted content of a quoted attribute value.
+	 *
+	 * If the view begins and ends with a double quote, returns inner content.
+	 * Otherwise returns "NONE".
+	 */
+	std::string GetAttributeValueString() const
 	{
-		return len==0;
-	}
-	
-	std::string tostring( void ) const
-	{
-		return std::string(ptr,len);
-	}
-	
-	std::string GetAttributeValueString( void ) const
-	{
-		std::string rc;
-		if( len>=2 && startswith(CHAR_QUOTE) )
-		{ // strip quotes
-			rc = std::string( ptr+1, len-2 );
-		}
-		else
+		assertInvariant();
+		if (len >= 2 && startswith(CHAR_QUOTE) && ptr[len - 1] == CHAR_QUOTE)
 		{
-			rc = "NONE";
+			return std::string(ptr + 1, len - 2);
 		}
-		return rc;
+		return "NONE";
 	}
-	
-	void ParseAttrList( void(*cb)(lstring attr, lstring value, void *context), void *context) const
+
+	/**
+	 * @brief Parses a comma-separated HLS attribute list and fires @p cb for each pair.
+	 *
+	 * Format: name=value[,name=value]*
+	 * Values may be optionally double-quoted; commas inside quotes do not split.
+	 * Parsing stops on empty view, CR, or embedded 0x00.
+	 *
+	 * @param cb Callback invoked for each (attr, value) pair.
+	 * @param context Opaque pointer passed to each callback invocation.
+	 */
+	void ParseAttrList(void(*cb)(lstring attr, lstring value, void *context), void *context) const
 	{
+		assertInvariant();
 		lstring iter = *this;
-		for(;;)
+
+		for (;;)
 		{
 			iter.stripLeadingSpaces();
-			if( iter.startswith('\r') )
-			{ // break out on carriage return
+			if (iter.startswith(CHAR_CR))
+			{
 				return;
 			}
-			
+
+			// Parse attribute name up to '='
 			lstring attr = iter;
 			attr.len = 0;
-			for(;;)
+			for (;;)
 			{
-				if( iter.empty() ) return;
+				if (iter.empty()) return;
 				char c = iter.popFirstChar();
-				if( c=='=' ) break;
+				if (c == '=') break;
 				attr.len++;
 			}
+
+			// Parse value up to comma (outside quotes) or end
 			lstring value = iter;
 			value.len = 0;
 			bool inQuote = false;
-			for(;;)
+
+			for (;;)
 			{
-				if( iter.empty() ) break;
+				if (iter.empty()) break;
 				char c = iter.popFirstChar();
-				if( c==0x00 )
-				{ // avoid parsing into trailing 0x00
+
+				if (c == 0x00)
+				{
 					break;
 				}
 				if (c == ',' && !inQuote)
-				{ // next attribute/value pair
+				{
 					break;
 				}
+
 				value.len++;
-				if( c == CHAR_QUOTE )
+				if (c == CHAR_QUOTE)
 				{
 					inQuote = !inQuote;
 				}
 			}
+
 			cb(attr, value, context);
-		} // read value
-	} // next attr
-	
-	// below only used internally (for now), but keeping public
-	char popFirstChar( void )
-	{
-		char c = 0;
-		if( len>0 )
-		{
-			len--;
-			c = *ptr++;
 		}
+	}
+
+	/**
+	 * @brief Removes and returns the first character of the view.
+	 *
+	 * If empty, returns '\0'.
+	 */
+	char popFirstChar() noexcept
+	{
+		assertInvariant();
+		if (len == 0)
+		{
+			return '\0';
+		}
+		char c = *ptr;
+		ptr++;
+		len--;
 		return c;
 	}
-	
-	char peekLastChar() const
+
+	/**
+	 * @brief Returns the last character without removing it.
+	 *
+	 * @return last char or '\0' if empty.
+	 */
+	char peekLastChar() const noexcept
 	{
-		char c = 0;
-		if( len )
+		assertInvariant();
+		return (len == 0) ? '\0' : ptr[len - 1];
+	}
+
+	/**
+	 * @brief Removes leading ASCII space characters (0x20) from the view.
+	 *
+	 * @note Deliberately trims only ' ' for backward compatibility with existing parsing.
+	 */
+	void stripLeadingSpaces() noexcept
+	{
+		assertInvariant();
+		while (startswith(' '))
 		{
-			c = ptr[len-1];
+			removePrefix(1);
 		}
-		return c;
 	}
-	
-	void stripLeadingSpaces( void )
+
+	/**
+	 * @brief Pointer-identity check: true if both views refer to same buffer region.
+	 *
+	 * This is NOT a content-equality check. Use equalsCString(), tostring(), or
+	 * equalsContent() below.
+	 */
+	bool isSameView(const lstring &other) const noexcept
 	{
-		while( startswith(' ') )
+		// No invariant asserts needed: identity check doesn't dereference pointers.
+		return (len == other.len && ptr == other.ptr);
+	}
+
+	/**
+	 * @brief Content equality check between two lstring objects.
+	 *
+	 * @return true iff same length and same bytes.
+	 */
+	bool equalsContent(const lstring &other) const noexcept
+	{
+		assertInvariant();
+		other.assertInvariant();
+
+		if (len != other.len)
 		{
-			removePrefix();
+			return false;
 		}
+		if (len == 0)
+		{
+			return true;
+		}
+		return (std::memcmp(ptr, other.ptr, len) == 0);
 	}
-	
-	bool equal( const lstring &c )
-	{
-		return ( len == c.len && ptr == c.ptr );
-	}
+
+#if LSTRING_ENABLE_LEGACY_EQUAL
+	/**
+	 * @brief Legacy wrapper for equalsCString().
+	 * @deprecated Prefer equalsCString().
+	 */
+	bool equal(const char *cstring) const noexcept { return equalsCString(cstring); }
+
+	/**
+	 * @brief Legacy wrapper for isSameView().
+	 * @deprecated Prefer isSameView().
+	 */
+	bool equal(const lstring &other) const noexcept { return isSameView(other); }
+#endif
 };
 
-#endif // __LSTRING_H__
-
+#endif // LSTRING_HPP

--- a/test/utests/tests/lstringTests/CMakeLists.txt
+++ b/test/utests/tests/lstringTests/CMakeLists.txt
@@ -21,11 +21,28 @@ set(AAMP_ROOT "../../../../")
 set(UTESTS_ROOT "../../")
 set(EXEC_NAME lstringTests)
 
-# Include common test directories
-include(${CMAKE_CURRENT_LIST_DIR}/../CommonTestIncludes.cmake)
+# lstringTests is intentionally self-contained: lstring.hpp has no GStreamer,
+# middleware, or priv_aamp dependency.  We do NOT include CommonTestIncludes.cmake
+# here because that file adds ${AAMP_ROOT}/middleware to the include path, which
+# transitively pulls in middleware/GstUtils.h → gst/gst.h.  On Mac developer
+# machines without GStreamer installed this breaks the build even though lstring
+# itself never touches a GStreamer symbol.
+#
+# For the same reason we do NOT link against the `fakes` library:
+#   fakes/FakeAampLogManager.cpp → priv_aamp.h → AampDemuxDataTypes.h
+#   → middleware/DemuxDataTypes.h → middleware/GstUtils.h → gst/gst.h
+#
+# FakeLstringDeps.cpp (in this directory) provides the only AampLogManager
+# symbols that lstring.cpp actually needs at link time.
+
+include_directories(${AAMP_ROOT})
+include_directories(${GTEST_INCLUDE_DIRS})
+include_directories(${GMOCK_INCLUDE_DIRS})
+include_directories(${GLIB_INCLUDE_DIRS})
 
 set(TEST_SOURCES lstringTests.cpp
-                 lstringRun.cpp)
+                 lstringRun.cpp
+                 FakeLstringDeps.cpp)
 
 set(AAMP_SOURCES ${AAMP_ROOT}/lstring.cpp)
 
@@ -43,7 +60,7 @@ if (COVERAGE_ENABLED)
     APPEND_COVERAGE_COMPILER_FLAGS()
 endif()
 
-target_link_libraries(${EXEC_NAME} fakes ${GLIB_LINK_LIBRARIES} ${OS_LD_FLAGS} ${GMOCK_LINK_LIBRARIES} ${GTEST_LINK_LIBRARIES} -lpthread ${LIBCJSON_LINK_LIBRARIES})
+target_link_libraries(${EXEC_NAME} ${GLIB_LINK_LIBRARIES} ${OS_LD_FLAGS} ${GMOCK_LINK_LIBRARIES} ${GTEST_LINK_LIBRARIES} -lpthread)
 
 set_target_properties(${EXEC_NAME} PROPERTIES FOLDER "utests")
 

--- a/test/utests/tests/lstringTests/FakeLstringDeps.cpp
+++ b/test/utests/tests/lstringTests/FakeLstringDeps.cpp
@@ -1,0 +1,88 @@
+/*
+ * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2024 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**
+ * @file FakeLstringDeps.cpp
+ * @brief Minimal linker-level stubs for the symbols that lstring.cpp
+ *        references from AampLogManager.h / aamplogging.cpp.
+ *
+ * lstring itself has no GStreamer, priv_aamp, or middleware dependency.
+ * The full `fakes` library is not needed here; including it would drag in
+ * FakeAampLogManager.cpp → priv_aamp.h → AampDemuxDataTypes.h →
+ * middleware/DemuxDataTypes.h → middleware/GstUtils.h → gst/gst.h,
+ * breaking the build on Mac developer machines that do not have GStreamer
+ * headers installed.
+ *
+ * The only AampLogManager symbols lstring.cpp ever touches are:
+ *   - AampLogManager::aampLoglevel  (log-level gate in AAMPLOG macro)
+ *   - logprintf()                   (called when the gate passes)
+ *   - gPlayerId                     (thread-local, used inside logprintf)
+ *   - GetMediaTypeName()            (extern declaration in AampLogManager.h;
+ *                                    not called by lstring, but must be
+ *                                    resolvable at link time)
+ *
+ * All other AampLogManager static members are defined here to satisfy ODR
+ * requirements when the translation unit that includes AampLogManager.h is
+ * compiled as part of this target.
+ */
+
+#include <cstdarg>
+#include <cstdio>
+
+#include "AampLogManager.h"
+
+// ---------------------------------------------------------------------------
+// AampLogManager static member definitions
+// ---------------------------------------------------------------------------
+
+AAMP_LogLevel AampLogManager::aampLoglevel       = eLOGLEVEL_WARN;
+bool          AampLogManager::locked              = false;
+bool          AampLogManager::logFilename         = false;
+bool          AampLogManager::disableLogRedirection     = false;
+bool          AampLogManager::enableEthanLogRedirection = false;
+
+// ---------------------------------------------------------------------------
+// Thread-local player-id used by the logging framework
+// ---------------------------------------------------------------------------
+
+thread_local int gPlayerId = -1;
+
+// ---------------------------------------------------------------------------
+// logprintf — minimal stderr sink; sufficient for unit-test diagnostics
+// ---------------------------------------------------------------------------
+
+void logprintf(AAMP_LogLevel /*level*/, const char* /*file*/, const char* func, int line,
+               const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    fprintf(stderr, "[lstring-test][%s:%d] ", func, line);
+    vfprintf(stderr, format, args);
+    va_end(args);
+    fputc('\n', stderr);
+}
+
+// ---------------------------------------------------------------------------
+// GetMediaTypeName — not called by lstring; stub satisfies extern declaration
+// ---------------------------------------------------------------------------
+
+const char* GetMediaTypeName(AampMediaType /*mediaType*/)
+{
+    return "unknown";
+}

--- a/test/utests/tests/lstringTests/lstringTests.cpp
+++ b/test/utests/tests/lstringTests/lstringTests.cpp
@@ -108,7 +108,10 @@ TEST(LStringAtofTest, OnlyDecimalPoint)
 
 TEST(LStringAtofTest, MultipleDecimalPoints)
 {
-	EXPECT_DOUBLE_EQ(lstring("12.34.56",8).atof(),0.0);
+	// New atof() uses best-effort parsing: stops at second '.', returns the
+	// partial value accumulated so far rather than failing the entire conversion.
+	// "12.34.56" parses "12.34", stops at the second '.', returns 12.34.
+	EXPECT_NEAR(lstring("12.34.56",8).atof(),12.34,1e-12);
 	EXPECT_NEAR(lstring("12.34.56",5).atof(),12.34,1e-12);
 }
 
@@ -230,4 +233,206 @@ TEST(lstring, test1)
 	}
 }
 
+// ===========================================================================
+// equalsCString tests
+// Covers the bug where attrName="KEYFORMATVERSIONS=" and cstring="KEYFORMAT"
+// caused an OOB read past cstring's null terminator in the old equal() impl.
+// ===========================================================================
 
+TEST(LStringEqualsCString, ExactMatch)
+{
+	// lstring content equals cstring exactly
+	EXPECT_TRUE(  lstring("KEYFORMAT", 9).equalsCString("KEYFORMAT") );
+	EXPECT_TRUE(  lstring("METHOD",    6).equalsCString("METHOD")    );
+	EXPECT_TRUE(  lstring("",          0).equalsCString("")           );
+}
+
+TEST(LStringEqualsCString, LstringLongerThanCstring)
+{
+	// Regression: attrName="KEYFORMATVERSIONS=" (18 chars), cstring="KEYFORMAT" (9 chars).
+	// Old code read past the null terminator of "KEYFORMAT" — must return false, not crash.
+	EXPECT_FALSE( lstring("KEYFORMATVERSIONS=", 18).equalsCString("KEYFORMAT") );
+	EXPECT_FALSE( lstring("BANDWIDTH=1000",     14).equalsCString("BANDWIDTH")  );
+}
+
+TEST(LStringEqualsCString, LstringShorterThanCstring)
+{
+	// lstring is a prefix of cstring — must return false
+	EXPECT_FALSE( lstring("KEY", 3).equalsCString("KEYFORMAT") );
+	EXPECT_FALSE( lstring("",    0).equalsCString("KEYFORMAT") );
+}
+
+TEST(LStringEqualsCString, ContentMismatch)
+{
+	// Same length, different content
+	EXPECT_FALSE( lstring("METHODS", 7).equalsCString("METHODX") );
+	EXPECT_FALSE( lstring("aac",     3).equalsCString("mp4")      );
+}
+
+TEST(LStringEqualsCString, SingleCharacter)
+{
+	EXPECT_TRUE(  lstring("X", 1).equalsCString("X") );
+	EXPECT_FALSE( lstring("X", 1).equalsCString("Y") );
+	EXPECT_FALSE( lstring("X", 1).equalsCString("XY") );
+	EXPECT_FALSE( lstring("XY", 2).equalsCString("X") );
+}
+
+TEST(LStringEqualsCString, EmptyLstring)
+{
+	EXPECT_TRUE(  lstring("", 0).equalsCString("") );
+	EXPECT_FALSE( lstring("", 0).equalsCString("A") );
+}
+
+TEST(LStringEqualsCString, EmptyCstring)
+{
+	// Non-empty lstring vs empty cstring — must return false
+	EXPECT_FALSE( lstring("A", 1).equalsCString("") );
+}
+
+// ===========================================================================
+// isSameView tests
+// isSameView() is a pointer-identity check, NOT a content-equality check.
+// ===========================================================================
+
+TEST(LStringIsSameView, IdenticalView)
+{
+	const char buf[] = "hello";
+	lstring a(buf, 5);
+	lstring b(buf, 5);
+	// Same pointer and same length — must be true
+	EXPECT_TRUE( a.isSameView(b) );
+}
+
+TEST(LStringIsSameView, SameContentDifferentBuffer)
+{
+	const char buf1[] = "hello";
+	const char buf2[] = "hello";
+	lstring a(buf1, 5);
+	lstring b(buf2, 5);
+	// Content identical but different backing pointers — must be false
+	// (isSameView is intentionally pointer-identity only)
+	EXPECT_FALSE( a.isSameView(b) );
+}
+
+TEST(LStringIsSameView, DifferentLength)
+{
+	const char buf[] = "hello";
+	lstring a(buf, 5);
+	lstring b(buf, 3);
+	EXPECT_FALSE( a.isSameView(b) );
+}
+
+TEST(LStringIsSameView, EmptyVsEmpty)
+{
+	lstring a, b;
+	// Both NULL ptr, len 0 — same view
+	EXPECT_TRUE( a.isSameView(b) );
+}
+
+// ===========================================================================
+// SubStringMatch tests
+// Old code read past the end of the lstring when cstring was longer than len.
+// ===========================================================================
+
+TEST(LStringSubStringMatch, ExactMatch)
+{
+	EXPECT_TRUE( lstring("KEYFORMAT", 9).SubStringMatch("KEYFORMAT") );
+}
+
+TEST(LStringSubStringMatch, CstringIsPrefix)
+{
+	// cstring shorter than lstring — should match (lstring starts with cstring)
+	EXPECT_TRUE( lstring("KEYFORMATVERSIONS", 17).SubStringMatch("KEYFORMAT") );
+}
+
+TEST(LStringSubStringMatch, CstringLongerThanLstring)
+{
+	// Old code would walk past the end of the lstring buffer here.
+	EXPECT_FALSE( lstring("KEY", 3).SubStringMatch("KEYFORMAT") );
+}
+
+TEST(LStringSubStringMatch, EmptyCstring)
+{
+	// Empty needle always matches
+	EXPECT_TRUE( lstring("anything", 8).SubStringMatch("") );
+	EXPECT_TRUE( lstring("", 0).SubStringMatch("") );
+}
+
+TEST(LStringSubStringMatch, EmptyLstring)
+{
+	EXPECT_FALSE( lstring("", 0).SubStringMatch("A") );
+}
+
+// ===========================================================================
+// removePrefix(const char*) tests
+// Old code walked past the end of the lstring when prefix was longer than len.
+// ===========================================================================
+
+TEST(LStringRemovePrefixStr, MatchAndRemove)
+{
+	lstring s("KEYFORMAT=identity", 18);
+	EXPECT_TRUE( s.removePrefix("KEYFORMAT=") );
+	EXPECT_EQ( s.tostring(), "identity" );
+}
+
+TEST(LStringRemovePrefixStr, PrefixLongerThanLstring)
+{
+	// Old code would walk past the end of the lstring buffer here.
+	lstring s("KEY", 3);
+	EXPECT_FALSE( s.removePrefix("KEYFORMAT") );
+	// View must be unchanged on failure
+	EXPECT_EQ( s.tostring(), "KEY" );
+}
+
+TEST(LStringRemovePrefixStr, NoMatch)
+{
+	lstring s("METHOD=AES-128", 14);
+	EXPECT_FALSE( s.removePrefix("KEYFORMAT") );
+	EXPECT_EQ( s.tostring(), "METHOD=AES-128" );
+}
+
+TEST(LStringRemovePrefixStr, EmptyPrefix)
+{
+	lstring s("hello", 5);
+	EXPECT_TRUE( s.removePrefix("") );
+	EXPECT_EQ( s.tostring(), "hello" );
+}
+
+// ===========================================================================
+// substr tests
+// Old code had no bounds check; negative or out-of-range offsets caused UB.
+// ===========================================================================
+
+TEST(LStringSubstr, NormalCase)
+{
+	lstring s("KEYFORMATVERSIONS=1", 19);
+	lstring sub = s.substr(9);
+	EXPECT_EQ( sub.tostring(), "VERSIONS=1" );
+}
+
+TEST(LStringSubstr, OffsetZero)
+{
+	lstring s("hello", 5);
+	EXPECT_EQ( s.substr(0).tostring(), "hello" );
+}
+
+TEST(LStringSubstr, OffsetEqualsLength)
+{
+	// Offset == len: should return empty, not UB
+	lstring s("hello", 5);
+	EXPECT_TRUE( s.substr(5).empty() );
+}
+
+TEST(LStringSubstr, OffsetBeyondLength)
+{
+	// Out-of-range: should return empty, not UB
+	lstring s("hello", 5);
+	EXPECT_TRUE( s.substr(99).empty() );
+}
+
+TEST(LStringSubstr, NegativeOffset)
+{
+	// Negative offset: should return empty, not UB
+	lstring s("hello", 5);
+	EXPECT_TRUE( s.substr(-1).empty() );
+}


### PR DESCRIPTION
Reason for change: To add safe return vaule to lstring.hpp.equal
Risks: Low
Priority: P1