### PR TITLE
RDKEMW-18993: [8.4][Xfinity][E040.021.00.8.4p22s1]VIPA container getting crashed on bootup

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5219,6 +5219,7 @@ void InterfacePlayerRDK::InitializePlayerGstreamerPlugins()
 	if (!gst_init_check(nullptr, nullptr, nullptr)) {
 		MW_LOG_ERR("gst_init_check() failed");
 	}
+	SocUtils::Init();
 
 #define PLUGINS_TO_LOWER_RANK_MAX    2
 	static const char *plugins_to_lower_rank[PLUGINS_TO_LOWER_RANK_MAX] = {

--- a/middleware/SocUtils.cpp
+++ b/middleware/SocUtils.cpp
@@ -27,7 +27,16 @@
 
 namespace SocUtils
 {
-	static std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
+	static std::shared_ptr<SocInterface> GetSocInterface()
+	{
+		static std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
+		return socInterface;
+	}
+
+	void Init()
+	{
+		(void)GetSocInterface();
+	}
 	/**
 	 * @brief Checks if AppSrc should be used for progressive playback.
 	 *
@@ -38,7 +47,7 @@ namespace SocUtils
 	 */
 	bool UseAppSrcForProgressivePlayback( void )
 	{
-		return socInterface->UseAppSrc();
+		return GetSocInterface()->UseAppSrc();
 	}
 
 	/**
@@ -51,7 +60,7 @@ namespace SocUtils
 	 */
 	bool UseWesterosSink( void )
 	{
-		return socInterface->UseWesterosSink();
+		return GetSocInterface()->UseWesterosSink();
 	}
 
 	/**
@@ -63,7 +72,7 @@ namespace SocUtils
 	 */
 	bool IsAudioFragmentSyncSupported( void )
 	{
-		return socInterface->IsAudioFragmentSyncSupported();
+		return GetSocInterface()->IsAudioFragmentSyncSupported();
 	}
 
 	/**
@@ -76,7 +85,7 @@ namespace SocUtils
 	 */
 	bool EnableLiveLatencyCorrection( void )
 	{
-		return socInterface->EnableLiveLatencyCorrection();
+		return GetSocInterface()->EnableLiveLatencyCorrection();
 	}
 
 	/**
@@ -89,7 +98,7 @@ namespace SocUtils
 	 */
 	int RequiredQueuedFrames( void )
 	{
-		return socInterface->RequiredQueuedFrames();
+		return GetSocInterface()->RequiredQueuedFrames();
 	}
 
 	/**
@@ -102,7 +111,7 @@ namespace SocUtils
 	 */
 	bool EnablePTSRestamp(void)
 	{
-		return socInterface->EnablePTSRestamp();
+		return GetSocInterface()->EnablePTSRestamp();
 	}
 	/**
 	 * @brief Resets segment event flags during trickplay transitions.
@@ -111,7 +120,7 @@ namespace SocUtils
 	 */
 	bool ResetNewSegmentEvent()
 	{
-		return socInterface->ResetNewSegmentEvent();
+		return GetSocInterface()->ResetNewSegmentEvent();
 	}
 	/**
 	 *	@brief Check if GST Subtec is enabled

--- a/middleware/SocUtils.h
+++ b/middleware/SocUtils.h
@@ -27,6 +27,13 @@
 namespace SocUtils
 {
 	/**
+	 * @brief Initializes access to SOC-specific runtime capabilities.
+	 *
+	 * This function can be used to perform eager initialization during startup.
+	 * SocUtils accessors also perform lazy initialization when needed.
+	 */
+	void Init();
+	/**
 	 * @brief Checks if AppSrc should be used for progressive playback.
 	 * 
 	 * This function queries the SOC interface to determine whether AppSrc

--- a/test/utests/fakes/FakeSocUtils.cpp
+++ b/test/utests/fakes/FakeSocUtils.cpp
@@ -21,6 +21,10 @@
 
 namespace SocUtils
 {
+	void Init()
+	{
+	}
+
 	void InitializePlatformConfigs()
 	{
 	}


### PR DESCRIPTION
RDKEMW-18993: [8.4][Xfinity][E040.021.00.8.4p22s1]VIPA container getting crashed on bootup
Reason for Change: Additional corner cases addresses while creating SocInterface

Test Guidance: updated in ticket

Risk: Low