### PR TITLE
Revert "VPAAMP-522 Building for macOS-15.6, but linking with dylib '/opt/homebrew/opt/gstreamer/lib/libgstvideo-1.0.0.dylib' which was built for newer version 26.0"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,7 @@ endif()
 
 # Platform specific settings
 if(APPLE)
-	if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
-		set(CMAKE_OSX_DEPLOYMENT_TARGET "26.0")
-	endif()
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "15.6")
 	set(CMAKE_C_COMPILER "/usr/bin/cc")
 	set(CMAKE_CXX_COMPILER "/usr/bin/c++")
 

--- a/scripts/install_aampcli.sh
+++ b/scripts/install_aampcli.sh
@@ -126,7 +126,6 @@ function aampcli_install_build_darwin_fn()
         -DUTEST_ENABLED=ON \
         -DCMAKE_INBUILT_AAMP_DEPENDENCIES=1 \
         -DCMAKE_ENABLE_PTS_RESTAMP:BOOL=TRUE \
-        -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-26.0}" \
         -DCMAKE_XCODE_ATTRIBUTE_SYMROOT="${AAMP_DIR}/build/XcodeDerivedData" \
         -DCMAKE_XCODE_ATTRIBUTE_OBJROOT="${AAMP_DIR}/build/XcodeDerivedData" \
         $(if [ "${OPTION_PLAYER_INTERFACE_SOURCE}" = "external" ]; then echo "-DCMAKE_EXTERNAL_PLAYER_INTERFACE_DEPENDENCIES=ON"; fi) \


### PR DESCRIPTION
Reverts rdkcentral/aamp#1555

**-lgstvideo-1.0 is only added when CMAKE_USE_OPENCDM_ADAPTER is set. The Xcode build (install-aamp.sh simulator path) apparently includes that flag but the Xcode linker can't find the library via -l lookup. The library exists at the full path, so it's a library search path issue specific to the Xcode generator — the -L flag for the GStreamer Cellar directory is not being passed to the Xcode linker for this target. This is a pre-existing interaction between VPAAMP-522's deployment-target change and the Xcode project generator