### PR TITLE
VPAAMP-528 fix null pointer dereference of pContext before track switch latency monitor re-enable 

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -568,7 +568,7 @@ void MediaTrack::UpdateTSAfterFetchStats(CachedFragment* cachedFragment, bool is
 		NotifyCachedSubtitleFragmentAvailable();
 		loadNewSubtitle = false;
 		// Re-enable latency rate correction after subtitle track switch only if it was previously enabled.
-		if (pContext->mSavedLatencyMonitorState )
+		if (pContext && pContext->mSavedLatencyMonitorState )
 		{
 			aamp->EnableLatencyMonitor(true);
 			pContext->mSavedLatencyMonitorState  = false;


### PR DESCRIPTION
Reason for Change: patch a gap in previous null guard fix