### PR TITLE
VPAAMP-468: [VIPA] Sky Sports UHD audio muted throughout adbreak

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6628,9 +6628,20 @@ void StreamAbstractionAAMP_MPD::SelectAudioTrack(std::vector<AudioTrackInfo> &aT
 	*/
 	if (aamp->previousAudioType != selectedCodecType)
 	{
+
 		AAMPLOG_MIL("StreamAbstractionAAMP_MPD: AudioType Changed %d -> %d", aamp->previousAudioType, selectedCodecType);
+
+		if ( (selectedCodecType == eAUDIO_DDPLUS && aamp->previousAudioType == eAUDIO_ATMOS)
+		|| (selectedCodecType == eAUDIO_ATMOS && aamp->previousAudioType == eAUDIO_DDPLUS))
+		{
+			/*Ignore change between 2 dolby audio types which should be compatible*/
+		}
+		else
+		{
+			SetESChangeStatus();
+		}
 		aamp->previousAudioType = selectedCodecType;
-		SetESChangeStatus();
+
 	}
 }
 

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6628,13 +6628,14 @@ void StreamAbstractionAAMP_MPD::SelectAudioTrack(std::vector<AudioTrackInfo> &aT
 	*/
 	if (aamp->previousAudioType != selectedCodecType)
 	{
-
 		AAMPLOG_MIL("StreamAbstractionAAMP_MPD: AudioType Changed %d -> %d", aamp->previousAudioType, selectedCodecType);
 
 		if ( (selectedCodecType == eAUDIO_DDPLUS && aamp->previousAudioType == eAUDIO_ATMOS)
 		|| (selectedCodecType == eAUDIO_ATMOS && aamp->previousAudioType == eAUDIO_DDPLUS))
 		{
-			/*Ignore change between 2 dolby audio types which should be compatible*/
+			/* Ignore change between 2 dolby audio types which should be compatible
+			* they will both be using the 'ec-3' codec
+			*/
 		}
 		else
 		{


### PR DESCRIPTION
Reason for change: At this time VIPA does not support mid stream audio change. An audio change is not needed when switching between DDPLAS and ATMOS because they both use the same codec.