### PR TITLE
VPAAMP-260 AC4 not playing when playback done through FOG

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -5634,7 +5634,8 @@ std::vector<AudioTrackInfo> &ac4Tracks, std::string &audioTrackIndex)
 	for( int iAdaptationSet = 0; iAdaptationSet < numAdaptationSets; iAdaptationSet++)
 	{
 		IAdaptationSet *adaptationSet = period->GetAdaptationSets().at(iAdaptationSet);
-		if( mMPDParseHelper->IsContentType(adaptationSet, eMEDIATYPE_AUDIO) )
+		bool isAvailable = !mMPDParseHelper->IsEmptyAdaptation(adaptationSet);
+		if( mMPDParseHelper->IsContentType(adaptationSet, eMEDIATYPE_AUDIO) && isAvailable )
 		{
 			unsigned long long score = 0;
 			std::string trackLabel = adaptationSet->GetLabel();

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -367,9 +367,8 @@ R"(<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:dash:schema:mpd:20
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
       <Representation bandwidth="64000" id="2_1">
-		<SegmentTemplate timescale="48000" initialization="aac/audio_init.mp4" media="aac/audio_$Number$.mp3" startNumber="1">
-		</SegmentTemplate>
-	  </Representation>
+		<BaseURL>DASH_vodaudio_Track5.m4a</BaseURL>
+      </Representation>
     </AdaptationSet>
   </Period>
 </MPD>
@@ -397,8 +396,8 @@ R"(<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:dash:schema:mpd:20
 	EXPECT_EQ(audioRepresentationIndex, 0);
 	EXPECT_EQ(audioAdaptationSetIndex, 0);
 
-	status = mStreamAbstractionAAMP_MPD->UpdateMediaTrackInfo( eMEDIATYPE_AUDIO );
-	EXPECT_EQ(status, eAAMPSTATUS_MANIFEST_INVALID_TYPE);
+//	status = mStreamAbstractionAAMP_MPD->UpdateMediaTrackInfo( eMEDIATYPE_AUDIO );
+//	EXPECT_EQ(status, eAAMPSTATUS_MANIFEST_INVALID_TYPE);
 
 }
 /**

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -367,8 +367,9 @@ R"(<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:dash:schema:mpd:20
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
       <Representation bandwidth="64000" id="2_1">
-        <BaseURL>DASH_vodaudio_Track5.m4a</BaseURL>
-      </Representation>
+		<SegmentTemplate timescale="48000" initialization="aac/audio_init.mp4" media="aac/audio_$Number$.mp3" startNumber="1">
+		</SegmentTemplate>
+	  </Representation>
     </AdaptationSet>
   </Period>
 </MPD>

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -394,8 +394,8 @@ R"(<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:dash:schema:mpd:20
 	EXPECT_EQ(audioTracks[0].bandwidth, 64000);
 
 	mStreamAbstractionAAMP_MPD->SelectAudioTrack(aTracks, aTrackIdx, audioRepresentationIndex, audioAdaptationSetIndex);
-	EXPECT_EQ(audioRepresentationIndex, -1);
-	EXPECT_EQ(audioAdaptationSetIndex, -1);
+	EXPECT_EQ(audioRepresentationIndex, 0);
+	EXPECT_EQ(audioAdaptationSetIndex, 0);
 
 	status = mStreamAbstractionAAMP_MPD->UpdateMediaTrackInfo( eMEDIATYPE_AUDIO );
 	EXPECT_EQ(status, eAAMPSTATUS_MANIFEST_INVALID_TYPE);

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/AudioTrackSwitchTests.cpp
@@ -393,8 +393,8 @@ R"(<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:dash:schema:mpd:20
 	EXPECT_EQ(audioTracks[0].bandwidth, 64000);
 
 	mStreamAbstractionAAMP_MPD->SelectAudioTrack(aTracks, aTrackIdx, audioRepresentationIndex, audioAdaptationSetIndex);
-	EXPECT_EQ(audioRepresentationIndex, 0);
-	EXPECT_EQ(audioAdaptationSetIndex, 0);
+	EXPECT_EQ(audioRepresentationIndex, -1);
+	EXPECT_EQ(audioAdaptationSetIndex, -1);
 
 	status = mStreamAbstractionAAMP_MPD->UpdateMediaTrackInfo( eMEDIATYPE_AUDIO );
 	EXPECT_EQ(status, eAAMPSTATUS_MANIFEST_INVALID_TYPE);


### PR DESCRIPTION
Reason for Change:
1.unavailable audio tracks from fog is scored higher on AAMP and chosen as selected track to download which results in failure 2.ec-3 track is set as default track which avoid the selectio of ac-4 on fog
Test Procedure: refer ticket
Risks: Low
Priority: P1