### PR TITLE
VPAAMP-406 suppress noisy logging

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -1842,6 +1842,15 @@ void AampConfig::ConfigureLogSettings()
 		AampLogManager::setLogLevel(eLOGLEVEL_INFO);
 		AampLogManager::lockLogLevel(true);
 	}
+	else if(logString.compare("warn") == 0 || logString.compare("mil") == 0 || logString.compare("error") == 0)
+	{
+		// Explicit quiet-level config: lock level so tune-start INFO elevation is suppressed
+		AAMP_LogLevel lvl = (logString.compare("error") == 0) ? eLOGLEVEL_ERROR
+		                  : (logString.compare("mil")   == 0) ? eLOGLEVEL_MIL
+		                  :                                     eLOGLEVEL_WARN;
+		AampLogManager::setLogLevel(lvl);
+		AampLogManager::lockLogLevel(true);
+	}
 
 	AampLogManager::logFilename = configValueBool[eAAMPConfig_LogFilename].value;
 }

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -196,7 +196,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				// In production (no persona loaded) this is the only overhead: one
 				// acquire-load (~1 ns) with no mutex, no clock call, nothing else.
 				const bool personaActive = AampNetworkPersona::Instance().IsLoaded();
-				AAMPLOG_WARN("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
+//				AAMPLOG_WARN("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
 
 				// Wall-clock start captured only when throttling is active, so
 				// production builds pay zero cost for the timeout-budget tracking.

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -196,8 +196,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				// In production (no persona loaded) this is the only overhead: one
 				// acquire-load (~1 ns) with no mutex, no clock call, nothing else.
 				const bool personaActive = AampNetworkPersona::Instance().IsLoaded();
-				AAMPLOG_DEBUG("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
-
+				
 				// Wall-clock start captured only when throttling is active, so
 				// production builds pay zero cost for the timeout-budget tracking.
 				const long long loopIterStartMs = personaActive ? NOW_STEADY_TS_MS : 0LL;

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -196,7 +196,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				// In production (no persona loaded) this is the only overhead: one
 				// acquire-load (~1 ns) with no mutex, no clock call, nothing else.
 				const bool personaActive = AampNetworkPersona::Instance().IsLoaded();
-//				AAMPLOG_WARN("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
+				AAMPLOG_DEBUG("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
 
 				// Wall-clock start captured only when throttling is active, so
 				// production builds pay zero cost for the timeout-budget tracking.

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4835,7 +4835,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				if (!personaPath.empty())
 					AampNetworkPersona::Instance().LoadFromFile(personaPath);
 			}
-			AAMPLOG_WARN("priv_aamp: download url=%s personaLoaded=%d", remoteUrl.c_str(), AampNetworkPersona::Instance().IsLoaded() ? 1 : 0);
+//			AAMPLOG_WARN("priv_aamp: download url=%s personaLoaded=%d", remoteUrl.c_str(), AampNetworkPersona::Instance().IsLoaded() ? 1 : 0);
 			if (AampNetworkPersona::Instance().IsLoaded())
 			{
 				// Chunk the TTFB sleep into 50 ms slices so that StopDownloads()

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4835,7 +4835,6 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				if (!personaPath.empty())
 					AampNetworkPersona::Instance().LoadFromFile(personaPath);
 			}
-//			AAMPLOG_WARN("priv_aamp: download url=%s personaLoaded=%d", remoteUrl.c_str(), AampNetworkPersona::Instance().IsLoaded() ? 1 : 0);
 			if (AampNetworkPersona::Instance().IsLoaded())
 			{
 				// Chunk the TTFB sleep into 50 ms slices so that StopDownloads()

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -670,7 +670,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		case AAMP_EVENT_MANIFEST_REFRESH_NOTIFY:
 		{
 			ManifestRefreshEventPtr ev = std::dynamic_pointer_cast<ManifestRefreshEvent>(e);
-			AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
+			//AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
 			AAMPPlayerState state = mAampcli.mSingleton->GetState();
 			switch( state )
 			{
@@ -685,7 +685,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 				default:
 				{
 					std::string manifest = mAampcli.mSingleton->GetManifest();
-					AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
+					//AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
 					break;
 				}
 			}

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -670,7 +670,10 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		case AAMP_EVENT_MANIFEST_REFRESH_NOTIFY:
 		{
 			ManifestRefreshEventPtr ev = std::dynamic_pointer_cast<ManifestRefreshEvent>(e);
-			//AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
+			if (!mAampcli.mQuiet)
+			{
+				AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
+			}
 			AAMPPlayerState state = mAampcli.mSingleton->GetState();
 			switch( state )
 			{
@@ -685,7 +688,10 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 				default:
 				{
 					std::string manifest = mAampcli.mSingleton->GetManifest();
-					//AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
+					if (!mAampcli.mQuiet)
+					{
+						AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
+					}
 					break;
 				}
 			}
@@ -695,7 +701,10 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		{
 			TuneTimeMetricsEventPtr ev = std::dynamic_pointer_cast<TuneTimeMetricsEvent>(e);
 			// below is redundant with IP_AAMP_TUNETIME logging done in core aamp
-			//AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_TUNE_TIME_METRICS\n\tData[%s]\n",ev->getTuneMetricsData().c_str());
+			if (!mAampcli.mQuiet)
+			{
+				AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_TUNE_TIME_METRICS\n\tData[%s]\n",ev->getTuneMetricsData().c_str());
+			}
 			break;
 		}
 

--- a/test/aampcli/Aampcli.h
+++ b/test/aampcli/Aampcli.h
@@ -63,6 +63,7 @@ class Aampcli
 		bool mEnableProgressLog;
 		bool mbAutoPlay;
 		bool mIndexedAds = false;
+		bool mQuiet = false;
 		std::string mContentType;
 		std::string mTuneFailureDescription;
 		PlayerInstanceAAMP *mSingleton;

--- a/test/aampcli/AampcliPlaybackCommand.cpp
+++ b/test/aampcli/AampcliPlaybackCommand.cpp
@@ -873,6 +873,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 	{
 		AampLogManager::lockLogLevel(false);
 		AampLogManager::setLogLevel(eLOGLEVEL_INFO);
+		mAampcli.mQuiet = false;
 		AAMPCLI_PRINTF( "[AAMPCLI] core logging noisy\n" );
 	}
 	else if( isCommandMatch(cmd,"quiet") )
@@ -880,6 +881,7 @@ bool PlaybackCommand::execute( const char *cmd, PlayerInstanceAAMP *playerInstan
 		AampLogManager::lockLogLevel(false);
 		AampLogManager::setLogLevel(eLOGLEVEL_ERROR);
 		AampLogManager::lockLogLevel(true);
+		mAampcli.mQuiet = true;
 		AAMPCLI_PRINTF( "[AAMPCLI] core logging quiet\n" );
 	}
 	else if (isCommandMatch(cmd, "exit") )


### PR DESCRIPTION
Reason for Change: tame noisy aampcli logging

aampcli is logging every manifest refresh.
This is excessive - there are events for this, that include manifest size, but logging every few seconds is excessive.  This should be moved to trace level or removed.
We also have warning level logs present for segment and manifest downloads - this appears to be accidentally included as part of the network persona support in aamp.
As warn level logs, it'll show up by default, spewing noise into logs.
Lastly, we have a longstanding behavior where aamp by default logs all info level log messages, and 'info' log level choice is only honored once tune is complete.  This is normally fine, but we have tests involving suppressDecode where the tune never succeeds, and we don't necessarily care about constant spew of info level logs.
Here, propose new semantic where log=WARN will force suppression of info level logs, even at tune time