### PR TITLE
VPLAY-13467 Handle edge case when rewinding to BOS

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2672,7 +2672,7 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 			}
 
 		}
-		if ((mReportProgressPosn == position) && !mSinkPaused.load() && beginningOfStream != true)
+		if ((mReportProgressPosn == position) && !mSinkPaused.load() && beginningOfStream != true && !reachedStart)
 		{
 			// Avoid sending the progress event, if the previous position and the current position is same when pipeline is in playing state.
 			// Added exception if it's beginning of stream to prevent JSPP not loading previous AD while rewind

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1629,6 +1629,77 @@ TEST_F(PrivAampTests, MonitorProgressRewindToBoS_ProgressBeforeSpeedChange)
 	p_aamp->MonitorProgress(true, false);
 }
 
+/**
+ * @brief Regression test for the de-dupe edge case (Copilot review on PR #1345).
+ *
+ * When the previous tick already reported position == start, the de-dupe logic
+ * (mReportProgressPosn == position) would normally suppress AAMP_EVENT_PROGRESS.
+ * This test verifies that the progress event is still emitted before the speed
+ * change when reachedStart bypasses the de-dupe.
+ */
+TEST_F(PrivAampTests, MonitorProgressRewindToBoS_DeDupeBypassedOnReachedStart)
+{
+	constexpr double REWIND_RATE = -4.0;
+	constexpr double CULLED_SECONDS = 10.0;
+	constexpr double DURATION_SECONDS = 100.0;
+
+	// Setup: configure player for rewind scenario.
+	p_aamp->rate = REWIND_RATE;
+	p_aamp->seek_pos_seconds = CULLED_SECONDS; // position == start on first call
+	p_aamp->culledSeconds = CULLED_SECONDS;
+	p_aamp->durationSeconds = DURATION_SECONDS;
+	p_aamp->mAbsoluteEndPosition = CULLED_SECONDS + DURATION_SECONDS;
+	p_aamp->mDownloadsEnabled = true;
+	p_aamp->mSinkPaused = false;
+	p_aamp->SetState(eSTATE_PLAYING, true);
+	p_aamp->SetLocalAAMPTsb(true);
+	p_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
+	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP_MPD;
+
+	p_aamp->trickStartUTCMS = 1;
+	p_aamp->mAdProgressId = "ad-1";
+	p_aamp->mAdAbsoluteStartTime = 0;
+	p_aamp->mAdDuration = 1000;
+
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnablePTSReStamp))
+		.WillRepeatedly(Return(true));
+	// Enable GstPositionQuery so we control position via mock sink rather
+	// than the elapsed-time calculation which is non-deterministic.
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableGstPositionQuery))
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockAampStreamSinkManager, GetStreamSink(_))
+		.WillRepeatedly(Return(g_mockAampGstPlayer));
+	// Sink reports 0 relative position; final position = seek_pos_seconds * 1000.
+	EXPECT_CALL(*g_mockAampGstPlayer, GetPositionMilliseconds())
+		.WillRepeatedly(Return(0));
+
+	// First call: position = seek_pos_seconds*1000 = 10000 = start.
+	// No reachedStart triggered; progress event is sent, setting
+	// mReportProgressPosn = start internally (the de-dupe anchor).
+	EXPECT_CALL(*g_mockAampEventManager, SendEvent(_, _)).Times(testing::AnyNumber());
+	p_aamp->MonitorProgress(true, false);
+
+	// Now set seek_pos_seconds = 0 so that position < start on the next call.
+	p_aamp->seek_pos_seconds = 0.0;
+
+	// Clear generic expectations and set ordering requirements for the
+	// second call: progress must still be emitted despite de-dupe match.
+	testing::Mock::VerifyAndClearExpectations(g_mockAampEventManager);
+
+	testing::InSequence seq;
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(AnEventOfType(AAMP_EVENT_AD_PLACEMENT_PROGRESS), _)).Times(1);
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(AnEventOfType(AAMP_EVENT_PROGRESS), _)).Times(1);
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(SpeedChanged(AAMP_NORMAL_PLAY_RATE), _)).Times(1);
+
+	// Second call: position (0) < start (10000) → reachedStart = true.
+	// De-dupe (mReportProgressPosn == position after clamping) is bypassed.
+	p_aamp->MonitorProgress(true, false);
+}
+
 TEST_F(PrivAampTests,UpdateDurationTest)
 {
 	p_aamp->UpdateDuration(232.436);


### PR DESCRIPTION
Reason for Change: Fix BoS edge case identified in review of PR #1345

Summary of Changes:
- Ensure progress event is always sent before BOS notification
- Test edge case in L1 test

Test Procedure: L1 test PrivAampTests should pass

Priority: P1

Risks: Low