### PR TITLE
RDKEMW-18953: [8.4p22s1] Observing WPEWebProcess crash with App ID "viper_crash"

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -395,7 +395,7 @@ AAMPGstPlayer::AAMPGstPlayer(PrivateInstanceAAMP *aamp, id3_callback_t id3Handle
 
 {
 	privateContext = new AAMPGstPlayerPriv();
-	playerInstance = new InterfacePlayerRDK();                                       // for time being to use across class and non-class members when progressive testing
+	playerInstance = new InterfacePlayerRDK(ISCONFIGSET(eAAMPConfig_useRialtoSink)); 
 	RegisterBusCb(this, playerInstance);
 	if(privateContext)
 	{

--- a/middleware/InterfacePlayerPriv.h
+++ b/middleware/InterfacePlayerPriv.h
@@ -262,7 +262,7 @@ class InterfacePlayerPriv
 	private:
 	protected:
 	public:
-		InterfacePlayerPriv();
+		InterfacePlayerPriv(bool isRialto);
 		~InterfacePlayerPriv();
 		GstPlayerPriv *gstPrivateContext;
 		std::shared_ptr<SocInterface> socInterface;

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -67,11 +67,11 @@ static const char* GstPluginNameVMX = "verimatrixdecryptor";
 #define GST_NORMAL_PLAY_RATE		1
 
 /*InterfacePlayerRDK constructor*/
-InterfacePlayerRDK::InterfacePlayerRDK() :
+InterfacePlayerRDK::InterfacePlayerRDK(bool isRialto) :
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
 mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL), mDRMSessionManager(NULL)
 {
-	interfacePlayerPriv = new InterfacePlayerPriv();
+	interfacePlayerPriv = new InterfacePlayerPriv(isRialto);
 	m_gstConfigParam = new Configs();
 	m_gstConfigParam->framesToQueue = SocUtils::RequiredQueuedFrames();
 	pthread_mutex_init(&mProtectionLock, NULL);
@@ -98,10 +98,10 @@ InterfacePlayerRDK::~InterfacePlayerRDK()
 	delete interfacePlayerPriv;
 }
 
-InterfacePlayerPriv::InterfacePlayerPriv():mPlayerName()
+InterfacePlayerPriv::InterfacePlayerPriv(bool isRialto):mPlayerName()
 {
 	gstPrivateContext = new GstPlayerPriv();
-	socInterface = SocInterface::CreateSocInterface();
+	socInterface = SocInterface::CreateSocInterface(isRialto);
 }
 
 InterfacePlayerPriv::~InterfacePlayerPriv()
@@ -5220,6 +5220,7 @@ void InterfacePlayerRDK::InitializePlayerGstreamerPlugins()
 		MW_LOG_ERR("gst_init_check() failed");
 	}
 
+	SocUtils::Init();
 #define PLUGINS_TO_LOWER_RANK_MAX    2
 	static const char *plugins_to_lower_rank[PLUGINS_TO_LOWER_RANK_MAX] = {
 		"aacparse",

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -164,7 +164,7 @@ class InterfacePlayerRDK
 		std::map<InterfaceCB, std::function<void(int)>> setupStreamCallbackMap;
         
 		PlayerScheduler mScheduler;
-        	InterfacePlayerRDK();
+		InterfacePlayerRDK(bool isRialto = false);
         	~InterfacePlayerRDK();
 		InterfacePlayerPriv* GetPrivatePlayer();
 		/**

--- a/middleware/SocUtils.h
+++ b/middleware/SocUtils.h
@@ -27,6 +27,13 @@
 namespace SocUtils
 {
 	/**
+	 * @brief Initializes access to SOC-specific runtime capabilities.
+	 *
+	 * This function can be used to perform eager initialization during startup.
+	 * SocUtils accessors also perform lazy initialization when needed.
+	 */
+	void Init();
+	/**
 	 * @brief Checks if AppSrc should be used for progressive playback.
 	 * 
 	 * This function queries the SOC interface to determine whether AppSrc

--- a/middleware/test/utests/fakes/FakeSocInterface.cpp
+++ b/middleware/test/utests/fakes/FakeSocInterface.cpp
@@ -29,6 +29,11 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
         std::shared_ptr<SocInterface> obj = std::make_shared<DefaultSocInterface>();
         return obj;
 }
+std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
+{
+        std::shared_ptr<SocInterface> obj = std::make_shared<DefaultSocInterface>();
+        return obj;
+}
 bool DefaultSocInterface::UseAppSrc()
 {
 #if defined (__APPLE__)

--- a/middleware/test/utests/fakes/FakeSocUtils.cpp
+++ b/middleware/test/utests/fakes/FakeSocUtils.cpp
@@ -21,6 +21,10 @@
 
 namespace SocUtils
 {
+	void Init()
+	{
+	}
+
 	void InitializePlatformConfigs()
 	{
 	}

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -24,6 +24,8 @@
 #include "vendor/realtek/RealtekSocInterface.h"
 #include "vendor/default/DefaultSocInterface.h"
 
+/**Initially re-sets the IsRialtoMode */
+bool SocInterface::mIsRialtoMode = false;
 /**
  * @brief Checks if the input string starts with the given prefix.
  *
@@ -144,6 +146,21 @@ SocPlatformType SocInterface::InferPlatformFromDeviceProperties( void )
 
 
 /**
+ * @brief Loads the instance with rialto mode or not 
+ *
+ * @return A pointer to the created SocInterface object, or nullptr on failure.
+ */
+std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
+{
+	if(isRialto == true)
+	{
+	    MW_LOG_MIL("Rialto is enabled and creating default soc");
+	}
+	mIsRialtoMode = isRialto;
+	return CreateSocInterface();
+}
+
+/**
  * @brief Creates an instance of the SoC-specific interface based on the detected platform.
  *
  * @return A pointer to the created SocInterface object, or nullptr on failure.
@@ -156,7 +173,11 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
 		SocPlatformType platformType = InferPlatformFromDeviceProperties();
 		if(platformType == SOC_PLATFORM_DEFAULT)
 		{
-			platformType = InferPlatformFromPluginScan();
+			if(!mIsRialtoMode)
+			{
+				MW_LOG_MIL("Performing InterfacePluginScan| Rialto-Disabled");
+				platformType = InferPlatformFromPluginScan();
+                        }
 		}
 		switch (platformType)
 		{

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -93,6 +93,11 @@ protected:
 public:
 	SocInterface() {}
 
+	/** 
+	 * @brief Set rialto mode or not
+	 * @return True when rialto is enabled 
+	 */
+	static bool mIsRialtoMode;
 	/**
 	 * @brief Sets the state of Westeros Sink usage.
 	 *
@@ -139,6 +144,11 @@ public:
 	 * @return A pointer to the created SocInterface object.
 	 */
 	static std::shared_ptr<SocInterface> CreateSocInterface();
+	/**
+	 * @brief Creates an instance of the SoC-specific interface with argument as rialtomode or not .
+	 * @return A pointer to the created SocInterface object.
+	 */
+	static std::shared_ptr<SocInterface> CreateSocInterface(bool isRialto);
 
 	/**
 	 * @brief Configure the accept caps


### PR DESCRIPTION
RDKEMW-18953: [8.4p22s1] Observing WPEWebProcess crash with App ID "viper_crash"

Reason for Change: Deprecation of InterfacePluginScan when rialto is enabled

Test Guidance: updated in ticket

Risk: Low