### PR TITLE
VPAAMP-416: Fix deadcode for Multiple returns observed on AampDRMLinseManager::handleLicenseResponse

### DIFF
--- a/drm/AampDRMLicManager.cpp
+++ b/drm/AampDRMLicManager.cpp
@@ -504,8 +504,7 @@ KeyState AampDRMLicenseManager::handleLicenseResponse(int &responseCode,std::sha
 			return KEY_ERROR;
 		}
 	}
-      return processLicenseResponse(std::move(drmHelper), sessionSlot, cdmError, std::move(licenseResponse), std::move(eventHandle), isLicenseRenewal);
-      return processLicenseResponse(std::move(drmHelper), sessionSlot, cdmError, std::move(licenseResponse), std::move(eventHandle), isLicenseRenewal);
+	return processLicenseResponse(std::move(drmHelper), sessionSlot, cdmError, std::move(licenseResponse), std::move(eventHandle), isLicenseRenewal);
 }
 KeyState AampDRMLicenseManager::processLicenseResponse(std::shared_ptr<DrmHelper> drmHelper, int sessionSlot, int &cdmError,
 		shared_ptr<DrmData> licenseResponse, DrmMetaDataEventPtr eventHandle, bool isLicenseRenewal)


### PR DESCRIPTION
Reason for change: Deprecated deadcode
Test Procedure: Refer jira ticket VPAAMP-416
Priority: P2