### PR TITLE
VPAAMP-394:[VIPA - TS DAI][cDVR on XiOne/Llama] Ads are not played on cdvr asset and getting "Error: Ad fetch failed" in logs

### DIFF
--- a/AdManagerBase.h
+++ b/AdManagerBase.h
@@ -106,10 +106,17 @@ public:
 	}
 
 	/**
+	 * @brief Mark reservation as complete for a given reservationId
+	 * @param[in] reservationId The reservation identifier
+	 */
+	virtual void NotifyReservationComplete(const std::string& reservationId) {}
+
+	/**
 	 * @brief Cancel ad reservation
 	 * @param[in] cancelAtReservationId The reservation identifier which needs to be cancelled
 	 */
 	virtual void CancelReservation(const std::string& cancelAtReservationId) {}
+
 };
 
 

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -54,6 +54,17 @@ void CDAIObjectMPD::SetAlternateContents(const std::string &periodId, const std:
 	mPrivObj->SetAlternateContents(periodId, adId, url, startMS, breakdur);
 }
 
+/**
+ * @brief Mark reservation as complete for a given reservationId
+ * @param[in] reservationId The reservation identifier
+ */
+void CDAIObjectMPD::NotifyReservationComplete(const std::string& reservationId)
+{
+	if (mPrivObj)
+	{
+		mPrivObj->NotifyReservationComplete(reservationId);
+	}
+}
 
 /**
  * @brief Cancel ad reservation
@@ -1683,7 +1694,7 @@ bool PrivateCDAIObjectMPD::WaitForNextAdResolved(int timeoutMs, std::string peri
 {
 	std::unique_lock<std::mutex> lock(mAdPlacementMtx);
 	bool completed = false;
-	AAMPLOG_INFO("Waiting for next ad placement in %s to complete with timeout %d ms.", periodId.c_str(), timeoutMs);
+	AAMPLOG_INFO("Attempting to wait for next ad placement in %s to complete with timeout %d ms.", periodId.c_str(), timeoutMs);
 	if (isAdBreakObjectExist(periodId))
 	{
 		if (mAdPlacementCV.wait_for(lock, std::chrono::milliseconds(timeoutMs), [this, periodId] {
@@ -1807,5 +1818,31 @@ void PrivateCDAIObjectMPD::CancelReservation(const std::string& cancelAtReservat
 	{
 		AAMPLOG_WARN("[CDAI] CancelReservation: adBreakId %s not found; no state updated",
 			mPlacementObj.pendingAdbrkId.c_str());
+	}
+}
+
+/**
+ * @brief Mark the reservation as complete for the ad break
+ * @param[in] reservationId Ad break ID
+ * @param[in] time Time to mark the reservation complete
+ */
+void PrivateCDAIObjectMPD::NotifyReservationComplete(const std::string& reservationId)
+{
+	std::lock_guard<std::mutex> lock(mDaiMtx);
+	if (isAdBreakObjectExist(reservationId))
+	{
+		AdBreakObject& abObj = mAdBreaks[reservationId];
+		abObj.resolved = true;
+		AAMPLOG_INFO("[CDAI] Marked reservation complete for adBreakId: %s", reservationId.c_str());
+		//We are Aborting the wait when the AdBreakObject is empty. Not for the each ad to be resolved.
+		if (!abObj.ads || abObj.ads->empty())
+		{
+			AAMPLOG_INFO("[CDAI] Ad break %s is empty. No ads to play.", reservationId.c_str());
+			AbortWaitForNextAdResolved();
+		}
+	}
+	else
+	{
+		AAMPLOG_WARN("[CDAI] NotifyReservationComplete: adBreakId %s not found", reservationId.c_str());
 	}
 }

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -93,10 +93,17 @@ public:
 	virtual void SetAlternateContents(const std::string &periodId, const std::string &adId, const std::string &url, uint64_t startMS=0, uint32_t breakdur=0) override;
 
 	/**
+	 * @brief Mark reservation as complete for a given reservationId
+	 * @param[in] reservationId The reservation identifier
+	 */
+	virtual void NotifyReservationComplete(const std::string& reservationId) override;
+
+	/**
 	 * @brief Request cancellation for the adbreak currently in progress
 	 * @param[in] cancelAtReservationId The reservation identifier at which cancellation should occur; applied to the AdBreak (not individual ads)
 	 */
 	virtual void CancelReservation(const std::string& cancelAtReservationId) override;
+
 };
 
 
@@ -413,10 +420,17 @@ public:
 	void SetAlternateContents(const std::string &periodId, const std::string &adId, const std::string &url,  uint64_t startMS, uint32_t breakdur=0);
 
 	/**
+	 * @brief Mark reservation as complete for a given reservationId
+	 * @param[in] reservationId The reservation identifier
+	 */
+	void NotifyReservationComplete(const std::string& reservationId);
+
+	/**
 	 * @brief Cancel ad reservation
 	 * @param[in] cancelAtReservationId The reservation identifier which needs to be cancelled
 	 */
 	void CancelReservation(const std::string& cancelAtReservationId);
+
 	/**
 	 * @fn FulFillAdObject
 	 *

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -5405,11 +5405,12 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 					}
 					AAMPLOG_INFO("SCTEDBG adjust start time %" PRIu64 " -> %" PRIu64 " (duration %d)", eventInfo.presentationTime, eventStartTime, eventInfo.duration);
 				}
-				//Call the SetAlternateContent API whenever the ClientDai flag is enabled, regardless of whether the stream is VOD or live. This is to ensure that the client has the necessary information to make decisions about ad insertion, even for VOD content.
+				// For unresolved DAI events, place an empty ad entry to
+				//guard against redundant SCTE-35 events on the same ad break.
 				aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
 				if(reportBulkMeta)
 				{
-					AAMPLOG_INFO("Saving timedMetadata for VOD %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
+					AAMPLOG_INFO("Saving timedMetadata  event %s for the period, %s", eventInfo.name.c_str(), prdId.c_str());
 					aamp->SaveTimedMetadata(eventStartTime, eventInfo.name.c_str() , eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
 				}
 				else

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4075,7 +4075,12 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			AAMPLOG_WARN("mCurrentPeriod  is null");  //CID:84770 - Null Return
 		}
 		mBasePeriodOffset = offsetFromStart;
-		onAdEvent(AdEvent::INIT, offsetFromStart);
+		//Avoid calling onAdEvent during a new tune to prevent ad processing in the tune-time period.
+		if ((tuneType != eTUNETYPE_NEW_NORMAL) &&
+			(tuneType != eTUNETYPE_NEW_SEEK))
+		{
+			onAdEvent(AdEvent::INIT, offsetFromStart);
+		}
 
 		UpdateLanguageList();
 
@@ -5400,34 +5405,16 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 					}
 					AAMPLOG_INFO("SCTEDBG adjust start time %" PRIu64 " -> %" PRIu64 " (duration %d)", eventInfo.presentationTime, eventStartTime, eventInfo.duration);
 				}
-
-				//for livestream send the timedMetadata only., because at init, control does not come here
-				if(mIsLiveManifest && ! ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive))
+				//Call the SetAlternateContent API whenever the ClientDai flag is enabled, regardless of whether the stream is VOD or live. This is to ensure that the client has the necessary information to make decisions about ad insertion, even for VOD content.
+				aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
+				if(reportBulkMeta)
 				{
-					// The current process relies on enabling eAAMPConfig_EnableClientDai and that may not be desirable
-					// for our requirements. We'll just skip this and use the VOD process to send events
-					bool modifySCTEProcessing = ISCONFIGSET(eAAMPConfig_EnableSCTE35PresentationTime);
-					if (modifySCTEProcessing)
-					{
-						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
-					}
-					else
-					{
-						aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
-					}
+					AAMPLOG_INFO("Saving timedMetadata for VOD %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
+					aamp->SaveTimedMetadata(eventStartTime, eventInfo.name.c_str() , eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
 				}
 				else
 				{
-					//for vod, send TimedMetadata only when bulkmetadata is not enabled
-					if(reportBulkMeta)
-					{
-						AAMPLOG_INFO("Saving timedMetadata for VOD %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
-						aamp->SaveTimedMetadata(eventStartTime, eventInfo.name.c_str() , eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
-					}
-					else
-					{
-						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
-					}
+					aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
 				}
 			}
 			ret = true;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4215,10 +4215,10 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 				//The default fragment time has been updated to an absolute time format. Therefore,
 				//the periodStartOffset should now be relative to the Availability Start Time.
 				mMediaStreamContext[i]->periodStartOffset = mPeriodStartTime;
-				if (mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0)
+				if (mCdaiObject != nullptr &&mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0)
 				{
 					//Ensuring basePeriodOffset has the proper value
-					if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != -1)
+					if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != INVALID_BASE_PERIOD_OFFSET)
 					{
 						/*When multiple DAI ads are mapped to a single source period, the periodStartOffset
 						needs to be updated with the basePeriodOffset for each ad. Otherwise,
@@ -8119,17 +8119,17 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 				aamp->mNextPeriodStartTime = mPeriodStartTime;
 				pMediaStreamContext->fragmentTime = mPeriodStartTime;
 				// For playing an ad in a ad break, we should update fragmentTime to PeriodStartTime + basePeriodOffset of ad;
-				if (mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0 )
+				if (mCdaiObject && mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0 
+					&& mCdaiObject->mCurAdIdx < mCdaiObject->mCurAds->size())
 				{
 					// Make sure basePeriodOffset is updated
-					if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != -1)
+					if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != INVALID_BASE_PERIOD_OFFSET)
 					{
 						//Set the period start back to the beginning of the base period and then add basePeriodOffset
 						//to get the start for this AD
 						double absoluteAdBreakStartTime = mCdaiObject->mAdBreaks[mBasePeriodId].mAbsoluteAdBreakStartTime.inSeconds();
 						// convert to seconds, standard implicit conversion
 						pMediaStreamContext->fragmentTime = absoluteAdBreakStartTime + mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset / 1000.0;
-
 						AAMPLOG_INFO("StreamAbstractionAAMP_MPD: Track %d Period changed, but within an adbreak, mPeriodStartTime:%lf basePeriodOffset:%d FragmentTime: %lf mAbsoluteAdBreakStartTime %f",
 							i, mPeriodStartTime, mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset, pMediaStreamContext->fragmentTime,
 							absoluteAdBreakStartTime);
@@ -9917,10 +9917,9 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
 						AAMPLOG_WARN("StreamAbstractionAAMP_MPD: Not updating mFirstPTS TimeScale(0) or mSeekedInPeriod(%d)", mSeekedInPeriod);
 					}
 					mSeekedInPeriod = false;
-					double startTime = (mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) - mAvailabilityStartTime);
-					if ((startTime != 0) && !aamp->IsUninterruptedTSB())
+					if (!aamp->IsUninterruptedTSB())
 					{
-						mStartTimeOfFirstPTS = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) * 1000;
+						UpdateStartTimeOfFirstPTS();
 					}
 				}
 				else if (nextSegmentTime != segmentStartTime || ISCONFIGSET(eAAMPConfig_ForceMultiPeriodDiscontinuity))
@@ -9931,10 +9930,9 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
 						mFirstPTS = (double)segmentStartTime / (double)segmentTemplates.GetTimescale();
 						mIsFinalFirstPTS = true;
 					}
-					double startTime = (mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) - mAvailabilityStartTime);
-					if ((startTime != 0) && !mIsFogTSB)
+					if (!mIsFogTSB)
 					{
-						mStartTimeOfFirstPTS = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) * 1000;
+						UpdateStartTimeOfFirstPTS();
 					}
 					AAMPLOG_WARN("StreamAbstractionAAMP_MPD: discontinuity detected nextSegmentTime %" PRIu64 " FirstSegmentStartTime %" PRIu64 " ", nextSegmentTime, segmentStartTime);
 				}
@@ -9957,6 +9955,34 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
 		}
 	}
 	FetchAndInjectInitFragments(discontinuity);
+}
+
+/**
+ * @brief Update the start time of first PTS
+ */
+void StreamAbstractionAAMP_MPD::UpdateStartTimeOfFirstPTS()
+{
+	double startTime = (mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) - mAvailabilityStartTime);
+	if (startTime != 0)
+	{
+		mStartTimeOfFirstPTS = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) * 1000.0;
+		if (mCdaiObject && mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0
+	 		&& mCdaiObject->mCurAdIdx < mCdaiObject->mCurAds->size())
+		{
+			if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != INVALID_BASE_PERIOD_OFFSET)
+			{
+				//Set the period start back to the beginning of the base period and then add basePeriodOffset
+				// to get the start for this AD (calculate directly in milliseconds)
+				mStartTimeOfFirstPTS = mCdaiObject->mAdBreaks[mBasePeriodId].mAbsoluteAdBreakStartTime.inSeconds() * 1000.0 + mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset;
+				AAMPLOG_INFO("UpdateStartTimeOfFirstPTS (ad): mStartTimeOfFirstPTS=%.0f ms basePeriodOffset=%d",
+							 mStartTimeOfFirstPTS, mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset);
+			}
+		}
+		else
+		{
+			AAMPLOG_WARN("skipping adPeriodOffset; using mStartTimeOfFirstPTS as %.0f ms", mStartTimeOfFirstPTS);
+		}
+	}
 }
 
 /**

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -8118,22 +8118,22 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 				aamp->mNextPeriodDuration = mPeriodDuration;
 				aamp->mNextPeriodStartTime = mPeriodStartTime;
 				pMediaStreamContext->fragmentTime = mPeriodStartTime;
-				// For playing an ad in a ad break, we should update fragmentTime to PeriodStartTime + basePeriodOffset of ad;
-				if (mCdaiObject && mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0 
-					&& mCdaiObject->mCurAdIdx < mCdaiObject->mCurAds->size())
+				// For playing an ad in an ad break, seed fragmentTime using absoluteAdBreakStartTime +
+				// cumulative duration of all previously played ads. This is robust against
+				// basePeriodOffset=0 being set incorrectly by the waitForNextPeriod path in
+				// PlaceAds when a prior ad's overflow has already consumed part of the next period.
+				// For split period, basePeriodId and AdbreakId might not match, so go with mCurPlayingBreakId
+				double adFragmentTime = GetCurrentAdStartTimeSeconds();
+				if (adFragmentTime >= 0)
 				{
-					// Make sure basePeriodOffset is updated
-					if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != INVALID_BASE_PERIOD_OFFSET)
-					{
-						//Set the period start back to the beginning of the base period and then add basePeriodOffset
-						//to get the start for this AD
-						double absoluteAdBreakStartTime = mCdaiObject->mAdBreaks[mBasePeriodId].mAbsoluteAdBreakStartTime.inSeconds();
-						// convert to seconds, standard implicit conversion
-						pMediaStreamContext->fragmentTime = absoluteAdBreakStartTime + mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset / 1000.0;
-						AAMPLOG_INFO("StreamAbstractionAAMP_MPD: Track %d Period changed, but within an adbreak, mPeriodStartTime:%lf basePeriodOffset:%d FragmentTime: %lf mAbsoluteAdBreakStartTime %f",
-							i, mPeriodStartTime, mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset, pMediaStreamContext->fragmentTime,
-							absoluteAdBreakStartTime);
-					}
+					pMediaStreamContext->fragmentTime = adFragmentTime;
+					AAMPLOG_INFO("StreamAbstractionAAMP_MPD: Track %d Period changed, but within an adbreak, mPeriodStartTime:%lf FragmentTime: %lf basePeriodOffset:%d",
+						i, mPeriodStartTime, pMediaStreamContext->fragmentTime,
+						mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset);
+				}
+				else
+				{
+					AAMPLOG_WARN("StreamAbstractionAAMP_MPD: Track %d absoluteAdBreakStartTime is 0 or not in multi-ad pod", i);
 				}
 				AAMPLOG_INFO("StreamAbstractionAAMP_MPD: Track %d Period changed, updating fragmentTime to %lf", i, pMediaStreamContext->fragmentTime);
 			}
@@ -9960,23 +9960,59 @@ void StreamAbstractionAAMP_MPD::DetectDiscontinuityAndFetchInit(bool periodChang
 /**
  * @brief Update the start time of first PTS
  */
+/**
+ * @brief Returns the fragment start time (seconds) for the current ad within a multi-ad pod.
+ *
+ * When the player is IN_ADBREAK_AD_PLAYING and mCurAdIdx > 0, the correct
+ * fragmentTime is: absoluteAdBreakStartTime + cumulative duration of all
+ * previously played ads.  This avoids relying on basePeriodOffset=0 being set
+ * correctly by the waitForNextPeriod path in PlaceAds.
+ *
+ * @return Start time in seconds if in a multi-ad pod with a valid break start
+ *         time, or -1.0 if the preconditions are not met.
+ */
+double StreamAbstractionAAMP_MPD::GetCurrentAdStartTimeSeconds() const
+{
+	if (!mCdaiObject ||
+		mCdaiObject->mAdState != AdState::IN_ADBREAK_AD_PLAYING ||
+		mCdaiObject->mCurAdIdx <= 0 ||
+		mCdaiObject->mCurAdIdx >= static_cast<int>(mCdaiObject->mCurAds->size()) ||
+		mCdaiObject->mCurPlayingBreakId.empty())
+	{
+		return -1.0;
+	}
+
+	auto it = mCdaiObject->mAdBreaks.find(mCdaiObject->mCurPlayingBreakId);
+	if (it == mCdaiObject->mAdBreaks.end())
+	{
+		AAMPLOG_WARN("GetCurrentAdStartTimeSeconds: AdBreak not found for breakId=%s", mCdaiObject->mCurPlayingBreakId.c_str());
+		return -1.0;
+	}
+
+	double absoluteAdBreakStartTime = it->second.mAbsoluteAdBreakStartTime.inSeconds();
+
+	double cumulativeAdDurationMs = 0;
+	for (int adIdx = 0; adIdx < mCdaiObject->mCurAdIdx; adIdx++)
+	{
+		cumulativeAdDurationMs += mCdaiObject->mCurAds->at(adIdx).duration;
+	}
+	AAMPLOG_INFO("GetCurrentAdStartTimeSeconds: AbsoluteAdBreakStartTime=%f cumulativeAdDuration=%.0f ms",
+		absoluteAdBreakStartTime, cumulativeAdDurationMs);
+	return absoluteAdBreakStartTime + (cumulativeAdDurationMs / 1000.0);
+}
+
 void StreamAbstractionAAMP_MPD::UpdateStartTimeOfFirstPTS()
 {
 	double startTime = (mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) - mAvailabilityStartTime);
 	if (startTime != 0)
 	{
 		mStartTimeOfFirstPTS = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs) * 1000.0;
-		if (mCdaiObject && mCdaiObject->mAdState == AdState::IN_ADBREAK_AD_PLAYING && mCdaiObject->mCurAdIdx > 0
-	 		&& mCdaiObject->mCurAdIdx < mCdaiObject->mCurAds->size())
+		AAMPLOG_INFO("UpdateStartTimeOfFirstPTS: mStartTimeOfFirstPTS=%.0f ms : PeriodStartTime=%f", mStartTimeOfFirstPTS, startTime);
+		double adStartTimeSec = GetCurrentAdStartTimeSeconds();
+		if (adStartTimeSec >= 0)
 		{
-			if (mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset != INVALID_BASE_PERIOD_OFFSET)
-			{
-				//Set the period start back to the beginning of the base period and then add basePeriodOffset
-				// to get the start for this AD (calculate directly in milliseconds)
-				mStartTimeOfFirstPTS = mCdaiObject->mAdBreaks[mBasePeriodId].mAbsoluteAdBreakStartTime.inSeconds() * 1000.0 + mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset;
-				AAMPLOG_INFO("UpdateStartTimeOfFirstPTS (ad): mStartTimeOfFirstPTS=%.0f ms basePeriodOffset=%d",
-							 mStartTimeOfFirstPTS, mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).basePeriodOffset);
-			}
+			mStartTimeOfFirstPTS = adStartTimeSec * 1000.0;
+			AAMPLOG_INFO("UpdateStartTimeOfFirstPTS (ad): mStartTimeOfFirstPTS=%.0f ms", mStartTimeOfFirstPTS);
 		}
 		else
 		{
@@ -12584,6 +12620,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 					if (abObj->mAbsoluteAdBreakStartTime == 0.0)
 					{
 						abObj->mAbsoluteAdBreakStartTime = mMPDParseHelper->GetPeriodStartTime(mCurrentPeriodIdx, mLastPlaylistDownloadTimeMs);
+						AAMPLOG_WARN("[CDAI] Updating AdBreak[%s] absolute start time to %lf", adbreakId2Send.c_str(), abObj->mAbsoluteAdBreakStartTime.inSeconds());
 					}
 					absReservationEventPosition = abObj->mAbsoluteAdBreakStartTime;
 					absPlacementEventPosition = abObj->mAbsoluteAdBreakStartTime;

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -1293,6 +1293,16 @@ protected:
 	 */
 	void UpdateStartTimeOfFirstPTS();
 
+	/**
+	 * @fn GetCurrentAdStartTimeSeconds
+	 * @brief When playing inside a multi-ad pod (mCurAdIdx > 0), returns
+	 *        absoluteAdBreakStartTime + sum-of-prior-ad-durations (in seconds).
+	 *        Returns -1.0 if the preconditions are not met (not in a pod, or
+	 *        absoluteAdBreakStartTime is not yet known).
+	 * @return Seeded fragment start time in seconds, or -1.0 if not applicable.
+	 */
+	double GetCurrentAdStartTimeSeconds() const;
+
 	std::vector<StreamInfo*> thumbnailtrack;
 	std::vector<TileInfo> indexedTileInfo;
 	double mFirstPeriodStartTime; /*< First period start time for progress report*/

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -44,6 +44,9 @@
 #include "AampMPDParseHelper.h"
 #include "AampTrackWorker.h"
 
+// Sentinel for invalid base period offset in ad nodes
+constexpr int32_t INVALID_BASE_PERIOD_OFFSET = -1;
+
 using namespace dash;
 using namespace std;
 using namespace dash::mpd;
@@ -1282,6 +1285,13 @@ protected:
 	 * @return The timeline segment repeat count or zero
 	 */
 	uint32_t GetSegmentRepeatCount(MediaStreamContext *pMediaStreamContext, int timeLineIndex);
+
+	/**
+	 * @fn UpdateStartTimeOfFirstPTS
+	 * @brief Recalculate and update mStartTimeOfFirstPTS.
+	 * @return void
+	 */
+	void UpdateStartTimeOfFirstPTS();
 
 	std::vector<StreamInfo*> thumbnailtrack;
 	std::vector<TileInfo> indexedTileInfo;

--- a/jsbindings/jsmediaplayer.cpp
+++ b/jsbindings/jsmediaplayer.cpp
@@ -3041,7 +3041,8 @@ static JSValueRef AAMPMediaPlayerJS_notifyReservationCompletion(JSContextRef ctx
 		long time = (long) JSValueToNumber(ctx, arguments[1], exception);
 		//Need an API in AAMP to notify that placements for this reservation are over and AAMP might have to trim
 		//the ads to the period duration or not depending on time param
-         	LOG_WARN(privObj,"Called reservation close for periodId:%s and time:%ld", reservationId, time);
+		LOG_WARN(privObj,"Called reservation close for periodId:%s and time:%ld", reservationId, time);
+		privObj->_aamp->NotifyReservationComplete(reservationId);
 		SAFE_DELETE_ARRAY(reservationId);
 	}
 	else

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -224,6 +224,13 @@ PlayerInstanceAAMP::~PlayerInstanceAAMP()
 	}
 }
 
+/**
+ *  @brief Notify AAMP that ad reservation is complete for a given reservationId
+ */
+void PlayerInstanceAAMP::NotifyReservationComplete(const std::string& reservationId)
+{
+	aamp->NotifyReservationComplete(reservationId);
+}
 
 /**
  *  @brief Cancel an ad reservation.

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -171,7 +171,13 @@ public:
 	void SetRate(float rate, int overshootcorrection=0);
 
 	/**
-	 * @brief Cancel ad reservation
+	 * @brief Notify AAMP that ad reservation is complete for a given reservationId
+	 * @param[in] reservationId The reservation identifier
+	 */
+	void NotifyReservationComplete(const std::string& reservationId);
+
+	/**
+	 *   @brief Cancel ad reservation
 	 *   @param[in]  cancelAtReservationId - Reservation Id at which the cancellation has to be done.
 	 *   @return void
 	 */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8651,6 +8651,22 @@ void PrivateInstanceAAMP::UpdateProfileCappedStatus(void)
 }
 
 /**
+ * @brief Notify AAMP that ad reservation is complete for a given reservationId
+ * @param[in] reservationId The reservation identifier
+ */
+void PrivateInstanceAAMP::NotifyReservationComplete(const std::string& reservationId)
+{
+	if (mCdaiObject)
+	{
+		mCdaiObject->NotifyReservationComplete(reservationId);
+	}
+	else
+	{
+		AAMPLOG_WARN("[AAMP] CDAIObject not set. Cannot notify reservation complete for reservationId: %s ", reservationId.c_str());
+	}
+}
+
+/**
  * @brief Cancel ad reservation
  * @param[in] cancelAtReservationId The reservation identifier which needs to be cancelled
  */

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -9476,17 +9476,7 @@ void PrivateInstanceAAMP::FoundEventBreak(const std::string &adBreakId, uint64_t
 			std::string url("");
 			mCdaiObject->SetAlternateContents(adBreakId, adId, url, startMS, brInfo.duration);	//A placeholder to avoid multiple scte35 event firing for the same adbreak
 		}
-		//Ignoring past SCTE events.
-		//mFogTSBEnabled check is added to ensure the change won't effect IPVOD
-		AAMPLOG_INFO("[CDAI] mTuneCompleted:%d mFogTSBEnabled:%d", mTuneCompleted, mFogTSBEnabled);
-		if (mTuneCompleted || !mFogTSBEnabled)
-		{
-			SaveNewTimedMetadata((long long) startMS, brInfo.name.c_str(), brInfo.payload.c_str(), (int)brInfo.payload.size(), adBreakId.c_str(), brInfo.duration);
-		}
-		else
-		{
-			AAMPLOG_WARN("[CDAI] Discarding SCTE event for period:%s  since tune is not completed",adBreakId.c_str());
-		}
+
 	}
 }
 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1577,6 +1577,12 @@ public:
 	void NotifyOnEnteringLive();
 
 	/**
+	 * @brief Notify AAMP that ad reservation is complete for a given reservationId
+	 * @param[in] reservationId The reservation identifier
+	 */
+	void NotifyReservationComplete(const std::string& reservationId);
+
+	/**
 	 * @brief Cancel ad reservation
 	 * @param[in] cancelAtReservationId The reservation identifier which needs to be cancelled
 	 * @return void

--- a/test/utests/fakes/FakeAdManager.cpp
+++ b/test/utests/fakes/FakeAdManager.cpp
@@ -151,6 +151,13 @@ void PrivateCDAIObjectMPD::InsertToPlacementQueue(const std::string& periodId)
 {
 }
 
+void CDAIObjectMPD::NotifyReservationComplete(const std::string& reservationId)
+{
+	if (g_MockPrivateCDAIObjectMPD)
+	{
+		g_MockPrivateCDAIObjectMPD->NotifyReservationComplete(reservationId);
+	}
+}
 
 void CDAIObjectMPD::CancelReservation(const std::string& cancelAtReservationId)
 {

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -169,6 +169,7 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 	void PlayerInstanceAAMP::SetContentProtectionDataUpdateTimeout(int timeout) {  }
 	void PlayerInstanceAAMP::ProcessContentProtectionDataConfig(const char *jsonbuffer) {  }
 	void PlayerInstanceAAMP::SetRuntimeDRMConfigSupport(bool DynamicDRMSupported) {  }
+	void PlayerInstanceAAMP::NotifyReservationComplete(const std::string& reservationId) {  }
 	void PlayerInstanceAAMP::CancelReservation(const std::string& cancelAtReservationId) { }
 	bool PlayerInstanceAAMP::IsLive() { return false; }
 	bool PlayerInstanceAAMP::GetVideoMute(void) { return false; }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -275,6 +275,14 @@ void PrivateInstanceAAMP::NotifySpeedChanged(float rate, bool changeState)
 	}
 }
 
+void PrivateInstanceAAMP::NotifyReservationComplete(const std::string& reservationId)
+{
+	if (g_mockPrivateInstanceAAMP != nullptr)
+	{
+		g_mockPrivateInstanceAAMP->NotifyReservationComplete(reservationId);
+	}
+}
+
 void PrivateInstanceAAMP::CancelReservation(const std::string& cancelAtReservationId)
 {
 

--- a/test/utests/mocks/MockAdManager.h
+++ b/test/utests/mocks/MockAdManager.h
@@ -31,6 +31,7 @@ public:
     MOCK_METHOD(bool, WaitForNextAdResolved, (int timeoutMs, std::string periodId));
     MOCK_METHOD(int, CheckForAdStart, (const float &rate, bool init, const std::string &periodId, double offSet, std::string &breakId, double &adOffset));
     MOCK_METHOD(void, SetAlternateContents, (const std::string &adBreakId, const std::string &adId, const std::string &url));
+    MOCK_METHOD(void, NotifyReservationComplete, (const std::string& reservationId));
 };
 
 extern MockPrivateCDAIObjectMPD *g_MockPrivateCDAIObjectMPD;

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -95,6 +95,7 @@ public:
 	MOCK_METHOD(bool, IsLiveStream, ());
 	MOCK_METHOD(void, Individualization, (const std::string &payload));
 	MOCK_METHOD(void, UpdateUseSinglePipeline, ());
+	MOCK_METHOD(void, NotifyReservationComplete, (const std::string& reservationId));
 };
 
 extern MockPrivateInstanceAAMP *g_mockPrivateInstanceAAMP;

--- a/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
@@ -118,14 +118,6 @@ class AdFallbackTests : public ::testing::Test
 			{
 				return StreamAbstractionAAMP_MPD::IndexNewMPDDocument(updateTrackInfo);
 			}
-
-			void SetBasePeriodId(const std::string& periodId, int periodIdx, double offset = 0.0)
-			{
-				mBasePeriodId = periodId;
-				mBasePeriodOffset = offset;
-				mCurrentPeriodIdx = periodIdx;
-				mIterPeriodIndex = periodIdx;
-			}
 		};
 		PrivateInstanceAAMP *mPrivateInstanceAAMP;
 		CDAIObjectMPD *mCdaiObj;
@@ -302,12 +294,13 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 {
 	static const char *manifest = R"(<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" type="static" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT1.5S" mediaPresentationDuration="PT2M0S">
-  <!-- Period 1 - no ad marker; Init() tunes here with eTUNETYPE_NEW_NORMAL -->
+  <!-- Period 1 with Ad Marker in the first 15 seconds -->
   <Period id="1" start="PT0H0M0.000S">
     <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="video_p1_init.mp4" media="video_p1_$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="video_init.mp4" media="video$Number$.mp4" duration="900000">
         <SegmentTimeline>
-          <S t="0" d="1350000"/>
+          <!-- Ad Marker SCTE placed here for first 15 seconds -->
+          <S t="0" d="1350000" scte35:signal="SCTE-35 AD_MARKER"/>
           <S t="1350000" d="1350000"/>
           <S t="2700000" d="1350000"/>
           <S t="4050000" d="1350000"/>
@@ -316,7 +309,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
       <Representation id="1" bandwidth="3000000" codecs="avc1.4d401f" width="1280" height="720" frameRate="30"/>
     </AdaptationSet>
 	<AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="audio_p1_init.mp4" media="audio_p1_$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="audio_init.mp4" media="audio$Number$.mp4" duration="900000">
         <SegmentTimeline>
           <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
@@ -328,17 +321,10 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
     </AdaptationSet>
   </Period>
 
-  <!-- Period 2 - with SCTE35 EventStream ad marker; FetcherLoop processes ad here -->
+  <!-- Period 2 -  without Ad Marker -->
   <Period id="2" start="PT1M0S">
-    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000">
-      <Event presentationTime="0" duration="1350000">
-        <scte35:Signal>
-          <scte35:Binary>/DAsAAAQdSsYAP/wBQb+3zKJFQAWAhRDVUVJAAAkQn/AAABOcUAAACIAAJR2FfM=</scte35:Binary>
-        </scte35:Signal>
-      </Event>
-    </EventStream>
     <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="video_p2_init.mp4" media="video_p2_$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="video_init.mp4" media="video$Number$.mp4" duration="900000">
         <SegmentTimeline>
           <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
@@ -349,7 +335,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
       <Representation id="1" bandwidth="3000000" codecs="avc1.4d401f" width="1280" height="720" frameRate="30"/>
     </AdaptationSet>
 	<AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="audio_p2_init.mp4" media="audio_p2_$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="audio_init.mp4" media="audio$Number$.mp4" duration="900000">
         <SegmentTimeline>
           <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
@@ -394,10 +380,8 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 
 	std::string AdInitFragmentUrl = std::string(TEST_AD_BASE_URL) + std::string("video_init.mp4");
 	std::string AdAudioInitFragmentUrl = std::string(TEST_AD_BASE_URL) + std::string("audio_init.mp4");
-	std::string SourceP1InitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_p1_init.mp4");
-	std::string SourceP1AudioInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_p1_init.mp4");
-	std::string SourceP2InitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_p2_init.mp4");
-	std::string SourceP2AudioInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_p2_init.mp4");
+	std::string SourceInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
+	std::string SourceAudioInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_init.mp4");
 	AAMPStatusType status;
 	mPrivateInstanceAAMP->rate = 1.0;
 
@@ -407,7 +391,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 					return config == eAAMPConfig_EnableClientDai;
 					}));
 
-	std::string periodId = "2"; // Ad break on Period 2
+	std::string periodId = "1";
 	std::string adId = "Ad1";
 	std::string adurl = "";
 	uint64_t startMS = 0;
@@ -448,45 +432,32 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 				return (++counter < 10);
 			});
 
-	// Period 1 source init fetched during Init() — no ad break on Period 1
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP1InitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
-		.Times(1)
-		.WillOnce(Return(true));
-
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP1AudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
-		.Times(1)
-		.WillOnce(Return(true));
-
-	// Ad init fetched in FetcherLoop (Period 2 ad break) — forced to fail
+	// Need to fail ad Video init fragment
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(AdInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.Times(1)
 		.WillOnce(Return(false));
 
+	//Need to fail ad audio init fragment
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(AdAudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
-		.Times(1)
-		.WillOnce(Return(false));
+        .Times(1)
+        .WillOnce(Return(false));
 
-	// Period 2 source init fetched in FetcherLoop fallback after ad init failure
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP2InitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.Times(1)
 		.WillOnce(Return(true));
 
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP2AudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceAudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.Times(1)
 		.WillOnce(Return(true));
 
 	TuneType tuneType = TuneType::eTUNETYPE_NEW_NORMAL;
-	// Init tunes to Period 1; onAdEvent(INIT) is skipped for NEW_NORMAL so state stays OUTSIDE_ADBREAK
+	// Will start fetching the ad, but fails in ad init fragment and should fallback to source period and its init fragment
 	status = Init(tuneType);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
-	EXPECT_EQ(mStreamAbstractionAAMP_MPD->mCdaiObject->mAdState, AdState::OUTSIDE_ADBREAK);
+	EXPECT_EQ(mStreamAbstractionAAMP_MPD->mCdaiObject->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
 
-	// Advance player state to Period 2 where the ad break is set up
-	mStreamAbstractionAAMP_MPD->SetBasePeriodId("2", 1);
-
-	// FetcherLoop: onAdEvent(DEFAULT) finds ad on Period 2 → IN_ADBREAK_AD_PLAYING
-	// → ad init fetch fails → AD_FAILED → IN_ADBREAK_AD_NOT_PLAYING → fallback to Period 2 source
 	mStreamAbstractionAAMP_MPD->InvokeFetcherLoop();
+	// Gets updated in FetcherLoop
 	EXPECT_EQ(mStreamAbstractionAAMP_MPD->mCdaiObject->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
 	EXPECT_DOUBLE_EQ(mStreamAbstractionAAMP_MPD->mPTSOffset.inSeconds(), 0.0);
 }

--- a/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
@@ -450,7 +450,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 		.Times(1)
 		.WillOnce(Return(true));
 
-	TuneType tuneType = TuneType::eTUNETYPE_NEW_NORMAL;
+	TuneType tuneType = TuneType::eTUNETYPE_RETUNE;
 	// Will start fetching the ad, but fails in ad init fragment and should fallback to source period and its init fragment
 	status = Init(tuneType);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);

--- a/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
@@ -118,6 +118,14 @@ class AdFallbackTests : public ::testing::Test
 			{
 				return StreamAbstractionAAMP_MPD::IndexNewMPDDocument(updateTrackInfo);
 			}
+
+			void SetBasePeriodId(const std::string& periodId, int periodIdx, double offset = 0.0)
+			{
+				mBasePeriodId = periodId;
+				mBasePeriodOffset = offset;
+				mCurrentPeriodIdx = periodIdx;
+				mIterPeriodIndex = periodIdx;
+			}
 		};
 		PrivateInstanceAAMP *mPrivateInstanceAAMP;
 		CDAIObjectMPD *mCdaiObj;
@@ -294,13 +302,12 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 {
 	static const char *manifest = R"(<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" type="static" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT1.5S" mediaPresentationDuration="PT2M0S">
-  <!-- Period 1 with Ad Marker in the first 15 seconds -->
+  <!-- Period 1 - no ad marker; Init() tunes here with eTUNETYPE_NEW_NORMAL -->
   <Period id="1" start="PT0H0M0.000S">
     <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="video_init.mp4" media="video$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="video_p1_init.mp4" media="video_p1_$Number$.mp4" duration="900000">
         <SegmentTimeline>
-          <!-- Ad Marker SCTE placed here for first 15 seconds -->
-          <S t="0" d="1350000" scte35:signal="SCTE-35 AD_MARKER"/>
+          <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
           <S t="2700000" d="1350000"/>
           <S t="4050000" d="1350000"/>
@@ -309,7 +316,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
       <Representation id="1" bandwidth="3000000" codecs="avc1.4d401f" width="1280" height="720" frameRate="30"/>
     </AdaptationSet>
 	<AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="audio_init.mp4" media="audio$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="audio_p1_init.mp4" media="audio_p1_$Number$.mp4" duration="900000">
         <SegmentTimeline>
           <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
@@ -321,10 +328,17 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
     </AdaptationSet>
   </Period>
 
-  <!-- Period 2 -  without Ad Marker -->
+  <!-- Period 2 - with SCTE35 EventStream ad marker; FetcherLoop processes ad here -->
   <Period id="2" start="PT1M0S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000">
+      <Event presentationTime="0" duration="1350000">
+        <scte35:Signal>
+          <scte35:Binary>/DAsAAAQdSsYAP/wBQb+3zKJFQAWAhRDVUVJAAAkQn/AAABOcUAAACIAAJR2FfM=</scte35:Binary>
+        </scte35:Signal>
+      </Event>
+    </EventStream>
     <AdaptationSet contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="video_init.mp4" media="video$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="video_p2_init.mp4" media="video_p2_$Number$.mp4" duration="900000">
         <SegmentTimeline>
           <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
@@ -335,7 +349,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
       <Representation id="1" bandwidth="3000000" codecs="avc1.4d401f" width="1280" height="720" frameRate="30"/>
     </AdaptationSet>
 	<AdaptationSet contentType="audio" mimeType="audio/mp4" segmentAlignment="true" startWithSAP="1">
-      <SegmentTemplate timescale="90000" initialization="audio_init.mp4" media="audio$Number$.mp4" duration="900000">
+      <SegmentTemplate timescale="90000" initialization="audio_p2_init.mp4" media="audio_p2_$Number$.mp4" duration="900000">
         <SegmentTimeline>
           <S t="0" d="1350000"/>
           <S t="1350000" d="1350000"/>
@@ -380,8 +394,10 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 
 	std::string AdInitFragmentUrl = std::string(TEST_AD_BASE_URL) + std::string("video_init.mp4");
 	std::string AdAudioInitFragmentUrl = std::string(TEST_AD_BASE_URL) + std::string("audio_init.mp4");
-	std::string SourceInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_init.mp4");
-	std::string SourceAudioInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_init.mp4");
+	std::string SourceP1InitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_p1_init.mp4");
+	std::string SourceP1AudioInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_p1_init.mp4");
+	std::string SourceP2InitFragmentUrl = std::string(TEST_BASE_URL) + std::string("video_p2_init.mp4");
+	std::string SourceP2AudioInitFragmentUrl = std::string(TEST_BASE_URL) + std::string("audio_p2_init.mp4");
 	AAMPStatusType status;
 	mPrivateInstanceAAMP->rate = 1.0;
 
@@ -391,7 +407,7 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 					return config == eAAMPConfig_EnableClientDai;
 					}));
 
-	std::string periodId = "1";
+	std::string periodId = "2"; // Ad break on Period 2
 	std::string adId = "Ad1";
 	std::string adurl = "";
 	uint64_t startMS = 0;
@@ -432,32 +448,45 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 				return (++counter < 10);
 			});
 
-	// Need to fail ad Video init fragment
+	// Period 1 source init fetched during Init() — no ad break on Period 1
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP1InitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP1AudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
+		.Times(1)
+		.WillOnce(Return(true));
+
+	// Ad init fetched in FetcherLoop (Period 2 ad break) — forced to fail
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(AdInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.Times(1)
 		.WillOnce(Return(false));
 
-	//Need to fail ad audio init fragment
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(AdAudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
-        .Times(1)
-        .WillOnce(Return(false));
+		.Times(1)
+		.WillOnce(Return(false));
 
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
+	// Period 2 source init fetched in FetcherLoop fallback after ad init failure
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP2InitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.Times(1)
 		.WillOnce(Return(true));
 
-	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceAudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(SourceP2AudioInitFragmentUrl, _, _, _, _, true, _, _, _, _, _))
 		.Times(1)
 		.WillOnce(Return(true));
 
 	TuneType tuneType = TuneType::eTUNETYPE_NEW_NORMAL;
-	// Will start fetching the ad, but fails in ad init fragment and should fallback to source period and its init fragment
+	// Init tunes to Period 1; onAdEvent(INIT) is skipped for NEW_NORMAL so state stays OUTSIDE_ADBREAK
 	status = Init(tuneType);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
-	EXPECT_EQ(mStreamAbstractionAAMP_MPD->mCdaiObject->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	EXPECT_EQ(mStreamAbstractionAAMP_MPD->mCdaiObject->mAdState, AdState::OUTSIDE_ADBREAK);
 
+	// Advance player state to Period 2 where the ad break is set up
+	mStreamAbstractionAAMP_MPD->SetBasePeriodId("2", 1);
+
+	// FetcherLoop: onAdEvent(DEFAULT) finds ad on Period 2 → IN_ADBREAK_AD_PLAYING
+	// → ad init fetch fails → AD_FAILED → IN_ADBREAK_AD_NOT_PLAYING → fallback to Period 2 source
 	mStreamAbstractionAAMP_MPD->InvokeFetcherLoop();
-	// Gets updated in FetcherLoop
 	EXPECT_EQ(mStreamAbstractionAAMP_MPD->mCdaiObject->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
 	EXPECT_DOUBLE_EQ(mStreamAbstractionAAMP_MPD->mPTSOffset.inSeconds(), 0.0);
 }

--- a/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
@@ -450,6 +450,11 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 		.Times(1)
 		.WillOnce(Return(true));
 
+	// eTUNETYPE_RETUNE is required here because Init() has a guard that skips onAdEvent(INIT)
+	// for eTUNETYPE_NEW_NORMAL and eTUNETYPE_NEW_SEEK. Skipping onAdEvent(INIT) means the CDAI
+	// state never transitions to IN_ADBREAK_AD_PLAYING during Init(), so StreamSelection() does
+	// not set the ad manifest URL and no ad init fragment is fetched. eTUNETYPE_RETUNE bypasses
+	// that guard, allowing onAdEvent(INIT) to run and the ad init path to be exercised as intended.
 	TuneType tuneType = TuneType::eTUNETYPE_RETUNE;
 	// Will start fetching the ad, but fails in ad init fragment and should fallback to source period and its init fragment
 	status = Init(tuneType);

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -4226,6 +4226,28 @@ TEST_F(AdManagerMPDTests, WaitForNextAdResolved_DisableDownloadsBeforeWait)
   EXPECT_LT(elapsedMs, 500) << "WaitForNextAdResolved did not abort immediately, waited for " << elapsedMs << " ms";
 }
 
+/**
+ * @brief Test NotifyReservationComplete for empty ad break: should resolve and notify waiting threads.
+ */
+TEST_F(AdManagerMPDTests, NotifyReservationComplete_EmptyAdBreak_NotifiesAndResolves)
+{
+    std::string periodId = "testPeriodId";
+    mPrivateCDAIObjectMPD->mAdBreaks[periodId] = AdBreakObject(10000, nullptr, "", 0, 0);
+ 
+    // Start a thread that waits for ad resolution (should be notified by NotifyReservationComplete)
+    bool completed = false;
+    std::thread waiter([&] {
+      completed = mPrivateCDAIObjectMPD->WaitForNextAdResolved(5000, periodId);
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    mPrivateCDAIObjectMPD->NotifyReservationComplete(periodId);
+ 
+    waiter.join();
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].resolved);
+    // The waiting thread should have completed (not timed out)
+    EXPECT_TRUE(completed);
+}
 
 /**
  * @brief CancelReservation should set cancelAtReservationId for active placement.

--- a/test/utests/tests/fragmentcollector_mpd/FindTimedMetadataTests.cpp
+++ b/test/utests/tests/fragmentcollector_mpd/FindTimedMetadataTests.cpp
@@ -245,10 +245,12 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     // LiveManifest=true and init=false
     ResetCDAIAdObject();
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 27120))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),27120.0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 
     // Duplicate Periods are not processed
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,_)).Times(0);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,_,_)).Times(0);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 }
 
@@ -287,17 +289,22 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     // LiveManifest=false and init=true
     InitializeMPD(manifest);
     mStreamAbstractionAAMP_MPD->SetIsLiveManifest(false);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 0))).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, true, false);
 
     // LiveManifest=false and init=false
     ResetCDAIAdObject();
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 0))).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 
     // Duplicate Periods are not processed
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,_)).Times(0);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,_,_)).Times(0);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 }
@@ -343,5 +350,7 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     mStreamAbstractionAAMP_MPD->SetIsLiveManifest(true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 27120))).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),27120.0)).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 }

--- a/test/utests/tests/fragmentcollector_mpd/fragmentcollector_mpd1.cpp
+++ b/test/utests/tests/fragmentcollector_mpd/fragmentcollector_mpd1.cpp
@@ -111,6 +111,31 @@ protected:
 				tsbReaderThreadID.join();
 			}
 		}
+
+        FRIEND_TEST(MpdTests, GetCurrentAdStartTimeSeconds_NotInAdBreak);
+        FRIEND_TEST(MpdTests, GetCurrentAdStartTimeSeconds_FirstAd);
+        FRIEND_TEST(MpdTests, GetCurrentAdStartTimeSeconds_SecondAd);
+        FRIEND_TEST(MpdTests, GetCurrentAdStartTimeSeconds_NoBreakId);
+        FRIEND_TEST(MpdTests, GetCurrentAdStartTimeSeconds_BreakAtStreamStart);
+
+        /**
+         * @brief Creates and injects a real CDAIObjectMPD so that
+         *        mCdaiObject is non-null for CDAI unit tests.
+         */
+        void CreateCDAIObject(PrivateInstanceAAMP *aamp)
+        {
+            mTestCdaiObj = new CDAIObjectMPD(aamp);
+            SetCDAIObject(mTestCdaiObj);
+        }
+
+        ~TestableStreamAbstractionAAMP_MPD()
+        {
+            delete mTestCdaiObj;
+            mTestCdaiObj = nullptr;
+        }
+
+    	private:
+        	CDAIObjectMPD *mTestCdaiObj = nullptr;
 	};
 
 	PrivateInstanceAAMP *mPrivateInstanceAAMP;
@@ -406,3 +431,129 @@ TEST_F(MpdTests, testRepeatedStartNotLocalTSB)
 	mStreamAbstractionAAMP_MPD->ShutdownThreads();
 }
 
+// ---------------------------------------------------------------------------
+// GetCurrentAdStartTimeSeconds tests
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief Returns -1.0 when not in an adbreak (OUTSIDE_ADBREAK state).
+ */
+TEST_F(MpdTests, GetCurrentAdStartTimeSeconds_NotInAdBreak)
+{
+        EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(false));
+        TestableStreamAbstractionAAMP_MPD stub(mPrivateInstanceAAMP);
+        stub.CreateCDAIObject(mPrivateInstanceAAMP);
+        ASSERT_NE(stub.mCdaiObject, nullptr);
+        stub.mCdaiObject->mAdState = AdState::OUTSIDE_ADBREAK;
+
+        EXPECT_DOUBLE_EQ(stub.GetCurrentAdStartTimeSeconds(), -1.0);
+}
+
+/**
+ * @brief Returns -1.0 when in an adbreak but mCurAdIdx == 0 (first ad — no prior ads to sum).
+ */
+TEST_F(MpdTests, GetCurrentAdStartTimeSeconds_FirstAd)
+{
+        EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(false));
+        TestableStreamAbstractionAAMP_MPD stub(mPrivateInstanceAAMP);
+        stub.CreateCDAIObject(mPrivateInstanceAAMP);
+        ASSERT_NE(stub.mCdaiObject, nullptr);
+
+        stub.mCdaiObject->mAdState = AdState::IN_ADBREAK_AD_PLAYING;
+        stub.mCdaiObject->mCurAdIdx = 0;  // first ad — no cumulative offset
+
+        EXPECT_DOUBLE_EQ(stub.GetCurrentAdStartTimeSeconds(), -1.0);
+}
+
+/**
+ * @brief Returns absoluteAdBreakStartTime + sum-of-prior-ad-durations when mCurAdIdx > 0.
+ *
+ * Pod: ad[0]=10000ms, ad[1]=8000ms, ad[2]=6000ms.
+ * Playing ad[2] (mCurAdIdx=2): expected = breakStart + (10000+8000)/1000 = 100 + 18 = 118.
+ */
+TEST_F(MpdTests, GetCurrentAdStartTimeSeconds_SecondAd)
+{
+        EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(false));
+        TestableStreamAbstractionAAMP_MPD stub(mPrivateInstanceAAMP);
+        stub.CreateCDAIObject(mPrivateInstanceAAMP);
+        ASSERT_NE(stub.mCdaiObject, nullptr);
+
+        const std::string breakId = "break1";
+
+        AdNode ad0, ad1, ad2;
+        ad0.duration = 10000; // ms
+        ad1.duration = 8000;
+        ad2.duration = 6000;
+        auto ads = std::make_shared<std::vector<AdNode>>();
+        ads->push_back(ad0);
+        ads->push_back(ad1);
+        ads->push_back(ad2);
+
+        AdBreakObject abObj;
+        abObj.mAbsoluteAdBreakStartTime = 100.0;
+        stub.mCdaiObject->mAdBreaks[breakId] = abObj;
+
+        stub.mCdaiObject->mCurPlayingBreakId = breakId;
+        stub.mCdaiObject->mCurAds = ads;
+        stub.mCdaiObject->mCurAdIdx = 2;  // playing 3rd ad
+        stub.mCdaiObject->mAdState = AdState::IN_ADBREAK_AD_PLAYING;
+
+        // Expected: 100 + (10000 + 8000) / 1000 = 118.0
+        EXPECT_DOUBLE_EQ(stub.GetCurrentAdStartTimeSeconds(), 118.0);
+}
+
+/**
+ * @brief Returns -1.0 when mCurPlayingBreakId is empty (break not yet identified).
+ */
+TEST_F(MpdTests, GetCurrentAdStartTimeSeconds_NoBreakId)
+{
+        EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(false));
+        TestableStreamAbstractionAAMP_MPD stub(mPrivateInstanceAAMP);
+        stub.CreateCDAIObject(mPrivateInstanceAAMP);
+        ASSERT_NE(stub.mCdaiObject, nullptr);
+
+        stub.mCdaiObject->mAdState = AdState::IN_ADBREAK_AD_PLAYING;
+        stub.mCdaiObject->mCurAdIdx = 1;
+        // mCurAds must be non-null with enough entries so the size guard doesn't
+        // crash before reaching the mCurPlayingBreakId.empty() check.
+        auto ads = std::make_shared<std::vector<AdNode>>();
+        ads->push_back(AdNode{});
+        ads->push_back(AdNode{});
+        stub.mCdaiObject->mCurAds = ads;
+        stub.mCdaiObject->mCurPlayingBreakId = "";  // no break id → early return
+
+        EXPECT_DOUBLE_EQ(stub.GetCurrentAdStartTimeSeconds(), -1.0);
+}
+
+/**
+ * @brief A break starting at t=0.0 (stream start) is valid and must not be rejected.
+ *
+ * Pod: ad[0]=10000ms. Playing ad[1] (mCurAdIdx=1): expected = 0 + 10000/1000 = 10.0.
+ */
+TEST_F(MpdTests, GetCurrentAdStartTimeSeconds_BreakAtStreamStart)
+{
+        EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(false));
+        TestableStreamAbstractionAAMP_MPD stub(mPrivateInstanceAAMP);
+        stub.CreateCDAIObject(mPrivateInstanceAAMP);
+        ASSERT_NE(stub.mCdaiObject, nullptr);
+
+        const std::string breakId = "break0";
+        AdNode ad0, ad1;
+        ad0.duration = 10000; // ms
+        ad1.duration = 8000;
+        auto ads = std::make_shared<std::vector<AdNode>>();
+        ads->push_back(ad0);
+        ads->push_back(ad1);
+
+        AdBreakObject abObj;
+        abObj.mAbsoluteAdBreakStartTime = 0.0;  // break at stream start
+        stub.mCdaiObject->mAdBreaks[breakId] = abObj;
+
+        stub.mCdaiObject->mCurPlayingBreakId = breakId;
+        stub.mCdaiObject->mCurAds = ads;
+        stub.mCdaiObject->mCurAdIdx = 1;
+        stub.mCdaiObject->mAdState = AdState::IN_ADBREAK_AD_PLAYING;
+
+        // Expected: 0.0 + 10000/1000 = 10.0 — must NOT return -1.0
+        EXPECT_DOUBLE_EQ(stub.GetCurrentAdStartTimeSeconds(), 10.0);
+}


### PR DESCRIPTION
Enable CDAI support for cold CDVR and fix DAI event handling

- Invoke FoundEventBreak for both static and dynamic manifests when CDAI is enabled to support CDAI on cold CDVR.
- Avoid calling onAdEvent from init() to prevent processing DAI events during the tune-time period for a new tune.