### PR TITLE
VPAAMP 498 ;Fix for out-of-bound access in CheckPreferredTextLanguages()

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12492,7 +12492,9 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	int currentTrackIndex = GetTextTrack();
 	int trackIdx = -1;
 
-	if (currentTrackIndex >= 0)
+
+	//Added out of bound check to prevent crash in case of currentTrackIndex is more than available tracks.
+	if (currentTrackIndex >= 0 && !(currentTrackIndex >= static_cast<int>(trackInfo.size())))
 	{
 		std::string currentPrefLanguage = Getiso639map_NormalizeLanguageCode(trackInfo[currentTrackIndex].language, this->GetLangCodePreference());
 		char *currentPrefRendition = const_cast<char *>(trackInfo[currentTrackIndex].rendition.c_str());
@@ -12582,6 +12584,11 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	}
 	else
 	{
+		if (currentTrackIndex >= static_cast<int>(trackInfo.size()))
+		{
+			AAMPLOG_WARN("CheckPreferredTextLanguages: currentTrackIndex=%d out of bounds (trackInfo.size()=%zu), treating as no selection",
+						 currentTrackIndex, trackInfo.size());
+		}
 		isSelectionChange = true;
 		// no track is currently selected but need to find closedCaptionTrackIdx if there is one
 	}


### PR DESCRIPTION
Reason for change : Fix for out of bound access happened due to a timing issue where in SetPreferredTextLanguages() in AAMP JS was called before PopulateTextTrack was called.
Test Procedure : Refer ticket
Risks : Medium