### PR TITLE
RDKEMW-18286: [Xione UK][VIPA]Parental PIN: 1–2 seconds of video preview visible before PIN screen on parental pin linear channels

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -444,6 +444,15 @@ void InterfacePlayerRDK::ConfigurePipeline(int format, int audioFormat, int auxF
 			gboolean videoOnly = (audioFormat == GST_FORMAT_INVALID);
 			MW_LOG_INFO("Setting single-path-stream to %d", videoOnly);
 			g_object_set(vidsink, "single-path-stream", videoOnly, NULL);
+			// RDKEMW-18286: Reinforce show-video-window before pipeline state change
+			if (interfacePlayerPriv->gstPrivateContext->videoMuted)
+			{
+                            MW_LOG_MIL("InterfacePlayerRDK - ConfigurePipeline: reinforcing "
+                                             "show-video-window=FALSE on %s (videoMuted=%d)",
+                                              GST_ELEMENT_NAME(vidsink),
+                                              interfacePlayerPriv->gstPrivateContext->videoMuted);
+                            g_object_set(vidsink, "show-video-window", FALSE, NULL);
+                        }
 		}
 		else
 		{
@@ -2319,6 +2328,21 @@ int InterfacePlayerRDK::SetupStream(int streamId,  void *playerInstance, std::st
 					g_object_set(vidsink, "has-drm", FALSE, NULL);
 				}
 				interfacePlayerPriv->gstPrivateContext->video_sink = vidsink;
+
+                                // RDKEMW-18286: Set show-video-window=FALSE at sink creation time.
+                                // This is the EARLIEST possible point. The Rialto delegate will queue
+                                // this (m_videoMuteQueued=true) and apply it server-side when the
+                                // source attaches — which happens BEFORE the pipeline goes to PLAYING
+                                // and BEFORE any frame can be decoded.
+                                if (interfacePlayerPriv->gstPrivateContext->videoMuted)
+                                {
+                                    MW_LOG_MIL("InterfacePlayerRDK - %s: setting show-video-window=FALSE "
+                                                 "at creation time (videoMuted=%d)",
+                                                 GST_ELEMENT_NAME(vidsink),
+                                                 interfacePlayerPriv->gstPrivateContext->videoMuted);
+                                    g_object_set(vidsink, "show-video-window", FALSE, NULL);
+                                }
+
 			}
 			else
 			{
@@ -4405,6 +4429,8 @@ static gboolean bus_message(GstBus * bus, GstMessage * msg, InterfacePlayerRDK *
 							gst_object_unref(sourceEleSrcPad);
 						}
 					}
+
+
 				}
 
 			}


### PR DESCRIPTION
Reason for change: Reinforce show-video-window before pipeline state change, and set show-video-window=FALSE at sink creation time. This is the EARLIEST possible point. The Rialto delegate will queue this (m_videoMuteQueued=true) and apply it server-side when the source attaches — which happens BEFORE the pipeline goes to PLAYING and BEFORE any frame can be decoded.

Test Procedure: Refer Ticket

Priority: P1

Risks: Low