### PR TITLE
VPAAMP-406 suppress noisy logging

### DIFF
--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -196,8 +196,6 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 				// In production (no persona loaded) this is the only overhead: one
 				// acquire-load (~1 ns) with no mutex, no clock call, nothing else.
 				const bool personaActive = AampNetworkPersona::Instance().IsLoaded();
-				AAMPLOG_WARN("AampCurlDownloader::Download personaActive=%d url=%s", personaActive ? 1 : 0, urlStr.c_str());
-
 				// Wall-clock start captured only when throttling is active, so
 				// production builds pay zero cost for the timeout-budget tracking.
 				const long long loopIterStartMs = personaActive ? NOW_STEADY_TS_MS : 0LL;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4678,7 +4678,6 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 				if (!personaPath.empty())
 					AampNetworkPersona::Instance().LoadFromFile(personaPath);
 			}
-			AAMPLOG_WARN("priv_aamp: download url=%s personaLoaded=%d", remoteUrl.c_str(), AampNetworkPersona::Instance().IsLoaded() ? 1 : 0);
 			if (AampNetworkPersona::Instance().IsLoaded())
 			{
 				// Chunk the TTFB sleep into 50 ms slices so that StopDownloads()


### PR DESCRIPTION
Reason for Change: persona was being logged unconditionally and unnecessarily as warning for every download.

Test Guidance: check logs

Risk: None