### PR TITLE
VPAAMP-470: [Timeshift DAI] Confirm TimedMetadata is reported in Hot/Cold CDVR/iVOD cases

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -383,6 +383,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "logFilename", eAAMPConfig_LogFilename, false},
 	{false, "processLicenseFromEAP", eAAMPConfig_ProcessLicenseFromEAP, false},
 	{false, "monitorMp4Integrity", eAAMPConfig_MonitorMp4Integrity, false},
+	{false, "enableTimeshiftDAI", eAAMPConfig_EnableTimeshiftDAI, false},
 };
 
 #define CONFIG_INT_ALIAS_COUNT 2

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -235,6 +235,7 @@ typedef enum
 	eAAMPConfig_LogFilename,				/**< Config to include source filename in log output */
 	eAAMPConfig_ProcessLicenseFromEAP,			/**< Config to enable non-VSS early available period DRM prefetch */
 	eAAMPConfig_MonitorMp4Integrity,			/**< Parse every downloaded video/audio segment with Mp4Demux; log each segment, write corrupt ones to harvestPath */
+	eAAMPConfig_EnableTimeshiftDAI,				/**< Enable Timeshift DAI: suppress timed metadata events before seek position for CDVR/iVOD */
 	eAAMPConfig_BoolMaxValue				/**< Max value of bool config always last element */	
 
 } AAMPConfigSettingBool;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -5328,6 +5328,16 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 					AAMPLOG_INFO("SCTEDBG adjust start time %" PRIu64 " -> %" PRIu64 " (duration %d)", eventInfo.presentationTime, eventStartTime, eventInfo.duration);
 				}
 
+				// [Timeshift DAI] For CDVR/iVOD recorded assets: only notify timed metadata for
+				// SCTE triggers encountered in the forward direction from the resumed playback position.
+				if (ISCONFIGSET(eAAMPConfig_EnableTimeshiftDAI) && (aamp->IsCDVRContent() || aamp->IsIVODContent()) &&
+				    seekPosition > 0.0 && static_cast<double>(eventStartTime) < seekPosition * 1000.0)
+				{
+					AAMPLOG_INFO("Timeshift DAI: skipping past SCTE event at %" PRIu64 "ms for %s content (seekPosition=%.3fs)",
+					             eventStartTime, aamp->IsCDVRContent() ? "CDVR" : "iVOD", seekPosition);
+					continue;
+				}
+
 				//for livestream send the timedMetadata only., because at init, control does not come here
 				if(mIsLiveManifest && ! ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive))
 				{


### PR DESCRIPTION
Reason for change: Added a check to report only future Ad events 
Test Procedure: Refer Jira ticket VPAAMP-470
Priority: P2