### PR TITLE
VPAAMP-239 Change the CURLOPT_DNS_CACHE_TIMEOUT config (#1393)

### DIFF
--- a/downloader/AampCurlDefine.h
+++ b/downloader/AampCurlDefine.h
@@ -37,12 +37,7 @@
 
 #define DEFAULT_CURL_TIMEOUT 5L		/**< Default timeout for Curl downloads */
 #define DEFAULT_CURL_CONNECTTIMEOUT 3L	/**< Curl socket connection timeout */
-#define DEFAULT_DNS_CACHE_TIMEOUT 3*60L	/***< Name resolve results for this number of seconds*/
-/**
- * @enum AampCurlStoreErrorCode
- * @brief Error codes returned by curlstore
- */
- 
+#define DEFAULT_DNS_CACHE_TIMEOUT 3*60L	/**< Name resolve results cached for this many seconds (180 s = 3x the libcurl default of 60 s) */
 
 /**
  * @brief Http Header Type

--- a/downloader/AampCurlStore.cpp
+++ b/downloader/AampCurlStore.cpp
@@ -353,7 +353,7 @@ CURL* CurlStore::CurlEasyInitWithOpt ( PrivateInstanceAAMP *aamp, const std::str
 	CURL_EASY_SETOPT_STRING(curlEasyhdl, CURLOPT_ACCEPT_ENCODING, "");//Enable all the encoding formats supported by client
 	CURL_EASY_SETOPT_FUNC(curlEasyhdl, CURLOPT_SSL_CTX_FUNCTION, ssl_callback); //Check for downloads disabled in btw ssl handshake
 	CURL_EASY_SETOPT_POINTER(curlEasyhdl, CURLOPT_SSL_CTX_DATA, aamp);
-	long dns_cache_timeout = 3*60;
+	long dns_cache_timeout = GETCONFIGVALUE(eAAMPConfig_Dns_CacheTimeout);
 	CURL_EASY_SETOPT_LONG(curlEasyhdl, CURLOPT_DNS_CACHE_TIMEOUT, dns_cache_timeout);
 	CURL_EASY_SETOPT_POINTER(curlEasyhdl, CURLOPT_SHARE, aamp->mCurlShared);
 

--- a/test/utests/fakes/FakeCurl.cpp
+++ b/test/utests/fakes/FakeCurl.cpp
@@ -133,6 +133,13 @@ CURLcode curl_easy_setopt(CURL *handle, CURLoption option, ...)
             }
             break;
 
+            case CURLOPT_DNS_CACHE_TIMEOUT:
+            {
+                long value = va_arg(arg, long);
+                curl_code = g_mockCurl->curl_easy_setopt_long(handle, option, value);
+            }
+            break;
+
             default:
                 // New cases might be required in this switch
                 break;

--- a/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
+++ b/test/utests/tests/AampCurlDownloader/FunctionalTests.cpp
@@ -55,6 +55,14 @@ protected:
 		g_mockCurl = new MockCurl();
 
 		mCurlEasyHandle = malloc(1);		// use a valid address for the handle
+
+		// Allow any curl_easy_setopt_long call by default so that tests which call
+		// Initialize() don't fail on long-option calls (e.g. CURLOPT_DNS_CACHE_TIMEOUT
+		// with the default value) that they don't explicitly expect.  Individual tests
+		// can add a stricter EXPECT_CALL which GMock will match first (LIFO order).
+		EXPECT_CALL(*g_mockCurl, curl_easy_setopt_long(::testing::_, ::testing::_, ::testing::_))
+			.Times(::testing::AnyNumber())
+			.WillRepeatedly(Return(CURLE_OK));
 	}
 
 	void TearDown() override
@@ -542,4 +550,42 @@ TEST_F(FunctionalTests, Release_BeforeCleanupCurlHeaderResources_PreventRaceCond
 	
 	// Verify no crash occurred and state is clean
 	EXPECT_FALSE(mAampCurlDownloader->IsDownloadActive());
+}
+
+/**
+ * @brief Verify CURLOPT_DNS_CACHE_TIMEOUT is set from DownloadConfig, not hard-coded.
+ *
+ * Regression test for the bug in AampCurlStore.cpp where dns_cache_timeout was
+ * hard-coded as 3*60 instead of reading eAAMPConfig_Dns_CacheTimeout from config.
+ * The equivalent risk in CurlDownloader is using a literal instead of
+ * mDnldCfg->iDnsCacheTimeOut.  This test would catch either regression:
+ * if the implementation hard-codes any value other than the one placed in
+ * DownloadConfig, the EXPECT_CALL for CURLOPT_DNS_CACHE_TIMEOUT will fail.
+ */
+TEST_F(FunctionalTests, DnsCacheTimeout_PassedFromDownloadConfig_NotHardCoded)
+{
+	const long kCustomDnsTimeout = 42L; // deliberately != DEFAULT_DNS_CACHE_TIMEOUT (180)
+
+	DownloadConfigPtr inpData = std::make_shared<DownloadConfig>();
+	inpData->iDnsCacheTimeOut = kCustomDnsTimeout;
+	inpData->bIgnoreResponseHeader = true;
+
+	EXPECT_CALL(*g_mockCurl, curl_easy_init()).WillOnce(Return(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_cleanup(mCurlEasyHandle));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_PROGRESSDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_xferinfo(mCurlEasyHandle, CURLOPT_XFERINFOFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlProgressCallback), Return(CURLE_OK)));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_ptr(mCurlEasyHandle, CURLOPT_WRITEDATA, mAampCurlDownloader))
+		.WillOnce(Return(CURLE_OK));
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_func_write(mCurlEasyHandle, CURLOPT_WRITEFUNCTION, NotNull()))
+		.WillOnce(DoAll(SaveArgPointee<2>(&mCurlWriteFunc), Return(CURLE_OK)));
+
+	// Key assertion: CURLOPT_DNS_CACHE_TIMEOUT must be set to kCustomDnsTimeout (42),
+	// not the hard-coded literal 3*60 (180).  If the implementation ever regresses to
+	// a hard-coded value, this expectation will be unsatisfied and the test will fail.
+	EXPECT_CALL(*g_mockCurl, curl_easy_setopt_long(mCurlEasyHandle, CURLOPT_DNS_CACHE_TIMEOUT, kCustomDnsTimeout))
+		.WillOnce(Return(CURLE_OK));
+
+	mAampCurlDownloader->Initialize(inpData);
 }


### PR DESCRIPTION
Reason for Change: Change the CURLOPT_DNS_CACHE_TIMEOUT config to be updated from config not as default
* Add L1 test verifying CURLOPT_DNS_CACHE_TIMEOUT uses config value
* AampCurlDefine.h: clarify DEFAULT_DNS_CACHE_TIMEOUT comment (180s = 3x libcurl default of 60s)
* ( FakeCurl.cpp: route CURLOPT_DNS_CACHE_TIMEOUT through curl_easy_setopt_long mock
* ( FunctionalTests.cpp: add DnsCacheTimeout_PassedFromDownloadConfig_NotHardCoded regression test; catches any future hard-coding of dns_cache_timeout instead of reading iDnsCacheTimeOut from DownloadConfig
* FunctionalTests.cpp SetUp: allow curl_easy_setopt_long by default so existing tests are not broken by the new FakeCurl routing

Test Procedure: refer ticket
Risks: Low
Priority: P1

---------