### PR TITLE
VPAAMP-102: Fix duplicate res metric key in drmMetadata networkMetrics and documentation

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -2233,31 +2233,71 @@ Example:
 ### drmMetadata
 
 **Event Payload:**
-- sessionId: string Refer to [load](#load-uri_autoplay_tuneparams) API for details
-- code: number
-- description: string
-- headers: array
-- responseData: string
-- networkMetrics: string
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| sessionId | string | Refer to [load](#load-uri_autoplay_tuneparams) API for details |
+| code | number | Access status value from DRM system |
+| description | string | Human-readable access status string |
+| headers | array | HTTP response headers from the license request. Populated only when `sendLicenseResponseHeaders` config is enabled |
+| responseData | string | Raw license server error response body. **Populated on failure only** — set to the server error body when the HTTP status code is not 200/206 (direct HTTP path), or when SecClient/SecManager reports failure. Falls back to `undefined` if the server returned an empty body. Empty string on success |
+| networkMetrics | string | **JSON-encoded** telemetry string. Must be `JSON.parse()`d before accessing individual fields. See schema below |
 
 **Description:**
 - Supported UVE version 0.7 and above.
-- Fired when there is a change in DRM metadata (especially expiration of DRM auth data)
-- Refer sendLicenseResponseHeaders configuration for headers
-- Provides the DRM license response metrics information Json format with below key & value fields
-    - req -> requestType: DRM license request type(0 - getLicense/ 1 - getLicenseSec)
-    - res -> resCode: HTTP Response code
-    - tot -> totalTime: download time in Ms
-    - con -> download connection time
-    - str -> StartTransfer: time to start the data transfer
-    - res -> resolve: DNS resolution time
-    - acn -> Appconnect: time to establish the application-level connection
-    - ptr -> PreTransfer: request pretransfer time
-    - rdt -> Redirect: request redirect time
-    - dls -> DlSize: size of the downloaded resource
-    - rqs -> ReqSize: request size
-    - url -> request url
+- Fired when a DRM license request completes (success or failure), or when DRM auth data changes/expires.
 
+**`networkMetrics` JSON Schema:**
+
+Keys always present:
+
+| Key | Type | Description |
+| --- | ---- | ----------- |
+| `req` | number | DRM license request type. `0` = direct HTTP fetch via curl (`getLicense`); `1` = SecClient / SecManager / FireboltSDK path (`getLicenseSec`) |
+| `res` | number | HTTP or curl response/error code (e.g. `200`, `412`, `28` for `CURLE_OPERATION_TIMEDOUT`). Consistently represents the HTTP/curl status code across all DRM flows |
+| `tot` | number | Total time in **milliseconds** from the first attempt to the final outcome, including all retries. Retries happen on network errors (timeout, DNS failure), HTTP responses, or SecClient/SecManager failures|
+| `url` | string | License server URL that was contacted |
+
+Keys present only when `req` = `0` (DRM_GET_LICENSE — direct HTTP/curl path). **Not available** when `req` = `1` (DRM_GET_LICENSE_SEC — SecClient/SecManager/FireboltSDK), because in that path the HTTP transaction is handled entirely inside SecClient/SecManager/FireboltSDK; AAMP never invokes curl for the license request and therefore cannot collect curl-level timing metrics.
+
+| Key | Type | Description |
+| --- | ---- | ----------- |
+| `con` | number | TCP connection establishment time (ms) |
+| `str` | number | Time until first response byte received — "start transfer" (ms) |
+| `dns` | number | DNS resolution time (ms) |
+| `acn` | number | Application-level connect time — TCP + TLS handshake (ms) |
+| `ptr` | number | Pre-transfer time; from start until just before first byte is sent (ms) |
+| `rdt` | number | Total redirect time (ms); `0` if no redirects |
+| `dls` | number | Downloaded response body size (bytes) |
+| `rqs` | number | Uploaded request body size (bytes) |
+
+**Example via direct HTTP (`req=0`):**
+```json
+{
+  "req": 0,
+  "res": 200,
+  "tot": 312,
+  "url": "https://license.example.com/widevine",
+  "con": 45,
+  "str": 290,
+  "dns": 12,
+  "acn": 80,
+  "ptr": 85,
+  "rdt": 0,
+  "dls": 1024,
+  "rqs": 768
+}
+```
+
+**Example via SecManager (`req=1`):**
+```json
+{
+  "req": 1,
+  "res": 412,
+  "tot": 520,
+  "url": "license.example.com"
+}
+```
 ---
 
 ### anomalyReport

--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -577,21 +577,21 @@ void AampDRMLicenseManager::UpdateLicenseMetrics(DrmRequestType requestType, int
 	item = cJSON_CreateObject();
 	if( nullptr != item)
 	{
-		cJSON_AddNumberToObject(item, "req",requestType);
-		cJSON_AddNumberToObject(item, "res", statusCode);
-		cJSON_AddNumberToObject(item, "tot",downloadTimeMS);
-		cJSON_AddStringToObject(item, "url",licenseRequestUrl.c_str());
+		cJSON_AddNumberToObject(item, "req", requestType);   // DRM license request type
+		cJSON_AddNumberToObject(item, "res", statusCode);    // HTTP response code from the license server (HTTP/curl/SecClient response code)
+		cJSON_AddNumberToObject(item, "tot", downloadTimeMS); // Total wall-clock time for DRM license acquisition (including retries)
+		cJSON_AddStringToObject(item, "url", licenseRequestUrl.c_str()); // License server URL
 
 		if( (nullptr != respData) && (DRM_GET_LICENSE == requestType))
 		{
-			cJSON_AddNumberToObject(item, "con", respData->downloadCompleteMetrics.connect);
-			cJSON_AddNumberToObject(item, "str", respData->downloadCompleteMetrics.startTransfer);
-			cJSON_AddNumberToObject(item, "res", respData->downloadCompleteMetrics.resolve);
-			cJSON_AddNumberToObject(item, "acn", respData->downloadCompleteMetrics.appConnect);
-			cJSON_AddNumberToObject(item, "ptr", respData->downloadCompleteMetrics.preTransfer);
-			cJSON_AddNumberToObject(item, "rdt", respData->downloadCompleteMetrics.redirect);
-			cJSON_AddNumberToObject(item, "dls", respData->downloadCompleteMetrics.dlSize);
-			cJSON_AddNumberToObject(item, "rqs", respData->downloadCompleteMetrics.reqSize);
+			cJSON_AddNumberToObject(item, "con", respData->downloadCompleteMetrics.connect);       // TCP connection establishment time
+			cJSON_AddNumberToObject(item, "str", respData->downloadCompleteMetrics.startTransfer); // Time from request start to first byte received
+			cJSON_AddNumberToObject(item, "dns", respData->downloadCompleteMetrics.resolve);       // DNS resolution time
+			cJSON_AddNumberToObject(item, "acn", respData->downloadCompleteMetrics.appConnect);    // TLS/SSL handshake completion time
+			cJSON_AddNumberToObject(item, "ptr", respData->downloadCompleteMetrics.preTransfer);   // Pre-transfer overhead time
+			cJSON_AddNumberToObject(item, "rdt", respData->downloadCompleteMetrics.redirect);      // Time spent following HTTP redirects
+			cJSON_AddNumberToObject(item, "dls", respData->downloadCompleteMetrics.dlSize);        // Number of bytes downloaded in the response body
+			cJSON_AddNumberToObject(item, "rqs", respData->downloadCompleteMetrics.reqSize);       // Number of bytes sent in the license request
 		}
 
 		char *jsonStr = cJSON_Print(item);

--- a/test/utests/fakes/FakeAampEvent.cpp
+++ b/test/utests/fakes/FakeAampEvent.cpp
@@ -214,6 +214,10 @@ const std::string &DrmMetaDataEvent::getNetworkMetricData() const
 
 void DrmMetaDataEvent::setNetworkMetricData(const std::string &data)
 {
+	if (g_mockDrmMetaDataEvent)
+	{
+		g_mockDrmMetaDataEvent->setNetworkMetricData(data);
+	}
 }
 
 int DrmMetaDataEvent::getAccessStatusValue() const

--- a/test/utests/mocks/MockDrmMetaDataEvent.h
+++ b/test/utests/mocks/MockDrmMetaDataEvent.h
@@ -41,6 +41,7 @@ public:
 
 	MOCK_METHOD(void, setFailure, (AAMPTuneFailure), ());
 	MOCK_METHOD(AAMPTuneFailure, getFailure, (), (const));
+	MOCK_METHOD(void, setNetworkMetricData, (const std::string &), ());
 
 	// Additional commonly-used setters/getters added to avoid future compile issues
 	MOCK_METHOD(void, setResponseCode, (int), ());

--- a/test/utests/tests/AampDRMLicManagerTests/AampDRMLicManagerTestCases.cpp
+++ b/test/utests/tests/AampDRMLicManagerTests/AampDRMLicManagerTestCases.cpp
@@ -427,3 +427,124 @@ TEST_F(AampDRMLicManagerTests, ValidateDRMSessionIdEmpty)
 	// Clear the global mock pointer
 	g_mockDrmMetaDataEvent = nullptr;
 }
+
+/**
+ * @brief Validates all networkMetrics JSON keys produced by UpdateLicenseMetrics
+ *
+ * Verifies that all expected keys (req, res, tot, url, con, str, dns, acn, ptr, rdt, dls, rqs)
+ * are present in the JSON output with correct values.
+ */
+TEST_F(AampDRMLicManagerTests, UpdateLicenseMetrics_ValidateAllNetworkMetricKeys)
+{
+	// Assign a unique value to every metric field so mismatches are detectable
+	auto respData = std::make_shared<DownloadResponse>();
+	respData->downloadCompleteMetrics.connect       = 10.0;   // "con"
+	respData->downloadCompleteMetrics.startTransfer = 20.0;   // "str"
+	respData->downloadCompleteMetrics.resolve       = 42.5;   // "dns"
+	respData->downloadCompleteMetrics.appConnect    = 30.0;   // "acn"
+	respData->downloadCompleteMetrics.preTransfer   = 50.0;   // "ptr"
+	respData->downloadCompleteMetrics.redirect      = 60.0;   // "rdt"
+	respData->downloadCompleteMetrics.dlSize        = 70.0;   // "dls"
+	respData->downloadCompleteMetrics.reqSize       = 80;     // "rqs"
+
+	// Create MockDrmMetaDataEvent to capture the setNetworkMetricData call
+	std::shared_ptr<MockDrmMetaDataEvent> mockEventHandle = std::make_shared<MockDrmMetaDataEvent>(
+		AAMP_TUNE_FAILURE_UNKNOWN,
+		"",
+		0,
+		0,
+		false,
+		""
+	);
+
+	// Set the global mock pointer so the fake delegates to it
+	g_mockDrmMetaDataEvent = mockEventHandle.get();
+
+	// setFailure must not be called in this path
+	EXPECT_CALL(*mockEventHandle, setFailure(_)).Times(0);
+
+	// Capture the JSON string produced by UpdateLicenseMetrics
+	std::string capturedJson;
+	EXPECT_CALL(*mockEventHandle, setNetworkMetricData(_))
+		.Times(1)
+		.WillOnce(::testing::SaveArg<0>(&capturedJson));
+
+	// Invoke UpdateLicenseMetrics directly — this is the function under test
+	mTestableDRMLicenseManager->UpdateLicenseMetrics(
+		DRM_GET_LICENSE,           // requestType    — stored under key "req" (== 0)
+		200,                       // statusCode     — stored under key "res"
+		"http://test-license.com", // licenseRequestUrl — stored under key "url"
+		1000,                      // downloadTimeMS — stored under key "tot"
+		mockEventHandle,           // eventHandle    — receives setNetworkMetricData call
+		respData                   // respData       — source of per-metric timing values (con/str/dns/acn/ptr/rdt/dls/rqs)
+	);
+
+	// Parse the captured JSON string
+	cJSON *root = cJSON_Parse(capturedJson.c_str());
+	ASSERT_NE(root, nullptr) << "JSON parsing failed for: " << capturedJson;
+
+	// "req" – DRM license request type (DRM_GET_LICENSE == 0)
+	cJSON *reqItem = cJSON_GetObjectItem(root, "req");
+	ASSERT_NE(reqItem, nullptr) << "Key \"req\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(reqItem->valuedouble, static_cast<double>(DRM_GET_LICENSE));
+
+	// "res" – HTTP response code returned by the license server
+	cJSON *resItem = cJSON_GetObjectItem(root, "res");
+	ASSERT_NE(resItem, nullptr) << "Key \"res\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(resItem->valuedouble, 200.0);
+
+	// "tot" – total wall-clock time for DRM license acquisition
+	cJSON *totItem = cJSON_GetObjectItem(root, "tot");
+	ASSERT_NE(totItem, nullptr) << "Key \"tot\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(totItem->valuedouble, 1000.0);
+
+	// "url" – license server URL used for the DRM request
+	cJSON *urlItem = cJSON_GetObjectItem(root, "url");
+	ASSERT_NE(urlItem, nullptr) << "Key \"url\" missing from networkMetrics JSON: " << capturedJson;
+	ASSERT_NE(urlItem->valuestring, nullptr);
+	EXPECT_STREQ(urlItem->valuestring, "http://test-license.com");
+
+	// "con" – TCP connection establishment time
+	cJSON *conItem = cJSON_GetObjectItem(root, "con");
+	ASSERT_NE(conItem, nullptr) << "Key \"con\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(conItem->valuedouble, 10.0);
+
+	// "str" – time from request start to first byte received
+	cJSON *strItem = cJSON_GetObjectItem(root, "str");
+	ASSERT_NE(strItem, nullptr) << "Key \"str\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(strItem->valuedouble, 20.0);
+
+	// "dns" – DNS resolution time
+	cJSON *dnsItem = cJSON_GetObjectItem(root, "dns");
+	ASSERT_NE(dnsItem, nullptr) << "Key \"dns\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(dnsItem->valuedouble, 42.5);
+
+	// "acn" – TLS/SSL handshake completion time
+	cJSON *acnItem = cJSON_GetObjectItem(root, "acn");
+	ASSERT_NE(acnItem, nullptr) << "Key \"acn\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(acnItem->valuedouble, 30.0);
+
+	// "ptr" – time from start to just before the transfer begins
+	cJSON *ptrItem = cJSON_GetObjectItem(root, "ptr");
+	ASSERT_NE(ptrItem, nullptr) << "Key \"ptr\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(ptrItem->valuedouble, 50.0);
+
+	// "rdt" – time spent following HTTP redirects
+	cJSON *rdtItem = cJSON_GetObjectItem(root, "rdt");
+	ASSERT_NE(rdtItem, nullptr) << "Key \"rdt\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(rdtItem->valuedouble, 60.0);
+
+	// "dls" – number of bytes downloaded in the response body
+	cJSON *dlsItem = cJSON_GetObjectItem(root, "dls");
+	ASSERT_NE(dlsItem, nullptr) << "Key \"dls\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(dlsItem->valuedouble, 70.0);
+
+	// "rqs" – number of bytes sent in the license request
+	cJSON *rqsItem = cJSON_GetObjectItem(root, "rqs");
+	ASSERT_NE(rqsItem, nullptr) << "Key \"rqs\" missing from networkMetrics JSON: " << capturedJson;
+	EXPECT_DOUBLE_EQ(rqsItem->valuedouble, 80.0);
+
+	cJSON_Delete(root);
+
+	g_mockDrmMetaDataEvent = nullptr;
+}


### PR DESCRIPTION
Reason for change: Modified res override with dns and updated Documentation.
Test Procedure: Refer Jira ticket VPAAMP-102
Priority: P1
