### PR TITLE
VPAAMP-535: Invalidate empty ad breaks on NotifyReservationComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ advert <params>
 		note: multiple sequential ads can be mapped to fill a single ad break by calling advert map multiple times with same adBreakId
 	advert clear (clear current advert map)
 	advert list	(display the advert list)
+	advert defer	(toggle deferred NotifyReservationComplete; when ON, the auto-notify on SCTE-35 ad-break start is suppressed)
+	advert rc <breakId>	(manually call NotifyReservationComplete for the given break ID)
 new <name>	create a new player instance with optional name
 select <val|name> move player val or name to foreground. With no option list all players
 detach		move current foreground player to background

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -1985,7 +1985,8 @@ void PrivateCDAIObjectMPD::NotifyReservationComplete(const std::string& reservat
 		//We are Aborting the wait when the AdBreakObject is empty. Not for the each ad to be resolved.
 		if (!abObj.ads || abObj.ads->empty())
 		{
-			AAMPLOG_INFO("[CDAI] Ad break %s is empty. No ads to play.", reservationId.c_str());
+			AAMPLOG_INFO("[CDAI] Ad break %s is empty. No ads to play. Marking reservation invalid", reservationId.c_str());
+			abObj.invalid = true;
 			AbortWaitForNextAdResolved();
 		}
 	}

--- a/test/aampcli/Aampcli.cpp
+++ b/test/aampcli/Aampcli.cpp
@@ -652,7 +652,15 @@ void MyAAMPEventListener::Event(const AAMPEventPtr& e)
 							}
 							if( !mapped )
 							{
-								AAMPCLI_PRINTF( "[AAMPCLI] unmapped breakId=%s\n", ev->getId().c_str() );
+								AAMPCLI_PRINTF( "[AAMPCLI] unmapped breakId=%s, notifying reservation complete\n", ev->getId().c_str() );
+							}
+							if( !mAampcli.mDeferReservationComplete )
+							{
+								mAampcli.mSingleton->NotifyReservationComplete(ev->getId());
+							}
+							else
+							{
+								AAMPCLI_PRINTF( "[AAMPCLI] [CDAI] deferred NotifyReservationComplete for breakId=%s\n", ev->getId().c_str() );
 							}
 							break;
 						case SCTE35SpliceInfo::SEGMENTATION_TYPE::PROGRAM_IMMEDIATE_RESUMPTION:

--- a/test/aampcli/Aampcli.h
+++ b/test/aampcli/Aampcli.h
@@ -63,6 +63,7 @@ class Aampcli
 		bool mEnableProgressLog;
 		bool mbAutoPlay;
 		bool mIndexedAds = false;
+		bool mDeferReservationComplete = false; /**< When true, suppress automatic NotifyReservationComplete on SCTE-35 ad break start */
 		std::string mContentType;
 		std::string mTuneFailureDescription;
 		PlayerInstanceAAMP *mSingleton;

--- a/test/aampcli/AampcliPlaybackCommand.cpp
+++ b/test/aampcli/AampcliPlaybackCommand.cpp
@@ -592,6 +592,25 @@ void PlaybackCommand::HandleCommandAdvert( const char *cmd, PlayerInstanceAAMP *
 			mAdvertList.push_back(advertInfo);
 			AAMPCLI_PRINTF("[AAMP-CLI] mapped adBreakId %s\n", advertInfo.adBreakId.c_str() );
 		}
+		else if( token == "defer" )
+		{
+			mAampcli.mDeferReservationComplete = !mAampcli.mDeferReservationComplete;
+			AAMPCLI_PRINTF("[AAMP-CLI] deferred NotifyReservationComplete: %s\n",
+				mAampcli.mDeferReservationComplete ? "ON" : "OFF" );
+		}
+		else if( token == "rc" )
+		{
+			std::string breakId;
+			if( std::getline(input, breakId, ' ') && !breakId.empty() )
+			{
+				AAMPCLI_PRINTF("[AAMP-CLI] NotifyReservationComplete breakId=%s\n", breakId.c_str() );
+				playerInstanceAamp->NotifyReservationComplete(breakId);
+			}
+			else
+			{
+				AAMPCLI_PRINTF("[AAMP-CLI] ERROR - expected 'advert rc <breakId>'\n");
+			}
+		}
 	}
 	else
 	{
@@ -1154,7 +1173,12 @@ void PlaybackCommand::registerPlaybackCommands()
 	addCommand("progress","Toggle progress event logging (default=false)");
 	addCommand("auto <params", "stress test with defaults: startChan(500) endChan(1000) maxTuneTime(6) playTime(15) betweenTime(15)" );
 	addCommand("exit","Exit aampcli");
-	addCommand("advert <params>", "manage injected advert list - 'list', 'add <url or channel in virtual channel map>', 'rm <url or index into list>'");
+	addCommand("advert <params>", "manage injected advert list:\n"
+		"\t  advert list                 - show current ad map\n"
+		"\t  advert map <breakId> <url>  - map a URL to an ad break ID\n"
+		"\t  advert clear                - clear all ad mappings\n"
+		"\t  advert defer                - toggle deferred NotifyReservationComplete (suppresses auto-notify on SCTE-35)\n"
+		"\t  advert rc <breakId>         - manually call NotifyReservationComplete for the given break ID");
 	addCommand("registerVodAdBreak <breakId> <breakType> <insertionPointSec> <breakDurationSec>", "register a VOD ad-break insertion point");
 	addCommand("cancelVodAdBreak <breakId>", "cancel a previously registered VOD ad-break");
 	addCommand("scte35 <base64>", "decode SCTE-35 signal base64 string");

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -4653,6 +4653,9 @@ TEST_F(AdManagerMPDTests, NotifyReservationComplete_EmptyAdBreak_NotifiesAndReso
 
     waiter.join();
     EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].resolved);
+    // Empty ad breaks must also be marked invalid so that subsequent
+    // SetAlternateContents() calls reject further ads for this break.
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].invalid);
     // The waiting thread should have completed (not timed out)
     EXPECT_TRUE(completed);
 }


### PR DESCRIPTION
Reason for change: Handle ad breaks closed with NotifyReservationComplete and invalidate empty ad breaks to prevent ad state issues during trickplay. 

Risks: Low
Test Procedure: Test with various ad break scenarios during trickplay
Change-Id: Ie25d404ec0edf9bed7ed0c9299fa8a0eda0d360e
Signed-off-by: Nandakishor U M <nu641001@gmail.com>