### PR TITLE
VPAAMP-490: Prioritize latencyParams present in manifest over init config

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -13722,45 +13722,45 @@ AAMPStatusType  StreamAbstractionAAMP_MPD::EnableAndSetLiveOffsetForLLDashPlayba
 
 			AAMPLOG_INFO("StreamAbstractionAAMP_MPD: Current Offset(s): %ld",(long)currentOffset);
 
-			if(	stLLServiceData.minLatency <= 0)
+			// Use configured values (which incorporate manifest values via stream settings
+			// and respect config priority). Fall back to defaults if invalid.
+			if (minLatency > 0)
 			{
-				if(minLatency <= 0 || minLatency > targetLatency )
-				{
-					stLLServiceData.minLatency = DEFAULT_MIN_LOW_LATENCY*1000;
-				}
-				else
-				{
-					stLLServiceData.minLatency = minLatency*1000;
-				}
+				stLLServiceData.minLatency = minLatency * 1000;
 			}
-			if(	stLLServiceData.maxLatency <= 0 ||
-				stLLServiceData.maxLatency < stLLServiceData.minLatency )
+			else if (stLLServiceData.minLatency <= 0)
 			{
-				if( maxLatency <=0 || maxLatency < minLatency )
-				{
-					stLLServiceData.maxLatency = DEFAULT_MAX_LOW_LATENCY*1000;
-					stLLServiceData.minLatency = DEFAULT_MIN_LOW_LATENCY*1000;
-				}
-				else
-				{
-					stLLServiceData.maxLatency = maxLatency*1000;
-				}
+				stLLServiceData.minLatency = DEFAULT_MIN_LOW_LATENCY * 1000;
 			}
-			if(	stLLServiceData.targetLatency <= 0 ||
-				stLLServiceData.targetLatency < stLLServiceData.minLatency ||
-				stLLServiceData.targetLatency > stLLServiceData.maxLatency )
 
+			if (targetLatency > 0)
 			{
-				if(targetLatency <=0 || targetLatency < minLatency || targetLatency > maxLatency )
-				{
-					stLLServiceData.targetLatency = DEFAULT_TARGET_LOW_LATENCY*1000;
-					stLLServiceData.maxLatency = DEFAULT_MAX_LOW_LATENCY*1000;
-					stLLServiceData.minLatency = DEFAULT_MIN_LOW_LATENCY*1000;
-				}
-				else
-				{
-					stLLServiceData.targetLatency = targetLatency*1000;
-				}
+				stLLServiceData.targetLatency = targetLatency * 1000;
+			}
+			else if (stLLServiceData.targetLatency <= 0)
+			{
+				stLLServiceData.targetLatency = DEFAULT_TARGET_LOW_LATENCY * 1000;
+			}
+
+			if (maxLatency > 0)
+			{
+				stLLServiceData.maxLatency = maxLatency * 1000;
+			}
+			else if (stLLServiceData.maxLatency <= 0)
+			{
+				stLLServiceData.maxLatency = DEFAULT_MAX_LOW_LATENCY * 1000;
+			}
+
+			// Consistency check: ensure min <= target <= max, otherwise reset to defaults
+			if (stLLServiceData.minLatency > stLLServiceData.targetLatency ||
+				stLLServiceData.targetLatency > stLLServiceData.maxLatency ||
+				stLLServiceData.maxLatency < stLLServiceData.minLatency)
+			{
+				AAMPLOG_WARN("Inconsistent LL-DASH latency values. Resetting to defaults (min: %d, target: %d, max: %d)",
+					stLLServiceData.minLatency, stLLServiceData.targetLatency, stLLServiceData.maxLatency);
+				stLLServiceData.targetLatency = DEFAULT_TARGET_LOW_LATENCY * 1000;
+				stLLServiceData.maxLatency = DEFAULT_MAX_LOW_LATENCY * 1000;
+				stLLServiceData.minLatency = DEFAULT_MIN_LOW_LATENCY * 1000;
 			}
 			double latencyOffsetMin = stLLServiceData.minLatency/(double)1000;
 			double latencyOffsetMax = stLLServiceData.maxLatency/(double)1000;
@@ -13949,6 +13949,7 @@ bool StreamAbstractionAAMP_MPD::ParseMPDLLData(MPD* mpd, AampLLDashServiceData &
 			{
 				stAampLLDashServiceData.targetLatency = latency->GetTarget();
 				AAMPLOG_INFO("targetLatency: %d", stAampLLDashServiceData.targetLatency);
+				SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_LLTargetLatency, stAampLLDashServiceData.targetLatency / 1000.0);
 			}
 
 			//check if attribute @max or @min is available in <Latency> element->raise info if not
@@ -13960,6 +13961,7 @@ bool StreamAbstractionAAMP_MPD::ParseMPDLLData(MPD* mpd, AampLLDashServiceData &
 			{
 				stAampLLDashServiceData.maxLatency = latency->GetMax();
 				AAMPLOG_INFO("maxLatency: %d", stAampLLDashServiceData.maxLatency);
+				SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_LLMaxLatency, stAampLLDashServiceData.maxLatency / 1000.0);
 			}
 			if(attributeMap.find("min") == attributeMap.end())
 			{
@@ -13969,6 +13971,7 @@ bool StreamAbstractionAAMP_MPD::ParseMPDLLData(MPD* mpd, AampLLDashServiceData &
 			{
 				stAampLLDashServiceData.minLatency = latency->GetMin();
 				AAMPLOG_INFO("minLatency: %d", stAampLLDashServiceData.minLatency);
+				SETCONFIGVALUE(AAMP_STREAM_SETTING, eAAMPConfig_LLMinLatency, stAampLLDashServiceData.minLatency / 1000.0);
 			}
 		}
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -5135,7 +5135,7 @@ R"(<?xml version="1.0" encoding="utf-8"?>
  * Parameter: pair<TuneType, bool> where bool indicates if CheckForAdStart should be called.
  */
 class CDAIInitTuneTypeTests : public FunctionalTestsBase,
-							  public ::testing::TestWithParam<std::pair<TuneType, bool>>
+						  public ::testing::TestWithParam<std::pair<TuneType, bool>>
 {
 protected:
 	void SetUp() override
@@ -5217,3 +5217,191 @@ INSTANTIATE_TEST_SUITE_P(AllTuneTypes,
 							std::make_pair(eTUNETYPE_RETUNE, true),
 							std::make_pair(eTUNETYPE_SEEKTOEND, true)
 						));
+
+/**
+ * @brief Verify ParseMPDLLData parses target, min, and max latency from ServiceDescription
+ * and sets them as stream config values.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_SetsLatencyConfigs)
+{
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:01.890Z" id="1" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" type="dynamic" profiles="urn:mpeg:dash:profile:full:2011" publishTime="2026-05-21T18:01:14Z" timeShiftBufferDepth="PT30S">
+	<ServiceDescription id="0">
+		<Latency target="3500" min="2000" max="6000"/>
+		<PlaybackRate min="0.9" max="1.1"/>
+	</ServiceDescription>
+	<Period id="1" start="PT0S">
+		<AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate timescale="1000" duration="2000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1280" height="720"/>
+		</AdaptationSet>
+		<AdaptationSet id="2" contentType="audio" mimeType="audio/mp4">
+			<SegmentTemplate timescale="48000" duration="96000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000"/>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	mManifest = manifest;
+	ManifestDownloadResponsePtr response = GetManifestForMPDDownloader();
+	ASSERT_NE(response, nullptr);
+	ASSERT_NE(response->mMPDInstance.get(), nullptr);
+
+	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
+
+	AampLLDashServiceData llData;
+	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
+
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLTargetLatency, 3.5));
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMinLatency, 2.0));
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMaxLatency, 6.0));
+
+	bool result = mStreamAbstractionAAMP_MPD->CallParseMPDLLData(mpd, llData);
+
+	EXPECT_TRUE(result);
+	EXPECT_EQ(llData.targetLatency, 3500);
+	EXPECT_EQ(llData.minLatency, 2000);
+	EXPECT_EQ(llData.maxLatency, 6000);
+	EXPECT_DOUBLE_EQ(llData.maxPlaybackRate, 1.1);
+	EXPECT_DOUBLE_EQ(llData.minPlaybackRate, 0.9);
+}
+
+/**
+ * @brief Verify ParseMPDLLData handles manifest with only target latency
+ * (no min/max) and sets only the target config.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_OnlyTargetLatency)
+{
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:01.890Z" id="1" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" type="dynamic" profiles="urn:mpeg:dash:profile:full:2011" publishTime="2026-05-21T18:01:14Z" timeShiftBufferDepth="PT30S">
+	<ServiceDescription id="0">
+		<Latency target="4000"/>
+	</ServiceDescription>
+	<Period id="1" start="PT0S">
+		<AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate timescale="1000" duration="2000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1280" height="720"/>
+		</AdaptationSet>
+		<AdaptationSet id="2" contentType="audio" mimeType="audio/mp4">
+			<SegmentTemplate timescale="48000" duration="96000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000"/>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	mManifest = manifest;
+	ManifestDownloadResponsePtr response = GetManifestForMPDDownloader();
+	ASSERT_NE(response, nullptr);
+	ASSERT_NE(response->mMPDInstance.get(), nullptr);
+
+	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
+
+	AampLLDashServiceData llData;
+	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
+
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLTargetLatency, 4.0));
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMinLatency, _)).Times(0);
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMaxLatency, _)).Times(0);
+
+	bool result = mStreamAbstractionAAMP_MPD->CallParseMPDLLData(mpd, llData);
+
+	EXPECT_TRUE(result);
+	EXPECT_EQ(llData.targetLatency, 4000);
+	EXPECT_EQ(llData.minLatency, 0);
+	EXPECT_EQ(llData.maxLatency, 0);
+}
+
+/**
+ * @brief Verify ParseMPDLLData handles manifest with no ServiceDescription element.
+ * No config values should be set.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_NoServiceDescription)
+{
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:01.890Z" id="1" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" type="dynamic" profiles="urn:mpeg:dash:profile:full:2011" publishTime="2026-05-21T18:01:14Z" timeShiftBufferDepth="PT30S">
+	<Period id="1" start="PT0S">
+		<AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate timescale="1000" duration="2000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1280" height="720"/>
+		</AdaptationSet>
+		<AdaptationSet id="2" contentType="audio" mimeType="audio/mp4">
+			<SegmentTemplate timescale="48000" duration="96000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000"/>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	mManifest = manifest;
+	ManifestDownloadResponsePtr response = GetManifestForMPDDownloader();
+	ASSERT_NE(response, nullptr);
+	ASSERT_NE(response->mMPDInstance.get(), nullptr);
+
+	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
+
+	AampLLDashServiceData llData;
+	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
+
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLTargetLatency, _)).Times(0);
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMinLatency, _)).Times(0);
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMaxLatency, _)).Times(0);
+
+	bool result = mStreamAbstractionAAMP_MPD->CallParseMPDLLData(mpd, llData);
+
+	EXPECT_TRUE(result);
+	EXPECT_EQ(llData.targetLatency, 0);
+	EXPECT_EQ(llData.minLatency, 0);
+	EXPECT_EQ(llData.maxLatency, 0);
+}
+
+/**
+ * @brief Verify ParseMPDLLData handles manifest with no Latency element in ServiceDescription.
+ * PlaybackRate values should still be parsed.
+ */
+TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_NoLatencyElement)
+{
+	static const char *manifest =
+		R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" availabilityStartTime="2023-01-01T00:00:01.890Z" id="1" maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="P100Y" type="dynamic" profiles="urn:mpeg:dash:profile:full:2011" publishTime="2026-05-21T18:01:14Z" timeShiftBufferDepth="PT30S">
+	<ServiceDescription id="0">
+		<PlaybackRate min="0.95" max="1.05"/>
+	</ServiceDescription>
+	<Period id="1" start="PT0S">
+		<AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+			<SegmentTemplate timescale="1000" duration="2000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="v1" bandwidth="1000000" codecs="avc1.640028" width="1280" height="720"/>
+		</AdaptationSet>
+		<AdaptationSet id="2" contentType="audio" mimeType="audio/mp4">
+			<SegmentTemplate timescale="48000" duration="96000" initialization="init-$RepresentationID$.m4s" media="chunk-$RepresentationID$-$Number$.m4s" startNumber="1"/>
+			<Representation id="a1" bandwidth="128000" codecs="mp4a.40.2" audioSamplingRate="48000"/>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	mManifest = manifest;
+	ManifestDownloadResponsePtr response = GetManifestForMPDDownloader();
+	ASSERT_NE(response, nullptr);
+	ASSERT_NE(response->mMPDInstance.get(), nullptr);
+
+	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
+
+	AampLLDashServiceData llData;
+	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
+
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLTargetLatency, _)).Times(0);
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMinLatency, _)).Times(0);
+	EXPECT_CALL(*g_mockAampConfig, SetConfigValue(eAAMPConfig_LLMaxLatency, _)).Times(0);
+
+	bool result = mStreamAbstractionAAMP_MPD->CallParseMPDLLData(mpd, llData);
+
+	EXPECT_TRUE(result);
+	EXPECT_EQ(llData.targetLatency, 0);
+	EXPECT_DOUBLE_EQ(llData.maxPlaybackRate, 1.05);
+	EXPECT_DOUBLE_EQ(llData.minPlaybackRate, 0.95);
+}

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -5249,8 +5249,6 @@ TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_SetsLatencyConfigs)
 	ASSERT_NE(response, nullptr);
 	ASSERT_NE(response->mMPDInstance.get(), nullptr);
 
-	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
-
 	AampLLDashServiceData llData;
 	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
 
@@ -5298,8 +5296,6 @@ TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_OnlyTargetLatency)
 	ASSERT_NE(response, nullptr);
 	ASSERT_NE(response->mMPDInstance.get(), nullptr);
 
-	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
-
 	AampLLDashServiceData llData;
 	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
 
@@ -5341,8 +5337,6 @@ TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_NoServiceDescription)
 	ManifestDownloadResponsePtr response = GetManifestForMPDDownloader();
 	ASSERT_NE(response, nullptr);
 	ASSERT_NE(response->mMPDInstance.get(), nullptr);
-
-	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
 
 	AampLLDashServiceData llData;
 	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());
@@ -5388,8 +5382,6 @@ TEST_F(StreamAbstractionAAMP_MPDTest, ParseMPDLLData_NoLatencyElement)
 	ManifestDownloadResponsePtr response = GetManifestForMPDDownloader();
 	ASSERT_NE(response, nullptr);
 	ASSERT_NE(response->mMPDInstance.get(), nullptr);
-
-	ASSERT_EQ(mStreamAbstractionAAMP_MPD->CallGetMPDFromManifest(response, false), eAAMPSTATUS_OK);
 
 	AampLLDashServiceData llData;
 	MPD *mpd = static_cast<MPD *>(response->mMPDInstance.get());


### PR DESCRIPTION
Reason for change: When latencyParams are present in the manifest, they should take precedence over the values provided in the initialization configuration. This change ensures that the player uses the most accurate and up-to-date latency parameters as specified by the content provider, leading to improved performance and user experience. Risks: Low
Test Procedure: Test with LLD streams
Priority: P1

Change-Id: I6a1efdee4c654012377604c31e9a221cd70aea68