### PR TITLE
RDKEMW-19256: [8.5][AAMP]Bringing Parental Pin changes and vipa container crash

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -465,6 +465,15 @@ void InterfacePlayerRDK::ConfigurePipeline(int format, int audioFormat, int subF
 			gboolean videoOnly = (audioFormat == GST_FORMAT_INVALID);
 			MW_LOG_INFO("Setting single-path-stream to %d", videoOnly);
 			g_object_set(vidsink, "single-path-stream", videoOnly, NULL);
+			// RDKEMW-18286: Reinforce show-video-window before pipeline state change
+			if (interfacePlayerPriv->gstPrivateContext->videoMuted)
+			{
+                            MW_LOG_MIL("InterfacePlayerRDK - ConfigurePipeline: reinforcing "
+                                             "show-video-window=FALSE on %s (videoMuted=%d)",
+                                              GST_ELEMENT_NAME(vidsink),
+                                              interfacePlayerPriv->gstPrivateContext->videoMuted);
+                            g_object_set(vidsink, "show-video-window", FALSE, NULL);
+                        }
 		}
 		else
 		{
@@ -2326,6 +2335,21 @@ int InterfacePlayerRDK::SetupStream(int streamId,  void *playerInstance, std::st
 					g_object_set(vidsink, "has-drm", FALSE, NULL);
 				}
 				interfacePlayerPriv->gstPrivateContext->video_sink = vidsink;
+
+                                // RDKEMW-18286: Set show-video-window=FALSE at sink creation time.
+                                // This is the EARLIEST possible point. The Rialto delegate will queue
+                                // this (m_videoMuteQueued=true) and apply it server-side when the
+                                // source attaches — which happens BEFORE the pipeline goes to PLAYING
+                                // and BEFORE any frame can be decoded.
+                                if (interfacePlayerPriv->gstPrivateContext->videoMuted)
+                                {
+                                    MW_LOG_MIL("InterfacePlayerRDK - %s: setting show-video-window=FALSE "
+                                                 "at creation time (videoMuted=%d)",
+                                                 GST_ELEMENT_NAME(vidsink),
+                                                 interfacePlayerPriv->gstPrivateContext->videoMuted);
+                                    g_object_set(vidsink, "show-video-window", FALSE, NULL);
+                                }
+
 			}
 			else
 			{
@@ -5139,6 +5163,7 @@ void InterfacePlayerRDK::InitializePlayerGstreamerPlugins()
 	if (!gst_init_check(nullptr, nullptr, nullptr)) {
 		MW_LOG_ERR("gst_init_check() failed");
 	}
+	SocUtils::Init();
 
 #define PLUGINS_TO_LOWER_RANK_MAX    2
 	static const char *plugins_to_lower_rank[PLUGINS_TO_LOWER_RANK_MAX] = {

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -468,12 +468,13 @@ void InterfacePlayerRDK::ConfigurePipeline(int format, int audioFormat, int subF
 			// RDKEMW-18286: Reinforce show-video-window before pipeline state change
 			if (interfacePlayerPriv->gstPrivateContext->videoMuted)
 			{
-                            MW_LOG_MIL("InterfacePlayerRDK - ConfigurePipeline: reinforcing "
-                                             "show-video-window=FALSE on %s (videoMuted=%d)",
-                                              GST_ELEMENT_NAME(vidsink),
-                                              interfacePlayerPriv->gstPrivateContext->videoMuted);
-                            g_object_set(vidsink, "show-video-window", FALSE, NULL);
-                        }
+				MW_LOG_MIL(
+					"InterfacePlayerRDK - ConfigurePipeline: reinforcing "
+					"show-video-window=FALSE on %s (videoMuted=%d)",
+					GST_ELEMENT_NAME(vidsink),
+					interfacePlayerPriv->gstPrivateContext->videoMuted);
+				g_object_set(vidsink, "show-video-window", FALSE, NULL);
+			}
 		}
 		else
 		{
@@ -2336,19 +2337,20 @@ int InterfacePlayerRDK::SetupStream(int streamId,  void *playerInstance, std::st
 				}
 				interfacePlayerPriv->gstPrivateContext->video_sink = vidsink;
 
-                                // RDKEMW-18286: Set show-video-window=FALSE at sink creation time.
-                                // This is the EARLIEST possible point. The Rialto delegate will queue
-                                // this (m_videoMuteQueued=true) and apply it server-side when the
-                                // source attaches — which happens BEFORE the pipeline goes to PLAYING
-                                // and BEFORE any frame can be decoded.
-                                if (interfacePlayerPriv->gstPrivateContext->videoMuted)
-                                {
-                                    MW_LOG_MIL("InterfacePlayerRDK - %s: setting show-video-window=FALSE "
-                                                 "at creation time (videoMuted=%d)",
-                                                 GST_ELEMENT_NAME(vidsink),
-                                                 interfacePlayerPriv->gstPrivateContext->videoMuted);
-                                    g_object_set(vidsink, "show-video-window", FALSE, NULL);
-                                }
+				// RDKEMW-18286: Set show-video-window=FALSE at sink creation time.
+				// This is the earliest possible point. The Rialto delegate will queue
+				// this (m_videoMuteQueued=true) and apply it server-side when the source
+				// attaches - which happens before the pipeline goes to PLAYING and before
+				// any frame can be decoded.
+				if (interfacePlayerPriv->gstPrivateContext->videoMuted)
+				{
+					MW_LOG_MIL(
+						"InterfacePlayerRDK - %s: setting show-video-window=FALSE "
+						"at creation time (videoMuted=%d)",
+						GST_ELEMENT_NAME(vidsink),
+						interfacePlayerPriv->gstPrivateContext->videoMuted);
+					g_object_set(vidsink, "show-video-window", FALSE, NULL);
+				}
 
 			}
 			else

--- a/middleware/SocUtils.cpp
+++ b/middleware/SocUtils.cpp
@@ -27,7 +27,16 @@
 
 namespace SocUtils
 {
-	static std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
+	static std::shared_ptr<SocInterface> GetSocInterface()
+	{
+		static std::shared_ptr<SocInterface> socInterface = SocInterface::CreateSocInterface();
+		return socInterface;
+	}
+
+	void Init()
+	{
+		(void)GetSocInterface();
+	}
 	/**
 	 * @brief Checks if AppSrc should be used for progressive playback.
 	 *
@@ -38,7 +47,7 @@ namespace SocUtils
 	 */
 	bool UseAppSrcForProgressivePlayback( void )
 	{
-		return socInterface->UseAppSrc();
+		return GetSocInterface()->UseAppSrc();
 	}
 
 	/**
@@ -51,7 +60,7 @@ namespace SocUtils
 	 */
 	bool UseWesterosSink( void )
 	{
-		return socInterface->UseWesterosSink();
+		return GetSocInterface()->UseWesterosSink();
 	}
 
 	/**
@@ -63,7 +72,7 @@ namespace SocUtils
 	 */
 	bool IsAudioFragmentSyncSupported( void )
 	{
-		return socInterface->IsAudioFragmentSyncSupported();
+		return GetSocInterface()->IsAudioFragmentSyncSupported();
 	}
 
 	/**
@@ -76,7 +85,7 @@ namespace SocUtils
 	 */
 	bool EnableLiveLatencyCorrection( void )
 	{
-		return socInterface->EnableLiveLatencyCorrection();
+		return GetSocInterface()->EnableLiveLatencyCorrection();
 	}
 
 	/**
@@ -89,7 +98,7 @@ namespace SocUtils
 	 */
 	int RequiredQueuedFrames( void )
 	{
-		return socInterface->RequiredQueuedFrames();
+		return GetSocInterface()->RequiredQueuedFrames();
 	}
 
 	/**
@@ -102,7 +111,7 @@ namespace SocUtils
 	 */
 	bool EnablePTSRestamp(void)
 	{
-		return socInterface->EnablePTSRestamp();
+		return GetSocInterface()->EnablePTSRestamp();
 	}
 	/**
 	 * @brief Resets segment event flags during trickplay transitions.
@@ -111,7 +120,7 @@ namespace SocUtils
 	 */
 	bool ResetNewSegmentEvent()
 	{
-		return socInterface->ResetNewSegmentEvent();
+		return GetSocInterface()->ResetNewSegmentEvent();
 	}
 	/**
 	 *	@brief Check if GST Subtec is enabled

--- a/middleware/SocUtils.h
+++ b/middleware/SocUtils.h
@@ -27,6 +27,13 @@
 namespace SocUtils
 {
 	/**
+	 * @brief Initializes access to SOC-specific runtime capabilities.
+	 *
+	 * This function can be used to perform eager initialization during startup.
+	 * SocUtils accessors also perform lazy initialization when needed.
+	 */
+	void Init();
+	/**
 	 * @brief Checks if AppSrc should be used for progressive playback.
 	 * 
 	 * This function queries the SOC interface to determine whether AppSrc

--- a/test/utests/fakes/FakeSocUtils.cpp
+++ b/test/utests/fakes/FakeSocUtils.cpp
@@ -21,6 +21,10 @@
 
 namespace SocUtils
 {
+	void Init()
+	{
+	}
+
 	void InitializePlatformConfigs()
 	{
 	}


### PR DESCRIPTION
RDKEMW-19256: [8.5][AAMP]Bringing Parental Pin changes and vipa container crash
Reason for change : Addressing vipa crash and parental pin changes update
Test Steps : E2E testing to check regression .
Signed-off by: Deepikasri Natarajan