### PR TITLE
VPLAY-13143 (#1239)  : frequent stuttering while playing clear multi-codec test stream 

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -249,6 +249,7 @@ static const ConfigLookupEntryBool mConfigLookupTableBool[AAMPCONFIG_BOOL_COUNT]
 	{false,"stereoOnly",eAAMPConfig_StereoOnly,true},
 	{false,"descriptiveTrackName",eAAMPConfig_DescriptiveTrackName,false},
 	{false,"disableAC3",eAAMPConfig_DisableAC3,true},
+	{true,"preferHEVC",eAAMPConfig_PreferHEVC,true},
 	{true,"disablePlaylistIndexEvent",eAAMPConfig_DisablePlaylistIndexEvent,false},
 	{true,"enableSubscribedTags",eAAMPConfig_EnableSubscribedTags,false},
 	{false,"dashIgnoreBaseUrlIfSlash",eAAMPConfig_DASHIgnoreBaseURLIfSlash,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -96,6 +96,7 @@ typedef enum
 	eAAMPConfig_StereoOnly,							/**< Enable Stereo Only playback, disables EC3/ATMOS.  */
 	eAAMPConfig_DescriptiveTrackName,					/**< Enable Descriptive track name*/
 	eAAMPConfig_DisableAC3,							/**< Disable AC3 Audio */
+	eAAMPConfig_PreferHEVC,							/**< When multiple video codec families are present (e.g. HEVC and AVC in separate AdaptationSets), prefer HEVC. Prevents cross-codec ABR switches at runtime. */
 	eAAMPConfig_DisablePlaylistIndexEvent,					/**< Disable playlist index event*/
 	eAAMPConfig_EnableSubscribedTags,					/**< Enabled subscribed tags*/
 	eAAMPConfig_DASHIgnoreBaseURLIfSlash,					/**< Ignore the constructed URI of DASH, if it is / */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -7624,6 +7624,29 @@ static bool IsWebmVideoCodec(const std::string &codec )
 }
 
 /**
+ * @brief Is this an HEVC video codec (hvc1 or hev1)
+ *
+ * @param codec Codec string from MPD Representation
+ * @return true if codec is HEVC, false otherwise
+ */
+static bool IsVideoCodecHEVC(const std::string &codec)
+{
+	return codec.rfind("hvc1.", 0) == 0 || codec.rfind("hev1.", 0) == 0 ||
+	       codec == "hvc1" || codec == "hev1";
+}
+
+/**
+ * @brief Is this an AVC/H.264 video codec (avc1)
+ *
+ * @param codec Codec string from MPD Representation
+ * @return true if codec is AVC, false otherwise
+ */
+static bool IsVideoCodecAVC(const std::string &codec)
+{
+	return codec.rfind("avc1.", 0) == 0 || codec == "avc1";
+}
+
+/**
  * @brief Updates track information based on current state
  */
 AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, bool resetTimeLineIndex, bool isInit)
@@ -7777,6 +7800,8 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 					int representationCount = 0;
 					std::set<uint32_t> blAdaptationIdxs;
 					bool bSeenNonWebmCodec = false;
+					bool bHasHEVC = false; /**< At least one HEVC representation is present */
+					bool bHasAVC  = false; /**< At least one AVC representation is present */
 
 					const auto &blacklistedProfiles = aamp->GetBlacklistedProfiles();
 					// Filter the blacklisted profiles in the period
@@ -7844,6 +7869,12 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 						for (int reprIdx = 0; reprIdx < representations.size(); reprIdx++)
 						{
 							IRepresentation *representation = representations.at(reprIdx);
+							// Reset selection-state fields before (re-)populating this slot so that
+							// stale values from a previous UpdateTrackInfo call cannot leak through
+							// the filtering logic below (enabled/validity drive GetVideoBitrates()
+							// and GetBWIndex()).
+							mStreamInfo[idx].enabled = false;
+							mStreamInfo[idx].validity = false;
 							mStreamInfo[idx].bandwidthBitsPerSecond = representation->GetBandwidth();
 							mStreamInfo[idx].isIframeTrack = !(AAMP_NORMAL_PLAY_RATE == mPlayRate);
 							mStreamInfo[idx].resolution.height = representation->GetHeight();
@@ -7872,9 +7903,11 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 									bSeenNonWebmCodec = true;
 								}
 							}
-
-							mStreamInfo[idx].enabled = false;
-							mStreamInfo[idx].validity = false;
+							// Track which codec families are present across all chosen AdaptationSets.
+							// Used below to restrict the ABR pool to a single family and prevent
+							// codec switches at runtime (e.g. AVC <-> HEVC).
+							if (IsVideoCodecHEVC(mStreamInfo[idx].codecs))     bHasHEVC = true;
+							else if (IsVideoCodecAVC(mStreamInfo[idx].codecs))  bHasAVC  = true;
 							if(repFrameRate.empty())
 								repFrameRate = adapFrameRate;
 							if(!repFrameRate.empty())
@@ -7927,6 +7960,19 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 						}
 					}
 					mProfileCount = idx;
+					// When both HEVC and AVC AdaptationSets are present, restrict the ABR pool
+					// to representations from the preferred codec family only.  Mixing codec
+					// families in the pool would cause GStreamer pipeline failures whenever ABR
+					// crosses between them (different init segments, codec reconfiguration
+					// required, no discontinuity signalled).
+					StreamOutputFormat preferredVideoFormat = FORMAT_INVALID; // FORMAT_INVALID = no restriction
+					if (bHasHEVC && bHasAVC)
+					{
+						bool preferHEVC = ISCONFIGSET(eAAMPConfig_PreferHEVC);
+						preferredVideoFormat = preferHEVC ? FORMAT_VIDEO_ES_HEVC : FORMAT_VIDEO_ES_H264;
+						AAMPLOG_WARN("Multiple video codec families present (HEVC+AVC); restricting ABR pool to %s codec family",
+									 preferHEVC ? "HEVC" : "AVC");
+					}
 					for (int pidx = 0; pidx < idx; pidx++)
 					{
 						if (false == aamp->userProfileStatus && resolutionCheckEnabled && (mStreamInfo[pidx].resolution.width > aamp->mDisplayWidth) &&
@@ -7939,6 +7985,20 @@ AAMPStatusType StreamAbstractionAAMP_MPD::UpdateTrackInfo(bool modifyDefaultBW, 
 						{
 							// Don't use VP8 or VP9 codecs if others are listed.
 							AAMPLOG_INFO("Video Profile ignoring for codec %s resolution= %d:%d display= %d:%d BW=%" BITSPERSECOND_FORMAT, mStreamInfo[pidx].codecs.c_str(), mStreamInfo[pidx].resolution.width, mStreamInfo[pidx].resolution.height, aamp->mDisplayWidth, aamp->mDisplayHeight, mStreamInfo[pidx].bandwidthBitsPerSecond);
+						}
+						else if (preferredVideoFormat != FORMAT_INVALID &&
+								 !mStreamInfo[pidx].codecs.empty() &&
+								 ((preferredVideoFormat == FORMAT_VIDEO_ES_HEVC && !IsVideoCodecHEVC(mStreamInfo[pidx].codecs)) ||
+								  (preferredVideoFormat == FORMAT_VIDEO_ES_H264 && !IsVideoCodecAVC(mStreamInfo[pidx].codecs))))
+						{
+							// Exclude representations from the non-preferred codec family to prevent
+							// cross-codec ABR switches (e.g. AVC<->HEVC) which require decoder
+							// reconfiguration and are not supported at runtime.
+							AAMPLOG_INFO("Video Profile ignoring codec %s (preferred %s family) res= %d:%d BW=%" BITSPERSECOND_FORMAT,
+										 mStreamInfo[pidx].codecs.c_str(),
+										 preferredVideoFormat == FORMAT_VIDEO_ES_HEVC ? "HEVC" : "AVC",
+										 mStreamInfo[pidx].resolution.width, mStreamInfo[pidx].resolution.height,
+										 mStreamInfo[pidx].bandwidthBitsPerSecond);
 						}
 						else
 						{

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -196,21 +196,21 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 	DRMSystems PlayerInstanceAAMP::GetPreferredDRM() { return eDRM_NONE; }
 	std::vector<BitsPerSecond> PlayerInstanceAAMP::GetVideoBitrates(void) { static std::vector<BitsPerSecond> temp; return temp; }
 	std::vector<BitsPerSecond> PlayerInstanceAAMP::GetAudioBitrates(void) { static std::vector<BitsPerSecond> temp; return temp; }
-    std::string PlayerInstanceAAMP::GetManifest(void) { return nullptr; }
-	std::string PlayerInstanceAAMP::GetAvailableVideoTracks() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetAvailableAudioTracks(bool allTrack) { return nullptr; }
-	std::string PlayerInstanceAAMP::GetAvailableTextTracks(bool allTrack) { return nullptr; }
-	std::string PlayerInstanceAAMP::GetVideoRectangle() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetAudioTrackInfo() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetTextTrackInfo() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetPreferredAudioProperties() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetPreferredTextProperties() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetTextStyle() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetAvailableThumbnailTracks(void) { return nullptr; }
-	std::string PlayerInstanceAAMP::GetThumbnails(double tStart, double tEnd) { return nullptr; }
-	std::string PlayerInstanceAAMP::GetAAMPConfig() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetPlaybackStats() { return nullptr; }
-	std::string PlayerInstanceAAMP::GetVideoPlaybackQuality(void) { return nullptr; }
+    std::string PlayerInstanceAAMP::GetManifest(void) { return {}; }
+	std::string PlayerInstanceAAMP::GetAvailableVideoTracks() { return {}; }
+	std::string PlayerInstanceAAMP::GetAvailableAudioTracks(bool allTrack) { return {}; }
+	std::string PlayerInstanceAAMP::GetAvailableTextTracks(bool allTrack) { return {}; }
+	std::string PlayerInstanceAAMP::GetVideoRectangle() { return {}; }
+	std::string PlayerInstanceAAMP::GetAudioTrackInfo() { return {}; }
+	std::string PlayerInstanceAAMP::GetTextTrackInfo() { return {}; }
+	std::string PlayerInstanceAAMP::GetPreferredAudioProperties() { return {}; }
+	std::string PlayerInstanceAAMP::GetPreferredTextProperties() { return {}; }
+	std::string PlayerInstanceAAMP::GetTextStyle() { return {}; }
+	std::string PlayerInstanceAAMP::GetAvailableThumbnailTracks(void) { return {}; }
+	std::string PlayerInstanceAAMP::GetThumbnails(double tStart, double tEnd) { return {}; }
+	std::string PlayerInstanceAAMP::GetAAMPConfig() { return {}; }
+	std::string PlayerInstanceAAMP::GetPlaybackStats() { return {}; }
+	std::string PlayerInstanceAAMP::GetVideoPlaybackQuality(void) { return {}; }
 	bool PlayerInstanceAAMP::SetUserAgent(std::string &userAgent){ return false; }
 	void PlayerInstanceAAMP::updateManifest(const char *manifestData){}
 	bool PlayerInstanceAAMP::IsJsInfoLoggingEnabled(void){ return false; }

--- a/test/utests/tests/AampTsbMetaDataManagerTests/AampTsbMetaDataManagerCases.cpp
+++ b/test/utests/tests/AampTsbMetaDataManagerTests/AampTsbMetaDataManagerCases.cpp
@@ -731,7 +731,7 @@ TEST_F(AampTsbMetaDataManagerTest, ThreadSafetyTest)
 	}
 
 	// Verify the manager is still in a valid state
-	(void)manager->RemoveMetaData(UINT64_MAX);
+	(void)manager->RemoveMetaData(static_cast<double>(UINT64_MAX));
 	EXPECT_EQ(manager->GetSize(), 1);
 }
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -165,6 +165,8 @@ protected:
 
 		g_mockIsoBmffProcessor = new NiceMock<MockIsoBmffProcessor>();
 
+		g_mockABRManager = new NiceMock<MockABRManager>();
+
 		mStreamAbstractionAAMP_MPD = nullptr;
 
 		mManifest = nullptr;
@@ -217,6 +219,9 @@ protected:
 
 		delete g_mockAampStreamSinkManager;
 		g_mockAampStreamSinkManager = nullptr;
+
+		delete g_mockABRManager;
+		g_mockABRManager = nullptr;
 
 		mManifest = nullptr;
 	}
@@ -4632,4 +4637,112 @@ R"(<?xml version="1.0" encoding="utf-8"?>
     double actualPosition = mStreamAbstractionAAMP_MPD->GetStreamPosition();
     double availabilityStartTime = ISO8601DateTimeToUTCSeconds("2025-11-15T00:00:00Z");
     EXPECT_EQ(actualPosition, availabilityStartTime + seekPosition);
+}
+
+/**
+ * @brief Multi-codec ABR pool restriction: preferHEVC=true selects HEVC representations only.
+ *
+ * Stream contains two video AdaptationSets, one HEVC (hvc1.*) and one AVC (avc1.*). With
+ * preferHEVC=true the HEVC init segment must be selected and GetVideoBitrates() must return
+ * only the HEVC bitrate, confirming AVC representations have been excluded from the ABR pool.
+ */
+TEST_F(FunctionalTests, MultiCodecABR_PreferHEVC_SelectsHEVCOnly)
+{
+    AAMPStatusType status;
+    static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT2M0.0S" minBufferTime="PT4.0S">
+    <Period id="0" start="PT0.0S">
+        <AdaptationSet id="0" contentType="video">
+            <Representation id="h1" mimeType="video/mp4" codecs="hvc1.1.6.L93.90" bandwidth="2000000" width="1280" height="720" frameRate="25">
+                <SegmentTemplate timescale="12800" initialization="hevc/video_init.mp4" media="hevc/video_$Number$.m4s" startNumber="1">
+                    <SegmentTimeline><S t="0" d="25600" r="59" /></SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="1" contentType="video">
+            <Representation id="a1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000" width="640" height="360" frameRate="25">
+                <SegmentTemplate timescale="12800" initialization="avc/video_init.mp4" media="avc/video_$Number$.m4s" startNumber="1">
+                    <SegmentTimeline><S t="0" d="25600" r="59" /></SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="2" contentType="audio">
+            <Representation id="au1" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="128000" audioSamplingRate="48000">
+                <SegmentTemplate timescale="48000" initialization="aac/audio_init.mp4" media="aac/audio_$Number$.mp4" startNumber="1">
+                    <SegmentTimeline><S t="0" d="96000" r="59" /></SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>
+)";
+
+    mBoolConfigSettings[eAAMPConfig_PreferHEVC] = true;
+
+    EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _, _, _))
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetLLDashChunkMode(_));
+    EXPECT_CALL(*g_mockABRManager, getProfileCount()).WillRepeatedly(Return(1));
+
+    status = InitializeMPD(manifest);
+    ASSERT_EQ(status, eAAMPSTATUS_OK);
+
+    std::vector<BitsPerSecond> bitrates = mStreamAbstractionAAMP_MPD->GetVideoBitrates();
+    ASSERT_EQ(bitrates.size(), 1u);
+    EXPECT_EQ(bitrates[0], 2000000);
+}
+
+/**
+ * @brief Multi-codec ABR pool restriction: preferHEVC=false selects AVC representations only.
+ *
+ * Same dual-codec stream as above. With preferHEVC=false the AVC init segment must be
+ * selected and GetVideoBitrates() must return only the AVC bitrate, confirming HEVC
+ * representations have been excluded from the ABR pool.
+ */
+TEST_F(FunctionalTests, MultiCodecABR_PreferAVC_SelectsAVCOnly)
+{
+    AAMPStatusType status;
+    static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT2M0.0S" minBufferTime="PT4.0S">
+    <Period id="0" start="PT0.0S">
+        <AdaptationSet id="0" contentType="video">
+            <Representation id="h1" mimeType="video/mp4" codecs="hvc1.1.6.L93.90" bandwidth="2000000" width="1280" height="720" frameRate="25">
+                <SegmentTemplate timescale="12800" initialization="hevc/video_init.mp4" media="hevc/video_$Number$.m4s" startNumber="1">
+                    <SegmentTimeline><S t="0" d="25600" r="59" /></SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="1" contentType="video">
+            <Representation id="a1" mimeType="video/mp4" codecs="avc1.640028" bandwidth="1000000" width="640" height="360" frameRate="25">
+                <SegmentTemplate timescale="12800" initialization="avc/video_init.mp4" media="avc/video_$Number$.m4s" startNumber="1">
+                    <SegmentTimeline><S t="0" d="25600" r="59" /></SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="2" contentType="audio">
+            <Representation id="au1" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="128000" audioSamplingRate="48000">
+                <SegmentTemplate timescale="48000" initialization="aac/audio_init.mp4" media="aac/audio_$Number$.mp4" startNumber="1">
+                    <SegmentTimeline><S t="0" d="96000" r="59" /></SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>
+)";
+
+    mBoolConfigSettings[eAAMPConfig_PreferHEVC] = false;
+
+    EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _, _, _))
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetLLDashChunkMode(_));
+    EXPECT_CALL(*g_mockABRManager, getProfileCount()).WillRepeatedly(Return(1));
+
+    status = InitializeMPD(manifest);
+    ASSERT_EQ(status, eAAMPSTATUS_OK);
+
+    std::vector<BitsPerSecond> bitrates = mStreamAbstractionAAMP_MPD->GetVideoBitrates();
+    ASSERT_EQ(bitrates.size(), 1u);
+    EXPECT_EQ(bitrates[0], 1000000);
 }


### PR DESCRIPTION
* VPLAY-13143 frequent stuttering while playing clear multi-codec test stream

Reason for Change: test hevc/ave filtering with multi-codec streams

Test Guidance: see ticket - includes a test stream that sufferes gstreamer pipeline errors without this.  new l1/l2 tests added

Risk: Medium

---------