### PR TITLE
VPAAMP-477: a single curl 56 on manifest refresh causes manifest refresh attempts to stop

### DIFF
--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -347,6 +347,7 @@ void AampMPDDownloader::downloadMPDThread1()
 	bool refreshNeeded = false;
 	std::string tuneUrl = mMPDDnldCfg->mTuneUrl;
 	bool firstDownload	=	true;
+	bool downloadFailed = false; // set when a refresh attempt fails; cleared on recovery to log the transition
 	ManifestDownloadResponsePtr cachedBackupData = nullptr;
 	do
 	{
@@ -418,9 +419,11 @@ void AampMPDDownloader::downloadMPDThread1()
 					doPush = readMPDData(mMPDData);
 				}
 				AAMPLOG_INFO("Successfully parsed Manifest ...IsLive[%d]",mMPDData->mIsLiveManifest);
-
-				// Update the effective url , so that next refresh uses the effective url
-				tuneUrl = mMPDData->mMPDDownloadResponse->sEffectiveUrl;
+				if(downloadFailed)
+				{
+					AAMPLOG_WARN("Manifest refresh recovered after previous download failure.");
+					downloadFailed = false;
+				}
 
 				// first time download complete . Do what need to be done . ....
 				if(firstDownload && mMPDData->mIsLiveManifest)
@@ -522,6 +525,7 @@ void AampMPDDownloader::downloadMPDThread1()
 			AAMPLOG_WARN("Refresh after 500ms to handle a manifest timeout error.");
 			//Forcefully go with 500 ms refresh after a download failure
 			mRefreshInterval = MIN_DELAY_BETWEEN_PLAYLIST_UPDATE_MS;
+			downloadFailed = true;
 			refreshNeeded = waitForRefreshInterval(mRefreshInterval);
 		}
 		else if(!firstDownload && !IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) && !mReleaseCalled)
@@ -529,8 +533,10 @@ void AampMPDDownloader::downloadMPDThread1()
 			// Other download failures (e.g. curl 56 CURLE_RECV_ERROR, transient HTTP errors)
 			// during an established live session: keep the refresh loop alive so the next
 			// manifest fetch is attempted rather than killing the downloader thread.
-			AAMPLOG_WARN("Refresh after 500ms to handle manifest download error [%d].", mMPDData->mMPDDownloadResponse->iHttpRetValue);
-			mRefreshInterval = MIN_DELAY_BETWEEN_PLAYLIST_UPDATE_MS;
+			// mRefreshInterval retains the MPD-derived value from the last successful parse
+			// so no override is needed; the stream's own minimumUpdatePeriod is respected.
+			AAMPLOG_WARN("Manifest download error [%d], will retry after %ums.", mMPDData->mMPDDownloadResponse->iHttpRetValue, mRefreshInterval);
+			downloadFailed = true;
 			refreshNeeded = waitForRefreshInterval(mRefreshInterval);
 		}
 

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -516,11 +516,20 @@ void AampMPDDownloader::downloadMPDThread1()
 			refreshNeeded = waitForRefreshInterval(waitMs);
 		}
 
-		//Timeout case during live refresh
+		//Timeout/connect failure during live refresh
 		if(!firstDownload && (IsCurlTimeoutFailure(mMPDData->mMPDDownloadResponse->iHttpRetValue) || CURLE_COULDNT_CONNECT == mMPDData->mMPDDownloadResponse->iHttpRetValue))
 		{
 			AAMPLOG_WARN("Refresh after 500ms to handle a manifest timeout error.");
 			//Forcefully go with 500 ms refresh after a download failure
+			mRefreshInterval = MIN_DELAY_BETWEEN_PLAYLIST_UPDATE_MS;
+			refreshNeeded = waitForRefreshInterval(mRefreshInterval);
+		}
+		else if(!firstDownload && !IS_HTTP_SUCCESS(mMPDData->mMPDDownloadResponse->iHttpRetValue) && !mReleaseCalled)
+		{
+			// Other download failures (e.g. curl 56 CURLE_RECV_ERROR, transient HTTP errors)
+			// during an established live session: keep the refresh loop alive so the next
+			// manifest fetch is attempted rather than killing the downloader thread.
+			AAMPLOG_WARN("Refresh after 500ms to handle manifest download error [%d].", mMPDData->mMPDDownloadResponse->iHttpRetValue);
 			mRefreshInterval = MIN_DELAY_BETWEEN_PLAYLIST_UPDATE_MS;
 			refreshNeeded = waitForRefreshInterval(mRefreshInterval);
 		}

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -189,7 +189,7 @@ AampMPDDownloader::~AampMPDDownloader()
 *   @fn Initialize
 *   @brief Initialize with MPD Download Input
 */
-void AampMPDDownloader::Initialize(ManifestDownloadConfigPtr mpdDnldCfg, std::string appName,std::function<std::string()> mpdPreProcessFuncptr)
+void AampMPDDownloader::Initialize(ManifestDownloadConfigPtr mpdDnldCfg, std::string appName,std::function<std::pair<std::string,int>()> mpdPreProcessFuncptr)
 {
 	if(mpdDnldCfg == nullptr)
 	{
@@ -384,7 +384,7 @@ void AampMPDDownloader::downloadMPDThread1()
 		{
 			if( NULL != mMpdPreProcessFuncptr)
 			{
-				std::string updatedManifest = mMpdPreProcessFuncptr();
+				auto [updatedManifest, httpCode] = mMpdPreProcessFuncptr();
 				if(!updatedManifest.empty())
 				{
 					mMPDData->mMPDDownloadResponse->replaceDownloadData(updatedManifest);
@@ -392,7 +392,7 @@ void AampMPDDownloader::downloadMPDThread1()
 				}
 				else
 				{
-					mMPDData->mMPDDownloadResponse->iHttpRetValue = CURLE_OPERATION_TIMEDOUT;
+					mMPDData->mMPDDownloadResponse->iHttpRetValue = httpCode;
 				}
 			}
 			else
@@ -537,11 +537,12 @@ void AampMPDDownloader::downloadMPDThread1()
 			// Other download failures (e.g. curl 56 CURLE_RECV_ERROR, transient HTTP errors)
 			// during an established live session: keep the refresh loop alive so the next
 			// manifest fetch is attempted rather than killing the downloader thread.
-			// mRefreshInterval retains the MPD-derived value from the last successful parse
-			// so no override is needed; the stream's own minimumUpdatePeriod is respected.
-			AAMPLOG_WARN("Manifest download error [%d], will retry after %ums.", mMPDData->mMPDDownloadResponse->iHttpRetValue, mRefreshInterval);
+			// Use 500ms fast-retry (same as timeout/COULDNT_CONNECT) to minimise buffer impact
+			// on LLD streams; mRefreshInterval is not permanently overwritten.
+			uint32_t fastRetry = MIN_DELAY_BETWEEN_PLAYLIST_UPDATE_MS;
+			AAMPLOG_WARN("Manifest download error [%d], will retry after %ums.", mMPDData->mMPDDownloadResponse->iHttpRetValue, fastRetry);
 			downloadFailed = true;
-			refreshNeeded = waitForRefreshInterval(mRefreshInterval);
+			refreshNeeded = waitForRefreshInterval(fastRetry);
 		}
 
 	}while(refreshNeeded && !mReleaseCalled);

--- a/AampMPDDownloader.cpp
+++ b/AampMPDDownloader.cpp
@@ -419,6 +419,10 @@ void AampMPDDownloader::downloadMPDThread1()
 					doPush = readMPDData(mMPDData);
 				}
 				AAMPLOG_INFO("Successfully parsed Manifest ...IsLive[%d]",mMPDData->mIsLiveManifest);
+
+				// Update the effective url , so that next refresh uses the effective url
+				tuneUrl = mMPDData->mMPDDownloadResponse->sEffectiveUrl;
+
 				if(downloadFailed)
 				{
 					AAMPLOG_WARN("Manifest refresh recovered after previous download failure.");

--- a/AampMPDDownloader.h
+++ b/AampMPDDownloader.h
@@ -214,7 +214,7 @@ public:
 	*	@fn Initialize
 	*	@brief Function to initialize MPD Downloader
 	*/
-	void Initialize(ManifestDownloadConfigPtr mpdDnldCfg, std::string appName="",std::function<std::string()> mpdPreProcessFuncptr = nullptr);
+	void Initialize(ManifestDownloadConfigPtr mpdDnldCfg, std::string appName="",std::function<std::pair<std::string,int>()> mpdPreProcessFuncptr = nullptr);
 
 	/**
 	*	@fn Release
@@ -442,7 +442,7 @@ private:
 	uint64_t mPublishTime; 		   /* Publish time of updated manifest*/
 	int mMinimalRefreshRetryCount;  /* A counter to checks if the publication time remains the same for 2 consecutive refresh*/
 	std::atomic_bool mMPDNotifyPending ; /*To allow wait for downloadNotifier based on NotifyPending Status */
-	std::function<std::string()> mMpdPreProcessFuncptr; /* function invoked to read the available preprocessed manifest data or to send event if manifest data is not available */
+	std::function<std::pair<std::string,int>()> mMpdPreProcessFuncptr; /* function invoked to read the available preprocessed manifest data or to send event if manifest data is not available */
 };
 
 #endif /* __AAMP_MPD_DOWNLOADER_H__ */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -5982,7 +5982,9 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 			std::shared_ptr<ManifestDownloadConfig> inpData = prepareManifestDownloadConfig();
 			if(!inpData->mPreProcessedManifest.empty())
 			{
-				mMPDDownloaderInstance->Initialize(std::move(inpData), mAppName, std::bind(&PrivateInstanceAAMP::SendManifestPreProcessEvent, this));
+				mMPDDownloaderInstance->Initialize(std::move(inpData), mAppName, [this]() -> std::pair<std::string,int> {
+					return SendManifestPreProcessEvent();
+				});
 			}
 			else
 			{
@@ -14622,7 +14624,7 @@ AampTSBSessionManager *PrivateInstanceAAMP::GetTSBSessionManager()
 	return NULL;
 }
 
-std::string PrivateInstanceAAMP::SendManifestPreProcessEvent()
+std::pair<std::string,int> PrivateInstanceAAMP::SendManifestPreProcessEvent()
 {
 	std::string  bRetManifestData;
 	std::lock_guard<std::mutex> guard(mPreProcessLock);
@@ -14636,7 +14638,7 @@ std::string PrivateInstanceAAMP::SendManifestPreProcessEvent()
 		AAMPLOG_WARN("PreProcessed Manifest not available send Need Manifest data event to application");
 		SendEvent(std::make_shared<AAMPEventObject>(AAMP_EVENT_NEED_MANIFEST_DATA, GetSessionId()),AAMP_EVENT_ASYNC_MODE);
 	}
-	return bRetManifestData;
+	return { bRetManifestData, CURLE_OPERATION_TIMEDOUT };
 }
 
 void PrivateInstanceAAMP::updateManifest(const char *manifestData)

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -871,7 +871,7 @@ public:
 	*
 	* @return modified manifest data
 	*/
-	std::string SendManifestPreProcessEvent();
+	std::pair<std::string,int> SendManifestPreProcessEvent();
 
 	/**
 	 * @brief This function is invoked by application with the available preprocessed manifest information

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -1319,14 +1319,14 @@ long long PrivateInstanceAAMP::GetPositionRelativeToSeekMilliseconds(long long r
 	return 0;
 }
 
-std::string PrivateInstanceAAMP::SendManifestPreProcessEvent()
+std::pair<std::string,int> PrivateInstanceAAMP::SendManifestPreProcessEvent()
 {
 	std::string  bRetManifestData;
 	if(!mProvidedManifestFile.empty())
 	{
 		bRetManifestData = std::move(mProvidedManifestFile);
 	}
-	return bRetManifestData;
+	return { bRetManifestData, CURLE_OPERATION_TIMEDOUT };
 }
 
 void PrivateInstanceAAMP::updateManifest(const char *manifestData)

--- a/test/utests/fakes/FakeAampMPDDownloader.cpp
+++ b/test/utests/fakes/FakeAampMPDDownloader.cpp
@@ -83,7 +83,7 @@ AampMPDDownloader::~AampMPDDownloader()
  *   @fn Initialize
  *   @brief Initialize with MPD Download Input
  */
-void AampMPDDownloader::Initialize(std::shared_ptr<ManifestDownloadConfig> mpdDnldCfg, std::string appName,std::function<std::string()> mpdPreProcessFuncptr)
+void AampMPDDownloader::Initialize(std::shared_ptr<ManifestDownloadConfig> mpdDnldCfg, std::string appName,std::function<std::pair<std::string,int>()> mpdPreProcessFuncptr)
 {
 }
 /**

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -1755,14 +1755,14 @@ bool PrivateInstanceAAMP::ReconfigureForElementaryStreamUpdate()
 	return false;
 }
 
-std::string PrivateInstanceAAMP::SendManifestPreProcessEvent()
+std::pair<std::string,int> PrivateInstanceAAMP::SendManifestPreProcessEvent()
 {
 	std::string  bRetManifestData;
 	if(!mProvidedManifestFile.empty())
 	{
 		bRetManifestData = std::move(mProvidedManifestFile);
 	}
-	return bRetManifestData;
+	return { bRetManifestData, CURLE_OPERATION_TIMEDOUT };
 }
 
 void PrivateInstanceAAMP::updateManifest(const char *manifestData)

--- a/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampMPDDownloader/FunctionalTests.cpp
@@ -279,7 +279,9 @@ TEST_F(FunctionalTests, AampMPDDownloader_PreInitTest_6)
 	inpData->mPreProcessedManifest = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<MPD xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"";
 	if(!inpData->mPreProcessedManifest.empty())
 	{
-		EXPECT_NO_THROW(mAampMPDDownloader->Initialize(inpData, appName,std::bind(&PrivateInstanceAAMP::SendManifestPreProcessEvent, mPrivateInstanceAAMP1)));
+		EXPECT_NO_THROW(mAampMPDDownloader->Initialize(inpData, appName, [this]() -> std::pair<std::string,int> {
+			return mPrivateInstanceAAMP1->SendManifestPreProcessEvent();
+		}));
 	}
 	else
 	{
@@ -328,13 +330,13 @@ TEST_F(FunctionalTests,
 	inpData->mTuneUrl = url1;
 
 	std::atomic<int> preProcessCount(0);
-	auto preProcessCallback = [&preProcessCount]() -> std::string
+	auto preProcessCallback = [&preProcessCount]() -> std::pair<std::string,int>
 	{
 		if (preProcessCount.fetch_add(1) == 0)
 		{
-			return std::string(kLiveMpdManifest);
+			return { std::string(kLiveMpdManifest), 200 };
 		}
-		return std::string();
+		return { std::string(), CURLE_OPERATION_TIMEDOUT };
 	};
 
 	mAampMPDDownloader->Initialize(inpData, appName, preProcessCallback);
@@ -395,6 +397,100 @@ TEST_F(FunctionalTests,
 	EXPECT_TRUE(thirdManifest.get() != secondManifest.get());
 	EXPECT_TRUE(IsCurlTimeoutFailure(
 		thirdManifest->mMPDDownloadResponse->iHttpRetValue));
+
+	mAampMPDDownloader->Release();
+}
+
+TEST_F(FunctionalTests,
+    AampMPDDownloader_LiveRefreshRetriesWhenFailureIsCurlRecvError)
+{
+    static const char *kLiveMpdManifest =
+    R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="dynamic" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT2.000S" maxSegmentDuration="PT0H0M1.92S" minimumUpdatePeriod="PT0.5S" availabilityStartTime="1977-05-25T18:00:00.000Z" timeShiftBufferDepth="PT0H0M30.000S" publishTime="2024-11-08T12:53:09.725Z">
+    <Period id="901591170" start="PT416006H37M27.854S">
+        <EventStream schemeIdUri="urn:example:test:2024" timescale="1000"/>
+        <AdaptationSet id="2" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+            <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+            <SegmentTemplate initialization="init-$RepresentationID$.mp4" media="seg-$Number$.m4s" timescale="90000" startNumber="901599260" presentationTimeOffset="20213">
+                <SegmentTimeline>
+                    <S t="1377581813" d="172800" r="14"/>
+                </SegmentTimeline>
+            </SegmentTemplate>
+            <Representation id="root_video4" bandwidth="562800" codecs="hvc1.1.6.L63.90" width="640" height="360" frameRate="25000/1000"/>
+        </AdaptationSet>
+    </Period>
+</MPD>
+)";
+
+	std::shared_ptr<ManifestDownloadConfig> inpData =
+		std::make_shared<ManifestDownloadConfig>(-1);
+	inpData->mTuneUrl = url1;
+
+	// First call returns a valid live manifest; all subsequent calls simulate
+	// CURLE_RECV_ERROR (curl 56) — the regression being tested is that the
+	// downloader loop must NOT exit on this error class.
+	std::atomic<int> preProcessCount(0);
+	const char *liveMpdManifestPtr = kLiveMpdManifest;
+	auto preProcessCallback = [&preProcessCount, liveMpdManifestPtr]() -> std::pair<std::string,int>
+	{
+		if (preProcessCount.fetch_add(1) == 0)
+		{
+			return { std::string(liveMpdManifestPtr), 200 };
+		}
+		return { std::string(), CURLE_RECV_ERROR };
+	};
+
+	mAampMPDDownloader->Initialize(inpData, appName, preProcessCallback);
+	mAampMPDDownloader->Start();
+
+	ManifestDownloadResponsePtr firstManifest =
+		mAampMPDDownloader->GetManifest(true, 2000);
+	ASSERT_TRUE(firstManifest != nullptr);
+	ASSERT_TRUE(IS_HTTP_SUCCESS(firstManifest->mMPDDownloadResponse->iHttpRetValue));
+	ASSERT_TRUE(firstManifest->mIsLiveManifest);
+
+	// Wait up to 2 seconds for the second manifest attempt (the CURLE_RECV_ERROR one).
+	ManifestDownloadResponsePtr secondManifest;
+	{
+		auto deadline = std::chrono::steady_clock::now() +
+			std::chrono::milliseconds(2000);
+		do
+		{
+			secondManifest = mAampMPDDownloader->GetManifest(false, 0);
+			if (!secondManifest ||
+				secondManifest.get() != firstManifest.get())
+			{
+				break;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		} while (std::chrono::steady_clock::now() < deadline);
+	}
+	ASSERT_TRUE(secondManifest != nullptr);
+	ASSERT_TRUE(secondManifest.get() != firstManifest.get());
+	ASSERT_EQ(secondManifest->mMPDDownloadResponse->iHttpRetValue, CURLE_RECV_ERROR);
+
+	// REGRESSION ASSERTION: the loop must have continued and produced a third
+	// manifest attempt within 1.5 seconds (fast 500ms retry, not a full
+	// mRefreshInterval stall).
+	ManifestDownloadResponsePtr thirdManifest;
+	{
+		auto deadline = std::chrono::steady_clock::now() +
+			std::chrono::milliseconds(1500);
+		do
+		{
+			thirdManifest = mAampMPDDownloader->GetManifest(false, 0);
+			if (!thirdManifest ||
+				thirdManifest.get() != secondManifest.get())
+			{
+				break;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		} while (std::chrono::steady_clock::now() < deadline);
+	}
+
+	EXPECT_TRUE(thirdManifest != nullptr);
+	EXPECT_TRUE(thirdManifest.get() != secondManifest.get());
+	EXPECT_EQ(thirdManifest->mMPDDownloadResponse->iHttpRetValue, CURLE_RECV_ERROR);
 
 	mAampMPDDownloader->Release();
 }


### PR DESCRIPTION
Reason for Change: After a download failure mMPDData->mIsLiveManifest is false (only set during successful parse), so refreshNeeded was never set and the downloader thread exited on the first refresh error.

Add an else-if branch below the existing timeout/COULDNT_CONNECT fast-retry block to catch all other non-success error codes (including CURLE_RECV_ERROR / curl 56) when past the first download. Sets a 500 ms retry interval and keeps the refresh loop alive so the next manifest fetch is attempted rather than killing the downloader thread.

The !firstDownload guard ensures tune-time failures still exit the loop immediately, preserving existing behaviour for initial tune failures.