### PR TITLE
RDKEMW-16544 : pre logger crash fix

### DIFF
--- a/middleware/externals/PlayerExternalUtils.h
+++ b/middleware/externals/PlayerExternalUtils.h
@@ -39,7 +39,7 @@
             (void)write(STDERR_FILENO, _log_buf,                            \
                        (_len < (int)sizeof(_log_buf)) ? _len :             \
                        (int)sizeof(_log_buf) - 1);                         \
-        }    
+        }                                                                  \
     } while (0)
 
 

--- a/middleware/externals/PlayerExternalUtils.h
+++ b/middleware/externals/PlayerExternalUtils.h
@@ -30,9 +30,16 @@
 
 #define MW_PRE_LOGGER_LOG(fmt, ...)                                            \
     do {                                                                    \
-        std::printf("[MIDDLEWARE] %s:%d %s: " fmt, __FILE__, __LINE__,      \
-                    __func__ , ##__VA_ARGS__);                              \
-        std::fflush(stdout);                                                \
+        char _log_buf[512];                                                 \
+        int _len = std::snprintf(_log_buf, sizeof(_log_buf),                \
+                                 "[PLAYER_IF] %s:%d %s: " fmt,              \
+                                 __FILE__, __LINE__, __func__,              \
+                                 ##__VA_ARGS__);                            \
+        if (_len > 0) {                                                     \
+            (void)write(STDERR_FILENO, _log_buf,                            \
+                       (_len < (int)sizeof(_log_buf)) ? _len :             \
+                       (int)sizeof(_log_buf) - 1);                         \
+        }    
     } while (0)
 
 


### PR DESCRIPTION
RDKEMW-16544 : pre logger crash fix
Reason for change : stdio/stderr not available to print logs during initial stages, causes crash
Test Steps : Load Image, Check for vipa_ipa crash during playback start
Signed-off by : R.Naren <naren_ramesh@comcast.com>
