### PR TITLE
VPAAMP-410 linear cdai race condition that can cause a required init segment to not be injected

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -1843,6 +1843,15 @@ void AampConfig::ConfigureLogSettings()
 		AampLogManager::setLogLevel(eLOGLEVEL_INFO);
 		AampLogManager::lockLogLevel(true);
 	}
+	else if(logString.compare("warn") == 0 || logString.compare("mil") == 0 || logString.compare("error") == 0)
+	{
+		// Explicit quiet-level config: lock level so tune-start INFO elevation is suppressed
+		AAMP_LogLevel lvl = (logString.compare("error") == 0) ? eLOGLEVEL_ERROR
+		                  : (logString.compare("mil")   == 0) ? eLOGLEVEL_MIL
+		                  :                                     eLOGLEVEL_WARN;
+		AampLogManager::setLogLevel(lvl);
+		AampLogManager::lockLogLevel(true);
+	}
 
 	AampLogManager::logFilename = configValueBool[eAAMPConfig_LogFilename].value;
 }

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -110,6 +110,8 @@ bool MediaStreamContext::CacheFragment(std::string fragmentUrl, unsigned int cur
 		if (initSegment)
 		{
 			ret = bReadfromcache = aamp->getAampCacheHandler()->RetrieveFromInitFragmentCache(fragmentUrl,cachedFragment->fragment,effectiveUrl);
+			AAMPLOG_INFO("[CDAI-DBG] InitFragmentCache %s url=%s size=%zu",
+				bReadfromcache ? "HIT" : "MISS", fragmentUrl.c_str(), cachedFragment->fragment.size());
 		}
 		if (!bReadfromcache)
 		{

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -196,7 +196,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				// In production (no persona loaded) this is the only overhead: one
 				// acquire-load (~1 ns) with no mutex, no clock call, nothing else.
 				const bool personaActive = AampNetworkPersona::Instance().IsLoaded();
-				AAMPLOG_WARN("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
+//				AAMPLOG_WARN("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
 
 				// Wall-clock start captured only when throttling is active, so
 				// production builds pay zero cost for the timeout-budget tracking.

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8597,6 +8597,8 @@ void StreamAbstractionAAMP_MPD::FetchAndInjectInitialization(int trackIdx, bool 
 		{
 			pMediaStreamContext->discontinuity = discontinuity;
 		}
+		AAMPLOG_INFO("[CDAI-DBG] FetchAndInjectInitialization track=%d enabled=%d profileChanged=%d discontinuity=%d",
+			trackIdx, pMediaStreamContext->enabled, pMediaStreamContext->profileChanged, pMediaStreamContext->discontinuity);
 		if(pMediaStreamContext->enabled && (pMediaStreamContext->profileChanged || pMediaStreamContext->discontinuity))
 		{
 			if (pMediaStreamContext->adaptationSet)
@@ -8616,6 +8618,8 @@ void StreamAbstractionAAMP_MPD::FetchAndInjectInitialization(int trackIdx, bool 
 							setNextobjectrequestUrl(std::move(media), &pMediaStreamContext->fragmentDescriptor, AampMediaType(pMediaStreamContext->type));
 						}
 						pMediaStreamContext->fragmentDescriptor.nextfragmentNum = pMediaStreamContext->fragmentDescriptor.Number+1;
+						AAMPLOG_INFO("[CDAI-DBG] FetchAndInjectInitialization track=%d fetching initUrl=%s discontinuity=%d",
+							trackIdx, initialization.c_str(), pMediaStreamContext->discontinuity);
 						FetchFragment(pMediaStreamContext, std::move(initialization), 0.0, true, getCurlInstanceByMediaType(pMediaStreamContext->mediaType), false, pMediaStreamContext->discontinuity);
 						pMediaStreamContext->discontinuity = false;
 						pMediaStreamContext->profileChanged = false;
@@ -9609,6 +9613,8 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 			}
 			adStateChanged = false;
 		}
+		AAMPLOG_INFO("[CDAI-DBG] SelectSourceOrAdPeriod exit: periodChanged=%d adStateChanged=%d requireStreamSelection=%d currentPeriodId=%s",
+			periodChanged, adStateChanged, requireStreamSelection, currentPeriodId.c_str());
 		ret = true;
 	}
 	return ret;
@@ -12428,6 +12434,11 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 							break;
 						}
 
+						AAMPLOG_INFO("[CDAI-DBG] onAdEvent OUTSIDE_ADBREAK: mCurrentPeriod=%s endPeriodId=%s endPeriodOffset=%u mCurrentPeriodIdx=%d",
+							mCurrentPeriod ? mCurrentPeriod->GetId().c_str() : "null",
+							mCdaiObject->mAdBreaks[mCdaiObject->mCurPlayingBreakId].endPeriodId.c_str(),
+							mCdaiObject->mAdBreaks[mCdaiObject->mCurPlayingBreakId].endPeriodOffset,
+							mCurrentPeriodIdx);
 						mBasePeriodId =	mCdaiObject->mAdBreaks[mCdaiObject->mCurPlayingBreakId].endPeriodId;
 						mCdaiObject->mContentSeekOffset = (double)(mCdaiObject->mAdBreaks[mCdaiObject->mCurPlayingBreakId].endPeriodOffset)/ 1000;
 					}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4896,7 +4896,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				if (!personaPath.empty())
 					AampNetworkPersona::Instance().LoadFromFile(personaPath);
 			}
-			AAMPLOG_WARN("priv_aamp: download url=%s personaLoaded=%d", remoteUrl.c_str(), AampNetworkPersona::Instance().IsLoaded() ? 1 : 0);
+//			AAMPLOG_WARN("priv_aamp: download url=%s personaLoaded=%d", remoteUrl.c_str(), AampNetworkPersona::Instance().IsLoaded() ? 1 : 0);
 			if (AampNetworkPersona::Instance().IsLoaded())
 			{
 				// Chunk the TTFB sleep into 50 ms slices so that StopDownloads()

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -66,6 +66,7 @@
 #include "AampDefine.h"
 #include "AampCurlDefine.h"
 #include "AampLLDASHData.h"
+#include "mp4demux/MP4Demux.h"
 #include "AampMPDPeriodInfo.h"
 #include "TsbApi.h"
 #include "AampTrackWorkerManager.hpp"

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -670,7 +670,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		case AAMP_EVENT_MANIFEST_REFRESH_NOTIFY:
 		{
 			ManifestRefreshEventPtr ev = std::dynamic_pointer_cast<ManifestRefreshEvent>(e);
-			AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
+			//AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_MANIFEST_REFRESH_NOTIFY received Dur[%u]:NoPeriods[%u]:PubTime[%u] manifestType[%s]\n",ev->getManifestDuration(),ev->getNoOfPeriods(),ev->getManifestPublishedTime(),ev->getManifestType().c_str());
 			AAMPPlayerState state = mAampcli.mSingleton->GetState();
 			switch( state )
 			{
@@ -685,7 +685,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 				default:
 				{
 					std::string manifest = mAampcli.mSingleton->GetManifest();
-					AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
+					//AAMPCLI_PRINTF("[AAMPCLI] Dash Manifest length [%zu]\n", manifest.length());
 					break;
 				}
 			}


### PR DESCRIPTION
Reason for Change: Add INFO-level diagnostic logs at four key points in the CDAI
clear-to-encrypted ad-to-content transition path:

1. FetchAndInjectInitialization gate: log profileChanged and
   discontinuity per track before the init fetch condition is
   evaluated, to detect silent skip of init injection.

2. FetchAndInjectInitialization fetch: log the resolved init URL
   and discontinuity flag when the gate passes, to detect use of
   a wrong (clear/ad) init segment URL.

3. onAdEvent OUTSIDE_ADBREAK: log mCurrentPeriod, endPeriodId,
   endPeriodOffset and mCurrentPeriodIdx at the point mBasePeriodId
   is updated, to detect period index mismatch after ad completion.

4. SelectSourceOrAdPeriod exit: log periodChanged, adStateChanged
   and requireStreamSelection before returning, to confirm
   StreamSelection will run for the content period.

5. MediaStreamContext init cache: log HIT/MISS and URL for every
   init segment fetch, to detect stale cache entries returning
   a clear init segment for an encrypted period URL.

All new log lines use [CDAI-DBG] prefix for easy filtering.

When the soak test captures the failure, grep the INFO logs for [CDAI-DBG] around the timestamp of the crash. The sequence to look for in the bad case will be SelectSourceOrAdPeriod exit showing requireStreamSelection=0, followed immediately by FetchAndInjectInitialization showing profileChanged=0 discontinuity=0 for the video track — confirming the init fetch was silently skipped before the encrypted segments began flowing.