### PR TITLE
VPAAMP-550 default enable mp4demux in sprint (over qtdemux)

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -371,7 +371,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "monitorAV", eAAMPConfig_MonitorAV, true},
 	{false, "enablePTSRestampForHlsTs", eAAMPConfig_HlsTsEnablePTSReStamp, true},
 	{true, "overrideMediaHeaderDuration", eAAMPConfig_OverrideMediaHeaderDuration, true},
-	{false, "useMp4Demux", eAAMPConfig_UseMp4Demux,false },
+	{true, "useMp4Demux", eAAMPConfig_UseMp4Demux,false },
 	{false, "curlThroughput", eAAMPConfig_CurlThroughput, false },
 	{false, "useFireboltSDK", eAAMPConfig_UseFireboltSDK, false},
 	{true, "enableChunkInjection", eAAMPConfig_EnableChunkInjection, true},

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -371,7 +371,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false, "monitorAV", eAAMPConfig_MonitorAV, true},
 	{false, "enablePTSRestampForHlsTs", eAAMPConfig_HlsTsEnablePTSReStamp, true},
 	{true, "overrideMediaHeaderDuration", eAAMPConfig_OverrideMediaHeaderDuration, true},
-	{true, "useMp4Demux", eAAMPConfig_UseMp4Demux,false },
+	{true, "useMp4Demux", eAAMPConfig_UseMp4Demux, false },
 	{false, "curlThroughput", eAAMPConfig_CurlThroughput, false },
 	{false, "useFireboltSDK", eAAMPConfig_UseFireboltSDK, false},
 	{true, "enableChunkInjection", eAAMPConfig_EnableChunkInjection, true},

--- a/AampTSBSessionManager.cpp
+++ b/AampTSBSessionManager.cpp
@@ -433,6 +433,10 @@ void AampTSBSessionManager::ProcessWriteQueue()
 						NOW_STEADY_TS_MS - tStartTime, writeData.cachedFragment->fragment.size(), writeData.cachedFragment->cacheFragStreamInfo.bandwidthBitsPerSecond, GetMediaTypeName(writeData.cachedFragment->type),
 						writeData.cachedFragment->discontinuity, writeData.pts, writeData.periodId.c_str(), writeData.url.c_str());
 					LockReadMutex();
+					// Cache the shared_ptr once so that a concurrent teardown that resets
+					// the member cannot destroy the AampTsbReader between the null-check
+					// and the method call (TOCTOU use-after-free).
+					std::shared_ptr<AampTsbReader> tsbReader = GetTsbReader(mediatype);
 					if (writeData.cachedFragment->initFragment)
 					{
 						TSBDataAddStatus = GetTsbDataManager(mediatype)->AddInitFragment(writeData.url,
@@ -447,26 +451,26 @@ void AampTSBSessionManager::ProcessWriteQueue()
 						TSBDataAddStatus = GetTsbDataManager(mediatype)->AddFragment(writeData,
 																					mediatype,
 																					writeData.cachedFragment->discontinuity);
-						if(GetTsbReader(mediatype))
+						if(tsbReader)
 						{
-							GetTsbReader(mediatype)->SetNewInitWaiting(false);
+							tsbReader->SetNewInitWaiting(false);
 						}
 					}
 					UpdateTotalStoreDuration(mediatype, writeData.cachedFragment->duration);
 					if (TSBDataAddStatus)
 					{
-						if (GetTsbReader(mediatype))
+						if (tsbReader)
 						{
 							if(writeData.cachedFragment->initFragment)
 							{
-								GetTsbReader(mediatype)->SetNewInitWaiting(true);
+								tsbReader->SetNewInitWaiting(true);
 								AAMPLOG_INFO("[%s] New init active at live edge %s", GetMediaTypeName(mediatype), writeData.url.c_str());
 							}
 							else if(eTUNETYPE_SEEKTOLIVE != mActiveTuneType)
 							{
 								// Reset EOS for all other tune types except seek to live
 								// For seek to live, segment injection has to go through chunked transfer and reader has to exit
-								GetTsbReader(mediatype)->ResetEos();
+								tsbReader->ResetEos();
 								AAMPLOG_INFO("[%s] Resetting EOS", GetMediaTypeName(mediatype));
 							}
 						}

--- a/MediaStreamContext.cpp
+++ b/MediaStreamContext.cpp
@@ -652,6 +652,18 @@ bool MediaStreamContext::CacheTsbFragment(std::shared_ptr<CachedFragment>&& frag
 		{
 			ret = true;
 			UpdateTSAfterFetch();
+			// OnFragmentDownloadSuccess is not called in the TSB read path, so
+			// lastDownloadedPosition is never advanced.  Without it, GetBufferedDuration()
+			// always returns 0, causing GetBufferStatus() to misreport BUFFER_STATUS_RED
+			// after elapsed time exceeds totalInjectedDuration and triggering a spurious
+			// retune/teardown.  Update it here from the fields populated by Read().
+			if (!cachedFragment->initFragment && cachedFragment->absPosition > 0.0)
+			{
+				lastDownloadedPosition.store(cachedFragment->absPosition + cachedFragment->duration);
+				AAMPLOG_DEBUG("[%s] (TSB) lastDownloadedPosition %.3fs (absPos %.3f + dur %.3f)",
+					name, lastDownloadedPosition.load(),
+					cachedFragment->absPosition, cachedFragment->duration);
+			}
 		}
 		else
 		{

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1149,7 +1149,17 @@ bool AAMPGstPlayer::Discontinuity(AampMediaType type)
 
 	bool CompleteDiscontinuityDataDeliverForPTSRestamp =false;
 	bool shouldHaltBuffering = false;
-	ret = playerInstance->CheckDiscontinuity((int)type,(int)aamp->mVideoFormat, aamp->ReconfigureForElementaryStreamUpdate(), CompleteDiscontinuityDataDeliverForPTSRestamp, shouldHaltBuffering);
+	// codecChange: true only for an actual audio/video ES codec change
+	// (GetESChangeStatus).  PTO-only discontinuities (GetPipelineFlushStatus
+	// but !GetESChangeStatus) set codecChange=false so the Mp4Demux no-EOS
+	// path in CheckDiscontinuity is correctly taken.
+	// ReconfigureForElementaryStreamUpdate() is kept for the non-Mp4Demux
+	// path which already handles pipeline-flush internally.
+	bool esChange = aamp->mpStreamAbstractionAAMP ?
+		aamp->mpStreamAbstractionAAMP->GetESChangeStatus() : false;
+	bool reconfigForES = aamp->ReconfigureForElementaryStreamUpdate();
+	bool codecChange = ISCONFIGSET(eAAMPConfig_UseMp4Demux) ? esChange : reconfigForES;
+	ret = playerInstance->CheckDiscontinuity((int)type,(int)aamp->mVideoFormat, codecChange, CompleteDiscontinuityDataDeliverForPTSRestamp, shouldHaltBuffering);
 
 	if(CompleteDiscontinuityDataDeliverForPTSRestamp)
 	{

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -5060,18 +5060,11 @@ void StreamAbstractionAAMP_HLS::Stop(bool clearChannelData)
 ***************************************************************************/
 void StreamAbstractionAAMP_HLS::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &subOutputFormat)
 {
-	if (ISCONFIGSET(eAAMPConfig_UseMp4Demux))
-	{
-		// Mp4Demuxer will set the format later once the init fragment is parsed
-		// format is only used for video and audio formats. Subtitle should be unaffected
-		primaryOutputFormat = FORMAT_UNKNOWN;
-		audioOutputFormat = FORMAT_UNKNOWN;
-	}
-	else
-	{
-		primaryOutputFormat = trackState[eMEDIATYPE_VIDEO]->streamOutputFormat;
-		audioOutputFormat = trackState[eMEDIATYPE_AUDIO]->streamOutputFormat;
-	}
+	/* AampMp4Demuxer is never used for HLS (UseMp4Demux is DASH-only).
+	 * Always report the actual track formats so that IsoBmffProcessor and
+	 * the GStreamer pipeline are configured correctly. */
+	primaryOutputFormat = trackState[eMEDIATYPE_VIDEO]->streamOutputFormat;
+	audioOutputFormat = trackState[eMEDIATYPE_AUDIO]->streamOutputFormat;
 	subOutputFormat = trackState[eMEDIATYPE_SUBTITLE]->streamOutputFormat;
 }
 /***************************************************************************

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -5060,9 +5060,6 @@ void StreamAbstractionAAMP_HLS::Stop(bool clearChannelData)
 ***************************************************************************/
 void StreamAbstractionAAMP_HLS::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &subOutputFormat)
 {
-	/* AampMp4Demuxer is never used for HLS (UseMp4Demux is DASH-only).
-	 * Always report the actual track formats so that IsoBmffProcessor and
-	 * the GStreamer pipeline are configured correctly. */
 	primaryOutputFormat = trackState[eMEDIATYPE_VIDEO]->streamOutputFormat;
 	audioOutputFormat = trackState[eMEDIATYPE_AUDIO]->streamOutputFormat;
 	subOutputFormat = trackState[eMEDIATYPE_SUBTITLE]->streamOutputFormat;

--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -5063,6 +5063,19 @@ void StreamAbstractionAAMP_HLS::GetStreamFormat(StreamOutputFormat &primaryOutpu
 	primaryOutputFormat = trackState[eMEDIATYPE_VIDEO]->streamOutputFormat;
 	audioOutputFormat = trackState[eMEDIATYPE_AUDIO]->streamOutputFormat;
 	subOutputFormat = trackState[eMEDIATYPE_SUBTITLE]->streamOutputFormat;
+	/* When AampMp4Demuxer is active for HLS-fMP4, tell Configure() that the
+	 * initial appsrc format is unknown.  This suppresses qtdemux insertion and
+	 * enables typefind on the appsrc so that GStreamer auto-detects caps from
+	 * the first demuxed ES sample pushed by AampMp4Demuxer::SetStreamCaps().
+	 * This mirrors the behaviour of the DASH path where GetStreamFormat already
+	 * returns FORMAT_UNKNOWN when useMp4Demux is set. */
+	if (ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+	{
+		if (primaryOutputFormat == FORMAT_ISO_BMFF)
+			primaryOutputFormat = FORMAT_UNKNOWN;
+		if (audioOutputFormat == FORMAT_ISO_BMFF)
+			audioOutputFormat = FORMAT_UNKNOWN;
+	}
 }
 /***************************************************************************
 * @brief Function to get available video bitrates

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4232,7 +4232,15 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 		AAMPLOG_MIL("StreamAbstractionAAMP_MPD: fetch initialization fragments");
 		// We have decided on the first period, calculate the PTSoffset to be applied to
 		// all segments including the init segments for the GST buffer that goes with the init
-		mPTSOffset = 0.0;
+		if (newTune || !ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+		{
+			/* Fresh tune: start the PTS accumulation from zero. */
+			mPTSOffset = 0.0;
+		}
+		/* else: non-new-tune re-init (e.g. back-to-back CDAI seek) with
+		 * AampMp4Demuxer active — preserve the accumulated mPTSOffset so
+		 * GStreamer receives monotonically increasing timestamps across the
+		 * new period sequence. */
 		mNextPts = 0.0;
 		UpdatePtsOffset(true);
 		FetchAndInjectInitFragments();

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4236,12 +4236,12 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 		{
 			/* Fresh tune: start the PTS accumulation from zero. */
 			mPTSOffset = 0.0;
+			mNextPts = 0.0;
 		}
-		/* else: non-new-tune re-init (e.g. back-to-back CDAI seek) with
-		 * AampMp4Demuxer active — preserve the accumulated mPTSOffset so
-		 * GStreamer receives monotonically increasing timestamps across the
-		 * new period sequence. */
-		mNextPts = 0.0;
+		/* else: non-new-tune re-init (e.g. back-to-back CDAI period transition)
+		 * with AampMp4Demuxer active — preserve mNextPts so UpdatePtsOffset()
+		 * carries forward the accumulated timeline position and computes a
+		 * correct (near-zero) mPTSOffset for the new period. */
 		UpdatePtsOffset(true);
 		FetchAndInjectInitFragments();
 	}

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -11130,12 +11130,13 @@ StreamOutputFormat GetSubtitleFormat(std::string mimeType)
  */
 void StreamAbstractionAAMP_MPD::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &subtitleOutputFormat)
 {
-	// When UseMp4Demux is true the pipeline is still configured as ISO_BMFF;
-	// AampMp4Demuxer demuxes the boxes and calls SetStreamCaps to push ES data
-	// directly into the appsrc. ConfigurePipeline must see FORMAT_ISO_BMFF so that
-	// it tears down and re-creates the pipeline correctly on period transitions and
-	// seeks, matching the behaviour of the non-mp4demux path.
-	StreamOutputFormat format = FORMAT_ISO_BMFF;
+	StreamOutputFormat format = FORMAT_ISO_BMFF; // Default format
+	if (ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+	{
+		// Mp4Demuxer will set the format later once the init fragment is parsed
+		// format is only used for video and audio formats. Subtitle should be unaffected
+		format = FORMAT_UNKNOWN;
+	}
 	if(mMediaStreamContext[eMEDIATYPE_VIDEO] && mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled )
 	{
 		primaryOutputFormat = format;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -11130,13 +11130,12 @@ StreamOutputFormat GetSubtitleFormat(std::string mimeType)
  */
 void StreamAbstractionAAMP_MPD::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &subtitleOutputFormat)
 {
-	StreamOutputFormat format = FORMAT_ISO_BMFF; // Default format
-	if (ISCONFIGSET(eAAMPConfig_UseMp4Demux))
-	{
-		// Mp4Demuxer will set the format later once the init fragment is parsed
-		// format is only used for video and audio formats. Subtitle should be unaffected
-		format = FORMAT_UNKNOWN;
-	}
+	// When UseMp4Demux is true the pipeline is still configured as ISO_BMFF;
+	// AampMp4Demuxer demuxes the boxes and calls SetStreamCaps to push ES data
+	// directly into the appsrc. ConfigurePipeline must see FORMAT_ISO_BMFF so that
+	// it tears down and re-creates the pipeline correctly on period transitions and
+	// seeks, matching the behaviour of the non-mp4demux path.
+	StreamOutputFormat format = FORMAT_ISO_BMFF;
 	if(mMediaStreamContext[eMEDIATYPE_VIDEO] && mMediaStreamContext[eMEDIATYPE_VIDEO]->enabled )
 	{
 		primaryOutputFormat = format;

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -10315,9 +10315,23 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 						// Decide whether to wait or exit
 						if (IsAtLiveEdge() && mCdaiObject->mAdState != AdState::IN_ADBREAK_WAIT2CATCHUP)
 						{
-							// At live edge, wait for manifest update to get new segments or period.
-							// Avoids tight looping.
-							WaitForManifestUpdate(snapshotCounter);
+							if (mPlayRate != AAMP_NORMAL_PLAY_RATE)
+							{
+								// Trickplay has consumed all available content at the live edge.
+								// Exit the fetch loop so the EOS already signalled to GStreamer can
+								// propagate cleanly (triggers SPEED_CHANGED rate=1.0 via NotifyEOS).
+								// Waiting for new live segments is incorrect here: the trickplay
+								// session is over and any new data pushed after EOS undoes the
+								// EOS signal from GStreamer's perspective.
+								AAMPLOG_MIL("Trickplay EOS at live edge, exiting fetch loop (rate=%.2f)", mPlayRate);
+								exitFetchLoop = true;
+							}
+							else
+							{
+								// Normal play at live edge: wait for manifest update to get new
+								// segments or a new period.  Avoids tight looping.
+								WaitForManifestUpdate(snapshotCounter);
+							}
 						}
 						else
 						{

--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -29,8 +29,9 @@ find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(GSTREAMER REQUIRED gstreamer-1.0>=1.18.0)
 pkg_check_modules(GSTREAMERBASE REQUIRED gstreamer-app-1.0)
+pkg_check_modules(GSTREAMERPBUTILS REQUIRED gstreamer-pbutils-1.0)
 
-include_directories(${GST_INCLUDE_DIRS} ${GSTREAMER_INCLUDE_DIRS} ${GSTREAMERBASE_INCLUDE_DIRS} ${GSTREAMERVIDEO_INCLUDE_DIRS})
+include_directories(${GST_INCLUDE_DIRS} ${GSTREAMER_INCLUDE_DIRS} ${GSTREAMERBASE_INCLUDE_DIRS} ${GSTREAMERVIDEO_INCLUDE_DIRS} ${GSTREAMERPBUTILS_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} subtitle playerisobmff isobmff
 	closedcaptions
 	closedcaptions/subtec
@@ -391,7 +392,7 @@ add_subdirectory(gst-plugins)
 
 target_link_libraries(playergstinterface ${LIBPLAYERGSTINTERFACE_DEPENDS})
 
-target_link_libraries(playergstinterface ${GST_LINK_LIBRARIES} ${GSTREAMER_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES})
+target_link_libraries(playergstinterface ${GST_LINK_LIBRARIES} ${GSTREAMER_LINK_LIBRARIES} ${GSTREAMERBASE_LINK_LIBRARIES} ${GSTREAMERPBUTILS_LINK_LIBRARIES})
 
 target_link_libraries(playergstinterface ${GSTREAMERVIDEO_LINK_LIBRARIES})
 

--- a/middleware/DemuxDataTypes.h
+++ b/middleware/DemuxDataTypes.h
@@ -93,6 +93,7 @@ struct MediaCodecInfo
 {
 	GstStreamOutputFormat mCodecFormat; // GST_FORMAT_VIDEO_ES_H264, etc
 	std::vector<uint8_t> mCodecData; // codec private data, e.g. avcC box
+	std::string mStreamFormat; // HEVC sample entry type: "hev1" (in-band params) or "hvc1" (out-of-band params)
 	bool mIsEncrypted;
 	union
 	{
@@ -116,7 +117,7 @@ struct MediaCodecInfo
 	 *       Uniform initialization is preferred for C++ types as it's type-safe, clearer in intent,
 	 *       and works correctly with all C++ types including those with constructors.
 	 */
-	MediaCodecInfo() : mCodecFormat(GST_FORMAT_INVALID), mIsEncrypted(false), mCodecData(), mInfo{0}
+	MediaCodecInfo() : mCodecFormat(GST_FORMAT_INVALID), mIsEncrypted(false), mCodecData(), mStreamFormat(), mInfo{0}
 	{
 	}
 
@@ -128,7 +129,7 @@ struct MediaCodecInfo
 	 *       Uniform initialization is preferred for C++ types as it's type-safe, clearer in intent,
 	 *       and works correctly with all C++ types including those with constructors.
 	 */
-	MediaCodecInfo(GstStreamOutputFormat format) : mCodecFormat(format), mIsEncrypted(false), mCodecData(), mInfo{0}
+	MediaCodecInfo(GstStreamOutputFormat format) : mCodecFormat(format), mIsEncrypted(false), mCodecData(), mStreamFormat(), mInfo{0}
 	{
 	}
 
@@ -143,6 +144,7 @@ struct MediaCodecInfo
 	MediaCodecInfo(MediaCodecInfo&& other) noexcept
         : mCodecFormat(exchange(other.mCodecFormat, GST_FORMAT_INVALID))
         , mCodecData(exchange(other.mCodecData, {}))
+        , mStreamFormat(std::move(other.mStreamFormat))
         , mIsEncrypted(exchange(other.mIsEncrypted, false))
         , mInfo(exchange(other.mInfo, {})) // POD union - exchange with zero-initialized union
     {
@@ -159,6 +161,7 @@ struct MediaCodecInfo
 		{
 			mCodecFormat = exchange(other.mCodecFormat, GST_FORMAT_INVALID);
 			mCodecData = exchange(other.mCodecData, {});
+			mStreamFormat = std::move(other.mStreamFormat);
 			mIsEncrypted = exchange(other.mIsEncrypted, false);
 			mInfo = exchange(other.mInfo, {}); // POD union - exchange with zero-initialized union
 		}

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -3584,14 +3584,17 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
 			unblockDiscProcess = true;
 			ret = true;
 		}
-		else if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback && !codecChange)
+		else if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback)
 		{
-			// AampMp4Demuxer always applies fragmentPTSoffset to maintain a
-			// monotonic PTS sequence across period boundaries, so the decoder
-			// sees a continuous stream and no GStreamer EOS/flush is needed.
+			// AampMp4Demuxer maintains monotonic PTS via fragmentPTSoffset and
+			// calls SetStreamCaps() for format changes; no GStreamer EOS/flush
+			// is needed regardless of codec change or PTO-induced pipeline-flush
+			// status.  Return ret=false so mProcessingDiscontinuity is NOT set
+			// and ProcessPendingDiscontinuity does not trigger a pipeline
+			// reconfigure.
 			MW_LOG_MIL("Mp4Demux playback: skipping GStreamer EOS for discontinuity (type=%d)", (int)type);
 			unblockDiscProcess = true;
-			ret = true;
+			ret = false;
 		}
 		else
 		{

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -31,6 +31,7 @@
 #include "TextStyleAttributes.h"
 #include <memory>
 #include <gst/gst.h>
+#include <gst/pbutils/pbutils.h>
 #ifdef USE_EXTERNAL_STATS
 #include "player-xternal-stats.h"
 #endif
@@ -5414,6 +5415,9 @@ void InterfacePlayerRDK::SetStreamCaps(GstMediaType type, MediaCodecInfo&& codec
 									"height", G_TYPE_INT, codecInfo.mInfo.video.mHeight,
 									"pixel-aspect-ratio", GST_TYPE_FRACTION, 1, 1,
 									NULL);
+				if (codecInfo.mCodecData.size() > 1)
+					gst_codec_utils_h264_caps_set_level_and_profile(caps,
+							codecInfo.mCodecData.data() + 1, codecInfo.mCodecData.size() - 1);
 			}
 			else if (codecInfo.mCodecFormat == GST_FORMAT_VIDEO_ES_HEVC)
 			{
@@ -5425,6 +5429,9 @@ void InterfacePlayerRDK::SetStreamCaps(GstMediaType type, MediaCodecInfo&& codec
 									"height", G_TYPE_INT, codecInfo.mInfo.video.mHeight,
 									"pixel-aspect-ratio", GST_TYPE_FRACTION, 1, 1,
 									NULL);
+				if (codecInfo.mCodecData.size() > 1)
+					gst_codec_utils_h265_caps_set_level_tier_and_profile(caps,
+							codecInfo.mCodecData.data() + 1, codecInfo.mCodecData.size() - 1);
 			}
 		}
 		else if (type == eGST_MEDIATYPE_AUDIO)

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5394,7 +5394,9 @@ void InterfacePlayerRDK::SetStreamCaps(GstMediaType type, MediaCodecInfo&& codec
 {
 	GstCaps *caps = GetCaps(codecInfo.mCodecFormat);
 	gst_media_stream *stream = &interfacePlayerPriv->gstPrivateContext->stream[type];
-	stream->format = codecInfo.mCodecFormat;
+	// Do not overwrite stream->format here. ConfigurePipeline already set it to
+	// FORMAT_ISO_BMFF, which is correct for the pipeline topology. The actual
+	// appsrc caps (ES format + codec_data) are updated below via gst_app_src_set_caps.
 	interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback = true;
 	if (caps)
 	{

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5121,18 +5121,6 @@ void InterfacePlayerRDK::EndOfStreamReached(int mediaType, bool &shouldHaltBuffe
 			{
 				GstPlayer_SignalEOS(interfacePlayerPriv->gstPrivateContext->stream[eGST_MEDIATYPE_SUBTITLE]);
 			}
-			// With useMp4Demux=true (isMp4DemuxPlayback), CDAI period transitions during
-			// trickplay are handled inside AAMP (AampMp4Demuxer PTS adjustment) without
-			// GStreamer pipeline flushes.  The pipeline accumulates state across period
-			// boundaries, so GST_MESSAGE_EOS may not propagate reliably when trickplay
-			// reaches true end-of-content.  Call NotifyEOS() directly to guarantee the
-			// EOS callback fires.  NotifyEOS() is idempotent (eosSignalled guard), so a
-			// later GST_MESSAGE_EOS from GStreamer will be a harmless no-op.
-			if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback)
-			{
-				MW_LOG_MIL("Mp4Demux trickplay EOS: calling NotifyEOS() directly (GST_MESSAGE_EOS may not propagate)");
-				NotifyEOS();
-			}
 		}
 		else
 		{

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -3584,14 +3584,16 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
 			unblockDiscProcess = true;
 			ret = true;
 		}
-		else if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback)
+		else if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback && !codecChange)
 		{
 			// AampMp4Demuxer maintains monotonic PTS via fragmentPTSoffset and
-			// calls SetStreamCaps() for format changes; no GStreamer EOS/flush
-			// is needed regardless of codec change or PTO-induced pipeline-flush
-			// status.  Return ret=false so mProcessingDiscontinuity is NOT set
-			// and ProcessPendingDiscontinuity does not trigger a pipeline
-			// reconfigure.
+			// calls SetStreamCaps() for format changes.  Skip GStreamer EOS/flush
+			// when there is no codec change (e.g. PTO-only discontinuity where
+			// PipelineFlushStatus is set but ESChangeStatus is not).
+			// When codecChange is true due to a real audio/video codec change,
+			// fall through to GstPlayer_SignalEOS so the pipeline is reconfigured.
+			// Return ret=false so mProcessingDiscontinuity is NOT set and
+			// ProcessPendingDiscontinuity does not trigger a spurious reconfigure.
 			MW_LOG_MIL("Mp4Demux playback: skipping GStreamer EOS for discontinuity (type=%d)", (int)type);
 			unblockDiscProcess = true;
 			ret = false;

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5394,9 +5394,7 @@ void InterfacePlayerRDK::SetStreamCaps(GstMediaType type, MediaCodecInfo&& codec
 {
 	GstCaps *caps = GetCaps(codecInfo.mCodecFormat);
 	gst_media_stream *stream = &interfacePlayerPriv->gstPrivateContext->stream[type];
-	// Do not overwrite stream->format here. ConfigurePipeline already set it to
-	// FORMAT_ISO_BMFF, which is correct for the pipeline topology. The actual
-	// appsrc caps (ES format + codec_data) are updated below via gst_app_src_set_caps.
+	stream->format = codecInfo.mCodecFormat;
 	interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback = true;
 	if (caps)
 	{

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5417,8 +5417,9 @@ void InterfacePlayerRDK::SetStreamCaps(GstMediaType type, MediaCodecInfo&& codec
 			}
 			else if (codecInfo.mCodecFormat == GST_FORMAT_VIDEO_ES_HEVC)
 			{
+				const char* hevcStreamFormat = codecInfo.mStreamFormat.empty() ? "hvc1" : codecInfo.mStreamFormat.c_str();
 				gst_caps_set_simple(caps,
-									"stream-format", G_TYPE_STRING, "hvc1",
+									"stream-format", G_TYPE_STRING, hevcStreamFormat,
 									"alignment", G_TYPE_STRING, "au",
 									"width", G_TYPE_INT, codecInfo.mInfo.video.mWidth,
 									"height", G_TYPE_INT, codecInfo.mInfo.video.mHeight,

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5121,6 +5121,18 @@ void InterfacePlayerRDK::EndOfStreamReached(int mediaType, bool &shouldHaltBuffe
 			{
 				GstPlayer_SignalEOS(interfacePlayerPriv->gstPrivateContext->stream[eGST_MEDIATYPE_SUBTITLE]);
 			}
+			// With useMp4Demux=true (isMp4DemuxPlayback), CDAI period transitions during
+			// trickplay are handled inside AAMP (AampMp4Demuxer PTS adjustment) without
+			// GStreamer pipeline flushes.  The pipeline accumulates state across period
+			// boundaries, so GST_MESSAGE_EOS may not propagate reliably when trickplay
+			// reaches true end-of-content.  Call NotifyEOS() directly to guarantee the
+			// EOS callback fires.  NotifyEOS() is idempotent (eosSignalled guard), so a
+			// later GST_MESSAGE_EOS from GStreamer will be a harmless no-op.
+			if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback)
+			{
+				MW_LOG_MIL("Mp4Demux trickplay EOS: calling NotifyEOS() directly (GST_MESSAGE_EOS may not propagate)");
+				NotifyEOS();
+			}
 		}
 		else
 		{

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -3584,6 +3584,15 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
 			unblockDiscProcess = true;
 			ret = true;
 		}
+		else if (interfacePlayerPriv->gstPrivateContext->isMp4DemuxPlayback && !codecChange)
+		{
+			// AampMp4Demuxer always applies fragmentPTSoffset to maintain a
+			// monotonic PTS sequence across period boundaries, so the decoder
+			// sees a continuous stream and no GStreamer EOS/flush is needed.
+			MW_LOG_MIL("Mp4Demux playback: skipping GStreamer EOS for discontinuity (type=%d)", (int)type);
+			unblockDiscProcess = true;
+			ret = true;
+		}
 		else
 		{
 			if (m_gstConfigParam->enablePTSReStamp && codecChange)

--- a/middleware/test/utests/fakes/FakeGStreamer.cpp
+++ b/middleware/test/utests/fakes/FakeGStreamer.cpp
@@ -1081,6 +1081,16 @@ void gst_base_transform_set_gap_aware(GstBaseTransform *trans, gboolean gap_awar
 void gst_base_transform_set_in_place(GstBaseTransform *trans, gboolean in_place){}
 void gst_base_transform_set_passthrough(GstBaseTransform *trans, gboolean passthrough){}
 
+gboolean gst_codec_utils_h264_caps_set_level_and_profile(GstCaps *caps, const guint8 *sps, guint len)
+{
+	return FALSE;
+}
+
+gboolean gst_codec_utils_h265_caps_set_level_tier_and_profile(GstCaps *caps, const guint8 *profile_tier_level, guint len)
+{
+	return FALSE;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -240,7 +240,10 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 		if (!ret)
 		{
 			AAMPLOG_ERR("Failed to parse MP4 segment [err:%d] for type:%d position: %f, duration: %f, isInit: %d", mMp4Demux->GetLastError(), mMediaType, position, duration, isInit);
-
+			if (!isInit)
+			{
+				ptsError = true;
+			}
 		}
 		else
 		{

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -240,13 +240,7 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 		if (!ret)
 		{
 			AAMPLOG_ERR("Failed to parse MP4 segment [err:%d] for type:%d position: %f, duration: %f, isInit: %d", mMp4Demux->GetLastError(), mMediaType, position, duration, isInit);
-			/* Signal a PTS error for non-init segment parse failures so that
-			 * AAMP triggers playback-failure recovery (error code 80), matching
-			 * the behaviour of IsoBmffProcessor. */
-			if (!isInit)
-			{
-				ptsError = true;
-			}
+
 		}
 		else
 		{
@@ -276,12 +270,21 @@ TrickmodePtsRestamp(sample, duration, discontinuous);
 					for (auto& sample : samples)
 					{
 						double beforeDTS = sample.mDts;
-						/* Always apply the cross-period PTS offset so that GStreamer
-						 * receives monotonically increasing timestamps across period
-						 * boundaries.  The restamping flag controls only the within-
-						 * segment PTS continuity correction logged below. */
-						sample.mPts += fragmentPTSoffset;
-						sample.mDts += fragmentPTSoffset;
+						/* Apply the cross-period PTS offset when either PTS
+						 * restamping is active (mEnablePtsRestamp) or the offset is
+						 * positive (i.e. we are in period 1+ and the accumulated
+						 * duration must be added to keep timestamps monotonic).
+						 * A negative offset occurs for single-period streams where
+						 * UpdatePtsOffset normalizes the large timeline start time
+						 * to near-zero; applying that negative offset to raw Unix-
+						 * timestamp PTS would shift the GStreamer presentation time
+						 * far into the future (for live streams) causing PLAYING to
+						 * time out, so we skip it. */
+						if (mEnablePtsRestamp || fragmentPTSoffset > 0.0)
+						{
+							sample.mPts += fragmentPTSoffset;
+							sample.mDts += fragmentPTSoffset;
+						}
 						if (mEnablePtsRestamp && mEnablePtsRestampLogging)
 						{
 							uint32_t timeScale = mMp4Demux->GetTimeScale();

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -240,6 +240,13 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 		if (!ret)
 		{
 			AAMPLOG_ERR("Failed to parse MP4 segment [err:%d] for type:%d position: %f, duration: %f, isInit: %d", mMp4Demux->GetLastError(), mMediaType, position, duration, isInit);
+			/* Signal a PTS error for non-init segment parse failures so that
+			 * AAMP triggers playback-failure recovery (error code 80), matching
+			 * the behaviour of IsoBmffProcessor. */
+			if (!isInit)
+			{
+				ptsError = true;
+			}
 		}
 		else
 		{
@@ -268,23 +275,22 @@ TrickmodePtsRestamp(sample, duration, discontinuous);
 				{
 					for (auto& sample : samples)
 					{
-						// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.
-						if (mEnablePtsRestamp)
+						double beforeDTS = sample.mDts;
+						/* Always apply the cross-period PTS offset so that GStreamer
+						 * receives monotonically increasing timestamps across period
+						 * boundaries.  The restamping flag controls only the within-
+						 * segment PTS continuity correction logged below. */
+						sample.mPts += fragmentPTSoffset;
+						sample.mDts += fragmentPTSoffset;
+						if (mEnablePtsRestamp && mEnablePtsRestampLogging)
 						{
-							double beforeDTS = sample.mDts;
-							sample.mPts += fragmentPTSoffset;
-							sample.mDts += fragmentPTSoffset;
-							// Log the restamping if enabled. This can be helpful for debugging and verifying correct behavior, but may cause log flooding for large segments.
-							if (mEnablePtsRestampLogging)
-							{
-								uint32_t timeScale = mMp4Demux->GetTimeScale();
-								AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
-								GetMediaTypeName(mMediaType),
-								timeScale,
-								beforeDTS * timeScale,
-								sample.mDts * timeScale,
-								sample.mDuration * timeScale);
-							}
+							uint32_t timeScale = mMp4Demux->GetTimeScale();
+							AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
+							GetMediaTypeName(mMediaType),
+							timeScale,
+							beforeDTS * timeScale,
+							sample.mDts * timeScale,
+							sample.mDuration * timeScale);
 						}
 						mAamp->SendStreamTransfer(mMediaType, std::move(sample));
 					}

--- a/mp4demux/MP4Demux.cpp
+++ b/mp4demux/MP4Demux.cpp
@@ -1011,6 +1011,10 @@ void Mp4Demux::ParseSampleDescriptionBox(const uint8_t *next)
 void Mp4Demux::ParseStreamFormatBox(uint32_t type, const uint8_t *next)
 {
 	streamFormat = type;
+	if (type == MultiChar_Constant("hev1"))
+		codecInfo.mStreamFormat = "hev1";
+	else if (type == MultiChar_Constant("hvc1"))
+		codecInfo.mStreamFormat = "hvc1";
 	switch (streamFormat)
 	{
 		case MultiChar_Constant("hev1"):

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8938,21 +8938,6 @@ bool PrivateInstanceAAMP::Discontinuity(AampMediaType track, bool setDiscontinui
 	}
 	else
 	{
-		// With AampMp4Demuxer, fragments are injected at download speed rather than
-		// playback speed. This can cause the period-0->period-1 discontinuity to fire
-		// while the GStreamer pipeline is still in PREPARED state (before the first
-		// frame has been rendered). Calling sink->Discontinuity() (which issues a
-		// flush/seek) on a not-yet-playing pipeline discards all buffered frames and
-		// resets preroll, preventing the pipeline from ever reaching PLAYING.
-		// Wait for PLAYING before flushing the pipeline.
-		if (GetState() < eSTATE_PLAYING)
-		{
-			AAMPLOG_MIL("PrivateInstanceAAMP::Discontinuity track=%d: state is PREPARED, waiting for PLAYING before flush", (int)track);
-			std::unique_lock<std::mutex> guard(mMutexPlaystart);
-			waitforplaystart.wait_for(guard, std::chrono::seconds(5),
-				[this]{ return GetState() >= eSTATE_PLAYING || !mDownloadsEnabled; });
-			AAMPLOG_MIL("PrivateInstanceAAMP::Discontinuity track=%d: wait done, state=%d", (int)track, (int)GetState());
-		}
 		auto syncLock = SyncLock();
 		StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 		if (sink)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8938,6 +8938,21 @@ bool PrivateInstanceAAMP::Discontinuity(AampMediaType track, bool setDiscontinui
 	}
 	else
 	{
+		// With AampMp4Demuxer, fragments are injected at download speed rather than
+		// playback speed. This can cause the period-0->period-1 discontinuity to fire
+		// while the GStreamer pipeline is still in PREPARED state (before the first
+		// frame has been rendered). Calling sink->Discontinuity() (which issues a
+		// flush/seek) on a not-yet-playing pipeline discards all buffered frames and
+		// resets preroll, preventing the pipeline from ever reaching PLAYING.
+		// Wait for PLAYING before flushing the pipeline.
+		if (GetState() < eSTATE_PLAYING)
+		{
+			AAMPLOG_MIL("PrivateInstanceAAMP::Discontinuity track=%d: state is PREPARED, waiting for PLAYING before flush", (int)track);
+			std::unique_lock<std::mutex> guard(mMutexPlaystart);
+			waitforplaystart.wait_for(guard, std::chrono::seconds(5),
+				[this]{ return GetState() >= eSTATE_PLAYING || !mDownloadsEnabled; });
+			AAMPLOG_MIL("PrivateInstanceAAMP::Discontinuity track=%d: wait done, state=%d", (int)track, (int)GetState());
+		}
 		auto syncLock = SyncLock();
 		StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 		if (sink)

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4065,7 +4065,14 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 		// Some tracks can get enabled later during playback, example subtitle tracks in ad->content transition. Avoid overwriting playContext instance
 		if(track && track->enabled && track->playContext == nullptr)
 		{
-			if (!ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+			/* AampMp4Demuxer is only applicable for DASH streams. HLS (TS or fMP4),
+			 * TSB, and other formats must continue to use IsoBmffProcessor so that
+			 * TS demuxing, PTS restamping, and chunk injection work correctly.
+			 * Enabling UseMp4Demux on non-DASH streams feeds TS bytes into an MP4
+			 * box parser, causing all segments to be silently dropped. */
+			const bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux) &&
+			                         (aamp->mMediaFormat == eMEDIAFORMAT_DASH);
+			if (!useMp4Demux)
 			{
 				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - FORMAT_ISO_BMFF", track->name);
 				if(eMEDIATYPE_SUBTITLE != i)
@@ -4108,7 +4115,7 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 			}
 			else
 			{
-				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - Using Mp4Demux", track->name);
+				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - Using Mp4Demux (DASH)", track->name);
 				if (i != eMEDIATYPE_SUBTITLE)
 				{
 					track->playContext = std::make_shared<AampMp4Demuxer>(aamp, (AampMediaType)i, ISCONFIGSET(eAAMPConfig_EnablePTSReStamp));

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4069,14 +4069,17 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 			StreamOutputFormat trackFormat = (i == eMEDIATYPE_VIDEO)    ? videoFormat
 			                              : (i == eMEDIATYPE_AUDIO)    ? audioFormat
 			                              :                               subtitleFormat;
-			/* AampMp4Demuxer applies to any ISOBMFF track when useMp4Demux is enabled.
-			 * This covers both DASH (eMEDIAFORMAT_DASH) and HLS-fMP4 (FORMAT_ISO_BMFF)
-			 * segments — in both cases the elementary streams are carried in MP4 boxes
-			 * and AampMp4Demuxer is a drop-in replacement for qtdemux/IsoBmffProcessor.
-			 * HLS-TS segments (FORMAT_MPEGTS) must continue to use tsprocessor; they
-			 * never reach InitializeMediaProcessor from the HLS collector. */
+			/* AampMp4Demuxer applies to DASH streams and HLS-fMP4 segments when
+			 * useMp4Demux is enabled.  For DASH, GetStreamFormat returns FORMAT_UNKNOWN
+			 * (the real codec format is resolved later from the init segment); for
+			 * HLS-fMP4, it returns FORMAT_ISO_BMFF directly from the playlist parser.
+			 * HLS-TS (FORMAT_MPEGTS) never reaches InitializeMediaProcessor, so the
+			 * condition below only needs to block FORMAT_MPEGTS implicitly — any track
+			 * that is neither DASH nor HLS-fMP4 FORMAT_ISO_BMFF falls through to the
+			 * IsoBmffProcessor path. */
 			const bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux) &&
-			                         (trackFormat == FORMAT_ISO_BMFF);
+			                         (aamp->mMediaFormat == eMEDIAFORMAT_DASH ||
+			                          trackFormat == FORMAT_ISO_BMFF);
 			if (!useMp4Demux)
 			{
 				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - FORMAT_ISO_BMFF", track->name);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -911,15 +911,18 @@ bool MediaTrack::CheckForDiscontinuity(CachedFragment* cachedFragment, bool& fra
 						}
 					}
 				}
-				else if (ISCONFIGSET(eAAMPConfig_UseMp4Demux) && !context->GetESChangeStatus())
+				else if (ISCONFIGSET(eAAMPConfig_UseMp4Demux) && (eMEDIAFORMAT_DASH == aamp->mMediaFormat) && !context->GetESChangeStatus())
 				{
-					// AampMp4Demuxer maintains a monotonic PTS sequence via
-					// fragmentPTSoffset across period boundaries and signals
-					// format changes via SetStreamCaps().  No GStreamer EOS or
-					// inject-loop stop is needed for PTO-only discontinuities
-					// (PipelineFlushStatus set but no actual codec change).
+					// AampMp4Demuxer is only used for DASH content (mMediaFormat==DASH).
+					// It maintains a monotonic PTS sequence via fragmentPTSoffset across
+					// period boundaries and signals format changes via SetStreamCaps().
+					// No GStreamer EOS or inject-loop stop is needed for PTO-only
+					// discontinuities (PipelineFlushStatus set but no actual codec change).
 					// When ESChangeStatus is set (real codec change), fall through
 					// to the legacy EOS path so the pipeline is reconfigured.
+					// Non-DASH streams (e.g. HLS TS) must use the legacy EOS path even
+					// when eAAMPConfig_UseMp4Demux is set (the config is global but
+					// AampMp4Demuxer is not instantiated for HLS TS tracks).
 					context->ProcessDiscontinuity(type);
 					if (type != eTRACK_SUBTITLE)
 					{

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4065,13 +4065,18 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 		// Some tracks can get enabled later during playback, example subtitle tracks in ad->content transition. Avoid overwriting playContext instance
 		if(track && track->enabled && track->playContext == nullptr)
 		{
-			/* AampMp4Demuxer is only applicable for DASH streams. HLS (TS or fMP4),
-			 * TSB, and other formats must continue to use IsoBmffProcessor so that
-			 * TS demuxing, PTS restamping, and chunk injection work correctly.
-			 * Enabling UseMp4Demux on non-DASH streams feeds TS bytes into an MP4
-			 * box parser, causing all segments to be silently dropped. */
+			// Pick the output format for this specific track.
+			StreamOutputFormat trackFormat = (i == eMEDIATYPE_VIDEO)    ? videoFormat
+			                              : (i == eMEDIATYPE_AUDIO)    ? audioFormat
+			                              :                               subtitleFormat;
+			/* AampMp4Demuxer applies to any ISOBMFF track when useMp4Demux is enabled.
+			 * This covers both DASH (eMEDIAFORMAT_DASH) and HLS-fMP4 (FORMAT_ISO_BMFF)
+			 * segments — in both cases the elementary streams are carried in MP4 boxes
+			 * and AampMp4Demuxer is a drop-in replacement for qtdemux/IsoBmffProcessor.
+			 * HLS-TS segments (FORMAT_MPEGTS) must continue to use tsprocessor; they
+			 * never reach InitializeMediaProcessor from the HLS collector. */
 			const bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux) &&
-			                         (aamp->mMediaFormat == eMEDIAFORMAT_DASH);
+			                         (trackFormat == FORMAT_ISO_BMFF);
 			if (!useMp4Demux)
 			{
 				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - FORMAT_ISO_BMFF", track->name);
@@ -4115,7 +4120,7 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 			}
 			else
 			{
-				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - Using Mp4Demux (DASH)", track->name);
+				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - Using Mp4Demux", track->name);
 				if (i != eMEDIATYPE_SUBTITLE)
 				{
 					track->playContext = std::make_shared<AampMp4Demuxer>(aamp, (AampMediaType)i, ISCONFIGSET(eAAMPConfig_EnablePTSReStamp));

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -875,7 +875,13 @@ bool MediaTrack::CheckForDiscontinuity(CachedFragment* cachedFragment, bool& fra
 				// discontinuity.
 				if(IsPTSRestampEnabled())
 				{
-					if (context->GetESChangeStatus() || context->GetPipelineFlushStatus())
+					// For AampMp4Demuxer PTO-only discontinuities (PipelineFlushStatus
+					// set but !ESChangeStatus), injection must continue uninterrupted —
+					// the Flush triggered by mProcessingDiscontinuity (ret=true from
+					// CheckDiscontinuity) recovers the pipeline via ASYNC_DONE→PLAYING.
+					// Only set stopInjection for a real codec/ES change.
+					bool mp4DemuxPtoOnly = ISCONFIGSET(eAAMPConfig_UseMp4Demux) && !context->GetESChangeStatus();
+					if ((context->GetESChangeStatus() || context->GetPipelineFlushStatus()) && !mp4DemuxPtoOnly)
 					{
 						stopInjection = context->ProcessDiscontinuity(type);
 					}

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -905,6 +905,20 @@ bool MediaTrack::CheckForDiscontinuity(CachedFragment* cachedFragment, bool& fra
 						}
 					}
 				}
+				else if (ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+				{
+					// AampMp4Demuxer maintains a monotonic PTS sequence via
+					// fragmentPTSoffset across period boundaries and signals
+					// format changes via SetStreamCaps().  No GStreamer EOS or
+					// inject-loop stop is needed; just notify the sink and keep
+					// injecting period-1 data without interruption.
+					context->ProcessDiscontinuity(type);
+					if (type != eTRACK_SUBTITLE)
+					{
+						context->resetDiscontinuityTrackState();
+						aamp->ResetDiscontinuityInTracks();
+					}
+				}
 				else
 				{
 					stopInjection = context->ProcessDiscontinuity(type);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -4070,16 +4070,17 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 			                              : (i == eMEDIATYPE_AUDIO)    ? audioFormat
 			                              :                               subtitleFormat;
 			/* AampMp4Demuxer applies to DASH streams and HLS-fMP4 segments when
-			 * useMp4Demux is enabled.  For DASH, GetStreamFormat returns FORMAT_UNKNOWN
-			 * (the real codec format is resolved later from the init segment); for
-			 * HLS-fMP4, it returns FORMAT_ISO_BMFF directly from the playlist parser.
-			 * HLS-TS (FORMAT_MPEGTS) never reaches InitializeMediaProcessor, so the
-			 * condition below only needs to block FORMAT_MPEGTS implicitly — any track
-			 * that is neither DASH nor HLS-fMP4 FORMAT_ISO_BMFF falls through to the
-			 * IsoBmffProcessor path. */
+			 * useMp4Demux is enabled.  For DASH and HLS-fMP4, GetStreamFormat returns
+			 * FORMAT_UNKNOWN (the real codec format is resolved later from the init
+			 * segment); the original FORMAT_ISO_BMFF is suppressed so that typefind
+			 * is enabled on the appsrc instead of inserting qtdemux.
+			 * HLS-TS tracks stay as FORMAT_MPEGTS and fall through to IsoBmffProcessor.
+			 * The third clause catches HLS-fMP4 where GetStreamFormat changed the
+			 * original FORMAT_ISO_BMFF to FORMAT_UNKNOWN (i.e. useMp4Demux is on). */
 			const bool useMp4Demux = ISCONFIGSET(eAAMPConfig_UseMp4Demux) &&
 			                         (aamp->mMediaFormat == eMEDIAFORMAT_DASH ||
-			                          trackFormat == FORMAT_ISO_BMFF);
+			                          trackFormat == FORMAT_ISO_BMFF ||
+			                          (aamp->mMediaFormat == eMEDIAFORMAT_HLS && trackFormat == FORMAT_UNKNOWN));
 			if (!useMp4Demux)
 			{
 				AAMPLOG_MIL("StreamAbstractionAAMP : Track[%s] - FORMAT_ISO_BMFF", track->name);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -905,13 +905,15 @@ bool MediaTrack::CheckForDiscontinuity(CachedFragment* cachedFragment, bool& fra
 						}
 					}
 				}
-				else if (ISCONFIGSET(eAAMPConfig_UseMp4Demux))
+				else if (ISCONFIGSET(eAAMPConfig_UseMp4Demux) && !context->GetESChangeStatus())
 				{
 					// AampMp4Demuxer maintains a monotonic PTS sequence via
 					// fragmentPTSoffset across period boundaries and signals
 					// format changes via SetStreamCaps().  No GStreamer EOS or
-					// inject-loop stop is needed; just notify the sink and keep
-					// injecting period-1 data without interruption.
+					// inject-loop stop is needed for PTO-only discontinuities
+					// (PipelineFlushStatus set but no actual codec change).
+					// When ESChangeStatus is set (real codec change), fall through
+					// to the legacy EOS path so the pipeline is reconfigured.
 					context->ProcessDiscontinuity(type);
 					if (type != eTRACK_SUBTITLE)
 					{


### PR DESCRIPTION
Reason for Change: we believe the last few functional gaps with mp4demux have been fixed.  enabling by default in June sprint, to ensure soak time in case any lingering subtle regressions

Risk: Medium

Test Guidance: regression-only