### PR TITLE
VPAAMP-528 address compilation warnings from tip of sprint (unused functions/variables, incompatible types, and potential null pointer dereferences)

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1019,6 +1019,7 @@ void AAMPGstPlayer::FlushTrack(AampMediaType type,double pos)
 	double audioDelta = aamp->mAudioDelta;
 	double subDelta = aamp->mSubtitleDelta;
 	double rate = playerInstance->FlushTrack(mediaType, pos, audioDelta, subDelta);
+	(void)rate;
 }
 
 /**

--- a/downloader/AampCurlDownloader.cpp
+++ b/downloader/AampCurlDownloader.cpp
@@ -354,7 +354,7 @@ int AampCurlDownloader::Download(const std::string &urlStr, std::shared_ptr<Down
 								mDownloadResponse->iHttpRetValue >= 500 ))
 						{
 							AAMPLOG_WARN("Download failed due to Server error http-%d numDownloadAttempts %d numRetriesAllowed %d",mDownloadResponse->iHttpRetValue,numDownloadAttempts,numRetriesAllowed);
-							int retryDelayMs = (mDownloadResponse->iHttpRetValue == 502) ? mDnldCfg->iDownload502RetryWaitMs : mDnldCfg->iDownloadRetryWaitMs;
+							int retryDelayMs = mDnldCfg ? ((mDownloadResponse->iHttpRetValue == 502) ? mDnldCfg->iDownload502RetryWaitMs : mDnldCfg->iDownloadRetryWaitMs) : 0;
 							std::this_thread::sleep_for(std::chrono::milliseconds(retryDelayMs));
 							loopAgain = true; //retry on manifest download failure
 							// In the unlikely event that we get http failure status and also a http body then the

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7323,7 +7323,7 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 	// set to 1 at trick-play only when an iframe track is found, which also sets
 	// mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled=true, making !enabled false.
 	// At normal play rate all contexts are allocated, so the dereference is safe.
-	if(1 == mNumberOfTracks && !mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled)
+	if(1 == mNumberOfTracks && mMediaStreamContext[eMEDIATYPE_VIDEO] && !mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled)
 	{ // what about audio+subtitles?
 		if(newTune)
 		{
@@ -7331,13 +7331,16 @@ void StreamAbstractionAAMP_MPD::StreamSelection( bool newTune, bool forceSpeedsC
 			// set audio only playback flag to true
 			aamp->mAudioOnlyPb = true;
 		}
-		mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled = mMediaStreamContext[eMEDIATYPE_AUDIO]->enabled;
-		mMediaStreamContext[eMEDIATYPE_VIDEO]->adaptationSetIdx = mMediaStreamContext[eMEDIATYPE_AUDIO]->adaptationSetIdx;
-		mMediaStreamContext[eMEDIATYPE_VIDEO]->representationIndex = mMediaStreamContext[eMEDIATYPE_AUDIO]->representationIndex;
-		mMediaStreamContext[eMEDIATYPE_VIDEO]->mediaType = eMEDIATYPE_VIDEO;
-		mMediaStreamContext[eMEDIATYPE_VIDEO]->type = eTRACK_VIDEO;
-		mMediaStreamContext[eMEDIATYPE_VIDEO]->profileChanged = true;
-		mMediaStreamContext[eMEDIATYPE_AUDIO]->enabled = false;
+		if(mMediaStreamContext[eMEDIATYPE_AUDIO])
+		{
+			mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled = mMediaStreamContext[eMEDIATYPE_AUDIO]->enabled;
+			mMediaStreamContext[eMEDIATYPE_VIDEO]->adaptationSetIdx = mMediaStreamContext[eMEDIATYPE_AUDIO]->adaptationSetIdx;
+			mMediaStreamContext[eMEDIATYPE_VIDEO]->representationIndex = mMediaStreamContext[eMEDIATYPE_AUDIO]->representationIndex;
+			mMediaStreamContext[eMEDIATYPE_VIDEO]->mediaType = eMEDIATYPE_VIDEO;
+			mMediaStreamContext[eMEDIATYPE_VIDEO]->type = eTRACK_VIDEO;
+			mMediaStreamContext[eMEDIATYPE_VIDEO]->profileChanged = true;
+			mMediaStreamContext[eMEDIATYPE_AUDIO]->enabled = false;
+		}
 	}
 	// Set audio/text track related structures
 	SetAudioTrackInfo(aTracks, aTrackIdx);

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -1328,7 +1328,7 @@ int IsoBmffBuffer::getLastMdatBoxIndex() const
 	{
 		if (IS_TYPE(boxes.at(i)->getType(), Box::MDAT))
 		{
-			index = (int)i;
+			index = static_cast<int>(i);
 		}
 	}
 	return index;

--- a/isobmff/isobmffbuffer.cpp
+++ b/isobmff/isobmffbuffer.cpp
@@ -1328,7 +1328,7 @@ int IsoBmffBuffer::getLastMdatBoxIndex() const
 	{
 		if (IS_TYPE(boxes.at(i)->getType(), Box::MDAT))
 		{
-			index = i;
+			index = (int)i;
 		}
 	}
 	return index;

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -548,7 +548,7 @@ void MediaTrack::UpdateTSAfterFetchStats(CachedFragment* cachedFragment, bool is
 		NotifyCachedAudioFragmentAvailable();
 		loadNewAudio = false;
 		// Re-enable latency rate correction after audio track switch only if it was previously enabled.
-		if (pContext->mSavedLatencyMonitorState )
+		if (pContext && pContext->mSavedLatencyMonitorState )
 		{
 			aamp->EnableLatencyMonitor(true);
 			pContext->mSavedLatencyMonitorState  = false;
@@ -1231,16 +1231,6 @@ void MediaTrack::TrickModePtsRestamp(CachedFragment *cachedFragment)
 {
 	TrickModePtsRestamp(cachedFragment->fragment, cachedFragment->position, cachedFragment->duration,
 						cachedFragment->initFragment, cachedFragment->discontinuity);
-}
-
-static bool isWebVttSegment( const char *buffer, size_t bufferLen )
-{
-	if( bufferLen>=3 && buffer[0]==(char)0xEF && buffer[1]==(char)0xBB && buffer[2]==(char)0xBF )
-	{ // skip UTF-8 BOM if present
-		buffer += 3;
-		bufferLen -= 3;
-	}
-	return bufferLen>=6 && memcmp(buffer,"WEBVTT",6)==0;
 }
 
 void MediaTrack::ClearMediaHeaderDuration(CachedFragment *fragment)


### PR DESCRIPTION
Reason for Change: Xcode static code analysis cites several problems with current sprint
