### PR TITLE
VPAAMP-498 : Fix for out-of-bound access in CheckPreferredTextLanguages()

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13243,7 +13243,9 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	int currentTrackIndex = GetTextTrack();
 	int trackIdx = -1;
 
-	if (currentTrackIndex >= 0)
+
+	//Added out of bound check to prevent crash in case of currentTrackIndex is more than available tracks.
+	if (currentTrackIndex >= 0 && !(currentTrackIndex >= static_cast<int>(trackInfo.size())))
 	{
 		std::string currentPrefLanguage = Getiso639map_NormalizeLanguageCode(trackInfo[currentTrackIndex].language, this->GetLangCodePreference());
 		char *currentPrefRendition = const_cast<char *>(trackInfo[currentTrackIndex].rendition.c_str());
@@ -13333,6 +13335,11 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	}
 	else
 	{
+		if (currentTrackIndex >= static_cast<int>(trackInfo.size()))
+		{
+			AAMPLOG_WARN("CheckPreferredTextLanguages: currentTrackIndex=%d out of bounds (trackInfo.size()=%zu), treating as no selection",
+						 currentTrackIndex, trackInfo.size());
+		}
 		isSelectionChange = true;
 		// no track is currently selected but need to find closedCaptionTrackIdx if there is one
 	}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13245,7 +13245,7 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 
 
 	//Added out of bound check to prevent crash in case of currentTrackIndex is more than available tracks.
-	if (currentTrackIndex >= 0 && !(currentTrackIndex >= static_cast<int>(trackInfo.size())))
+	if (currentTrackIndex >= 0 && (currentTrackIndex < static_cast<int>(trackInfo.size())))
 	{
 		std::string currentPrefLanguage = Getiso639map_NormalizeLanguageCode(trackInfo[currentTrackIndex].language, this->GetLangCodePreference());
 		char *currentPrefRendition = const_cast<char *>(trackInfo[currentTrackIndex].rendition.c_str());
@@ -13335,11 +13335,8 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	}
 	else
 	{
-		if (currentTrackIndex >= static_cast<int>(trackInfo.size()))
-		{
-			AAMPLOG_WARN("CheckPreferredTextLanguages: currentTrackIndex=%d out of bounds (trackInfo.size()=%zu), treating as no selection",
+			AAMPLOG_INFO("CheckPreferredTextLanguages: currentTrackIndex=%d , trackInfo.size()=%zu either no track is currently selected or currentTrackIndex is out of bounds, so we will check for closed caption track index if there is one",
 						 currentTrackIndex, trackInfo.size());
-		}
 		isSelectionChange = true;
 		// no track is currently selected but need to find closedCaptionTrackIdx if there is one
 	}

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -13243,9 +13243,7 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	int currentTrackIndex = GetTextTrack();
 	int trackIdx = -1;
 
-
-	//Added out of bound check to prevent crash in case of currentTrackIndex is more than available tracks.
-	if (currentTrackIndex >= 0 && !(currentTrackIndex >= static_cast<int>(trackInfo.size())))
+	if (currentTrackIndex >= 0)
 	{
 		std::string currentPrefLanguage = Getiso639map_NormalizeLanguageCode(trackInfo[currentTrackIndex].language, this->GetLangCodePreference());
 		char *currentPrefRendition = const_cast<char *>(trackInfo[currentTrackIndex].rendition.c_str());
@@ -13335,11 +13333,6 @@ void PrivateInstanceAAMP::CheckPreferredTextLanguages(const std::vector<TextTrac
 	}
 	else
 	{
-		if (currentTrackIndex >= static_cast<int>(trackInfo.size()))
-		{
-			AAMPLOG_WARN("CheckPreferredTextLanguages: currentTrackIndex=%d out of bounds (trackInfo.size()=%zu), treating as no selection",
-						 currentTrackIndex, trackInfo.size());
-		}
 		isSelectionChange = true;
 		// no track is currently selected but need to find closedCaptionTrackIdx if there is one
 	}

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -1013,19 +1013,6 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenTeardownRacesWithSetPreferredTex
 /**
  * @brief Reproduce crash when PopulateAudioAndTextTracks races with
  *        SetPreferredTextLanguages on separate threads.
- *
- *        This simulates the exact crash from the field:
- *        Thread A (Tune/d562ce71): Inside Init() calling
- *                  PopulateAudioAndTextTracks() to populate mTextTracks.
- *        Thread B (JS API/78fa9c43): Calls SetPreferredTextLanguages() which
- *                  reads mTextTracks via GetAvailableTextTracks().
- *
- *        Because PopulateAudioAndTextTracks has NOT yet populated mTextTracks,
- *        GetAvailableTextTracks() returns an EMPTY vector. But
- *        mCurrentTextTrackIndex is already set to 0 .
- *        CheckPreferredTextLanguages then tries trackInfo[0] on an empty
- *        vector → SIGSEGV.
-
  */
 TEST_F(SetPreferredTextLanguagesTests, CrashWhenPopulateTracksRacesWithSetPreferredText)
 {

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -1009,3 +1009,87 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenTeardownRacesWithSetPreferredTex
 
 	EXPECT_TRUE(teardownDone.load());
 }
+
+/**
+ * @brief Reproduce crash when PopulateAudioAndTextTracks races with
+ *        SetPreferredTextLanguages on separate threads.
+ *
+ *        This simulates the exact crash from the field:
+ *        Thread A  Holds mStreamLock, inside Init() which
+ *                  calls PopulateAudioAndTextTracks() to populate mTextTracks.
+ *        Thread B Calls SetPreferredTextLanguages() which
+ *                  reads mTextTracks via GetAvailableTextTracks().
+ *
+ */
+TEST_F(SetPreferredTextLanguagesTests, CrashWhenPopulateTracksRacesWithSetPreferredText)
+{
+
+	std::vector<TextTrackInfo> populatedTracks;
+	populatedTracks.push_back(TextTrackInfo("idx0", "eng", false, "rend0", "English", "codecStr0", "cha0", "typ0", "lab0", "type0", Accessibility(), true));
+
+
+	std::vector<TextTrackInfo> emptyTracks;
+
+	mPrivateInstanceAAMP->preferredTextLanguagesString = "eng";
+	mPrivateInstanceAAMP->preferredTextLanguagesList.clear();
+	mPrivateInstanceAAMP->preferredTextLanguagesList.push_back("eng");
+	mPrivateInstanceAAMP->subtitles_muted = false;
+	mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_HLS;
+
+	mPrivateInstanceAAMP->mCurrentTextTrackIndex = 0;
+
+	std::mutex syncMtx;
+	std::condition_variable cvLockHeld;
+	std::condition_variable cvTestDone;
+	bool lockHeld = false;
+	bool testDone = false;
+	std::atomic<bool> threadBCompleted{false};
+	std::atomic<bool> threadBGotEmptyTracks{false};
+
+
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(_))
+		.WillOnce(Invoke([&](bool) -> std::vector<TextTrackInfo>& {
+			return populatedTracks;
+		}));
+
+	/* Thread A: Simulates the Tune thread holding mStreamLock while
+	 * PopulateAudioAndTextTracks is running. In production this is:
+	 * aamp_Tune -> AcquireStreamLock -> TuneHelper -> Init ->
+	 * PopulateAudioAndTextTracks (writes mTextTracks) -> ... ->
+	 * ReleaseStreamLock */
+	std::thread threadA([&]() {
+
+		mPrivateInstanceAAMP->AcquireStreamLock();
+
+		/* Signal Thread B that the lock is held (Tune in progress) */
+		{
+			std::lock_guard<std::mutex> lk(syncMtx);
+			lockHeld = true;
+		}
+		cvLockHeld.notify_one();
+
+		/* Hold the lock for a brief period simulating PopulateAudioAndTextTracks
+		 * execution time. In the real crash, this was ~50ms. */
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+		/* Release stream lock - simulates end of TuneHelper/Init path */
+		mPrivateInstanceAAMP->ReleaseStreamLock();
+	});
+
+	/* Thread B (main test thread): Calls SetPreferredTextLanguages.
+	 * Wait for Thread A to hold the lock first to reproduce the race window. */
+	{
+		std::unique_lock<std::mutex> lk(syncMtx);
+		cvLockHeld.wait(lk, [&] { return lockHeld; });
+	}
+
+
+	mPrivateInstanceAAMP->SetPreferredTextLanguages("{\"languages\":[\"eng\",\"\"],\"sub-type\":\"SUBTITLES\"}");
+	threadBCompleted.store(true);
+
+	threadA.join();
+
+	EXPECT_TRUE(threadBCompleted.load());
+
+	EXPECT_FALSE(threadBGotEmptyTracks.load());
+}

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -1015,18 +1015,20 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenTeardownRacesWithSetPreferredTex
  *        SetPreferredTextLanguages on separate threads.
  *
  *        This simulates the exact crash from the field:
- *        Thread A  Holds mStreamLock, inside Init() which
- *                  calls PopulateAudioAndTextTracks() to populate mTextTracks.
- *        Thread B Calls SetPreferredTextLanguages() which
+ *        Thread A (Tune/d562ce71): Inside Init() calling
+ *                  PopulateAudioAndTextTracks() to populate mTextTracks.
+ *        Thread B (JS API/78fa9c43): Calls SetPreferredTextLanguages() which
  *                  reads mTextTracks via GetAvailableTextTracks().
  *
+ *        Because PopulateAudioAndTextTracks has NOT yet populated mTextTracks,
+ *        GetAvailableTextTracks() returns an EMPTY vector. But
+ *        mCurrentTextTrackIndex is already set to 0 .
+ *        CheckPreferredTextLanguages then tries trackInfo[0] on an empty
+ *        vector → SIGSEGV.
+
  */
 TEST_F(SetPreferredTextLanguagesTests, CrashWhenPopulateTracksRacesWithSetPreferredText)
 {
-
-	std::vector<TextTrackInfo> populatedTracks;
-	populatedTracks.push_back(TextTrackInfo("idx0", "eng", false, "rend0", "English", "codecStr0", "cha0", "typ0", "lab0", "type0", Accessibility(), true));
-
 
 	std::vector<TextTrackInfo> emptyTracks;
 
@@ -1035,60 +1037,23 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenPopulateTracksRacesWithSetPrefer
 	mPrivateInstanceAAMP->preferredTextLanguagesList.push_back("eng");
 	mPrivateInstanceAAMP->subtitles_muted = false;
 	mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_HLS;
-
 	mPrivateInstanceAAMP->mCurrentTextTrackIndex = 0;
-
-	std::mutex syncMtx;
-	std::condition_variable cvLockHeld;
-	std::condition_variable cvTestDone;
-	bool lockHeld = false;
-	bool testDone = false;
-	std::atomic<bool> threadBCompleted{false};
-	std::atomic<bool> threadBGotEmptyTracks{false};
 
 
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(_))
-		.WillOnce(Invoke([&](bool) -> std::vector<TextTrackInfo>& {
-			return populatedTracks;
-		}));
+		.WillOnce(ReturnRef(emptyTracks));
 
-	/* Thread A: Simulates the Tune thread holding mStreamLock while
-	 * PopulateAudioAndTextTracks is running. In production this is:
-	 * aamp_Tune -> AcquireStreamLock -> TuneHelper -> Init ->
-	 * PopulateAudioAndTextTracks (writes mTextTracks) -> ... ->
-	 * ReleaseStreamLock */
-	std::thread threadA([&]() {
-
-		std::lock_guard<std::recursive_mutex> lock(mPrivateInstanceAAMP->GetStreamLock());
-
-		/* Signal Thread B that the lock is held (Tune in progress) */
-		{
-			std::lock_guard<std::mutex> lk(syncMtx);
-			lockHeld = true;
-		}
-		cvLockHeld.notify_one();
-
-		/* Hold the lock for a brief period simulating PopulateAudioAndTextTracks
-		 * execution time. In the real crash, this was ~50ms. */
-		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-
-	});
-
-	/* Thread B (main test thread): Calls SetPreferredTextLanguages.
-	 * Wait for Thread A to hold the lock first to reproduce the race window. */
-	{
-		std::unique_lock<std::mutex> lk(syncMtx);
-		cvLockHeld.wait(lk, [&] { return lockHeld; });
-	}
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
+		.WillOnce(Return(false));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
+		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
+	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_, _, _))
+		.Times(::testing::AnyNumber());
 
 
 	mPrivateInstanceAAMP->SetPreferredTextLanguages("{\"languages\":[\"eng\",\"\"],\"sub-type\":\"SUBTITLES\"}");
-	threadBCompleted.store(true);
 
-	threadA.join();
-
-	EXPECT_TRUE(threadBCompleted.load());
-
-	EXPECT_FALSE(threadBGotEmptyTracks.load());
+	/* If we reach here, the bounds check prevented the crash */
+	EXPECT_STREQ(mPrivateInstanceAAMP->preferredTextLanguagesString.c_str(), "eng,");
 }

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -1059,7 +1059,7 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenPopulateTracksRacesWithSetPrefer
 	 * ReleaseStreamLock */
 	std::thread threadA([&]() {
 
-		mPrivateInstanceAAMP->AcquireStreamLock();
+		std::lock_guard<std::recursive_mutex> lock(mPrivateInstanceAAMP->GetStreamLock());
 
 		/* Signal Thread B that the lock is held (Tune in progress) */
 		{
@@ -1072,8 +1072,7 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenPopulateTracksRacesWithSetPrefer
 		 * execution time. In the real crash, this was ~50ms. */
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-		/* Release stream lock - simulates end of TuneHelper/Init path */
-		mPrivateInstanceAAMP->ReleaseStreamLock();
+
 	});
 
 	/* Thread B (main test thread): Calls SetPreferredTextLanguages.


### PR DESCRIPTION
Reason for change : Fix for out of bound access happened due to a timing issue where in SetPreferredTextLanguages() in AAMP JS was called before PopulateTextTrack was called.
Test Procedure : Refer ticket
Risks : Medium