### PR TITLE
VPAAMP-475 Enable DirectRialto when useRialtoSink=true

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -364,6 +364,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "seamlessAudioSwitch", eAAMPConfig_SeamlessAudioSwitch, true},
 	{false, "useRialtoSink", eAAMPConfig_useRialtoSink, false},
 	{false, "useDirectRialto", eAAMPConfig_useDirectRialto, false},
+	{true, "RialtoSinkSetsDirectRialto", eAAMPConfig_RialtoSinkSetsDirectRialto, false},
 	{false, "localTSBEnabled", eAAMPConfig_LocalTSBEnabled, true},
 	{false, "enableIFrameTrackExtract", eAAMPConfig_EnableIFrameTrackExtract, true},
 	{false, "forceMultiPeriodDiscontinuity", eAAMPConfig_ForceMultiPeriodDiscontinuity, false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -216,6 +216,7 @@ typedef enum
 	eAAMPConfig_SeamlessAudioSwitch,					/**< To enable audio Restart - Currently supported for HLS_MP4 on same codec streams*/
 	eAAMPConfig_useRialtoSink,                      /**< Enable/Disable player to use Rialto sink based video and audio pipeline */
 	eAAMPConfig_useDirectRialto,                    /**< Enable/Disable direct AampRialtoPlayer usage instead of AAMPGstPlayer */
+	eAAMPConfig_RialtoSinkSetsDirectRialto,         /**< HACK for testing only - When enabled, enabling Rialto sink also enables direct Rialto usage */
 	eAAMPConfig_LocalTSBEnabled,                                            /**< To enable/disable Local TSB in LLD */
 	eAAMPConfig_EnableIFrameTrackExtract,			/**< Config to enable and disable iFrame extraction from video track*/
 	eAAMPConfig_ForceMultiPeriodDiscontinuity,		/**< Config to forcefully process multiperiod discontinuity even if they are continuous in PTS */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1833,7 +1833,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 
 	// HACK used for testing only - if Rialto sink is enabled, then also enable direct rialto,
 	// mp4 demux and any other desired configuration
-	if (GETCONFIGVALUE_PRIV(eAAMPConfig_useRialtoSink))
+	if (GETCONFIGVALUE_PRIV(eAAMPConfig_RialtoSinkSetsDirectRialto) && GETCONFIGVALUE_PRIV(eAAMPConfig_useRialtoSink))
 	{
 		AAMPLOG_MIL("Rialto sink enabled, enabling direct rialto");
 		SETCONFIGVALUE_PRIV(AAMP_DEV_CFG_SETTING, eAAMPConfig_useDirectRialto, true);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1831,6 +1831,17 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	// Create the CMCD collector
 	mCMCDCollector = new AampCMCDCollector();
 
+	// HACK used for testing only - if Rialto sink is enabled, then also enable direct rialto,
+	// mp4 demux and any other desired configuration
+	if (GETCONFIGVALUE_PRIV(eAAMPConfig_useRialtoSink))
+	{
+		AAMPLOG_MIL("Rialto sink enabled, enabling direct rialto");
+		SETCONFIGVALUE_PRIV(AAMP_DEV_CFG_SETTING, eAAMPConfig_useDirectRialto, true);
+		SETCONFIGVALUE_PRIV(AAMP_DEV_CFG_SETTING, eAAMPConfig_UseMp4Demux, true);
+		SETCONFIGVALUE_PRIV(AAMP_DEV_CFG_SETTING, eAAMPConfig_ProgressLogging, true);
+		SETCONFIGVALUE_PRIV(AAMP_DEV_CFG_SETTING, eAAMPConfig_LogFilename, true);
+	}
+
 	// Ensure the correct CC variant class will be used
 	PlayerCCManager::SetRialto(GETCONFIGVALUE_PRIV(eAAMPConfig_useRialtoSink));
 


### PR DESCRIPTION
Reason for Change: To run existing L3 tests with DirectRialto

Summary of Changes:
- If useRialtoSink=true, set DirectRialto and other config

Test Procedure: Confirm DirectRialto is enabled when running L3 tests

Priority: P1

Risks: Low