### PR TITLE
VPAAMP-229: [Xione UK]Intermittent Tech Fault error when tuned to VOD

### DIFF
--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -557,7 +557,7 @@ void MediaStreamContext::SignalTrickModeDiscontinuity()
  */
 bool MediaStreamContext::IsAtEndOfTrack()
 {
-	return eosReached;
+	return eosReached.load(std::memory_order_acquire);
 }
 
 /**

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -33,6 +33,7 @@
 #include <iterator>
 #include <vector>
 #include <array>
+#include <atomic>
 #include <condition_variable>
 
 #include <glib.h>
@@ -548,7 +549,10 @@ public:
 	/**
 	 * @brief Returns if the end of track reached.
 	 */
-	virtual bool IsAtEndOfTrack() { return eosReached;}
+	virtual bool IsAtEndOfTrack()
+	{
+		return eosReached.load(std::memory_order_acquire);
+	}
 
 	/**
 	 * @fn CheckForFutureDiscontinuity
@@ -779,7 +783,7 @@ private:
 	void ClearMediaHeaderDuration(CachedFragment* cachedFragment);
 
 public:
-	bool eosReached;                    /**< set to true when a vod asset has been played to completion */
+	std::atomic_bool eosReached;        /**< set to true when a vod asset has been played to completion */
 	bool enabled;                       /**< set to true if track is enabled */
 	int numberOfFragmentsCached;        /**< Number of fragments cached in this track*/
 	const char* name;                   /**< Track name used for debugging*/

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -3832,7 +3832,7 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			{
 				for (int i = 0; i < mNumberOfTracks; i++)
 				{
-					mMediaStreamContext[i]->eosReached=true;
+					mMediaStreamContext[i]->eosReached.store(true, std::memory_order_release);
 				}
 				AAMPLOG_WARN("seek target out of range, mark EOS. playTarget:%f End:%f. ",
 					seekPosition, seekWindowEnd);
@@ -9233,11 +9233,11 @@ bool StreamAbstractionAAMP_MPD::CheckEndOfStream(bool waitForAdBreakCatchup)
 		// During rewind, due to miscalculations in fragmentTime, we could end up exiting collector loop without pushing EOS
 		// For the time being, will check additionally here to push EOS
 		if ((mPlayRate < AAMP_NORMAL_PLAY_RATE && mIterPeriodIndex < 0) &&
-			(!mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached))
+			(!mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached.load(std::memory_order_acquire)))
 		{
 			AAMPLOG_INFO("EOS Reached. mPlayRate=%f mIterPeriodIndex=%d", mPlayRate, mIterPeriodIndex);
 			auto dashWorkerJob = std::make_shared<AampDashWorkerJob>([this]() {
-				mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
+				mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached.store(true, std::memory_order_release);
 				mMediaStreamContext[eMEDIATYPE_VIDEO]->AbortWaitForCachedAndFreeFragment(false);
 				AAMPLOG_INFO("Video EOS Marked after checking EOS on manifest");
 			});
@@ -10019,7 +10019,7 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 						if (vEos)
 						{
 							auto dashWorkerJob = std::make_shared<AampDashWorkerJob>([this]() {
-								mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
+								mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached.store(true, std::memory_order_release);
 								mMediaStreamContext[eMEDIATYPE_VIDEO]->AbortWaitForCachedAndFreeFragment(false);
 								AAMPLOG_INFO("Video EOS Marked");
 							});
@@ -10038,7 +10038,7 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 							if (mMediaStreamContext[eMEDIATYPE_AUDIO]->eos)
 							{
 								auto dashWorkerJob = std::make_shared<AampDashWorkerJob>([this]() {
-									mMediaStreamContext[eMEDIATYPE_AUDIO]->eosReached = true;
+									mMediaStreamContext[eMEDIATYPE_AUDIO]->eosReached.store(true, std::memory_order_release);
 									mMediaStreamContext[eMEDIATYPE_AUDIO]->AbortWaitForCachedAndFreeFragment(false);
 									AAMPLOG_INFO("Audio EOS Marked");
 								});
@@ -10309,7 +10309,7 @@ void StreamAbstractionAAMP_MPD::TsbReader()
 					{
 						// Mark trickplay EOS and inform injector to perform seek or seek to live
 						AAMPLOG_INFO("Reader at EOS while trickplay");
-						mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
+						mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached.store(true, std::memory_order_release);
 						mMediaStreamContext[eMEDIATYPE_VIDEO]->AbortWaitForCachedAndFreeFragment(false);
 						breakLoop = true;
 					}
@@ -10736,7 +10736,7 @@ void StreamAbstractionAAMP_MPD::StartFromAampLocalTsb(void)
 			mMediaStreamContext[i]->SetCachedFragmentSize(static_cast<size_t>(GETCONFIGVALUE(eAAMPConfig_MaxFragmentCached)));
 		}
 
-		mMediaStreamContext[i]->eosReached = false;
+		mMediaStreamContext[i]->eosReached.store(false, std::memory_order_release);
 		if(aamp->IsPlayEnabled())
 		{
 			aamp->ResumeTrackInjection((AampMediaType) i);

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7756,6 +7756,10 @@ void PrivateInstanceAAMP::EndOfStreamReached(AampMediaType mediaType)
 			SetState(eSTATE_PLAYING);
 		}
 	}
+	else
+	{
+		AAMPLOG_WARN("End of stream reached for media type %d", mediaType);
+	}
 }
 
 /**

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -708,9 +708,10 @@ bool MediaTrack::WaitForCachedFragmentAvailable()
 
 	if ((numberOfFragmentsCached == 0) && !(abort || abortInject))
 	{
-		AAMPLOG_DEBUG("## [%s] Waiting for CachedFragment to be available, eosReached=%d ##", name, eosReached);
+		bool eos = eosReached.load(std::memory_order_acquire);
+		AAMPLOG_DEBUG("## [%s] Waiting for CachedFragment to be available, eosReached=%d ##", name, eos);
 
-		if (!eosReached)
+		if (!eos)
 		{
 			fragmentFetched.wait(lock);
 			AAMPLOG_DEBUG("[%s] wait complete for fragmentFetched", name);
@@ -1552,7 +1553,7 @@ bool MediaTrack::SignalIfEOSReached()
 {
 	bool ret = false;
 	//EOS should not be triggered when subtitle sets its "eosReached" in any circumstances
-	if (eosReached && (eTRACK_SUBTITLE != type))
+	if (eosReached.load(std::memory_order_acquire) && (eTRACK_SUBTITLE != type))
 	{
 		//Save the playback rate prior to sending EOS
 		StreamAbstractionAAMP* pContext = GetContext();
@@ -1573,6 +1574,10 @@ bool MediaTrack::SignalIfEOSReached()
 		{
 			AAMPLOG_WARN("GetContext is null");  //CID:81799 - Null Return
 		}
+	}
+	else
+	{
+		AAMPLOG_WARN("media type %d, EOS not Reached %d", type, eosReached.load(std::memory_order_acquire));
 	}
 	return ret;
 }


### PR DESCRIPTION
Reason for change: End of stream not notified during the Preroll AD playback caused this issue. Changed eosReached variable in MediaTrack class to atomic_bool to avoid any data race.