### PR TITLE
VPAAMP-473:Place CDAI ads for cold CDVR and iVOD

### DIFF
--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -83,7 +83,8 @@ void CDAIObjectMPD::CancelReservation(const std::string& cancelAtReservationId)
  */
 PrivateCDAIObjectMPD::PrivateCDAIObjectMPD(PrivateInstanceAAMP* aamp) : mAamp(aamp),mDaiMtx(), mIsFogTSB(false), mAdBreaks(), mPeriodMap(), mCurPlayingBreakId(), mAdObjThreadID(), mCurAds(nullptr),
 					mCurAdIdx(-1), mContentSeekOffset(0), mAdState(AdState::OUTSIDE_ADBREAK),mPlacementObj(), mAdFulfillObj(),currentAdPeriodClosed(false),mAdtoInsertInNextBreakVec(),
-					mAdBrkVecMtx(), mAdFulfillMtx(), mAdFulfillCV(), mAdFulfillQ(), mExitFulfillAdLoop(false), mAdPlacementMtx(), mAdPlacementCV()
+					mAdBrkVecMtx(), mAdFulfillMtx(), mAdFulfillCV(), mAdFulfillQ(), mExitFulfillAdLoop(false), mAdPlacementMtx(), mAdPlacementCV(),
+					mWaitForManifestUpdate(0), mBaseMPDParseHelper(nullptr), mBaseMPDHelperMtx()
 {
 	StartFulfillAdLoop();
 	mAamp->CurlInit(eCURLINSTANCE_DAI,1,mAamp->GetNetworkProxy());
@@ -133,7 +134,7 @@ bool PrivateCDAIObjectMPD::isAdBreakObjectExist(const std::string &adBrkId)
 void PrivateCDAIObjectMPD::PrunePeriodMaps(std::vector<std::string> &newPeriodIds)
 {
 	//Erase all adbreaks other than new adbreaks
-	std::lock_guard<std::mutex> lock( mDaiMtx );
+	std::lock_guard<std::recursive_mutex> lock( mDaiMtx );
 	for (auto it = mAdBreaks.begin(); it != mAdBreaks.end();)
 	{
 		/* We should not remove the adbreakObj that is currently getting placed (probably due to a bug in PlaceAds)
@@ -185,7 +186,7 @@ void PrivateCDAIObjectMPD::ResetState()
 	 mIsFogTSB = false;
 	 mCurPlayingBreakId = "";
 	 mCurAds = nullptr;
-	 std::lock_guard<std::mutex> lock(mDaiMtx);
+	 std::lock_guard<std::recursive_mutex> lock(mDaiMtx);
 	 mCurAdIdx = -1;
 	 mContentSeekOffset = 0;
 	 mAdState = AdState::OUTSIDE_ADBREAK;
@@ -221,6 +222,7 @@ void PrivateCDAIObjectMPD::ClearMaps()
  */
 void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 {
+	std::lock_guard<std::recursive_mutex> lock(mDaiMtx);
 	//Some Ad is still waiting for the placement
 	const dash::mpd::IMPD* mpd = nullptr;
 	if (adMPDParseHelper)
@@ -229,10 +231,12 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 	}
 	if(mpd && (-1 != mPlacementObj.curAdIdx) && "" != mPlacementObj.pendingAdbrkId && isAdBreakObjectExist(mPlacementObj.pendingAdbrkId))
 	{
+		AAMPLOG_INFO("[CDAI] PlaceAds started for adbreak:%s curAdIdx:%d", mPlacementObj.pendingAdbrkId.c_str(), mPlacementObj.curAdIdx);
 		AdBreakObject &abObj = mAdBreaks[mPlacementObj.pendingAdbrkId];
 		vector<IPeriod *> periods = mpd->GetPeriods();
 		if(!abObj.adjustEndPeriodOffset) // not all ads are placed
 		{
+			AAMPLOG_DEBUG("[CDAI] Adjusting end period offset for adbreak:%s", mPlacementObj.pendingAdbrkId.c_str());
 			bool openPrdFound = false;
 			std::string prevOpenperiodId = mPlacementObj.openPeriodId;
 
@@ -758,6 +762,11 @@ void PrivateCDAIObjectMPD::PlaceAds(AampMPDParseHelperPtr adMPDParseHelper)
 			}
 		}
 	}
+	else
+	{
+		AAMPLOG_DEBUG("[CDAI] PlaceAds skipped. mpd:%p, curAdIdx:%d, pendingAdbrkId:%s, isAdBreakObjectExist:%d",
+			mpd, mPlacementObj.curAdIdx, mPlacementObj.pendingAdbrkId.c_str(), isAdBreakObjectExist(mPlacementObj.pendingAdbrkId));
+	}
 }
 
 /**
@@ -774,7 +783,7 @@ void PrivateCDAIObjectMPD::UpdateNextPeriodAdPlacement(IPeriod* nextPeriod, uint
 		if (isAdBreakObjectExist(nextPeriodId) && mAdBreaks[nextPeriodId].adsDuration > 0)
 		{
 			// Lock the mutex, so we can delete this entry
-			std::lock_guard<std::mutex> lock(mDaiMtx);
+			std::lock_guard<std::recursive_mutex> lock(mDaiMtx);
 			const auto& adBreakObj = mAdBreaks[nextPeriodId];
 			AAMPLOG_ERR("[CDAI] Detected ads for next period[id:%s, breakdur:%" PRIu32 ", numads:%zu] in split periods, not expected",
 				nextPeriodId.c_str(), adBreakObj.brkDuration, adBreakObj.ads->size());
@@ -1160,6 +1169,73 @@ void PrivateCDAIObjectMPD::InsertToPlacementQueue(const std::string& periodId)
 }
 
 /**
+ * @brief Check if all ads in an adbreak are resolved.
+ * @param[in] periodId Ad break ID
+ * @return true if all ads in the break are resolved
+ */
+bool PrivateCDAIObjectMPD::AreAllAdsResolved(const std::string& periodId)
+{
+	if (!isAdBreakObjectExist(periodId))
+	{
+		return false;
+	}
+
+	const AdBreakObject &adbreakObj = mAdBreaks[periodId];
+	if (!adbreakObj.ads || adbreakObj.ads->empty())
+	{
+		return true;
+	}
+
+	for (const auto &node : *adbreakObj.ads)
+	{
+		if (!node.resolved)
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * @brief Store the latest base-stream MPD parse helper.
+ *        Called on every manifest refresh so that FulFillAdObject can call
+ *        PlaceAds immediately for static manifest.
+ * @param[in] helper Shared pointer to the current AampMPDParseHelper
+ */
+void PrivateCDAIObjectMPD::SetBaseMPDParseHelper(AampMPDParseHelperPtr helper)
+{
+	std::lock_guard<std::mutex> lock(mBaseMPDHelperMtx);
+	mBaseMPDParseHelper = helper;
+	AAMPLOG_INFO("mBaseMPDParseHelper updated: %p", (void*)mBaseMPDParseHelper.get());
+}
+
+/**
+ * @brief Trigger PlaceAds for static-manifest flow using cached base MPD helper.
+ * @param[in] reservationId Reservation/ad break ID
+ */
+void PrivateCDAIObjectMPD::PlaceAdsForStaticManifest(const std::string& reservationId)
+{
+	AampMPDParseHelperPtr baseMPDHelper;
+	{
+		std::lock_guard<std::mutex> helperLock(mBaseMPDHelperMtx);
+		baseMPDHelper = mBaseMPDParseHelper;
+	}
+
+	if (baseMPDHelper)
+	{
+		AAMPLOG_INFO("[CDAI] triggering PlaceAds for reservation [%s]",
+			reservationId.c_str());
+		PlaceAds(baseMPDHelper);
+	}
+	else
+	{
+		AAMPLOG_WARN("[CDAI] deferred placement for reservation [%s] skipped: base MPD helper unavailable",
+			reservationId.c_str());
+	}
+}
+
+/**
  * @fn ValidateAdManifest
  * @brief Validate the ad manifest for basic requirements
  * @param[in] adMPDParseHelper - AampMPDParseHelper reference of the ad manifest
@@ -1213,13 +1289,15 @@ bool PrivateCDAIObjectMPD::FulFillAdObject()
 {
 	UsingPlayerId playerId(mAamp->mPlayerId);
 	bool ret = true;
+	bool shouldTriggerPlacement = false;
+	std::string placementPeriodId;
 	AampMPDParseHelper adMPDParseHelper;
 	AAMPCDAIError adErrorCode = eCDAI_ERROR_NONE;
 	bool adStatus = false;
 	uint64_t startMS = 0;
 	uint32_t durationMs = 0;
 	bool finalManifest = false;
-	std::lock_guard<std::mutex> lock( mDaiMtx );
+	std::unique_lock<std::recursive_mutex> lock( mDaiMtx );
 	int http_error = 0;
 	double downloadTime = 0;
 	MPD *ad = GetAdMPD(mAdFulfillObj.url, finalManifest, http_error, downloadTime, adErrorCode, true);
@@ -1280,6 +1358,8 @@ bool PrivateCDAIObjectMPD::FulFillAdObject()
 								adStatus = true;
 							}
 						}
+						// Set node properties before calling PlaceAds so that
+						// PlaceAds sees the correct ad duration.
 						node.mpd = ad;
 						node.duration = durationMs;
 						if (iter == 0)
@@ -1300,6 +1380,11 @@ bool PrivateCDAIObjectMPD::FulFillAdObject()
 				}
 				// Resolve the full adbreak object, this is used for conditional wait if it was primarily waiting on this ad
 				adbreakObj.resolved = true;
+				if (adbreakObj.reservationComplete && AreAllAdsResolved(periodId))
+				{
+					shouldTriggerPlacement = true;
+					placementPeriodId = periodId;
+				}
 			}
 			else
 			{
@@ -1350,6 +1435,12 @@ bool PrivateCDAIObjectMPD::FulFillAdObject()
 			AAMPLOG_ERR("Failed to get Ad MPD[%s].", mAdFulfillObj.url.c_str());
 		}
 	}
+
+	if (shouldTriggerPlacement)
+	{
+		PlaceAdsForStaticManifest(placementPeriodId);
+	}
+
 	// Send the resolved event
 	if(ret)
 	{
@@ -1377,7 +1468,7 @@ void PrivateCDAIObjectMPD::SetAlternateContents(const std::string &periodId, con
 {
 	if("" == adId || "" == url)
 	{
-		std::lock_guard<std::mutex> lock(mDaiMtx);
+		std::lock_guard<std::recursive_mutex> lock(mDaiMtx);
 		//Putting a place holder
 		if(!(isAdBreakObjectExist(periodId)))
 		{
@@ -1790,7 +1881,7 @@ bool PrivateCDAIObjectMPD::GetNextAdInBreakToPlace()
  */
 void PrivateCDAIObjectMPD::CancelReservation(const std::string& cancelAtReservationId)
 {
-	std::lock_guard<std::mutex> lock(mDaiMtx); // Ensure thread safety if ad state is shared
+	std::lock_guard<std::recursive_mutex> lock(mDaiMtx); // Ensure thread safety if ad state is shared
 
 	if (cancelAtReservationId.empty())
 	{
@@ -1828,10 +1919,11 @@ void PrivateCDAIObjectMPD::CancelReservation(const std::string& cancelAtReservat
  */
 void PrivateCDAIObjectMPD::NotifyReservationComplete(const std::string& reservationId)
 {
-	std::lock_guard<std::mutex> lock(mDaiMtx);
+	std::lock_guard<std::recursive_mutex> lock(mDaiMtx);
 	if (isAdBreakObjectExist(reservationId))
 	{
 		AdBreakObject& abObj = mAdBreaks[reservationId];
+		abObj.reservationComplete = true;
 		abObj.resolved = true;
 		AAMPLOG_INFO("[CDAI] Marked reservation complete for adBreakId: %s", reservationId.c_str());
 		//We are Aborting the wait when the AdBreakObject is empty. Not for the each ad to be resolved.
@@ -1839,6 +1931,20 @@ void PrivateCDAIObjectMPD::NotifyReservationComplete(const std::string& reservat
 		{
 			AAMPLOG_INFO("[CDAI] Ad break %s is empty. No ads to play.", reservationId.c_str());
 			AbortWaitForNextAdResolved();
+		}
+		else
+		{
+			// For static manifest content, trigger PlaceAds only after all ads in the
+			// reservation are resolved. This avoids a race where ad duration isn't known yet.
+			if (AreAllAdsResolved(reservationId))
+			{
+				PlaceAdsForStaticManifest(reservationId);
+			}
+			else
+			{
+				AAMPLOG_INFO("[CDAI] Reservation [%s] marked complete; waiting for all ads to resolve before PlaceAds",
+					reservationId.c_str());
+			}
 		}
 	}
 	else

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -206,6 +206,7 @@ struct AdBreakObject{
 	bool                                 mSplitPeriod;    /**< To identify whether the ad is split period ad or not */
 	bool                                 invalid;         /**< flag marks if the adbreak is invalid or not */
 	bool                                 resolved;       /**< flag marks if the adbreak is resolved or not */
+	bool                                 reservationComplete; /**< reservation-complete signal received for this adbreak */
 	AampTime                             mAbsoluteAdBreakStartTime; /**< Period start time */
 	std::string                          cancelAtPeriodId; /**< Period at which this adbreak should be cancelled (applies to the whole break) */
 	/**
@@ -213,7 +214,7 @@ struct AdBreakObject{
 	*/
 	AdBreakObject()
 		: brkDuration(0), ads(), endPeriodId(), endPeriodOffset(0), adsDuration(0), adjustEndPeriodOffset(false),
-		mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), resolved(false), mAbsoluteAdBreakStartTime(0.0), cancelAtPeriodId()
+		mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), resolved(false), reservationComplete(false), mAbsoluteAdBreakStartTime(0.0), cancelAtPeriodId()
 	{
 	}
 
@@ -229,7 +230,7 @@ struct AdBreakObject{
 	AdBreakObject(uint32_t _duration, AdNodeVectorPtr _ads, std::string _endPeriodId,
 		uint64_t _endPeriodOffset, uint32_t _adsDuration)
 		: brkDuration(_duration), ads(std::move(_ads)), endPeriodId(std::move(_endPeriodId)), endPeriodOffset(_endPeriodOffset),
-		adsDuration(_adsDuration), adjustEndPeriodOffset(false), mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), resolved(false), mAbsoluteAdBreakStartTime(0.0), cancelAtPeriodId()
+		adsDuration(_adsDuration), adjustEndPeriodOffset(false), mAdBreakPlaced(false), mAdFailed(false), mSplitPeriod(false), invalid(false), resolved(false), reservationComplete(false), mAbsoluteAdBreakStartTime(0.0), cancelAtPeriodId()
 	{
 	}
 };
@@ -364,7 +365,7 @@ class PrivateCDAIObjectMPD
 {
 public:
 	PrivateInstanceAAMP*                           mAamp;               /**< AAMP player's private instance */
-	std::mutex                                     mDaiMtx;             /**< Mutex protecting DAI critical section */
+	std::recursive_mutex                           mDaiMtx;             /**< Mutex protecting DAI critical section (recursive to allow PlaceAds to lock from within a caller already holding mDaiMtx) */
 	bool                                           mIsFogTSB;           /**< Channel playing from TSB or not */
 	std::unordered_map<std::string, AdBreakObject> mAdBreaks;           /**< Periodid to adbreakobject map*/
 	std::unordered_map<std::string, Period2AdData> mPeriodMap;          /**< periodId to Ad map */
@@ -386,6 +387,8 @@ public:
 	std::mutex                                     mAdPlacementMtx;       /**< Mutex protecting Ad placement */
 	std::condition_variable                        mAdPlacementCV;        /**< Condition variable for Ad placement */
 	uint64_t                                       mWaitForManifestUpdate;/**< segment position in manifest at end of Ad */
+	AampMPDParseHelperPtr                          mBaseMPDParseHelper;   /**< Latest base-stream MPD parse helper; used by FulFillAdObject to call PlaceAds immediately for static manifest */
+	std::mutex                                     mBaseMPDHelperMtx;     /**< Mutex protecting mBaseMPDParseHelper */
 	/**
 	 * @fn PrivateCDAIObjectMPD
 	 *
@@ -643,6 +646,26 @@ public:
 	 * @param[in] periodId Period ID for ad placement
 	 */
 	void InsertToPlacementQueue(const std::string& periodId);
+
+	/**
+	 * @brief Check if all ads in an adbreak are resolved.
+	 * @param[in] periodId Ad break ID
+	 * @return true if all ads in the break are resolved
+	 */
+	bool AreAllAdsResolved(const std::string& periodId);
+
+	/**
+	 * @brief Store the latest base-stream MPD parse helper so that PlaceAds
+	 *        can be called immediately from FulFillAdObject for cold CDVR/IVOD.
+	 * @param[in] helper Shared pointer to the current AampMPDParseHelper
+	 */
+	void SetBaseMPDParseHelper(AampMPDParseHelperPtr helper);
+
+	/**
+	 * @brief Trigger PlaceAds for static-manifest flow using cached base MPD helper.
+	 * @param[in] reservationId Reservation/ad break ID
+	 */
+	void PlaceAdsForStaticManifest(const std::string& reservationId);
 };
 
 #endif /* ADMANAGER_MPD_H_ */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -3216,10 +3216,25 @@ AAMPStatusType StreamAbstractionAAMP_MPD::GetMPDFromManifest( ManifestDownloadRe
 		{
 			aamp->SetManifestUrl(locationUrl[0].c_str());
 		}
-
 		mLastPlaylistDownloadTimeMs = aamp_GetCurrentTimeMS();
-		if(mIsLiveStream && ISCONFIGSET(eAAMPConfig_EnableClientDai))
+		if(ISCONFIGSET(eAAMPConfig_EnableClientDai))
 		{
+			// Gate on mIsLiveManifest (refreshed every manifest download) rather than
+			// mIsLiveStream (frozen at init-time) so that a CDVR dynamic→static
+			// transition is detected correctly.
+			if (!mIsLiveManifest)
+			{
+				AAMPLOG_INFO("Setting MPD helper for static manifest content");
+				mCdaiObject->SetBaseMPDParseHelper(mMPDParseHelper);
+			}
+			else
+			{
+				// Manifest is currently live; clear any stale helper that may have
+				// been set during a previous static playback on the same mCdaiObject
+				// so it is not incorrectly used as the static-manifest gate.
+				mCdaiObject->SetBaseMPDParseHelper(nullptr);
+			}
+			AAMPLOG_INFO("Placing ads for %s stream", mIsLiveManifest ? "live" : "static manifest");
 			mCdaiObject->PlaceAds(mMPDParseHelper);
 		}
 
@@ -9717,7 +9732,7 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 				mBasePeriodOffset = (mPlayRate > AAMP_RATE_PAUSE) ? 0 : (mMPDParseHelper->GetPeriodDuration(mIterPeriodIndex, mLastPlaylistDownloadTimeMs, (mPlayRate != AAMP_NORMAL_PLAY_RATE), aamp->IsUninterruptedTSB()) / 1000.00);
 
 				{
-					std::lock_guard<std::mutex> lock(mCdaiObject->mDaiMtx);
+					std::lock_guard<std::recursive_mutex> lock(mCdaiObject->mDaiMtx);
 					if (mCdaiObject->mContentSeekOffset > 0)
 					{
 						// Set mBasePeriodOffset as mContentSeekOffset to handle cases of partial ads.
@@ -9897,7 +9912,7 @@ bool StreamAbstractionAAMP_MPD::IndexSelectedPeriod(bool periodChanged, bool adS
 
 		// CID:190371 - Data race condition
 		// Get and clear mContentSeekOffset atomically.
-		std::lock_guard<std::mutex> lock(mCdaiObject->mDaiMtx);
+		std::lock_guard<std::recursive_mutex> lock(mCdaiObject->mDaiMtx);
 		seekPositionSeconds = mCdaiObject->mContentSeekOffset;
 		mCdaiObject->mContentSeekOffset = 0;
 
@@ -12289,7 +12304,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 			return false;
 		}
 	}
-	std::unique_lock<std::mutex> lock(mCdaiObject->mDaiMtx);
+	std::unique_lock<std::recursive_mutex> lock(mCdaiObject->mDaiMtx);
 	bool stateChanged = false;
 	AdState oldState = mCdaiObject->mAdState;
 	AAMPEventType reservationEvt2Send = AAMP_MAX_NUM_EVENTS; //None

--- a/test/aampcli/AampcliSet.cpp
+++ b/test/aampcli/AampcliSet.cpp
@@ -495,6 +495,28 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						break;
 					}
 
+				case 58:
+					{
+						std::string reservationId;
+						AAMPCLI_PRINTF("[AAMPCLI] Matched Command NotifyReservationComplete - %s\n", cmd);
+						std::istringstream iss(cmd);
+						std::vector<std::string> tokens;
+						std::string token;
+						while (iss >> token) {
+							tokens.push_back(token);
+						}
+						if (tokens.size() == 3) {
+							reservationId = tokens[2];
+							playerInstanceAamp->NotifyReservationComplete(reservationId);
+						}
+						else
+						{
+							AAMPCLI_PRINTF("[AAMPCLI] ERROR: Mismatch in arguments\n");
+							AAMPCLI_PRINTF("[AAMPCLI] Expected: set %s <reservationId>\n", command);
+						}
+						break;
+					}
+
 				case 25:
 					{
 						char networkProxy[128];
@@ -1372,6 +1394,7 @@ void Set::registerSetCommands()
 	addCommand(55,"dynamicDrm"," <x> ","set Dynamic DRM config in Json format x=Timeout value for response message ");
 	addCommand(56,"liveOffset4K"," <x> ","Set Live offset 4K stream(int x=offset)");
 	addCommand(57,"subtecSimulator"," <x> ","Set the SubTec simulator (1 to start the simulator, 0 to stop it)");
+	addCommand(58,"notifyReservationComplete"," <x>","Notify ad reservation completion (string x=reservationId/adBreakId)");
 	commands.push_back("help");
 }
 

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -21,6 +21,8 @@
 #include <gmock/gmock.h>
 #include <thread>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include "priv_aamp.h"
 #include "AampConfig.h"
 #include "AampUtils.h"
@@ -50,6 +52,38 @@ using namespace dash::xml;
 using namespace dash::mpd;
 
 AampConfig *gpGlobalConfig{nullptr};
+
+// Shared 10-second ad manifest used across SetAlternateContents and static-manifest tests.
+static const char *kSharedTenSecondAdManifest =
+R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="static" id="TSS_ICEJ010_010-LIN_c4_HD" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT0H0M1.000S" maxSegmentDuration="PT0H0M1S" mediaPresentationDuration="PT0H0M10.027S">
+  <Period id="1" start="PT0H0M0.000S">
+    <AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="manifest/track-video-repid-$RepresentationID$-tc--header.mp4" media="manifest/track-video-repid-$RepresentationID$-tc--frag-$Number$.mp4" timescale="48000" startNumber="0">
+        <SegmentTimeline>
+          <S t="0" d="92160" r="3"/>
+          <S t="368640" d="111360" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="LE5" bandwidth="5250000" codecs="hvc1.1.6.L123.b0" width="1920" height="1080" frameRate="50">
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet id="2" contentType="audio" mimeType="audio/mp4" lang="en">
+      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate initialization="manifest-eac3/track-audio-repid-$RepresentationID$-tc--header.mp4" media="manifest-eac3/track-audio-repid-$RepresentationID$-tc--frag-$Number$.mp4" timescale="48000" startNumber="0">
+        <SegmentTimeline>
+          <S t="0" d="92160" r="3"/>
+          <S t="368640" d="112128" r="0"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="DDen" bandwidth="99450" codecs="ec-3" audioSamplingRate="48000">
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>
+)";
 
 /**
  * @brief AdManagerMPDTests tests common base class.
@@ -361,36 +395,7 @@ TEST_F(AdManagerMPDTests, SetAlternateContentsTests_1)
  */
 TEST_F(AdManagerMPDTests, SetAlternateContentsTests_2)
 {
-  static const char *manifest =
-R"(<?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" xmlns:scte214="scte214" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:mspr="mspr" type="static" id="TSS_ICEJ010_010-LIN_c4_HD" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" minBufferTime="PT0H0M1.000S" maxSegmentDuration="PT0H0M1S" mediaPresentationDuration="PT0H0M10.027S">
-  <Period id="1" start="PT0H0M0.000S">
-    <AdaptationSet id="1" contentType="video" mimeType="video/mp4" segmentAlignment="true" startWithSAP="1">
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
-      <SegmentTemplate initialization="manifest/track-video-repid-$RepresentationID$-tc--header.mp4" media="manifest/track-video-repid-$RepresentationID$-tc--frag-$Number$.mp4" timescale="48000" startNumber="0">
-        <SegmentTimeline>
-          <S t="0" d="92160" r="3"/>
-          <S t="368640" d="111360" r="0"/>
-        </SegmentTimeline>
-      </SegmentTemplate>
-      <Representation id="LE5" bandwidth="5250000" codecs="hvc1.1.6.L123.b0" width="1920" height="1080" frameRate="50">
-      </Representation>
-    </AdaptationSet>
-    <AdaptationSet id="2" contentType="audio" mimeType="audio/mp4" lang="en">
-      <AudioChannelConfiguration schemeIdUri="tag:dolby.com,2014:dash:audio_channel_configuration:2011" value="a000"/>
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
-      <SegmentTemplate initialization="manifest-eac3/track-audio-repid-$RepresentationID$-tc--header.mp4" media="manifest-eac3/track-audio-repid-$RepresentationID$-tc--frag-$Number$.mp4" timescale="48000" startNumber="0">
-        <SegmentTimeline>
-          <S t="0" d="92160" r="3"/>
-          <S t="368640" d="112128" r="0"/>
-        </SegmentTimeline>
-      </SegmentTemplate>
-      <Representation id="DDen" bandwidth="99450" codecs="ec-3" audioSamplingRate="48000">
-      </Representation>
-    </AdaptationSet>
-  </Period>
-</MPD>
-)";
+  const char *manifest = kSharedTenSecondAdManifest;
   std::string periodId = "testPeriodId";
   std::string adId = "testAdId";
   std::string url = "";
@@ -4310,4 +4315,402 @@ TEST_F(AdManagerMPDTests, CancelReservation_PlacementBreakMissing_NoChange)
 
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[existingBreakId].
     cancelAtPeriodId.empty());
+}
+
+// ============================================================================
+// Integration tests: static-manifest placement synchronization (VPAAMP-473)
+//
+// These tests cover cold CDVR/static-manifest flows where there is no periodic
+// manifest refresh to drive PlaceAds(). Placement is triggered by
+// NotifyReservationComplete once ads are resolved, with a deferred trigger from
+// FulFillAdObject when reservation was completed earlier.
+// ============================================================================
+
+// Source MPD used by all three tests below:
+//   Period 0  : testPeriodId0    - 30 s background content  (start=0)
+//   Period 1  : testPeriodId1    - 30 s ad-break period     (start=30s)
+//   Period 2  : testPeriodId_nxt - 4 s following content    (start=60s)
+// The ad manifest (reused from SetAlternateContentsTests_2) gives a 10 000 ms ad.
+static const char *kStaticSourceManifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static"
+     mediaPresentationDuration="PT1M4S" minBufferTime="PT4S"
+     profiles="urn:mpeg:dash:profile:isoff-on-demand:2011">
+  <Period id="testPeriodId0" start="PT0S">
+    <AdaptationSet id="0" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p0_init.mp4" media="video_p0_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="0" d="5000" r="14" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="testPeriodId1" start="PT30S">
+    <AdaptationSet id="1" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="0" d="5000" r="14" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="testPeriodId_nxt" start="PT60S">
+    <AdaptationSet id="1" contentType="video">
+      <Representation id="0" mimeType="video/mp4" codecs="avc1.640028" bandwidth="800000" width="640" height="360" frameRate="25">
+        <SegmentTemplate timescale="2500" initialization="video_p1_init.mp4" media="video_p1_$Number$.m4s" startNumber="1">
+          <SegmentTimeline>
+            <S t="0" d="5000" r="1" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>
+)";
+
+// Ad manifest: one period, video + audio, total duration ~10 000 ms.
+// Shared with SetAlternateContentsTests_2 to avoid redefining the same content.
+static const char *kStaticAdManifest = kSharedTenSecondAdManifest;
+
+/**
+ * @brief Integration test: static-manifest placement is triggered on
+ *        NotifyReservationComplete after ad fulfillment resolves the ad.
+ *
+ * Verifies that after ad fulfillment and reservation completion, the
+ * period-to-ad map is built (mPeriodMap[periodId].duration > 0, ad marked
+ * placed) without any manifest refresh.
+ */
+TEST_F(AdManagerMPDTests, StaticManifest_NotifyComplete_TriggersPlacement)
+{
+    const std::string periodId = "testPeriodId1";
+    const std::string adId     = "testAdId";
+    const std::string url      = TEST_AD_MANIFEST_URL;
+    constexpr uint64_t startMS   = 0;
+    constexpr uint32_t breakdur  = 30000; // matches source period duration (30 s)
+    std::mutex adResolvedMtx;
+    std::condition_variable adResolvedCv;
+    bool adResolved = false;
+
+    // Step 1: create the placeholder ad-break entry.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, "", "", startMS, breakdur);
+
+    // Step 2: parse the static source MPD and store it as the base helper so
+    //         NotifyReservationComplete/deferred fulfillment can trigger PlaceAds.
+    // Generate mAdMPDParseHelper here so it can be passed via SetBaseMPDParseHelper.
+    ProcessSourceMPD(kStaticSourceManifest);
+    ASSERT_TRUE(mAdMPDParseHelper != nullptr);
+    mPrivateCDAIObjectMPD->SetBaseMPDParseHelper(mAdMPDParseHelper);
+
+    // Step 3: set up the mock to serve the ad manifest on download.
+    mManifest = kStaticAdManifest;
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        GetFile(std::string(TEST_AD_MANIFEST_URL), _, _, _, _, _, _, _, _, _, _, _, _, _))
+        .WillOnce(WithArgs<0,2,3,4>(Invoke(this, &AdManagerMPDTests::GetManifest)));
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        SendAdResolvedEvent(adId, true, startMS, 10000u, eCDAI_ERROR_NONE))
+      .Times(1)
+      .WillOnce(Invoke([&](const std::string&, bool, uint64_t, uint64_t, AAMPCDAIError)
+      {
+        {
+          std::lock_guard<std::mutex> lock(adResolvedMtx);
+          adResolved = true;
+        }
+        adResolvedCv.notify_one();
+      }));
+
+    // Step 4: trigger the fulfillment loop.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, adId, url, startMS, breakdur);
+    // Wait for async FulFillAdObject completion signal from SendAdResolvedEvent.
+    {
+      std::unique_lock<std::mutex> lock(adResolvedMtx);
+      ASSERT_TRUE(adResolvedCv.wait_for(lock, std::chrono::milliseconds(500), [&]() { return adResolved; }))
+        << "Timed out waiting for SendAdResolvedEvent callback";
+    }
+
+    // Step 5: all ads resolved. Now mark reservation complete, which triggers PlaceAds for static manifest.
+    mPrivateCDAIObjectMPD->NotifyReservationComplete(periodId);
+
+    // Step 6: assert the period-to-ad map was built by PlaceAds (no refresh needed).
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->isAdBreakObjectExist(periodId));
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->size(), 1u);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).resolved);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).invalid);
+
+    // PlaceAds ran → ad is fully placed and the adbreak is marked complete.
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed)
+        << "PlaceAds should have marked the ad as placed after NotifyReservationComplete";
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced)
+        << "PlaceAds should have marked the adbreak as placed after NotifyReservationComplete";
+
+    // mPeriodMap must be populated: duration is the amount of source-period content
+    // consumed while placing the ad (30 000 ms for the 30 s source period).
+    EXPECT_GT(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 0u)
+        << "PlaceAds should have accumulated period duration into mPeriodMap";
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, periodId);
+
+    // Placement is complete: mPlacementObj should be reset/empty.
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId.empty());
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mPlacementObj.openPeriodId.empty());
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.curAdIdx, -1);
+}
+
+/**
+ * @brief Integration test: 20s ad break with two 10s ads fulfilled via
+ *        SetAlternateContents should complete placement only after
+ *        NotifyReservationComplete is called.
+ */
+TEST_F(AdManagerMPDTests, StaticManifest_TwoAds_CompleteTwentySecondBreak)
+{
+    const std::string periodId = "testPeriodId1";
+    const std::string adId1    = "testAdId1";
+    const std::string adId2    = "testAdId2";
+    const std::string url      = TEST_AD_MANIFEST_URL;
+    constexpr uint64_t startMS      = 0;
+    constexpr uint32_t breakdur     = 20000;
+    constexpr uint32_t adDurationMS = 10000;
+
+    std::mutex adResolvedMtx;
+    std::condition_variable adResolvedCv;
+    int adResolvedCount = 0;
+
+    // Step 1: create the 20s placeholder ad-break entry.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, "", "", startMS, breakdur);
+
+    // Step 2: parse source MPD and set base helper so static-manifest
+    //         placement can run when reservation completion is notified.
+    ProcessSourceMPD(kStaticSourceManifest);
+    ASSERT_TRUE(mAdMPDParseHelper != nullptr);
+    mPrivateCDAIObjectMPD->SetBaseMPDParseHelper(mAdMPDParseHelper);
+
+    // Step 3: each ad fulfillment downloads the same 10s ad manifest.
+    mManifest = kStaticAdManifest;
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        GetFile(std::string(TEST_AD_MANIFEST_URL), _, _, _, _, _, _, _, _, _, _, _, _, _))
+        .Times(2)
+        .WillRepeatedly(WithArgs<0,2,3,4>(Invoke(this, &AdManagerMPDTests::GetManifest)));
+
+    {
+      ::testing::InSequence seq;
+      EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+          SendAdResolvedEvent(adId1, true, startMS, adDurationMS, eCDAI_ERROR_NONE))
+        .Times(1)
+        .WillOnce(Invoke([&](const std::string&, bool, uint64_t, uint64_t, AAMPCDAIError)
+        {
+          {
+            std::lock_guard<std::mutex> lock(adResolvedMtx);
+            ++adResolvedCount;
+          }
+          adResolvedCv.notify_one();
+        }));
+
+      EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+          SendAdResolvedEvent(adId2, true, startMS + adDurationMS, adDurationMS, eCDAI_ERROR_NONE))
+        .Times(1)
+        .WillOnce(Invoke([&](const std::string&, bool, uint64_t, uint64_t, AAMPCDAIError)
+        {
+          {
+            std::lock_guard<std::mutex> lock(adResolvedMtx);
+            ++adResolvedCount;
+          }
+          adResolvedCv.notify_one();
+        }));
+    }
+
+    // Step 4: fulfill ad1 and validate partial placement state.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, adId1, url, startMS, adDurationMS);
+    {
+      std::unique_lock<std::mutex> lock(adResolvedMtx);
+      ASSERT_TRUE(adResolvedCv.wait_for(lock, std::chrono::milliseconds(500), [&]() { return adResolvedCount >= 1; }))
+        << "Timed out waiting for first SendAdResolvedEvent callback";
+    }
+
+    ASSERT_TRUE(mPrivateCDAIObjectMPD->isAdBreakObjectExist(periodId));
+    ASSERT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->size(), 1u);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).resolved);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).invalid);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed)
+        << "Ad1 should not be marked placed until PlaceAds runs (after NotifyReservationComplete)";
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced)
+        << "Ad break should remain incomplete until PlaceAds runs";
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].adsDuration, adDurationMS);
+
+    // Step 5: fulfill ad2 and validate that ad-break placement is complete.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, adId2, url, startMS, adDurationMS);
+    {
+      std::unique_lock<std::mutex> lock(adResolvedMtx);
+      ASSERT_TRUE(adResolvedCv.wait_for(lock, std::chrono::milliseconds(500), [&]() { return adResolvedCount >= 2; }))
+        << "Timed out waiting for second SendAdResolvedEvent callback";
+    }
+
+    ASSERT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->size(), 2u);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(1).resolved);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(1).invalid);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(1).placed)
+        << "Ad2 should not be marked placed until PlaceAds runs (after NotifyReservationComplete)";
+    // Ad break placement should still be incomplete until NotifyReservationComplete is called
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced)
+        << "Ad break should remain incomplete after second ad is fulfilled but before reservation is marked complete";
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mAdBreaks[periodId].adsDuration, breakdur)
+        << "Ad break should be completely filled with both 10s ads (total 20s)";
+
+    // Step 6: all ads resolved. Now mark reservation complete, which triggers PlaceAds for static manifest.
+    mPrivateCDAIObjectMPD->NotifyReservationComplete(periodId);
+
+    // After PlaceAds runs, both ads should be marked as placed
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed)
+        << "Ad1 should be marked placed after PlaceAds runs";
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(1).placed)
+        << "Ad2 should be marked placed after PlaceAds runs";
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced)
+        << "Ad break should be marked placed after NotifyReservationComplete triggers PlaceAds";
+
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].adBreakId, periodId);
+    EXPECT_GT(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 0u);
+
+    // Placement should be complete and pending placement queue should be clear.
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId.empty());
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mPlacementObj.openPeriodId.empty());
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.curAdIdx, -1);
+}
+
+/**
+ * @brief Integration test: with no base MPD helper, reservation completion
+ *        does not trigger placement even after ad fulfillment resolves.
+ *
+ * Verifies that after NotifyReservationComplete, placement is skipped when
+ * mBaseMPDParseHelper is null and mPeriodMap remains unpopulated.
+ */
+TEST_F(AdManagerMPDTests, StaticManifest_NoBaseHelper_NotifyComplete_DoesNotPlaceAds)
+{
+    const std::string periodId = "testPeriodId1";
+    const std::string adId     = "testAdId";
+    const std::string url      = TEST_AD_MANIFEST_URL;
+    constexpr uint64_t startMS  = 0;
+    constexpr uint32_t breakdur = 30000;
+    std::mutex adResolvedMtx;
+    std::condition_variable adResolvedCv;
+    bool adResolved = false;
+
+    // Step 1: placeholder entry — mBaseMPDParseHelper intentionally NOT set.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, "", "", startMS, breakdur);
+
+    // Step 2: mock ad manifest download.
+    mManifest = kStaticAdManifest;
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        GetFile(std::string(TEST_AD_MANIFEST_URL), _, _, _, _, _, _, _, _, _, _, _, _, _))
+        .WillOnce(WithArgs<0,2,3,4>(Invoke(this, &AdManagerMPDTests::GetManifest)));
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        SendAdResolvedEvent(adId, true, startMS, 10000u, eCDAI_ERROR_NONE))
+      .Times(1)
+      .WillOnce(Invoke([&](const std::string&, bool, uint64_t, uint64_t, AAMPCDAIError)
+      {
+        {
+          std::lock_guard<std::mutex> lock(adResolvedMtx);
+          adResolved = true;
+        }
+        adResolvedCv.notify_one();
+      }));
+
+    // Step 3: trigger fulfillment.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, adId, url, startMS, breakdur);
+    {
+      std::unique_lock<std::mutex> lock(adResolvedMtx);
+      ASSERT_TRUE(adResolvedCv.wait_for(lock, std::chrono::milliseconds(500), [&]() { return adResolved; }))
+        << "Timed out waiting for SendAdResolvedEvent callback";
+    }
+
+    // Step 4: ad resolved. Now call NotifyReservationComplete to trigger PlaceAds (which should be skipped).
+    mPrivateCDAIObjectMPD->NotifyReservationComplete(periodId);
+
+    // Step 5: verify reservation was marked complete/resolved, but PlaceAds was
+    //         NOT called because mBaseMPDParseHelper is null.
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].reservationComplete);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].resolved);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).resolved);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).invalid);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed)
+        << "PlaceAds should NOT have been called when mBaseMPDParseHelper is null";
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced)
+        << "adbreak should not be marked placed when PlaceAds was not triggered";
+
+    // mPeriodMap duration must still be zero — PlaceAds never ran.
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 0u)
+        << "mPeriodMap should not be populated when PlaceAds was skipped";
+
+    // curAdIdx stays at 0 (placement queued but not yet executed by PlaceAds).
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.curAdIdx, 0);
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.pendingAdbrkId, periodId);
+}
+
+/**
+ * @brief Integration test: with base helper set, a failed ad download keeps
+ *        placement skipped even after NotifyReservationComplete.
+ *
+ * Verifies that when ad download fails, the ad remains invalid and PlaceAds is
+ * not executed, so mPeriodMap stays empty.
+ */
+TEST_F(AdManagerMPDTests, StaticManifest_AdDownloadFails_NotifyComplete_DoesNotPlaceAds)
+{
+    const std::string periodId = "testPeriodId1";
+    const std::string adId     = "testAdId";
+    const std::string url      = TEST_AD_MANIFEST_URL;
+    constexpr uint64_t startMS  = 0;
+    constexpr uint32_t breakdur = 30000;
+    std::mutex adResolvedMtx;
+    std::condition_variable adResolvedCv;
+    bool adResolved = false;
+
+    // Step 1: placeholder entry.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, "", "", startMS, breakdur);
+
+    // Step 2: parse and register the base-stream helper (static manifest gate is open).
+    ProcessSourceMPD(kStaticSourceManifest);
+    ASSERT_TRUE(mAdMPDParseHelper != nullptr);
+    mPrivateCDAIObjectMPD->SetBaseMPDParseHelper(mAdMPDParseHelper);
+
+    // Step 3: make the ad manifest download fail with HTTP 404.
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        GetFile(std::string(TEST_AD_MANIFEST_URL), _, _, _, _, _, _, _, _, _, _, _, _, _))
+        .WillOnce(WithArgs<4>(Invoke([](int* err){ *err = 404; return false; })));
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+        SendAdResolvedEvent(adId, false, 0, 0, eCDAI_ERROR_DELIVERY_HTTP_ERROR))
+      .Times(1)
+      .WillOnce(Invoke([&](const std::string&, bool, uint64_t, uint64_t, AAMPCDAIError)
+      {
+        {
+          std::lock_guard<std::mutex> lock(adResolvedMtx);
+          adResolved = true;
+        }
+        adResolvedCv.notify_one();
+      }));
+
+    // Step 4: trigger fulfillment.
+    mPrivateCDAIObjectMPD->SetAlternateContents(periodId, adId, url, startMS, breakdur);
+    {
+      std::unique_lock<std::mutex> lock(adResolvedMtx);
+      ASSERT_TRUE(adResolvedCv.wait_for(lock, std::chrono::milliseconds(500), [&]() { return adResolved; }))
+        << "Timed out waiting for SendAdResolvedEvent callback";
+    }
+
+    // Step 5: ad resolved (but marked invalid). Now call NotifyReservationComplete to trigger PlaceAds (which should be skipped due to ad failure).
+    mPrivateCDAIObjectMPD->NotifyReservationComplete(periodId);
+
+    // Step 6: verify ad marked invalid; PlaceAds must NOT have been called.
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).resolved);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).invalid);
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].ads->at(0).placed)
+        << "PlaceAds must not be called when ad download failed";
+    EXPECT_FALSE(mPrivateCDAIObjectMPD->mAdBreaks[periodId].mAdBreakPlaced);
+
+    // mPeriodMap duration must be zero — PlaceAds never ran.
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPeriodMap[periodId].duration, 0u)
+        << "mPeriodMap should not be populated when ad download failed";
+
+    // No placement queued (adStatus was false).
+    EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.curAdIdx, -1);
+    EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
 }


### PR DESCRIPTION
Reason for change:Cold CDVR/static manifests never refresh, so ad placement was never triggered after fulfillment, causing playback to freeze waiting for ads that were never mapped.Fixed by immediately calling ad placement as soon as an ad is resolved, instead of waiting for a manifest refresh that never comes.
Risks: p1

Signed-off-by: varshnie <varshniblue14@gmail.com>
