### PR TITLE
VPAAMP-390 monitorintegrity feature to detect malformed audio/video segments

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -381,6 +381,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "netTraceCsvDump", eAAMPConfig_NetTraceCsvDump, false},
 	{false, "logFilename", eAAMPConfig_LogFilename, false},
 	{false, "processLicenseFromEAP", eAAMPConfig_ProcessLicenseFromEAP, false},
+	{false, "monitorMp4Integrity", eAAMPConfig_MonitorMp4Integrity, false},
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -233,6 +233,7 @@ typedef enum
 	eAAMPConfig_NetTraceCsvDump,			/**< Write AAMP_NET_TRACE CSV files when true (default path: /tmp; may be overridden via AAMP_REQ_CSV/AAMP_BUR_CSV; output includes a PID suffix; default: false) */
 	eAAMPConfig_LogFilename,				/**< Config to include source filename in log output */
 	eAAMPConfig_ProcessLicenseFromEAP,			/**< Config to enable non-VSS early available period DRM prefetch */
+	eAAMPConfig_MonitorMp4Integrity,			/**< Parse every downloaded video/audio segment with Mp4Demux; log each segment, write corrupt ones to harvestPath */
 	eAAMPConfig_BoolMaxValue				/**< Max value of bool config always last element */	
 
 } AAMPConfigSettingBool;

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -36,6 +36,12 @@ void MediaStreamContext::InjectFragmentInternal(CachedFragment* cachedFragment, 
 {
 	assert(!aamp->GetLLDashChunkMode());
 
+	if(ISCONFIGSET(eAAMPConfig_SuppressDecode))
+	{
+		fragmentDiscarded = false;
+		return;
+	}
+
 	if(playContext)
 	{
 		MediaProcessor::process_fcn_t processor = [this](AampMediaType type, SegmentInfo_t info, std::vector<uint8_t> buf)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4555,7 +4555,12 @@ void PrivateInstanceAAMP::CheckSegmentIntegrity(const std::vector<uint8_t>& buff
 
 	// Copy the buffer so the download pipeline's copy remains intact.
 	auto segment = std::make_shared<std::vector<uint8_t>>(buffer);
-	if (!(*validatorPtr)->Parse(std::move(segment)))
+	bool parseOk = (*validatorPtr)->Parse(std::move(segment));
+	// Drop the aliasing shared_ptrs the demuxer stored for its sample list so the
+	// copied segment buffer can be freed immediately rather than pinned until the
+	// next Parse() call clears them.
+	(*validatorPtr)->GetSamples();
+	if (!parseOk)
 	{
 		AAMPLOG_WARN("[Mp4Mon][%s] CORRUPT err=%d url=%s",
 			GetMediaTypeName(mediaType),

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5466,7 +5466,6 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 			}
 
 			if (ISCONFIGSET_PRIV(eAAMPConfig_MonitorMp4Integrity) &&
-				ISCONFIGSET_PRIV(eAAMPConfig_UseMp4Demux) &&
 				!buffer.empty() &&
 				(mediaType == eMEDIATYPE_VIDEO || mediaType == eMEDIATYPE_INIT_VIDEO ||
 				 mediaType == eMEDIATYPE_AUDIO || mediaType == eMEDIATYPE_INIT_AUDIO))

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -79,6 +79,7 @@ static constexpr double kNetTraceLateGapThresholdS = 0.120;  // 120 milliseconds
 #include "AampSegmentInfo.hpp"
 
 #include "AampCurlStore.h"
+#include "mp4demux/MP4Demux.h"
 
 #include <iomanip>
 #include <unordered_set>
@@ -4518,6 +4519,61 @@ static inline bool HasDownloadTimedOutWithData(CURLcode curlCode, CurlAbortReaso
 }
 
 /**
+ * @brief Parse a downloaded segment with a persistent per-track Mp4Demux to detect
+ *        structural corruption (any condition that triggers Mp4Demux::setParseError).
+ *        Every video/audio segment is logged at INFO level regardless of validity.
+ *        Corrupt segments are logged at WARN level and written to harvestPath or /tmp.
+ */
+void PrivateInstanceAAMP::CheckSegmentIntegrity(const std::vector<uint8_t>& buffer,
+	AampMediaType mediaType,
+	const std::string& remoteUrl)
+{
+	AAMPLOG_INFO("[Mp4Mon][%s] url=%s size=%zu",
+		GetMediaTypeName(mediaType), remoteUrl.c_str(), buffer.size());
+
+	// Select the appropriate persistent validator; init lazily on first use.
+	// A single validator per track preserves init-segment state (timescale, IV size)
+	// so that subsequent media-segment parses do not produce false-positive failures.
+	std::unique_ptr<Mp4Demux>* validatorPtr{nullptr};
+	if (mediaType == eMEDIATYPE_VIDEO || mediaType == eMEDIATYPE_INIT_VIDEO)
+	{
+		validatorPtr = &mVideoIntegrityValidator;
+	}
+	else if (mediaType == eMEDIATYPE_AUDIO || mediaType == eMEDIATYPE_INIT_AUDIO)
+	{
+		validatorPtr = &mAudioIntegrityValidator;
+	}
+	else
+	{
+		return;
+	}
+
+	if (!(*validatorPtr))
+	{
+		*validatorPtr = std::make_unique<Mp4Demux>();
+	}
+
+	// Copy the buffer so the download pipeline's copy remains intact.
+	auto segment = std::make_shared<std::vector<uint8_t>>(buffer);
+	if (!(*validatorPtr)->Parse(std::move(segment)))
+	{
+		AAMPLOG_WARN("[Mp4Mon][%s] CORRUPT err=%d url=%s",
+			GetMediaTypeName(mediaType),
+			static_cast<int>((*validatorPtr)->GetLastError()),
+			remoteUrl.c_str());
+
+		std::string dumpPath = GETCONFIGVALUE_PRIV(eAAMPConfig_HarvestPath);
+		if (dumpPath.empty())
+		{
+			dumpPath = "/tmp";
+		}
+		aamp_WriteFile(remoteUrl,
+			reinterpret_cast<const char*>(buffer.data()),
+			buffer.size(), mediaType, 0, dumpPath.c_str());
+	}
+}
+
+/**
  * @brief Download a file from the CDN
  */
 bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaType, std::vector<uint8_t> &buffer, std::string& effectiveUrl, int& http_error, double *downloadTimeS, const char *range, unsigned int curlInstance, bool resetBuffer, BitsPerSecond *bitrate, int * fogError, double fragmentDurationS, ProfilerBucketType bucketType, int maxInitDownloadTimeMS)
@@ -5403,6 +5459,16 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 						mHarvestCountLimit--;
 				} // CID:168113 - forward null
 			}
+
+			if (ISCONFIGSET_PRIV(eAAMPConfig_MonitorMp4Integrity) &&
+				ISCONFIGSET_PRIV(eAAMPConfig_UseMp4Demux) &&
+				!buffer.empty() &&
+				(mediaType == eMEDIATYPE_VIDEO || mediaType == eMEDIATYPE_INIT_VIDEO ||
+				 mediaType == eMEDIATYPE_AUDIO || mediaType == eMEDIATYPE_INIT_AUDIO))
+			{
+				CheckSegmentIntegrity(buffer, mediaType, remoteUrl);
+			}
+
 			ret = true; // default
 			if( !context.downloadIsEncoded )
 			{

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -66,7 +66,6 @@
 #include "AampDefine.h"
 #include "AampCurlDefine.h"
 #include "AampLLDASHData.h"
-#include "mp4demux/MP4Demux.h"
 #include "AampMPDPeriodInfo.h"
 #include "TsbApi.h"
 #include "AampTrackWorkerManager.hpp"
@@ -78,6 +77,7 @@
 #define FAKE_TUNE_URL "file:///etc/manifest.mpd" /**< Fake tune URL for testing purposes */
 
 // forward declaration to avoid circular dependency
+class Mp4Demux;
 class AampMPDDownloader;
 class AampLatencyMonitor;
 struct LatencyConfig;

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -66,6 +66,7 @@
 #include "AampDefine.h"
 #include "AampCurlDefine.h"
 #include "AampLLDASHData.h"
+#include "mp4demux/MP4Demux.h"
 #include "AampMPDPeriodInfo.h"
 #include "TsbApi.h"
 #include "AampTrackWorkerManager.hpp"
@@ -1391,6 +1392,21 @@ public:
 				bool resetBuffer = true, BitsPerSecond *bitrate = NULL,
 				int *fogError = NULL, double fragmentDurationS = 0,
 				ProfilerBucketType bucketType=PROFILE_BUCKET_TYPE_COUNT, int maxInitDownloadTimeMS = 0);
+
+	/**
+	 * @fn CheckSegmentIntegrity
+	 * @brief Parse a downloaded segment with a persistent Mp4Demux validator to
+	 *        detect structural corruption (any condition reaching Mp4Demux::setParseError).
+	 *        Logs every segment at INFO level. On parse failure logs a warning and
+	 *        writes the raw bytes to harvestPath (or /tmp if unset).
+	 *
+	 * @param[in] buffer    Raw segment bytes; read-only, caller retains ownership.
+	 * @param[in] mediaType Media type of the segment.
+	 * @param[in] remoteUrl CDN URL of the segment, used as the dump filename.
+	 */
+	void CheckSegmentIntegrity(const std::vector<uint8_t>& buffer,
+	                           AampMediaType mediaType,
+	                           const std::string& remoteUrl);
 
 	/**
 	 * @fn getUUID
@@ -4288,6 +4304,8 @@ protected:
 	std::recursive_mutex mStreamLock; 		/**< Mutex for accessing mpStreamAbstractionAAMP */
 	int mHarvestCountLimit;			/**< Harvest count */
 	int mHarvestConfig;			/**< Harvest config */
+	std::unique_ptr<Mp4Demux> mVideoIntegrityValidator; /**< Persistent Mp4Demux for video-track integrity monitoring */
+	std::unique_ptr<Mp4Demux> mAudioIntegrityValidator; /**< Persistent Mp4Demux for audio-track integrity monitoring */
 	int mCCId;
 	AampLLDashServiceData mAampLLDashServiceData; /**< Low Latency Service Configuration Data */
 	bool bLowLatencyServiceConfigured;

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -26,6 +26,7 @@
 #include "DrmUtils.h"
 #include "AampConfig.h"
 #include "priv_aamp.h"
+#include "mp4demux/MP4Demux.h"
 #include "aampgstplayer.h"
 #include "AampLatencyMonitor.h"
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "priv_aamp.h"
+#include "mp4demux/MP4Demux.h"
 #include "MockPrivateInstanceAAMP.h"
 #include "AampMPDDownloader.h"
 


### PR DESCRIPTION
Reason for Change: We have live streams believed to occasionally have malformed senc boxes, and want to be able to run long automatic test to monitor for any such occurances.