### PR TITLE
VPAAMP-371 Replatce SyncBegin and Sync end with modern cpp RAII imple…

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1051,7 +1051,7 @@ long long AAMPGstPlayer::GetPositionMilliseconds(void)
  */
 bool AAMPGstPlayer::Pause( bool pause, bool forceStopGstreamerPreBuffering )
 {
-	aamp->SyncBegin();					/* Obtains a mutex lock */
+	auto syncLock = aamp->SyncLock();
 
 	AAMPLOG_MIL("entering AAMPGstPlayer_Pause - pause(%d) stop-pre-buffering(%d)", pause, forceStopGstreamerPreBuffering);
 
@@ -1061,8 +1061,6 @@ bool AAMPGstPlayer::Pause( bool pause, bool forceStopGstreamerPreBuffering )
 		if(!aamp->IsGstreamerSubsEnabled())
 			aamp->PauseSubtitleParser(pause);
 	}
-
-	aamp->SyncEnd();					/* Releases the mutex */
 
 	return res;
 	//return retValue;

--- a/drm/DrmInterface.cpp
+++ b/drm/DrmInterface.cpp
@@ -102,10 +102,8 @@ DrmInterface::~DrmInterface()
  */
 void DrmInterface::TerminateCurlInstance(int mCurlInstance)
 {
-	{
-		auto syncLock = mpAamp->SyncLock();
-		mpAamp->CurlTerm((AampCurlInstance)mCurlInstance);
-	}
+	auto syncLock = mpAamp->SyncLock();
+	mpAamp->CurlTerm((AampCurlInstance)mCurlInstance);
 }
 
 /**

--- a/drm/DrmInterface.cpp
+++ b/drm/DrmInterface.cpp
@@ -102,9 +102,10 @@ DrmInterface::~DrmInterface()
  */
 void DrmInterface::TerminateCurlInstance(int mCurlInstance)
 {
-	mpAamp->SyncBegin();
-	mpAamp->CurlTerm((AampCurlInstance)mCurlInstance);
-	mpAamp->SyncEnd();
+	{
+		auto syncLock = mpAamp->SyncLock();
+		mpAamp->CurlTerm((AampCurlInstance)mCurlInstance);
+	}
 }
 
 /**

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -4916,10 +4916,11 @@ StreamAbstractionAAMP_HLS::~StreamAbstractionAAMP_HLS()
 		SAFE_DELETE(track);
 	}
 
-	aamp->SyncBegin();
-	aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
-	aamp->CurlTerm(eCURLINSTANCE_MANIFEST_PLAYLIST_VIDEO, AAMP_TRACK_COUNT);
-	aamp->SyncEnd();
+	{
+		auto syncLock = aamp->SyncLock();
+		aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
+		aamp->CurlTerm(eCURLINSTANCE_MANIFEST_PLAYLIST_VIDEO, AAMP_TRACK_COUNT);
+	}
 }
 
 /**

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -4916,11 +4916,9 @@ StreamAbstractionAAMP_HLS::~StreamAbstractionAAMP_HLS()
 		SAFE_DELETE(track);
 	}
 
-	{
-		auto syncLock = aamp->SyncLock();
-		aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
-		aamp->CurlTerm(eCURLINSTANCE_MANIFEST_PLAYLIST_VIDEO, AAMP_TRACK_COUNT);
-	}
+	auto syncLock = aamp->SyncLock();
+	aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
+	aamp->CurlTerm(eCURLINSTANCE_MANIFEST_PLAYLIST_VIDEO, AAMP_TRACK_COUNT);
 }
 
 /**

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10769,23 +10769,24 @@ StreamAbstractionAAMP_MPD::~StreamAbstractionAAMP_MPD()
 	mManifestUpdateHandleFlag       =       false;
 	dnldInstance->UnRegisterCallback();
 
-	aamp->SyncBegin();
-
-	// mStreamInfo is now a vector and will be automatically destroyed
-	deIndexTileInfo(indexedTileInfo);
-	if(!thumbnailtrack.empty())
 	{
-		for(int i = 0; i < thumbnailtrack.size() ; i++)
-		{
-			StreamInfo *tmp = thumbnailtrack[i];
-			SAFE_DELETE(tmp);
-		}
-	}
+		auto syncLock = aamp->SyncLock();
 
-	aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
-	aamp->GetLLDashServiceData()->clear();
-	aamp->SetLowLatencyServiceConfigured(false);
-	aamp->SyncEnd();
+		// mStreamInfo is now a vector and will be automatically destroyed
+		deIndexTileInfo(indexedTileInfo);
+		if(!thumbnailtrack.empty())
+		{
+			for(int i = 0; i < thumbnailtrack.size() ; i++)
+			{
+				StreamInfo *tmp = thumbnailtrack[i];
+				SAFE_DELETE(tmp);
+			}
+		}
+
+		aamp->CurlTerm(eCURLINSTANCE_VIDEO, DEFAULT_CURL_INSTANCE_COUNT);
+		aamp->GetLLDashServiceData()->clear();
+		aamp->SetLowLatencyServiceConfigured(false);
+	}
 	mManifestDnldRespPtr = nullptr;
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2351,7 +2351,7 @@ void PrivateInstanceAAMP::CompleteDiscontinuityDataDeliverForPTSRestamp(AampMedi
  * @brief Acquire the GStreamer operation lock (RAII).
  *
  * Returns a std::unique_lock that holds mLock for its lifetime.
- * The lock is released automatically when the guard is destroyed.
+ * The lock is released automatically when the lock object is destroyed.
  */
 std::unique_lock<std::recursive_mutex> PrivateInstanceAAMP::SyncLock()
 {
@@ -3683,15 +3683,16 @@ double PrivateInstanceAAMP::getLastInjectedPosition()
 bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 {
 	bool ret = true;
+	bool operationInProgress;
 	{
 		auto syncLock = SyncLock();
-		if (mDiscontinuityTuneOperationInProgress)
-		{
-			// syncLock released automatically before early return
-			AAMPLOG_WARN("PrivateInstanceAAMP: Discontinuity Tune Operation already in progress");
-			UnblockWaitForDiscontinuityProcessToComplete();
-			return ret; // true so that PrivateInstanceAAMP_ProcessDiscontinuity can cleanup properly
-		}
+		operationInProgress = mDiscontinuityTuneOperationInProgress;
+	}
+	if (operationInProgress)
+	{
+		AAMPLOG_WARN("PrivateInstanceAAMP: Discontinuity Tune Operation already in progress");
+		UnblockWaitForDiscontinuityProcessToComplete();
+		return ret; // true so that PrivateInstanceAAMP_ProcessDiscontinuity can cleanup properly
 	}
 
 	if (!(DiscontinuitySeenInAllTracks()))

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -378,9 +378,8 @@ static gboolean PrivateInstanceAAMP_ProcessDiscontinuity(gpointer ptr)
 		// This is to avoid calling cond signal, in case Stop() interrupts the ProcessPendingDiscontinuity
 		if (ret)
 		{
-			aamp->SyncBegin();
+			auto syncLock = aamp->SyncLock();
 			aamp->mDiscontinuityTuneOperationId = 0;
-			aamp->SyncEnd();
 		}
 		aamp->mCondDiscontinuity.notify_one();
 	}
@@ -1531,13 +1530,13 @@ int PrivateInstanceAAMP::HandleSSLProgressCallback ( void *clientp, double dltot
 		}
 	}
 
-	context->aamp->SyncBegin();
-	if (!context->aamp->mDownloadsEnabled && context->aamp->mMediaDownloadsEnabled[context->mediaType])
 	{
-		rc = 1; // CURLE_ABORTED_BY_CALLBACK
+		auto syncLock = context->aamp->SyncLock();
+		if (!context->aamp->mDownloadsEnabled && context->aamp->mMediaDownloadsEnabled[context->mediaType])
+		{
+			rc = 1; // CURLE_ABORTED_BY_CALLBACK
+		}
 	}
-
-	context->aamp->SyncEnd();
 	if( rc==0 )
 	{ // only proceed if not an aborted download
 		if (dlnow > 0 && context->stallTimeout > 0)
@@ -2349,20 +2348,14 @@ void PrivateInstanceAAMP::CompleteDiscontinuityDataDeliverForPTSRestamp(AampMedi
 }
 
 /**
- *   @brief GStreamer operation start
- */
-void PrivateInstanceAAMP::SyncBegin(void)
-{
-	mLock.lock();
-}
-
-/**
- * @brief GStreamer operation end
+ * @brief Acquire the GStreamer operation lock (RAII).
  *
+ * Returns a std::unique_lock that holds mLock for its lifetime.
+ * The lock is released automatically when the guard is destroyed.
  */
-void PrivateInstanceAAMP::SyncEnd(void)
+std::unique_lock<std::recursive_mutex> PrivateInstanceAAMP::SyncLock()
 {
-	mLock.unlock();
+	return std::unique_lock<std::recursive_mutex>(mLock);
 }
 
 /**
@@ -3690,15 +3683,16 @@ double PrivateInstanceAAMP::getLastInjectedPosition()
 bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 {
 	bool ret = true;
-	SyncBegin();
-	if (mDiscontinuityTuneOperationInProgress)
 	{
-		SyncEnd();
-		AAMPLOG_WARN("PrivateInstanceAAMP: Discontinuity Tune Operation already in progress");
-		UnblockWaitForDiscontinuityProcessToComplete();
-		return ret; // true so that PrivateInstanceAAMP_ProcessDiscontinuity can cleanup properly
+		auto syncLock = SyncLock();
+		if (mDiscontinuityTuneOperationInProgress)
+		{
+			// syncLock released automatically before early return
+			AAMPLOG_WARN("PrivateInstanceAAMP: Discontinuity Tune Operation already in progress");
+			UnblockWaitForDiscontinuityProcessToComplete();
+			return ret; // true so that PrivateInstanceAAMP_ProcessDiscontinuity can cleanup properly
+		}
 	}
-	SyncEnd();
 
 	if (!(DiscontinuitySeenInAllTracks()))
 	{
@@ -3707,9 +3701,10 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 		return ret; // true so that PrivateInstanceAAMP_ProcessDiscontinuity can cleanup properly
 	}
 
-	SyncBegin();
-	mDiscontinuityTuneOperationInProgress = true;
-	SyncEnd();
+	{
+		auto syncLock = SyncLock();
+		mDiscontinuityTuneOperationInProgress = true;
+	}
 
 	if (DiscontinuitySeenInAllTracks())
 	{
@@ -3754,20 +3749,22 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 		}
 		trickStartUTCMS = -1;
 
-		SyncBegin();
-		mProgressReportFromProcessDiscontinuity = true;
-		SyncEnd();
+		{
+			auto syncLock = SyncLock();
+			mProgressReportFromProcessDiscontinuity = true;
+		}
 
 		// To notify app of discontinuity processing complete
 		MonitorProgress();
 
 		// There is a chance some other operation maybe invoked from JS/App because of the above MonitorProgress
 		// Make sure we have still mDiscontinuityTuneOperationInProgress set
-		SyncBegin();
-		AAMPLOG_WARN("Progress event sent as part of ProcessPendingDiscontinuity, mDiscontinuityTuneOperationInProgress:%d", mDiscontinuityTuneOperationInProgress);
-		mProgressReportFromProcessDiscontinuity = false;
-		continueDiscontProcessing = mDiscontinuityTuneOperationInProgress;
-		SyncEnd();
+		{
+			auto syncLock = SyncLock();
+			AAMPLOG_WARN("Progress event sent as part of ProcessPendingDiscontinuity, mDiscontinuityTuneOperationInProgress:%d", mDiscontinuityTuneOperationInProgress);
+			mProgressReportFromProcessDiscontinuity = false;
+			continueDiscontProcessing = mDiscontinuityTuneOperationInProgress;
+		}
 
 		if (continueDiscontProcessing)
 		{
@@ -3854,9 +3851,8 @@ bool PrivateInstanceAAMP::ProcessPendingDiscontinuity()
 
 	if (ret)
 	{
-		SyncBegin();
+		auto syncLock = SyncLock();
 		mDiscontinuityTuneOperationInProgress = false;
-		SyncEnd();
 	}
 
 	UnblockWaitForDiscontinuityProcessToComplete();
@@ -7734,13 +7730,14 @@ void PrivateInstanceAAMP::EndOfStreamReached(AampMediaType mediaType)
 {
 	if (mediaType != eMEDIATYPE_SUBTITLE)
 	{
-		SyncBegin();
-		StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
-		if (sink)
 		{
-			sink->EndOfStreamReached(mediaType);
-		}
-		SyncEnd();
+			auto syncLock = SyncLock();
+			StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
+			if (sink)
+			{
+				sink->EndOfStreamReached(mediaType);
+			}
+		} // syncLock released — matches original SyncEnd() position
 
 		// If EOS during Buffering, set Playing and let buffer to dry out
 		// Sink is already unpaused by EndOfStreamReached()
@@ -9083,13 +9080,12 @@ bool PrivateInstanceAAMP::Discontinuity(AampMediaType track, bool setDiscontinui
 	}
 	else
 	{
-		SyncBegin();
+		auto syncLock = SyncLock();
 		StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 		if (sink)
 		{
 			ret = sink->Discontinuity(track);
 		}
-		SyncEnd();
 	}
 
 	if (ret)

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -2167,18 +2167,16 @@ public:
 	void InitializeCC(unsigned long decoderHandle);
 
 	/**
-	 *   @brief GStreamer operation start
+	 * @brief Acquire the GStreamer operation lock (RAII).
 	 *
-	 *   @return void
-	 */
-	void SyncBegin(void);
-
-	/**
-	 * @fn SyncEnd
+	 * The lock is released automatically when the returned guard goes
+	 * out of scope, guaranteeing exception safety. The [[nodiscard]]
+	 * attribute causes a compile-time warning if the guard is discarded
+	 * immediately (which would release the lock at once, not at scope end).
 	 *
-	 * @return void
+	 * @return std::unique_lock<std::recursive_mutex> holding mLock.
 	 */
-	void SyncEnd(void);
+	[[nodiscard]] std::unique_lock<std::recursive_mutex> SyncLock();
 
 	/**
 	 * @fn GetSeekBase

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -815,7 +815,7 @@ void PrivateInstanceAAMP::StopTrackInjection(AampMediaType type)
 
 std::unique_lock<std::recursive_mutex> PrivateInstanceAAMP::SyncLock()
 {
-	return std::unique_lock<std::recursive_mutex>(mLock);
+	return std::unique_lock<std::recursive_mutex>(); // no-op mock: does not acquire mLock
 }
 
 void PrivateInstanceAAMP::UpdateCullingState(double culledSecs)

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -813,12 +813,9 @@ void PrivateInstanceAAMP::StopTrackInjection(AampMediaType type)
 {
 }
 
-void PrivateInstanceAAMP::SyncBegin(void)
+std::unique_lock<std::recursive_mutex> PrivateInstanceAAMP::SyncLock()
 {
-}
-
-void PrivateInstanceAAMP::SyncEnd(void)
-{
+	return std::unique_lock<std::recursive_mutex>(mLock);
 }
 
 void PrivateInstanceAAMP::UpdateCullingState(double culledSecs)

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1030,12 +1030,9 @@ void PrivateInstanceAAMP::StopTrackInjection(AampMediaType type)
 {
 }
 
-void PrivateInstanceAAMP::SyncBegin(void)
+std::unique_lock<std::recursive_mutex> PrivateInstanceAAMP::SyncLock()
 {
-}
-
-void PrivateInstanceAAMP::SyncEnd(void)
-{
+	return std::unique_lock<std::recursive_mutex>(mLock);
 }
 
 void PrivateInstanceAAMP::UpdateCullingState(double culledSecs)

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1032,7 +1032,7 @@ void PrivateInstanceAAMP::StopTrackInjection(AampMediaType type)
 
 std::unique_lock<std::recursive_mutex> PrivateInstanceAAMP::SyncLock()
 {
-	return std::unique_lock<std::recursive_mutex>(mLock);
+	return std::unique_lock<std::recursive_mutex>(); // no-op fake: does not acquire mLock
 }
 
 void PrivateInstanceAAMP::UpdateCullingState(double culledSecs)

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1388,10 +1388,10 @@ TEST_F(PrivAampTests,SetIsPeriodChangeMarkedTest)
 	EXPECT_FALSE(p_aamp->GetIsPeriodChangeMarked());
 }
 
-TEST_F(PrivAampTests,SyncBeginTest)
+TEST_F(PrivAampTests,SyncLockTest)
 {
-	p_aamp->SyncBegin();
-	p_aamp->SyncEnd();
+	auto lock = p_aamp->SyncLock();
+	// lock released automatically at end of scope
 }
 TEST_F(PrivAampTests,GetVideoPTSTest)
 {


### PR DESCRIPTION
SyncBegin()/SyncEnd() were thin wrappers around mLock.lock()/mLock.unlock()] that required callers to manually match every acquire with a release.