### PR TITLE
VPAAMP-413 Speed up L1 tests

### DIFF
--- a/downloader/AampCurlDefine.h
+++ b/downloader/AampCurlDefine.h
@@ -38,6 +38,7 @@
 #define DEFAULT_CURL_TIMEOUT 5L		/**< Default timeout for Curl downloads */
 #define DEFAULT_CURL_CONNECTTIMEOUT 3L	/**< Curl socket connection timeout */
 #define DEFAULT_DNS_CACHE_TIMEOUT 3*60L	/**< Name resolve results cached for this many seconds (180 s = 3x the libcurl default of 60 s) */
+#define MIN_DELAY_BETWEEN_MANIFEST_UPDATE_FOR_502_MS (1000) // 1000mSec
 
 /**
  * @brief Http Header Type

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -356,7 +356,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 								mDownloadResponse->iHttpRetValue >= 500 ))
 						{
 							AAMPLOG_WARN("Download failed due to Server error http-%d numDownloadAttempts %d numRetriesAllowed %d",mDownloadResponse->iHttpRetValue,numDownloadAttempts,numRetriesAllowed);
-							int retryDelayMs = (mDownloadResponse->iHttpRetValue == 502) ? MIN_DELAY_BETWEEN_MANIFEST_UPDATE_FOR_502_MS : mDnldCfg->iDownloadRetryWaitMs;
+							int retryDelayMs = (mDownloadResponse->iHttpRetValue == 502) ? mDnldCfg->iDownload502RetryWaitMs : mDnldCfg->iDownloadRetryWaitMs;
 							std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
 							loopAgain = true; //retry on manifest download failure
 							// In the unlikely event that we get http failure status and also a http body then the

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -40,6 +40,7 @@
 #include <chrono>
 #include <memory>
 #include "AampCurlDefine.h"
+#include "AampDefine.h"
 #include "AampMediaType.h"
 
 typedef std::map<int,std::string> RespHeader;
@@ -59,6 +60,7 @@ typedef struct _downloadConfig
 	uint32_t iDownloadRetryCount;
 	uint32_t iDownloadRetryWaitMs;
 	uint32_t iDownload502RetryCount; 		//Non zero value then use this for 502 retries
+	uint32_t iDownload502RetryWaitMs;		//Delay between 502 retries (ms)
 
 	CurlRequest eRequestType;
 	long    lSupportedTLSVersion;
@@ -80,7 +82,7 @@ typedef struct _downloadConfig
 	_downloadConfig() : pCurl(nullptr),iDownloadTimeout(DEFAULT_CURL_TIMEOUT),iLowBWTimeout(0),iCurlConnectionTimeout(DEFAULT_CURL_CONNECTTIMEOUT),
 			iStallTimeout(0),iStartTimeout(0),bSSLVerifyPeer(false),lSupportedTLSVersion(CURL_SSLVERSION_TLSv1_2),proxyName(""),userAgentString(""),sCustomHeaders(),
 			bVerbose(false),bIgnoreResponseHeader(false),bNeedDownloadMetrics(false),eRequestType(eCURL_GET),postData(""),iDownloadRetryCount(0),iDownload502RetryCount(0),
-			iDownloadRetryWaitMs(50),iDnsCacheTimeOut(DEFAULT_DNS_CACHE_TIMEOUT), bCurlThroughput(false), networkPersonaFile()
+			iDownloadRetryWaitMs(50),iDownload502RetryWaitMs(MIN_DELAY_BETWEEN_MANIFEST_UPDATE_FOR_502_MS),iDnsCacheTimeOut(DEFAULT_DNS_CACHE_TIMEOUT), bCurlThroughput(false), networkPersonaFile()
 	{
 	}
 	

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -40,7 +40,6 @@
 #include <chrono>
 #include <memory>
 #include "AampCurlDefine.h"
-#include "AampDefine.h"
 #include "AampMediaType.h"
 
 typedef std::map<int,std::string> RespHeader;

--- a/test/utests/list_slow_tests.py
+++ b/test/utests/list_slow_tests.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# If not stated otherwise in this file or this component's license file the
+# following copyright and licenses apply:
+#
+# Copyright 2026 RDK Management
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""List L1 tests that took longer than a given threshold.
+
+Usage:
+    ./list_slow_tests.py [OPTIONS] [XML_FILE]
+
+Arguments:
+    XML_FILE    Path to CTest JUnit XML results (default: build/ctest-results.xml)
+
+Options:
+    -t, --threshold SECONDS   Minimum duration to report (default: 1.0)
+    -h, --help                Show this help message
+"""
+
+import argparse
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+
+def list_slow_tests(xml_path: str, threshold: float) -> list[tuple[float, str]]:
+    """Parse JUnit XML and return tests exceeding the threshold, sorted longest first."""
+    tree = ET.parse(xml_path)
+    slow = []
+    for tc in tree.iter("testcase"):
+        duration = float(tc.get("time", 0))
+        if duration > threshold:
+            slow.append((duration, tc.get("name", "unknown")))
+    slow.sort(reverse=True)
+    return slow
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List L1 tests that exceeded a duration threshold."
+    )
+    parser.add_argument(
+        "xml_file",
+        nargs="?",
+        default="build/ctest-results.xml",
+        help="Path to CTest JUnit XML results (default: build/ctest-results.xml)",
+    )
+    parser.add_argument(
+        "-t", "--threshold",
+        type=float,
+        default=1.0,
+        help="Minimum duration in seconds to report (default: 1.0)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.xml_file):
+        print(f"No results file found: {args.xml_file}", file=sys.stderr)
+        print("Run tests first with: cd test/utests && ./run.sh", file=sys.stderr)
+        sys.exit(1)
+
+    slow = list_slow_tests(args.xml_file, args.threshold)
+
+    if not slow:
+        print(f"No tests exceeded {args.threshold:.1f}s threshold.")
+        return
+
+    print(f"\nTests that took longer than {args.threshold:.1f}s (longest first):")
+    for duration, name in slow:
+        print(f"  {duration:7.2f}s  {name}")
+    print(f"\n  Total: {len(slow)} slow test(s)\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/utests/run.sh
+++ b/test/utests/run.sh
@@ -53,6 +53,16 @@ cat << EOF > test_details.json
 EOF
 }
 
+# List tests that took longer than 1 second, ordered by duration (longest first)
+list_slow_tests()
+{
+    local xml_file="$1"
+    if [[ ! -f "$xml_file" ]]; then
+        return
+    fi
+    python3 "${TESTDIR}/list_slow_tests.py" "$xml_file"
+}
+
 # "corrupt arc tag"
 find . -name "*.gcda" -print0 | xargs -0 --no-run-if-empty rm
 
@@ -165,7 +175,7 @@ if [ "$rdke_build" -eq "1" ]; then
 	echo "RDKE build"
 
 	export GTEST_OUTPUT="json"
-  ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR || true  # Don't exit script if a test fails
+  ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR --output-junit ctest-results.xml || true  # Don't exit script if a test fails
 
   cd tests
 
@@ -218,6 +228,8 @@ EOF
 else
     ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR --output-junit ctest-results.xml
 fi
+
+list_slow_tests ctest-results.xml
 
 if [ "$build_coverage" -eq "1" ]; then
 #We are in utests/build

--- a/test/utests/run.sh
+++ b/test/utests/run.sh
@@ -165,17 +165,18 @@ cmake_version=$(cmake --version | head -n 1 | awk '{print $3}')
 major_version=$(echo "$cmake_version" | cut -d. -f1)
 minor_version=$(echo "$cmake_version" | cut -d. -f2)
 if [[ "$major_version" -gt 3 ]] || [[ "$major_version" -eq 3 && "$minor_version" -ge 21 ]]; then
-  CT_TESTDIR="" 
+  CT_TESTDIR=""
+  CT_OUTPUT_JUNIT="--output-junit ctest-results.xml"
 else
-  CT_TESTDIR="--testdir build" 
-    
+  CT_TESTDIR="--testdir build"
+  CT_OUTPUT_JUNIT=""
 fi
 
 if [ "$rdke_build" -eq "1" ]; then
 	echo "RDKE build"
 
 	export GTEST_OUTPUT="json"
-  ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR --output-junit ctest-results.xml || true  # Don't exit script if a test fails
+  ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR $CT_OUTPUT_JUNIT || true  # Don't exit script if a test fails
 
   cd tests
 
@@ -226,10 +227,12 @@ EOF
 	find . -name test_detail\*.json | xargs cat |  jq -s '{test_cases_results: {tests: map(.tests) | add,failures: map(.failures) | add,disabled: map(.disabled) | add,errors: map(.errors) | add,time: ((map(.time | rtrimstr("s") | tonumber) | add) | tostring + "s"),name: .[0].name,testsuites: map(.testsuites[])}}' > L1Report.json
 
 else
-    ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR --output-junit ctest-results.xml
+    ctest -j 4 --timeout "${CTEST_TIMEOUT}" --output-on-failure --no-compress-output -T Test $CT_TESTDIR $CT_OUTPUT_JUNIT
 fi
 
-list_slow_tests ctest-results.xml
+if [[ -n "$CT_OUTPUT_JUNIT" ]]; then
+    list_slow_tests ctest-results.xml
+fi
 
 if [ "$build_coverage" -eq "1" ]; then
 #We are in utests/build

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -413,6 +413,7 @@ TEST_F(FunctionalTests, AampCurlDownloader_Retry_502)
 	inpData->bNeedDownloadMetrics = true;
 	inpData->bIgnoreResponseHeader = true;
 	inpData->iDownload502RetryCount = MANIFEST_DOWNLOAD_502_RETRY_COUNT;
+	inpData->iDownload502RetryWaitMs = 0;
 
 	// The first attempt is not a retry hence +1
 	int triesExpected = MANIFEST_DOWNLOAD_502_RETRY_COUNT + 1;

--- a/test/utests/tests/AampLatencyMonitorTests/AampLatencyMonitorTestCases.cpp
+++ b/test/utests/tests/AampLatencyMonitorTests/AampLatencyMonitorTestCases.cpp
@@ -1017,7 +1017,7 @@ TEST_F(AampLatencyMonitorTest, Restoration_MultipleSteps_ThresholdsReturnToBase)
 	mMonitor->Start(MakeFastConfig(
 		DEFAULT_NORMAL_RATE_CORRECTION_SPEED, DEFAULT_MIN_RATE_CORRECTION_SPEED, DEFAULT_MAX_RATE_CORRECTION_SPEED,
 		DEFAULT_MIN_LATENCY_MS, DEFAULT_TARGET_LATENCY_MS, DEFAULT_MAX_LATENCY_MS,
-		/*bufToEnable=*/0.0, kStep, kMaxIncr, /*dangerBufferMs=*/1000.0, /*latencyStableSec=*/5.0));
+		/*bufToEnable=*/0.0, kStep, kMaxIncr, /*dangerBufferMs=*/1000.0, /*latencyStableSec=*/0.05));
 	ASSERT_TRUE(WaitForRunning());
 
 	// Accumulate maximum shift via 3 distinct episodes.
@@ -1038,10 +1038,10 @@ TEST_F(AampLatencyMonitorTest, Restoration_MultipleSteps_ThresholdsReturnToBase)
 	}
 
 	// Now keep buffer healthy so Run() drives 3 restoration cycles.
-	// Each cycle: Run() observes healthy buffer for >= latencyStableSec (5.0s) → one restore step.
-	// Wait long enough for all 3 windows to complete (3 * 5.0s + margin).
+	// Each cycle: Run() observes healthy buffer for >= latencyStableSec (0.05s) → one restore step.
+	// With monitorIntervalMs=5ms, each 50ms window needs ~10 polls.
 	bufSecs.store(5.0);
-	ASSERT_TRUE(WaitForMinLatency(DEFAULT_MIN_LATENCY_MS, 20000));
+	ASSERT_TRUE(WaitForMinLatency(DEFAULT_MIN_LATENCY_MS, 2000));
 
 	auto [minMs, targetMs, maxMs] = mMonitor->GetCurrentThresholds();
 	EXPECT_DOUBLE_EQ(minMs,    DEFAULT_MIN_LATENCY_MS);

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -307,8 +307,9 @@ TEST_F(FunctionalTests,
 {
     static const char *kLiveMpdManifest =
     R"(<?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2.000S" maxSegmentDuration="PT0H0M1.92S" minimumUpdatePeriod="PT0H0M3.0S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2024-11-08T12:53:09.725Z">
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2.000S" maxSegmentDuration="PT0H0M1.92S" minimumUpdatePeriod="PT0.5S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2024-11-08T12:53:09.725Z">
     <Period id="901591170" start="PT416006H37M27.854S">
+        <EventStream schemeIdUri="urn:example:test:2024" timescale="1000"/>
         <AdaptationSet id="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
             <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
             <SegmentTemplate initialization="init-$RepresentationID$.mp4" media="seg-$Number$.m4s" timescale="90000" startNumber="901599260" presentationTimeOffset="20213">
@@ -345,14 +346,14 @@ TEST_F(FunctionalTests,
 	ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
 	ASSERT_TRUE(firstManifest->mIsLiveManifest);
 
-	// Wait up to 8 seconds for the second manifest to become available.
+	// Wait up to 2 seconds for the second manifest to become available.
 	// Since GetManifest(false, ...) does not block for new data, poll
 	// until the returned pointer differs from the first manifest or the
 	// deadline is reached.
 	ManifestDownloadResponsePtr secondManifest;
 	{
 		auto deadline = std::chrono::steady_clock::now() +
-			std::chrono::milliseconds(8000);
+			std::chrono::milliseconds(2000);
 		do
 		{
 			secondManifest = mAampMPDDownloader->GetManifest(false, 0);
@@ -370,13 +371,13 @@ TEST_F(FunctionalTests,
 	ASSERT_TRUE(IsCurlTimeoutFailure(
 		secondManifest->mMPDDownloadResponse->iHttpRetValue));
 
-	// Wait up to 1.8 seconds for the next manifest refresh. As above,
+	// Wait up to 1.5 seconds for the next manifest refresh. As above,
 	// poll until a different manifest pointer is observed or the
 	// deadline expires.
 	ManifestDownloadResponsePtr thirdManifest;
 	{
 		auto deadline = std::chrono::steady_clock::now() +
-			std::chrono::milliseconds(1800);
+			std::chrono::milliseconds(1500);
 		do
 		{
 			thirdManifest = mAampMPDDownloader->GetManifest(false, 0);

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -1181,7 +1181,7 @@ TEST_F(MediaTrackTests, WaitForCachedFragmentInjected_SignaledButStillFull_Retur
 	});
 
 	// Must return false: was signaled, abort is clear, but cache is still full.
-	bool result = videoTrack.WaitForCachedFragmentInjected(5000 /*ms*/);
+	bool result = videoTrack.WaitForCachedFragmentInjected(100 /*ms*/);
 	signalThread.join();
 
 	EXPECT_FALSE(result);

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -1181,7 +1181,7 @@ TEST_F(MediaTrackTests, WaitForCachedFragmentInjected_SignaledButStillFull_Retur
 	});
 
 	// Must return false: was signaled, abort is clear, but cache is still full.
-	bool result = videoTrack.WaitForCachedFragmentInjected(100 /*ms*/);
+	bool result = videoTrack.WaitForCachedFragmentInjected(200 /*ms*/);
 	signalThread.join();
 
 	EXPECT_FALSE(result);

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1413,41 +1413,6 @@ TEST_F(PrivAampTests,GetVideoPTSTest)
 
 	EXPECT_EQ(videoPTS,0);
 }
-TEST_F(PrivAampTests,WakeupLatencyCheckTest)
-{
-	p_aamp->WakeupLatencyCheck();
-}
-TEST_F(PrivAampTests,TimedWaitForLatencyCheckTest)
-{
-	int timeInMs = 1;
-	p_aamp->TimedWaitForLatencyCheck(timeInMs);
-
-	// below are stress level test case
-	p_aamp->TimedWaitForLatencyCheck(0);
-	p_aamp->TimedWaitForLatencyCheck(2);
-	p_aamp->TimedWaitForLatencyCheck(-10);
-	p_aamp->TimedWaitForLatencyCheck(-12355);
-	p_aamp->TimedWaitForLatencyCheck(5);
-
-	EXPECT_FALSE(p_aamp->mAbortRateCorrection);
-}
-
-TEST_F(PrivAampTests,StopRateCorrectionWorkerThreadTest)
-{
-	p_aamp->StartRateCorrectionWorkerThread();
-	EXPECT_FALSE(p_aamp->mAbortRateCorrection);
-
-	p_aamp->StopRateCorrectionWorkerThread();
-	EXPECT_FALSE(p_aamp->mAbortRateCorrection);
-}
-
-TEST_F(PrivAampTests,RateCorrectionWorkerThreadTest1)
-{
-	p_aamp->RateCorrectionWorkerThread();
-
-	EXPECT_NE(p_aamp->mCorrectionRate,0);
-	EXPECT_FALSE(p_aamp->mDisableRateCorrection);
-}
 
 TEST_F(PrivAampTests,MonitorProgressTest1)
 {

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1413,6 +1413,41 @@ TEST_F(PrivAampTests,GetVideoPTSTest)
 
 	EXPECT_EQ(videoPTS,0);
 }
+TEST_F(PrivAampTests,WakeupLatencyCheckTest)
+{
+	p_aamp->WakeupLatencyCheck();
+}
+TEST_F(PrivAampTests,TimedWaitForLatencyCheckTest)
+{
+	int timeInMs = 1;
+	p_aamp->TimedWaitForLatencyCheck(timeInMs);
+
+	// below are stress level test case
+	p_aamp->TimedWaitForLatencyCheck(0);
+	p_aamp->TimedWaitForLatencyCheck(2);
+	p_aamp->TimedWaitForLatencyCheck(-10);
+	p_aamp->TimedWaitForLatencyCheck(-12355);
+	p_aamp->TimedWaitForLatencyCheck(5);
+
+	EXPECT_FALSE(p_aamp->mAbortRateCorrection);
+}
+
+TEST_F(PrivAampTests,StopRateCorrectionWorkerThreadTest)
+{
+	p_aamp->StartRateCorrectionWorkerThread();
+	EXPECT_FALSE(p_aamp->mAbortRateCorrection);
+
+	p_aamp->StopRateCorrectionWorkerThread();
+	EXPECT_FALSE(p_aamp->mAbortRateCorrection);
+}
+
+TEST_F(PrivAampTests,RateCorrectionWorkerThreadTest1)
+{
+	p_aamp->RateCorrectionWorkerThread();
+
+	EXPECT_NE(p_aamp->mCorrectionRate,0);
+	EXPECT_FALSE(p_aamp->mDisableRateCorrection);
+}
 
 TEST_F(PrivAampTests,MonitorProgressTest1)
 {
@@ -5940,7 +5975,7 @@ TEST_F(PrivAampTests, DetachFlushesAndBlocksAsyncEvents)
 
 	// After detach, sync events should not be called
 	EXPECT_CALL(*g_mockAampEventManager, SendEvent(_, AAMP_EVENT_SYNC_MODE)).Times(0);
-	sleep(1);
+	std::this_thread::sleep_for(std::chrono::milliseconds(10));
 }
 
 /**


### PR DESCRIPTION
Reason for Change: Speed up L1 tests

Summary of Changes:
- Modify run.sh to print list of slow tests that take longer than 1s
- Make AampCurlDownloader delay between 502 retries configurable
- Modify various L1 tests to make them quicker

Test Procedure: L1 tests should pass and slow tests printed

Priority: P2

Risks: Low