### PR TITLE
VPAAMP-261: AAMP_EVENT_TUNE_TIME_METRICS dispatched before PLAYING state event (#1485)

### DIFF
--- a/AampEvent.cpp
+++ b/AampEvent.cpp
@@ -1655,8 +1655,8 @@ uint32_t ManifestRefreshEvent::getManifestPublishedTime() const
 /**
  * @brief TuneTimeMetricsEvent Constructor
  */
-TuneTimeMetricsEvent::TuneTimeMetricsEvent(const std::string &timeMetricData, std::string sid):
-		AAMPEventObject(AAMP_EVENT_TUNE_TIME_METRICS, std::move(sid)), mTuneMetricsData(timeMetricData)
+TuneTimeMetricsEvent::TuneTimeMetricsEvent(std::string &&tuneMetricData, std::string sid):
+		AAMPEventObject(AAMP_EVENT_TUNE_TIME_METRICS, std::move(sid)), mTuneMetricsData(std::move(tuneMetricData))
 {
 
 }

--- a/AampEvent.h
+++ b/AampEvent.h
@@ -2429,9 +2429,9 @@ public:
 	/**
 	 * @fn TuneTimeMetricsEvent
 	 *
-	 * @param[in] profilingData - tune profiling data
+	 * @param[in] tuneMetricData - tune profiling data
 	 */
-	TuneTimeMetricsEvent(const std::string &profilingData, std::string sid);
+	TuneTimeMetricsEvent(std::string &&tuneMetricData, std::string sid);
 
 	/**
 	 * @brief TuneTimeMetricsEvent Destructor

--- a/AampProfiler.cpp
+++ b/AampProfiler.cpp
@@ -45,8 +45,8 @@ ProfileEventAAMP::ProfileEventAAMP():
 }
 
 std::string ProfileEventAAMP::GetTuneTimeMetricAsJson(TuneEndMetrics tuneMetricsData, const char *tuneTimeStrPrefix,
-				unsigned int licenseAcqNWTime, bool playerPreBuffered,
-				unsigned int durationSeconds, bool interfaceWifi, std::string failureReason, std::string appName)
+				bool playerPreBuffered, unsigned int durationSeconds, bool interfaceWifi,
+				std::string failureReason, std::string appName)
 {
 	//Convert to JSON format
 	std::string metrics = "";
@@ -98,7 +98,7 @@ std::string ProfileEventAAMP::GetTuneTimeMetricAsJson(TuneEndMetrics tuneMetrics
 	cJSON_AddNumberToObject(item, "dfe", drmErrorCode);
 
 	cJSON_AddNumberToObject(item, "lpr", bucketDuration(PROFILE_BUCKET_LA_PREPROC));
-	cJSON_AddNumberToObject(item, "lnw", licenseAcqNWTime);
+	cJSON_AddNumberToObject(item, "lnw", bucketDuration(PROFILE_BUCKET_LA_NETWORK));
 	cJSON_AddNumberToObject(item, "lps", bucketDuration(PROFILE_BUCKET_LA_POSTPROC));
 
 	cJSON_AddNumberToObject(item, "vdd", bucketDuration(PROFILE_BUCKET_DECRYPT_VIDEO));
@@ -274,7 +274,6 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 		return;
 	}
 	enabled = false;
-	unsigned int licenseAcqNWTime = bucketDuration(PROFILE_BUCKET_LA_NETWORK);
 	char tuneTimeStrPrefix[128];
 	memset(tuneTimeStrPrefix, '\0', sizeof(tuneTimeStrPrefix));
 	int totalTuneTime = 0;
@@ -286,7 +285,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 	auto tPreBufferStart = buckets[PROFILE_BUCKET_PLAYER_PRE_BUFFERED].tStart;
 	
 	// compute gstreamer decode time, excluding decryption. For clear streams, measure from first buffer start time
-	auto tDecode = tFirstFrameStart - (tDecryptVideoFinish?tDecryptVideoFinish:tFirstBufferStart);
+	auto tDecode = tFirstFrameStart - (tDecryptVideoFinish ? tDecryptVideoFinish : tFirstBufferStart);
 
 	if (mTuneEndMetrics.success > 0)
 	{
@@ -353,7 +352,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 		buckets[PROFILE_BUCKET_FRAGMENT_AUDIO].tStart, bucketDuration(PROFILE_BUCKET_FRAGMENT_AUDIO), buckets[PROFILE_BUCKET_FRAGMENT_AUDIO].errorCount,bandwidthBitsPerSecondAudio,
 
 		buckets[PROFILE_BUCKET_LA_TOTAL].tStart, bucketDuration(PROFILE_BUCKET_LA_TOTAL), drmErrorCode,
-		bucketDuration(PROFILE_BUCKET_LA_PREPROC), licenseAcqNWTime, bucketDuration(PROFILE_BUCKET_LA_POSTPROC),
+		bucketDuration(PROFILE_BUCKET_LA_PREPROC), bucketDuration(PROFILE_BUCKET_LA_NETWORK), bucketDuration(PROFILE_BUCKET_LA_POSTPROC),
 		bucketDuration(PROFILE_BUCKET_DECRYPT_VIDEO),bucketDuration(PROFILE_BUCKET_DECRYPT_AUDIO),
 
 		(playerPreBuffered && mTuneEndMetrics.success > 0) ? tFirstBufferStart - tPreBufferStart : tFirstBufferStart, // gstPlaying: offset in ms from tunestart when pipeline first fed data
@@ -370,7 +369,7 @@ void ProfileEventAAMP::TuneEnd(TuneEndMetrics &mTuneEndMetrics,std::string appNa
 		);
 
 		// Telemetry is generated in GetTuneTimeMetricAsJson hence calling always,
-		std::string metricsDataJson = GetTuneTimeMetricAsJson(mTuneEndMetrics, tuneTimeStrPrefix, licenseAcqNWTime, playerPreBuffered, durationSeconds, interfaceWifi, std::move(failureReason), std::move(appName));
+		std::string metricsDataJson = GetTuneTimeMetricAsJson(mTuneEndMetrics, tuneTimeStrPrefix, playerPreBuffered, durationSeconds, interfaceWifi, std::move(failureReason), std::move(appName));
 
 		// tuneMetricData could be NULL if application has not registered for tuneMetrics event,
 		if( NULL != tuneMetricData)

--- a/AampProfiler.h
+++ b/AampProfiler.h
@@ -329,17 +329,50 @@ public:
 	 * @fn GetTuneMetricInfoasJson
 	 *
 	 * @param[in] tuneMetricsData - tuneend metric data
-	 * @param[in] licenseAcqNWTime - license Acq Network Time
 	 * @param[in] playerPreBuffered - prebuffered mode
 	 * @param[in] durationSeconds - Asset duration in seconds
 	 * @param[in] interfaceWifi - Connection is wifi or not - wifi(1) ethernet(0)
 	 * @param[in] failureReason - Failure Reason
 	 * @param[in] appName - App name
-	 * @return string
+	 * @return JSON-formatted string (unformatted/compact) containing tune-time
+	 *         metrics, with the following keys:
+	 *           "pre" - player-mode prefix (FG/BG)
+	 *           "ver" - tune-time schema version (AAMP_TUNETIME_VERSION)
+	 *           "bld" - AAMP build version string
+	 *           "tbu" - tune start base UTC timestamp (ms)
+	 *           "mms"/"mmt"/"mme" - manifest fetch start/duration/error-count
+	 *           "vps"/"vpt"/"vpe" - video playlist fetch start/duration/error-count
+	 *           "aps"/"apt"/"ape" - audio playlist fetch start/duration/error-count
+	 *           "vis"/"vit"/"vie" - video init fragment start/duration/error-count
+	 *           "ais"/"ait"/"aie" - audio init fragment start/duration/error-count
+	 *           "vfs"/"vft"/"vfe"/"vfb" - video fragment start/duration/error-count/bandwidth (bps)
+	 *           "afs"/"aft"/"afe"/"afb" - audio fragment start/duration/error-count/bandwidth (bps)
+	 *           "las"/"lat" - licence acquisition total start/duration
+	 *           "lpr"/"lnw"/"lps" - licence pre-processing/network/post-processing durations
+	 *           "dfe" - DRM error code
+	 *           "vdd"/"add" - video/audio decrypt durations
+	 *           "gps" - time to first buffer (ms, adjusted for pre-buffered mode)
+	 *           "gff" - time to first frame (ms, adjusted for pre-buffered mode)
+	 *           "gdt" - gap between last decrypt finish and first frame (ms)
+	 *           "cnt" - content type (ContentType enum value)
+	 *           "stt" - stream type
+	 *           "ftt" - first-tune flag (bool)
+	 *           "pbm" - player-pre-buffered mode flag
+	 *           "tpb" - pre-buffered timestamp (ms, 0 if not pre-buffered)
+	 *           "dus" - asset duration (seconds)
+	 *           "ifw" - interface type: wifi(1) / ethernet(0)
+	 *           "tat" - total tune attempt count
+	 *           "tst" - tune success flag
+	 *           "frs" - failure reason string
+	 *           "app" - application name
+	 *           "tsb" - FOG TSB enabled flag
+	 *           "tot" - total tune time (ms)
+	 *           "pst" - stop duration (ms)
+	 *         Returns an empty string if JSON object creation fails.
 	 */
 	std::string GetTuneTimeMetricAsJson(TuneEndMetrics tuneMetricsData, const char *tuneTimeStrPrefix,
-				unsigned int licenseAcqNWTime, bool playerPreBuffered,
-				unsigned int durationSeconds, bool interfaceWifi, std::string failureReason, std::string appName);
+				bool playerPreBuffered, unsigned int durationSeconds, bool interfaceWifi,
+				std::string failureReason, std::string appName);
 
 	/**
 	 * @fn TuneBegin

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1302,6 +1302,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, mIsFlushOperationInProgress(false)
 	, mThumbnailLastProgramDateTime(0)
 	, mLastSleThumbnailInfo()
+	, mTuneTimeMetricData()
 {
 	AAMPLOG_MIL("Create Private Player %d", mPlayerId);
 	mAampCacheHandler = new AampCacheHandler(mPlayerId);
@@ -2090,6 +2091,11 @@ void PrivateInstanceAAMP::MonitorProgress(bool sync, bool beginningOfStream)
 		(state != eSTATE_COMPLETE) &&
 		(state != eSTATE_SEEKING))
 	{
+		// mTuneMetricDataPending is checked inside SendTuneMetricsEvent()
+		if (state == eSTATE_PLAYING)
+		{
+			SendTuneMetricsEvent();
+		}
 		// set position to 0 if the rewind operation has reached Beginning Of Stream
 		double position = beginningOfStream? 0: GetPositionMilliseconds();
 		double duration = durationSeconds * 1000.0;
@@ -2761,13 +2767,16 @@ bool PrivateInstanceAAMP::PausePipeline(bool pause, bool forceStopGstreamerPreBu
 /**
  * @brief providing the Tune Timemetric info
  */
-void PrivateInstanceAAMP::SendTuneMetricsEvent(std::string &timeMetricData)
+void PrivateInstanceAAMP::SendTuneMetricsEvent()
 {
-	// Providing the Tune Timemetric info as an event
-	TuneTimeMetricsEventPtr e = std::make_shared<TuneTimeMetricsEvent>(timeMetricData, GetSessionId());
+	if (!mTuneTimeMetricData.empty() && mTuneMetricDataPending.load())
+	{
+		TuneTimeMetricsEventPtr e = std::make_shared<TuneTimeMetricsEvent>(std::move(mTuneTimeMetricData), GetSessionId());
 
-	AAMPLOG_TRACE("PrivateInstanceAAMP: Sending TuneTimeMetric event: %s", e->getTuneMetricsData().c_str());
-	SendEvent(e,AAMP_EVENT_ASYNC_MODE);
+		AAMPLOG_TRACE("PrivateInstanceAAMP: Sending TuneTimeMetric event: %s", e->getTuneMetricsData().c_str());
+		SendEvent(e,AAMP_EVENT_ASYNC_MODE);
+	}
+	mTuneMetricDataPending.store(false);
 }
 
 /**
@@ -3498,14 +3507,13 @@ void PrivateInstanceAAMP::TuneFail(bool fail)
 	{
 		LogPlayerPreBuffered();        //Need to calculate prebuffered time when tune interruption happens with player prebuffer
 	}
+
 	bool eventAvailStatus = IsEventListenerAvailable(AAMP_EVENT_TUNE_TIME_METRICS);
-	std::string tuneData("");
 	activeInterfaceWifi =  pPlayerExternalsInterface->GetActiveInterface();
-	profiler.TuneEnd(mTuneMetrics, mAppName,(mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), mPlayerId, mPlayerPreBuffered, durationSeconds, activeInterfaceWifi, mFailureReason, eventAvailStatus ? &tuneData : NULL);
-	if(eventAvailStatus)
-	{
-		SendTuneMetricsEvent(tuneData);
-	}
+	profiler.TuneEnd(mTuneMetrics, mAppName,(mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), mPlayerId, mPlayerPreBuffered, durationSeconds, activeInterfaceWifi, mFailureReason, eventAvailStatus ? &mTuneTimeMetricData : NULL);
+	mTuneMetricDataPending.store(eventAvailStatus);
+	// Send the tune time metrics event as the progress event will not fire here.
+	SendTuneMetricsEvent();
 	AdditionalTuneFailLogEntries();
 }
 
@@ -3527,13 +3535,13 @@ void PrivateInstanceAAMP::LogTuneComplete(void)
 	mTuneMetrics.mFogTSBEnabled              = mFogTSBEnabled;
 	mTuneMetrics.mFirstTune                  = mFirstTune;
 	bool eventAvailStatus = IsEventListenerAvailable(AAMP_EVENT_TUNE_TIME_METRICS);
-	std::string tuneData("");
 	activeInterfaceWifi =  pPlayerExternalsInterface->GetActiveInterface();
-	profiler.TuneEnd(mTuneMetrics,mAppName,(mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), mPlayerId, mPlayerPreBuffered, durationSeconds, activeInterfaceWifi, mFailureReason, eventAvailStatus ? &tuneData : NULL);
-	if(eventAvailStatus)
-	{
-		SendTuneMetricsEvent(tuneData);
-	}
+
+	profiler.TuneEnd(mTuneMetrics,mAppName,(mbPlayEnabled?STRFGPLAYER:STRBGPLAYER), mPlayerId, mPlayerPreBuffered, durationSeconds, activeInterfaceWifi, mFailureReason, eventAvailStatus ? &mTuneTimeMetricData : NULL);
+	mTuneMetricDataPending.store(eventAvailStatus);
+	// Tune Metrics event will be sent as part of progress event, as this guarantees the event
+	// is sent after state=PLAYING whose timing is critical for upstream components.
+
 	//update tunedManifestUrl if FOG was NOT used as manifestUrl might be updated with redirected url.
 	if(!IsFogTSBSupported())
 	{
@@ -8139,6 +8147,7 @@ void PrivateInstanceAAMP::NotifyFirstFrameReceived(unsigned long ccDecoderHandle
 	// If mFirstVideoFrameDisplayedEnabled, state will be changed in NotifyFirstVideoDisplayed()
 	if(!mFirstVideoFrameDisplayedEnabled)
 	{
+		AAMPLOG_MIL("Player changing state to PLAYING on first frame received");
 		SetState(eSTATE_PLAYING);
 	}
 	{
@@ -8423,7 +8432,20 @@ void PrivateInstanceAAMP::SetState(AAMPPlayerState state)
 		return;
 	}
 
-	if ( (state == eSTATE_PLAYING || state == eSTATE_BUFFERING || state == eSTATE_PAUSED)
+	static const char* const kStateNames[] = {
+		"IDLE", "INITIALIZING", "INITIALIZED", "PREPARING", "PREPARED",
+		"BUFFERING", "PAUSED", "SEEKING", "PLAYING", "STOPPING",
+		"STOPPED", "COMPLETE", "ERROR", "RELEASED", "BLOCKED"
+	};
+	auto stateName = [](AAMPPlayerState s) -> const char* {
+		return (s >= 0 && s < (int)(sizeof(kStateNames)/sizeof(kStateNames[0])))
+			? kStateNames[s] : "UNKNOWN";
+	};
+	AAMPLOG_MIL("Player state changed: %s -> %s", stateName(mState), stateName(state));
+
+	// Handle SEEKED event based on the actual previous state
+	// Only the thread that performed this specific transition will send the event
+	if ((state == eSTATE_PLAYING || state == eSTATE_BUFFERING || state == eSTATE_PAUSED)
 		&& mState == eSTATE_SEEKING && (mEventManager->IsEventListenerAvailable(AAMP_EVENT_SEEKED)))
 	{
 		SeekedEventPtr event = std::make_shared<SeekedEvent>(GetPositionMilliseconds(), GetSessionId());
@@ -10647,6 +10669,7 @@ bool PrivateInstanceAAMP::SetStateBufferingIfRequired()
 		AAMPPlayerState state = GetState();
 		if(state != eSTATE_BUFFERING)
 		{
+			AAMPLOG_MIL("Player changing state to BUFFERING as fragment caching is required");
 			if(mpStreamAbstractionAAMP)
 			{
 				mpStreamAbstractionAAMP->NotifyPlaybackPaused(true);

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1518,11 +1518,10 @@ public:
 
 	/**
 	 * @fn SendTuneMetricsEvent
-	 *
-	 * @param[in] timeMetricData- Providing the Tune Timemetric info as an event
+	 * @brief Send tune metrics event to registered listeners
 	 * @return void
 	 */
-	void SendTuneMetricsEvent(std::string &timeMetricData);
+	void SendTuneMetricsEvent();
 
 	/* Buffer Under flow status flag, under flow Start(buffering stopped) is true and under flow end is false*/
 	bool mBufUnderFlowStatus;
@@ -4245,6 +4244,8 @@ protected:
 	std::mutex mPreProcessLock;
 	bool mIsChunkMode;		/** LLD ChunkMode */
 	bool mLocalAAMPTsbFromConfig;						/**< AAMP TSB enabled in the configuration, regardless of the current channel */
+	std::atomic<bool> mTuneMetricDataPending{false}; /**< True when mTuneTimeMetricData has been populated and not yet consumed */
+	std::string mTuneTimeMetricData{}; /**< JSON string containing data for tune time metrics */
 
 private:
 	/**

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -675,6 +675,7 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 		case AAMP_EVENT_TUNE_TIME_METRICS:
 		{
 			TuneTimeMetricsEventPtr ev = std::dynamic_pointer_cast<TuneTimeMetricsEvent>(e);
+			AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_TUNE_TIME_METRICS received\n");
 			// below is redundant with IP_AAMP_TUNETIME logging done in core aamp
 			//AAMPCLI_PRINTF("[AAMPCLI] AAMP_EVENT_TUNE_TIME_METRICS\n\tData[%s]\n",ev->getTuneMetricsData().c_str());
 			break;

--- a/test/utests/fakes/FakeAampEvent.cpp
+++ b/test/utests/fakes/FakeAampEvent.cpp
@@ -519,15 +519,16 @@ uint32_t ManifestRefreshEvent::getManifestPublishedTime() const
 
 
 
-TuneTimeMetricsEvent::TuneTimeMetricsEvent(const std::string &timeMetricData, std::string sid):
+TuneTimeMetricsEvent::TuneTimeMetricsEvent(std::string &&timeMetricData, std::string sid):
 	AAMPEventObject(AAMP_EVENT_TUNE_TIME_METRICS, std::move(sid))
+	, mTuneMetricsData(std::move(timeMetricData))
 {
 
 }
 
 const std::string &TuneTimeMetricsEvent::getTuneMetricsData() const
 {
-		return mTuneMetricsData;
+	return mTuneMetricsData;
 }
 
 void MediaMetadataEvent::SetAudioMetaData(const std::string &audioCodec,const std::string &mixType,bool  isAtmos  )

--- a/test/utests/tests/AampEventTests/AampEventTests.cpp
+++ b/test/utests/tests/AampEventTests/AampEventTests.cpp
@@ -1067,7 +1067,7 @@ protected:
     void SetUp() override {
         
         timeMetricData = "SampleTimeMetricsData";
-        event = new TuneTimeMetricsEvent(timeMetricData, session_id);
+        event = new TuneTimeMetricsEvent(std::string{timeMetricData}, session_id);
     }
 
     void TearDown() override {

--- a/test/utests/tests/AampProfilerTests/AampProfilerTests.cpp
+++ b/test/utests/tests/AampProfilerTests/AampProfilerTests.cpp
@@ -65,9 +65,7 @@ TEST_F(AampProfilertests, SetLatencyParamTest13)
 TEST_F(AampProfilertests, GetTuneTimeMetricAsJsonTest)
 {
     TuneEndMetrics tuneMetricsData;
-    char tuneTimeStrPrefixdata[] = {1,2,3,4,5};
-    char *tuneTimeStrPrefix = tuneTimeStrPrefixdata;
-    unsigned int licenseAcqNWTime = 2;
+    const char *tuneTimeStrPrefix = "[tuneTimeStrPrefix]";
     bool playerPreBuffered = true;
     unsigned int durationSeconds = 3;
     bool interfaceWifi = true;
@@ -75,7 +73,7 @@ TEST_F(AampProfilertests, GetTuneTimeMetricAsJsonTest)
     std::string appName = "test3";
     cJSON *item = cJSON_CreateObject();
     cJSON_AddNumberToObject(item,"ver",AAMP_TUNETIME_VERSION);
-    std::string s1 = profileEvent->GetTuneTimeMetricAsJson(tuneMetricsData, tuneTimeStrPrefix,licenseAcqNWTime, playerPreBuffered,durationSeconds,interfaceWifi, failureReason, appName);
+    std::string s1 = profileEvent->GetTuneTimeMetricAsJson(tuneMetricsData, tuneTimeStrPrefix, playerPreBuffered,durationSeconds,interfaceWifi, failureReason, appName);
     profileEvent->TuneBegin();
     profileEvent->SetDiscontinuityParam();
 }

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -382,6 +382,16 @@ public:
 	{
 		return mLocalAAMPTsbFromConfig;
 	}
+	// Helpers for accessing protected tune-metrics members from tests.
+	void SetTuneTimeMetricData(const std::string& data)
+	{
+		mTuneTimeMetricData = data;
+		mTuneMetricDataPending.store(true);
+	}
+	bool GetTuneMetricDataPending() const
+	{
+		return mTuneMetricDataPending.load();
+	}
 	};
 	TestablePrivAamp *testp_aamp{nullptr};
 };
@@ -746,6 +756,104 @@ TEST_F(PrivAampPrivTests,RemoveCustomHTTPHeaderTest)
 
 	result = testp_aamp->GetCustomLicenseHeaders();
 	EXPECT_TRUE (result.find("string:") == result.end());
+}
+
+/**
+ * Verify that SendTuneMetricsEvent is no-op when there is no mTuneTimeMetricData.
+ */
+TEST_F(PrivAampPrivTests,SendTuneMetricsEventTest1)
+{
+	EXPECT_CALL(*g_mockAampEventManager, SendEvent(AnEventOfType(AAMP_EVENT_TUNE_TIME_METRICS), AAMP_EVENT_ASYNC_MODE))
+		.Times(0);
+	testp_aamp->SendTuneMetricsEvent();
+
+	// Data is consumed exactly once; a second call must be a no-op.
+	EXPECT_FALSE(testp_aamp->GetTuneMetricDataPending());
+}
+
+/**
+ * Verify that SendTuneMetricsEvent dispatches AAMP_EVENT_TUNE_TIME_METRICS and consumes the pending data exactly once.
+ */
+TEST_F(PrivAampPrivTests,SendTuneMetricsEventTest2)
+{
+	// Populate the pending data and flag that LogTuneComplete/Failure would normally set.
+	testp_aamp->SetTuneTimeMetricData("{\"metric\":\"test\"}");
+
+	EXPECT_CALL(*g_mockAampEventManager, SendEvent(AnEventOfType(AAMP_EVENT_TUNE_TIME_METRICS), AAMP_EVENT_ASYNC_MODE))
+		.Times(1);
+	testp_aamp->SendTuneMetricsEvent();
+
+	// Data is consumed exactly once; a second call must be a no-op.
+	EXPECT_FALSE(testp_aamp->GetTuneMetricDataPending());
+}
+
+/**
+ * Verify that AAMP_EVENT_TUNE_TIME_METRICS is dispatched by MonitorProgress
+ * strictly after the state-changed-to-PLAYING event.
+ */
+TEST_F(PrivAampPrivTests, MonitorProgressTuneMetricsAfterPlayingStateChange)
+{
+	// Simulate the pending metrics JSON that LogTuneComplete/LogTuneFailure populates.
+	testp_aamp->SetTuneTimeMetricData("{\"metric\":\"test\"}");
+	testp_aamp->mDownloadsEnabled = true;
+	testp_aamp->pipeline_paused = false;
+
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(_)).WillRepeatedly(Return(false));
+
+	// Allow SetState to fire the state-changed event.
+	EXPECT_CALL(*g_mockAampEventManager, IsEventListenerAvailable(AAMP_EVENT_STATE_CHANGED))
+		.WillOnce(Return(true));
+
+	// Ordering assertion: STATE_CHANGED(PLAYING) must be observed before TUNE_TIME_METRICS.
+	// Any other SendEvent calls (e.g. AAMP_EVENT_PROGRESS) are absorbed by NiceMock.
+	{
+		testing::InSequence seq;
+		EXPECT_CALL(*g_mockAampEventManager,
+			SendEvent(AnEventOfType(AAMP_EVENT_STATE_CHANGED), AAMP_EVENT_SYNC_MODE)).Times(1);
+		EXPECT_CALL(*g_mockAampEventManager,
+			SendEvent(AnEventOfType(AAMP_EVENT_TUNE_TIME_METRICS), AAMP_EVENT_ASYNC_MODE)).Times(1);
+	}
+
+	// Step 1: transition to PLAYING — fires AAMP_EVENT_STATE_CHANGED synchronously.
+	testp_aamp->SetState(eSTATE_PLAYING);
+	// Step 2: first progress tick — fires AAMP_EVENT_TUNE_TIME_METRICS via SendTuneMetricsEvent.
+	testp_aamp->MonitorProgress(true, false);
+
+	// Data is consumed exactly once; subsequent MonitorProgress ticks are no-ops.
+	EXPECT_FALSE(testp_aamp->GetTuneMetricDataPending());
+}
+
+/**
+ * Verify that TuneFail explicitly calls SendTuneMetricsEvent — dispatching
+ * AAMP_EVENT_TUNE_TIME_METRICS — when a listener is registered and the
+ * manifest URL is not the fake-tune sentinel.
+ *
+ * Contract: TuneFail must synchronously send the tune-metrics event because
+ * no future MonitorProgress tick will fire after a tune failure.
+ */
+TEST_F(PrivAampPrivTests, TuneFailSendsTuneMetricsEvent)
+{
+	// Arrange: use a real manifest URL so TuneFail does not skip the
+	// metrics path (which it guards with mManifestUrl != FAKE_TUNE_URL).
+	testp_aamp->mManifestUrl = SAMPLE_URL;
+	// Simulate the pending metrics JSON that LogTuneComplete/LogTuneFailure populates.
+	testp_aamp->SetTuneTimeMetricData("{\"metric\":\"test\"}");
+
+	// IsEventListenerAvailable gates both TuneEnd metric population and
+	// the subsequent SendTuneMetricsEvent call.
+	EXPECT_CALL(*g_mockAampEventManager,
+		IsEventListenerAvailable(AAMP_EVENT_TUNE_TIME_METRICS))
+		.WillOnce(Return(true));
+
+	// SendTuneMetricsEvent must fire exactly once from within TuneFail.
+	EXPECT_CALL(*g_mockAampEventManager,
+		SendEvent(AnEventOfType(AAMP_EVENT_TUNE_TIME_METRICS), AAMP_EVENT_ASYNC_MODE))
+		.Times(1);
+
+	testp_aamp->TuneFail(true);
+
+	// Pending flag must be cleared after the event is dispatched.
+	EXPECT_FALSE(testp_aamp->GetTuneMetricDataPending());
 }
 
 struct TsbConfigurationData
@@ -1195,8 +1303,8 @@ TEST_F(PrivAampTests, MonitorProgressRewindToBoS_ProgressBeforeSpeedChange)
 	p_aamp->culledSeconds = CULLED_SECONDS;
 	p_aamp->durationSeconds = DURATION_SECONDS;
 	p_aamp->mDownloadsEnabled = true;
-	p_aamp->mSinkPaused = false;
-	p_aamp->SetState(eSTATE_PLAYING, true);
+	p_aamp->pipeline_paused = false;
+	p_aamp->SetState(eSTATE_PLAYING);
 	p_aamp->SetLocalAAMPTsb(true);
 	p_aamp->mMediaFormat = eMEDIAFORMAT_DASH;
 	p_aamp->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP_MPD;
@@ -4089,11 +4197,6 @@ TEST_F(PrivAampTests,GetLicenseServerUrlForDrmTest2)
 {
 	std::string str = p_aamp->GetLicenseServerUrlForDrm(eDRM_ClearKey);
 	EXPECT_STRNE("sample",str.c_str());
-}
-TEST_F(PrivAampTests,SendTuneMetricsEventTest)
-{
-	std::string timeMetricData = "Sample time metric data";
-   p_aamp->SendTuneMetricsEvent(timeMetricData);
 }
 
 TEST_F(PrivAampTests,mediaType2BucketTest_122)


### PR DESCRIPTION
* VPAAMP-261: AAMP_EVENT_TUNE_TIME_METRICS dispatched before STATE_CHANGED(PLAYING)

Reason for change: Sent the tunetime metrics event from the progress callback to time it always after the player has moved to PLAYING state. In TuneFailure case, it will be sent during Stop call. PLAYING state event is used by VIPA and EPG to measure total tune time and hence should not be delayed. Test Procedure: Confirm from logs that tune time metrics event is sent after state=PLAYING event in tune success. Ensure the event is still sent in tune fail case
Risks: Low



* VPAAMP-261: address code review comments

- priv_aamp.cpp: move mTuneMetricDataPending.load() guard inside SendTuneMetricsEvent() so the check lives in one place; remove redundant outer guard at the progress-event call site
- priv_aamp.cpp: collapse if(eventAvailStatus){store(true)} patterns at LogTuneFailure and LogTuneComplete sites to store(eventAvailStatus)
- priv_aamp.cpp: add centralised AAMPLOG_MIL state-transition log in SetState(); remove per-site redundant log at first-frame call site
- AampEvent.h / AampEvent.cpp / FakeAampEvent.cpp: change TuneTimeMetricsEvent tuneMetricData parameter to rvalue reference (&&)
- AampProfiler.h: expand GetTuneTimeMetricAsJson @return doc comment to describe the JSON object and all its keys

* VPAAMP-261: fix TuneTimeMetricsEvent test call site for rvalue ref parameter

std::move() the lvalue timeMetricData at the call site in AampEventTests SetUp() to match the updated TuneTimeMetricsEvent constructor signature which takes tuneMetricData as std::string &&.

* VPAAMP-261: fix TuneTimeMetricsEventTest failures after rvalue ref change

After the constructor was changed to take tuneMetricData as std::string&&, std::move(timeMetricData) in SetUp() left the member in a moved-from (empty) state, causing both Constructor and GetTuneMetricsData assertions to compare against "" instead of the expected value.

Pass std::string{timeMetricData} instead: constructs an rvalue temporary that satisfies the && parameter while keeping the member intact for assertions.

---------