### PR TITLE
VPAAMP-513: Fix SetCurlTimeout no-op on Stop due to late SetLLDashChunkMode call

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4199,7 +4199,7 @@ bool PrivateInstanceAAMP::SetCurlTimeout(long timeoutMS, AampCurlInstance instan
 	}
 	else
 	{
-		AAMPLOG_ERR("Failed to update timeout for curl instance %d",instance);
+		AAMPLOG_WARN("SetCurlTimeout: curl[%d] not initialized, skipping timeout update",instance);
 	}
 
 	return timeoutChanged;
@@ -8458,6 +8458,7 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 			}
 		}
 	}
+	SetLLDashChunkMode(false); //Reset ChunkMode before curl handles are torn down
 	TeardownStream(true,true); //disable download as well
 	
 	// Moved the tsb delete request from XRE to AAMP to avoid the HTTP-404 errors
@@ -8547,7 +8548,6 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	mPreferredTextTrack = TextTrackInfo(); // reset
 	// send signal to any thread waiting for play
 	mDiscontinuityFound = false;
-	SetLLDashChunkMode(false); //Reset ChunkMode
 	{
 		std::lock_guard<std::mutex> guard(mMutexPlaystart);
 		waitforplaystart.notify_all();

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -4190,16 +4190,20 @@ bool PrivateInstanceAAMP::SetCurlTimeout(long timeoutMS, AampCurlInstance instan
 	if(ContentType_EAS == mContentType)
 		return false;
 
-	if(instance < eCURLINSTANCE_MAX && curl[instance])
+	if(instance >= eCURLINSTANCE_MAX)
 	{
-		timeoutChanged = (curlDLTimeout[instance] != timeoutMS); // return true if the timeout is changing
-		
-		CURL_EASY_SETOPT_LONG(curl[instance], CURLOPT_TIMEOUT_MS, timeoutMS);
-		curlDLTimeout[instance] = timeoutMS;
+		AAMPLOG_ERR("SetCurlTimeout: curl instance %d is out of range (max %d)", instance, eCURLINSTANCE_MAX);
+	}
+	else if(!curl[instance])
+	{
+		AAMPLOG_WARN("SetCurlTimeout: curl[%d] not initialized, skipping timeout update", instance);
 	}
 	else
 	{
-		AAMPLOG_WARN("SetCurlTimeout: curl[%d] not initialized, skipping timeout update",instance);
+		timeoutChanged = (curlDLTimeout[instance] != timeoutMS); // return true if the timeout is changing
+
+		CURL_EASY_SETOPT_LONG(curl[instance], CURLOPT_TIMEOUT_MS, timeoutMS);
+		curlDLTimeout[instance] = timeoutMS;
 	}
 
 	return timeoutChanged;


### PR DESCRIPTION
SetLLDashChunkMode(false) was called after TeardownStream() in Stop(), by which point CurlTerm() had already nulled out curl[0..AAMP_TRACK_COUNT-1]. The else-branch in SetCurlTimeout logged an error (now WARN) for each null handle, and the intended timeout restore was silently skipped.

Fix: move SetLLDashChunkMode(false) to immediately before TeardownStream() so the curl handles are still alive when the timeout values are restored.

Also downgrade the no-handle diagnostic in SetCurlTimeout from ERR to WARN with a clearer message (curl handle not initialized, skipping timeout update) since the condition is benign.