### PR TITLE
VPAAMP-396 Modify Mp4Demux to ignore unknown MP4 box types

### DIFF
--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -195,7 +195,7 @@ Mp4Demux::~Mp4Demux()
 	LogMetrics();
 }
 
-void Mp4Demux::setParseError( Mp4ParseError err )
+void Mp4Demux::setParseError( Mp4ParseError err, const char* what )
 {
 	parseError = err;
 	const char *text = nullptr;
@@ -250,7 +250,14 @@ void Mp4Demux::setParseError( Mp4ParseError err )
 			text = "UNEXPECTED_IS_ENCRYPTED_FIELD";
 			break;
 	}
-	MP4_LOG_ERR( "%s", text );
+	if (what && what[0] != '\0')
+	{
+		MP4_LOG_ERR( "%s: %s", text, what );
+	}
+	else
+	{
+		MP4_LOG_ERR( "%s", text );
+	}
 }
 
 /**
@@ -1413,7 +1420,7 @@ bool Mp4Demux::Parse(std::shared_ptr<std::vector<uint8_t>>&& segment)
 			MP4_LOG_DEBUG("Demux metrics: %u frames in %.3f ms", frameCount, demuxDuration.count());
 		}
 	} catch (const Mp4ParseException& ex) {
-		setParseError(ex.code());
+		setParseError(ex.code(), ex.what());
 		ret = false;
 	} catch (const std::exception& /*ex*/) {
 		// Map unknown std exceptions to a generic parse error

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -1328,7 +1328,7 @@ void Mp4Demux::DemuxHelper(const uint8_t *fin)
 				break;
 			default:
 				// Unknown/unhandled box — skip payload and continue
-				MP4_LOG_DEBUG("Skipping unknown box type: %s, size: %" PRIu64, FourCCToString(type).c_str(), size);
+				MP4_LOG_WARN("Skipping unknown box type: %s, size: %" PRIu64, FourCCToString(type).c_str(), size);
 				ptr = next;
 				break;
 		}
@@ -1414,7 +1414,6 @@ bool Mp4Demux::Parse(std::shared_ptr<std::vector<uint8_t>>&& segment)
 		}
 	} catch (const Mp4ParseException& ex) {
 		setParseError(ex.code());
-		MP4_LOG_ERR("%s", ex.what());
 		ret = false;
 	} catch (const std::exception& /*ex*/) {
 		// Map unknown std exceptions to a generic parse error

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -645,12 +645,19 @@ void Mp4Demux::ParseSampleAuxiliaryInformationOffsets()
  * - Initialization vector (IV)
  * - Subsample encryption information (clear/encrypted byte pairs)
  * - Cipher mode and pattern encryption settings
+ *
+ * @param next Pointer to next box
  */
-void Mp4Demux::ParseSampleEncryption()
+void Mp4Demux::ParseSampleEncryption(const uint8_t *next)
 {
 	ReadHeader();
 	uint32_t sampleCount = ReadU32();
 	uint64_t maxSampleCount = sampleOffset + sampleCount;
+	MP4_LOG_DEBUG("senc: sampleCount=%" PRIu32 " ivSize=%u flags=0x%x subSamplePresent=%d boxRemaining=%zu",
+		sampleCount, ivSize, flags,
+		(flags & SENC_SUBSAMPLE_ENCRYPTION_PRESENT) ? 1 : 0,
+		static_cast<size_t>(next - ptr));
+
 	if (samples.size() != maxSampleCount)
 	{
 		throw Mp4ParseException(MP4_PARSE_ERROR_SAMPLE_COUNT_MISMATCH, "senc: sampleCount mismatch");
@@ -1219,7 +1226,7 @@ void Mp4Demux::DemuxHelper(const uint8_t *fin)
 				ParseSampleAuxiliaryInformationSizes();
 				break;
 			case MultiChar_Constant("senc"): // modern, optional
-				ParseSampleEncryption();
+				ParseSampleEncryption(next);
 				break;
 			case MultiChar_Constant("tfhd"):
 				ParseTrackFragmentHeader();
@@ -1320,6 +1327,9 @@ void Mp4Demux::DemuxHelper(const uint8_t *fin)
 				ptr = next; // skip payload
 				break;
 			default:
+				// Unknown/unhandled box — skip payload and continue
+				MP4_LOG_DEBUG("Skipping unknown box type: %s, size: %" PRIu64, FourCCToString(type).c_str(), size);
+				ptr = next;
 				break;
 		}
 		if (ptr != next)
@@ -1404,6 +1414,7 @@ bool Mp4Demux::Parse(std::shared_ptr<std::vector<uint8_t>>&& segment)
 		}
 	} catch (const Mp4ParseException& ex) {
 		setParseError(ex.code());
+		MP4_LOG_ERR("%s", ex.what());
 		ret = false;
 	} catch (const std::exception& /*ex*/) {
 		// Map unknown std exceptions to a generic parse error

--- a/mp4demux/MP4Demux.h
+++ b/mp4demux/MP4Demux.h
@@ -320,8 +320,10 @@ private:
 	void ParseProtectionSchemeInfo();
 	/** @brief Parse sample auxiliary information offsets box */
 	void ParseSampleAuxiliaryInformationOffsets();
-	/** @brief Parse sample encryption box (SENC) */
-	void ParseSampleEncryption();
+	/** @brief Parse sample encryption box (SENC)
+	 * @param next Pointer to next box
+	 */
+	void ParseSampleEncryption(const uint8_t *next);
 	/** @brief Parse track run box (TRUN) */
 	void ParseTrackRun();
 	/**

--- a/mp4demux/MP4Demux.h
+++ b/mp4demux/MP4Demux.h
@@ -253,10 +253,11 @@ private:
 	/**
 	 * @brief log human readable parse error and update state
 	 * @param parseError one of Mp4ParseError
+	 * @param what optional error detail string (e.g. from exception)
 	 *
 	 * Note: still used from the Parse(...) catch block to centralize logging.
 	 */
-	void setParseError( Mp4ParseError );
+	void setParseError( Mp4ParseError, const char* what = nullptr );
 
 	/**
 	 * @brief Read n bytes from current position in big-endian format

--- a/test/utests/tests/Mp4BoxParsingTests/EsdsReadLenTests.cpp
+++ b/test/utests/tests/Mp4BoxParsingTests/EsdsReadLenTests.cpp
@@ -453,7 +453,7 @@ static std::vector<uint8_t> build_zero_size_unknown_box(const char type[4], uint
     return box;
 }
 
-TEST_F(EsdsReadLenTests, ZeroSizeUnknownTypeTriggersDataBoundaryMismatch)
+TEST_F(EsdsReadLenTests, ZeroSizeUnknownTypeIsSkippedSuccessfully)
 {
     // Prelude: a valid stsd->mp4a->esds so parser is in a good state
     auto lenBytes = encode_len(8);
@@ -471,11 +471,10 @@ TEST_F(EsdsReadLenTests, ZeroSizeUnknownTypeTriggersDataBoundaryMismatch)
     Mp4Demux demux;
     bool ok = demux.Parse(std::make_shared<std::vector<uint8_t>>(std::move(buffer)));
 
-    // Rationale: For size==0, DemuxHelper sets next=fin. Since the type is unknown,
-    // it falls into default: (no ptr advance). The final ptr!=next check fires and sets
-    // MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH.
-    EXPECT_FALSE(ok) << "Parse should fail: zero-size box with unknown type leaves ptr!=next";
-    EXPECT_EQ(demux.GetLastError(), MP4_PARSE_ERROR_DATA_BOUNDARY_MISMATCH);
+    // Rationale: For size==0, DemuxHelper sets next=fin. Unknown box types are now
+    // gracefully skipped (ptr=next in default case). Parse succeeds.
+    EXPECT_TRUE(ok) << "Parse should succeed: unknown box type is skipped";
+    EXPECT_EQ(demux.GetLastError(), MP4_PARSE_OK);
 }
 
 
@@ -680,5 +679,118 @@ TEST_F(EsdsReadLenTests, SizeZeroFreeWithExtraPaddingParsesSuccessfully)
 
     // Expected: next=fin for size==0, ptr set to next for 'free'; extra padding is part of the box payload.
     EXPECT_TRUE(ok) << "Parse should succeed: size==0 free with extra padding still extends to end";
+    EXPECT_EQ(demux.GetLastError(), MP4_PARSE_OK);
+}
+
+
+// === Tests for unknown box type skip behavior ===
+
+// Build a fixed-size box with a given type and payload
+static std::vector<uint8_t> build_fixed_size_box(const char type[4], uint32_t payloadSize)
+{
+    std::vector<uint8_t> box;
+    uint32_t totalSize = 8 + payloadSize;
+    append_u32(box, totalSize);
+    append_type(box, type);
+    box.resize(totalSize, 0xAB); // fill payload with arbitrary data
+    return box;
+}
+
+TEST_F(EsdsReadLenTests, FixedSizeUnknownBoxIsSkippedSuccessfully)
+{
+    // Prelude: valid stsd->mp4a->esds
+    auto lenBytes = encode_len(8);
+    auto esdsPayload = build_esds_payload(lenBytes, /*payload*/ 8);
+    auto mp4aBox = build_mp4a_box(esdsPayload);
+    auto stsdBox = build_stsd_with_mp4a(mp4aBox);
+
+    // Create a fixed-size unknown box ('xyzw') with 32 bytes payload
+    auto unknownBox = build_fixed_size_box("xyzw", 32);
+
+    std::vector<uint8_t> buffer;
+    buffer.insert(buffer.end(), stsdBox.begin(), stsdBox.end());
+    buffer.insert(buffer.end(), unknownBox.begin(), unknownBox.end());
+
+    Mp4Demux demux;
+    bool ok = demux.Parse(std::make_shared<std::vector<uint8_t>>(std::move(buffer)));
+
+    // Expected: DemuxHelper encounters unknown type 'xyzw', sets ptr=next to skip it.
+    // Parse succeeds since ptr==next after the skip.
+    EXPECT_TRUE(ok) << "Parse should succeed: fixed-size unknown box is skipped";
+    EXPECT_EQ(demux.GetLastError(), MP4_PARSE_OK);
+}
+
+TEST_F(EsdsReadLenTests, MultipleUnknownBoxesAreSkippedSuccessfully)
+{
+    // Prelude: valid stsd->mp4a->esds
+    auto lenBytes = encode_len(8);
+    auto esdsPayload = build_esds_payload(lenBytes, /*payload*/ 8);
+    auto mp4aBox = build_mp4a_box(esdsPayload);
+    auto stsdBox = build_stsd_with_mp4a(mp4aBox);
+
+    // Create several unknown boxes with different types
+    auto unknownBox1 = build_fixed_size_box("aaaa", 16);
+    auto unknownBox2 = build_fixed_size_box("bbbb", 64);
+    auto unknownBox3 = build_fixed_size_box("cccc", 8);
+
+    std::vector<uint8_t> buffer;
+    buffer.insert(buffer.end(), stsdBox.begin(), stsdBox.end());
+    buffer.insert(buffer.end(), unknownBox1.begin(), unknownBox1.end());
+    buffer.insert(buffer.end(), unknownBox2.begin(), unknownBox2.end());
+    buffer.insert(buffer.end(), unknownBox3.begin(), unknownBox3.end());
+
+    Mp4Demux demux;
+    bool ok = demux.Parse(std::make_shared<std::vector<uint8_t>>(std::move(buffer)));
+
+    // Expected: All three unknown boxes are skipped in sequence. Parse succeeds.
+    EXPECT_TRUE(ok) << "Parse should succeed: multiple unknown boxes skipped in sequence";
+    EXPECT_EQ(demux.GetLastError(), MP4_PARSE_OK);
+}
+
+TEST_F(EsdsReadLenTests, UnknownBoxFollowedByKnownBoxParsesSuccessfully)
+{
+    // Prelude: valid stsd->mp4a->esds
+    auto lenBytes = encode_len(8);
+    auto esdsPayload = build_esds_payload(lenBytes, /*payload*/ 8);
+    auto mp4aBox = build_mp4a_box(esdsPayload);
+    auto stsdBox = build_stsd_with_mp4a(mp4aBox);
+
+    // Unknown box followed by a known 'free' box
+    auto unknownBox = build_fixed_size_box("qqqq", 48);
+    auto freeBox = build_free_box(32);
+
+    std::vector<uint8_t> buffer;
+    buffer.insert(buffer.end(), stsdBox.begin(), stsdBox.end());
+    buffer.insert(buffer.end(), unknownBox.begin(), unknownBox.end());
+    buffer.insert(buffer.end(), freeBox.begin(), freeBox.end());
+
+    Mp4Demux demux;
+    bool ok = demux.Parse(std::make_shared<std::vector<uint8_t>>(std::move(buffer)));
+
+    // Expected: Unknown box is skipped, then 'free' box is also skipped. Parse succeeds.
+    EXPECT_TRUE(ok) << "Parse should succeed: unknown box skipped before known box";
+    EXPECT_EQ(demux.GetLastError(), MP4_PARSE_OK);
+}
+
+TEST_F(EsdsReadLenTests, UnknownBoxWithEmptyPayloadIsSkipped)
+{
+    // Prelude: valid stsd->mp4a->esds
+    auto lenBytes = encode_len(8);
+    auto esdsPayload = build_esds_payload(lenBytes, /*payload*/ 8);
+    auto mp4aBox = build_mp4a_box(esdsPayload);
+    auto stsdBox = build_stsd_with_mp4a(mp4aBox);
+
+    // Unknown box with size=8 (header only, no payload)
+    auto unknownBox = build_fixed_size_box("zzzz", 0);
+
+    std::vector<uint8_t> buffer;
+    buffer.insert(buffer.end(), stsdBox.begin(), stsdBox.end());
+    buffer.insert(buffer.end(), unknownBox.begin(), unknownBox.end());
+
+    Mp4Demux demux;
+    bool ok = demux.Parse(std::make_shared<std::vector<uint8_t>>(std::move(buffer)));
+
+    // Expected: Unknown box with no payload is skipped (ptr already == next). Parse succeeds.
+    EXPECT_TRUE(ok) << "Parse should succeed: unknown box with empty payload";
     EXPECT_EQ(demux.GetLastError(), MP4_PARSE_OK);
 }


### PR DESCRIPTION
Reason for Change: Be able to play a stream with an unknown MP4 box
Summary of Changes:
- Ignore MP4 boxes of unknown type
- A WARN is printed when a MP4 box of unknown type is found
- Add what() text to the ERR printed when there is an Mp4Demux exception
- Add aditional log lines to Mp4Demux
- Verify this change in L1 tests

Test Procedure: EsdsReadLenTests L1 tests should pass

Priority: P2

Risks: Low