### PR TITLE
DELIA-70524: [Glass G1 UK -R40.23][Dhruv -40.11]observed "com.comcast.viper" crash on VIPA enabled devices contributing BERR/TECHFAULTOTT with fingerprint 61111371

### DIFF
--- a/middleware/drm/ocdm/OcdmGstSessionAdapter.cpp
+++ b/middleware/drm/ocdm/OcdmGstSessionAdapter.cpp
@@ -322,7 +322,7 @@ int OCDMGSTSessionAdapter::decrypt(GstBuffer *keyIDBuffer, GstBuffer *ivBuffer, 
 
 			/* Added GST_IS_CAPS check also before passing gst caps to OCDM decrypt() as gst_caps_is_empty returns false when caps object is not of 
 			type GST_TYPE_CAPS. This will avoid crash when caps is not of type GST_TYPE_CAPS. */
-			if (OCDMGSTSessionDecrypt && caps != NULL && !gst_caps_is_empty(caps) && GST_IS_CAPS(caps))
+			if (OCDMGSTSessionDecrypt && caps != nullptr && GST_IS_CAPS(caps) && !gst_caps_is_empty(caps))
 			{
 						GstProtectionMeta* protectionMeta = reinterpret_cast<GstProtectionMeta*>(gst_buffer_get_protection_meta(buffer));
 

--- a/middleware/drm/ocdm/OcdmGstSessionAdapter.cpp
+++ b/middleware/drm/ocdm/OcdmGstSessionAdapter.cpp
@@ -322,7 +322,7 @@ int OCDMGSTSessionAdapter::decrypt(GstBuffer *keyIDBuffer, GstBuffer *ivBuffer, 
 
 			/* Added GST_IS_CAPS check also before passing gst caps to OCDM decrypt() as gst_caps_is_empty returns false when caps object is not of 
 			type GST_TYPE_CAPS. This will avoid crash when caps is not of type GST_TYPE_CAPS. */
-			if (OCDMGSTSessionDecrypt && !gst_caps_is_empty(caps) && GST_IS_CAPS(caps))
+			if (OCDMGSTSessionDecrypt && caps != NULL && !gst_caps_is_empty(caps) && GST_IS_CAPS(caps))
 			{
 						GstProtectionMeta* protectionMeta = reinterpret_cast<GstProtectionMeta*>(gst_buffer_get_protection_meta(buffer));
 

--- a/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
@@ -219,6 +219,7 @@ static void gst_cdmidecryptor_init(
 	g_mutex_init(&cdmidecryptor->mutex);
 	//GST_DEBUG_OBJECT(cdmidecryptor, "\n Initialized plugin mutex\n");
 	g_cond_init(&cdmidecryptor->condition);
+	g_cond_init(&cdmidecryptor->sinkCapsCond);
 	cdmidecryptor->streamReceived = false;
 	// Lock access to canWait to keep Coverity happy
 	g_mutex_lock(&cdmidecryptor->mutex);
@@ -269,6 +270,7 @@ void gst_cdmidecryptor_dispose(GObject * object)
 
 	g_mutex_clear(&cdmidecryptor->mutex);
 	g_cond_clear(&cdmidecryptor->condition);
+	g_cond_clear(&cdmidecryptor->sinkCapsCond);
 
 	G_OBJECT_CLASS(gst_cdmidecryptor_parent_class)->dispose(object);
 }
@@ -465,7 +467,7 @@ gst_cdmidecryptor_transform_caps(GstBaseTransform * trans,
 			cdmidecryptor->sinkCaps = NULL;
 		}
 		cdmidecryptor->sinkCaps = gst_caps_copy(transformedCaps);
-		g_cond_signal(&cdmidecryptor->condition);
+		g_cond_signal(&cdmidecryptor->sinkCapsCond);
 		g_mutex_unlock(&cdmidecryptor->mutex);
 		GST_DEBUG_OBJECT(trans, "Set sinkCaps to %" GST_PTR_FORMAT, cdmidecryptor->sinkCaps);
 	}
@@ -513,15 +515,15 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 	mutexLocked = TRUE;
 
 	if (cdmidecryptor->sinkCaps == NULL && cdmidecryptor->streamReceived) {
-	    // Caps negotiation hasn't completed yet - wait briefly
-	    gint64 end_time = g_get_monotonic_time() + 500 * G_TIME_SPAN_MILLISECOND;
-	    while (cdmidecryptor->sinkCaps == NULL) {
-	        if (!g_cond_wait_until(&cdmidecryptor->condition, &cdmidecryptor->mutex, end_time)) {
-	            GST_WARNING_OBJECT(cdmidecryptor, "Timeout waiting for sinkCaps");
-	            result = GST_FLOW_NOT_SUPPORTED;
-	            goto free_resources;
-	        }
-	    }
+		// Caps negotiation hasn't completed yet - wait briefly
+		gint64 end_time = g_get_monotonic_time() + 500 * G_TIME_SPAN_MILLISECOND;
+		while (cdmidecryptor->sinkCaps == NULL) {
+			if (!g_cond_wait_until(&cdmidecryptor->sinkCapsCond, &cdmidecryptor->mutex, end_time)) {
+				GST_WARNING_OBJECT(cdmidecryptor, "Timeout waiting for sinkCaps");
+				result = GST_FLOW_NOT_SUPPORTED;
+				goto free_resources;
+			}
+		}
 	}
 
 	if (!protectionMeta)
@@ -537,7 +539,7 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 			else
 			{ /* If drmSession creation failed, then the call will be aborted here */
 				result = GST_FLOW_NOT_SUPPORTED;
-				GST_ERROR_OBJECT(cdmidecryptor, "drmSession is **** NULL ****, returning GST_FLOW_NOT_SUPPORTED");
+				GST_ERROR_OBJECT(cdmidecryptor, "drmSession or sinkCaps is **** NULL ****, returning GST_FLOW_NOT_SUPPORTED");
 			}
 		}
 		goto free_resources;

--- a/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
+++ b/middleware/gst-plugins/drm/gst/gstcdmidecryptor.cpp
@@ -465,6 +465,7 @@ gst_cdmidecryptor_transform_caps(GstBaseTransform * trans,
 			cdmidecryptor->sinkCaps = NULL;
 		}
 		cdmidecryptor->sinkCaps = gst_caps_copy(transformedCaps);
+		g_cond_signal(&cdmidecryptor->condition);
 		g_mutex_unlock(&cdmidecryptor->mutex);
 		GST_DEBUG_OBJECT(trans, "Set sinkCaps to %" GST_PTR_FORMAT, cdmidecryptor->sinkCaps);
 	}
@@ -510,6 +511,19 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 
 	g_mutex_lock(&cdmidecryptor->mutex);
 	mutexLocked = TRUE;
+
+	if (cdmidecryptor->sinkCaps == NULL && cdmidecryptor->streamReceived) {
+	    // Caps negotiation hasn't completed yet - wait briefly
+	    gint64 end_time = g_get_monotonic_time() + 500 * G_TIME_SPAN_MILLISECOND;
+	    while (cdmidecryptor->sinkCaps == NULL) {
+	        if (!g_cond_wait_until(&cdmidecryptor->condition, &cdmidecryptor->mutex, end_time)) {
+	            GST_WARNING_OBJECT(cdmidecryptor, "Timeout waiting for sinkCaps");
+	            result = GST_FLOW_NOT_SUPPORTED;
+	            goto free_resources;
+	        }
+	    }
+	}
+
 	if (!protectionMeta)
 	{
 		GST_DEBUG_OBJECT(cdmidecryptor,
@@ -518,7 +532,7 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 		{
 			// call decrypt even for clear samples in order to copy it to a secure buffer. If secure buffers are not supported
 			// decrypt() call will return without doing anything
-			if (cdmidecryptor->drmSession != NULL)
+			if (cdmidecryptor->drmSession != NULL && cdmidecryptor->sinkCaps != NULL)
 			   errorCode = cdmidecryptor->drmSession->decrypt(keyIDBuffer, ivBuffer, buffer, subSampleCount, subsamplesBuffer, cdmidecryptor->sinkCaps);
 			else
 			{ /* If drmSession creation failed, then the call will be aborted here */
@@ -635,7 +649,11 @@ static GstFlowReturn gst_cdmidecryptor_transform_ip(
 			goto free_resources;
 		}
 	}
-
+	if (cdmidecryptor->sinkCaps == NULL) {
+	    GST_WARNING_OBJECT(cdmidecryptor, "sinkCaps is NULL, skipping decrypt");
+	    result = GST_FLOW_NOT_SUPPORTED;
+	    goto free_resources;
+	}
 	errorCode = cdmidecryptor->drmSession->decrypt(keyIDBuffer, ivBuffer, buffer, subSampleCount, subsamplesBuffer, cdmidecryptor->sinkCaps);
 
 	cdmidecryptor->streamEncrypted = true;

--- a/middleware/gst-plugins/drm/gst/gstcdmidecryptor.h
+++ b/middleware/gst-plugins/drm/gst/gstcdmidecryptor.h
@@ -55,6 +55,7 @@ struct _GstCDMIDecryptor
 
     GMutex                          mutex;
     GCond                           condition;
+    GCond                           sinkCapsCond;
 
     GstEvent*                       protectionEvent;
     const gchar*                    selectedProtection;


### PR DESCRIPTION
Reason for Change: During rapid pipeline startup, transform_ip() can be called before transform_caps() sets sinkCaps. Instead of just returning error, this fix waits briefly for caps to arrive, improving user experience on rapid channel changes
Test Procedure: Refer Ticket
Risks: Low
Signed-off-by: Alsameema AhmedAnsar <Alsameema_AhmedAnsar@comcast.com>

