### PR TITLE
VPAAMP-558: restore per-host curl share locks; fix non-store USERDATA=NULL

### DIFF
--- a/downloader/AampCurlStore.cpp
+++ b/downloader/AampCurlStore.cpp
@@ -28,37 +28,26 @@
 #include <mutex>
 
 // Curl callback functions
-static std::mutex gCurlShMutex;
-
-
-/*
- * IMPORTANT: Static curl share lock is required.
- *
- * libcurl stores the pointer passed via CURLSHOPT_USERDATA internally and may
- * invoke curl_lock_callback / curl_unlock_callback asynchronously and from
- * different threads (e.g., during curl_easy_cleanup, curl_share_cleanup, or
- * other shared-state operations triggered by unrelated easy handles).
- *
- * libcurl has no knowledge of the caller’s object lifetime and does not
- * revalidate the USERDATA pointer before invoking callbacks. If the lock
- * object is dynamically allocated and freed by the caller, libcurl may later
- * dereference a dangling pointer, leading to use-after-free, deadlocks, or
- * process aborts.
- *
- * libcurl does not provide internal synchronization for data shared via
- * CURLSH handles; the application is responsible for providing thread-safe
- * locking for the entire duration libcurl may invoke these callbacks.
- *
- * NOTE: This shared lock is used only to protect libcurl shared state such as
- * DNS cache, SSL session cache, and connection bookkeeping. It does NOT
- * serialize actual media data transfers (audio/video/manifest downloads),
- * which continue to run in parallel.
- *
- * To guarantee correctness and thread safety, the lock object must have
- * process lifetime. Therefore, a single static CurlDataShareLock is used
- * here and must never be deleted.
- */
-CurlDataShareLock CurlStore::mSharedCurlLock;
+//
+// VPAAMP-558: per-host embedded lock (curlstorestruct::mShareLock).
+//
+// Each curlstorestruct embeds a CurlDataShareLock as a value member.
+// CURLSHOPT_USERDATA is set to &CurlSock->mShareLock so that DNS, SSL, and
+// general libcurl-share operations for each CDN hostname use independent
+// per-host mutexes, restoring the parallelism lost by the
+// VPAAMP-139 single-static-lock fix.
+//
+// Safety: every cleanup path (RemoveCurlSock, ~CurlStore, FlushCurlSockForHost)
+// follows the order:
+//   1. curl_easy_cleanup all queued handles  (no further easy-handle callbacks)
+//   2. curl_share_cleanup(mCurlShared)        (share teardown; lock may fire)
+//   3. SAFE_DELETE(CurlSock)                  (destroys embedded mShareLock)
+// The embedded lock is therefore always alive when curl_share_cleanup needs it.
+//
+// Non-store path: gCurlShLock (file-scope static, process lifetime) is passed
+// as CURLSHOPT_USERDATA in CurlInit when the curl store is disabled, giving
+// the same per-type DNS / SSL / general mutex granularity.
+static CurlDataShareLock gCurlShLock; // process-lifetime; used by non-store path
 
 /**
  * @brief
@@ -97,7 +86,7 @@ static void curl_lock_callback(CURL *curl, curl_lock_data data, curl_lock_access
 	}
 	else
 	{
-		gCurlShMutex.lock();
+		gCurlShLock.mCurlSharedlock.lock(); // defensive fallback; user_ptr should never be NULL
 	}
 }
 
@@ -136,7 +125,7 @@ static void curl_unlock_callback(CURL *curl, curl_lock_data data, void *user_ptr
 	}
 	else
 	{
-		gCurlShMutex.unlock();
+		gCurlShLock.mCurlSharedlock.unlock(); // defensive fallback; user_ptr should never be NULL
 	}
 }
 
@@ -274,7 +263,7 @@ static int eas_curl_debug_callback(CURL *handle, curl_infotype type, char *data,
 CurlSocketStoreStruct *CurlStore::CreateCurlStore ( const std::string &hostname )
 {
 	CurlSocketStoreStruct *CurlSock = new curlstorestruct(); // throws std::bad_alloc on failure; no NULL check needed
-	CurlDataShareLock *locks = &CurlStore::mSharedCurlLock;
+	CurlDataShareLock *locks = &CurlSock->mShareLock; // per-host embedded lock (VPAAMP-558)
 
 	CurlSock->timestamp = aamp_GetCurrentTimeMS();
 	CurlSock->mCurlStoreUserCount += 1;
@@ -455,7 +444,7 @@ void CurlStore::CurlInit(PrivateInstanceAAMP *aamp, AampCurlInstance startIdx, u
 			if(NULL==aamp->mCurlShared)
 			{
 				aamp->mCurlShared = curl_share_init();
-				CURL_SHARE_SETOPT(aamp->mCurlShared, CURLSHOPT_USERDATA, (void*)NULL);
+				CURL_SHARE_SETOPT(aamp->mCurlShared, CURLSHOPT_USERDATA, (void*)&gCurlShLock);
 				CURL_SHARE_SETOPT(aamp->mCurlShared, CURLSHOPT_LOCKFUNC, curl_lock_callback);
 				CURL_SHARE_SETOPT(aamp->mCurlShared, CURLSHOPT_UNLOCKFUNC, curl_unlock_callback);
 				CURL_SHARE_SETOPT(aamp->mCurlShared, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -85,7 +85,7 @@ typedef struct curlstorestruct
 	unsigned int mCurlStoreUserCount;
 	long long timestamp;
 
-	curlstorestruct():mCurlShared(NULL), timestamp(0), mCurlStoreUserCount(0), mFreeQ(), mShareLock()
+	curlstorestruct():mFreeQ(), mCurlShared(NULL), mShareLock(), mCurlStoreUserCount(0), timestamp(0)
 	{}
 
 	//Disabled for now

--- a/downloader/AampCurlStore.h
+++ b/downloader/AampCurlStore.h
@@ -80,12 +80,12 @@ typedef struct curlstorestruct
 {
 	std::deque<CurlHandleStruct> mFreeQ;
 	CURLSH* mCurlShared;
-	// pstShareLocks removed: lock lifetime is managed by CurlStore::mSharedCurlLock (static)
+	CurlDataShareLock mShareLock; // per-host lock; lifetime equals this struct
 
 	unsigned int mCurlStoreUserCount;
 	long long timestamp;
 
-	curlstorestruct():mCurlShared(NULL), timestamp(0), mCurlStoreUserCount(0), mFreeQ()
+	curlstorestruct():mCurlShared(NULL), timestamp(0), mCurlStoreUserCount(0), mFreeQ(), mShareLock()
 	{}
 
 	//Disabled for now
@@ -103,8 +103,8 @@ class CurlStore
 private:
 	std::mutex mCurlInstLock{};
 	int MaxCurlSockStore;
-	static CurlDataShareLock mSharedCurlLock; // Single shared curl share lock (process lifetime)
-
+	// mSharedCurlLock removed (VPAAMP-558): each curlstorestruct now embeds its own
+	// CurlDataShareLock (mShareLock), restoring per-host DNS/SSL lock granularity.
 
 	typedef std::unordered_map <std::string, CurlSocketStoreStruct*> CurlSockData ;
 	typedef std::unordered_map <std::string, CurlSocketStoreStruct*>::iterator CurlSockDataIter;

--- a/test/utests/tests/AampCurlStore/CurlStoreTests.cpp
+++ b/test/utests/tests/AampCurlStore/CurlStoreTests.cpp
@@ -190,13 +190,18 @@ TEST_F(CurlStoreTests, CreateCurlStore_UserDataDiffersAcrossHosts)
         .WillOnce(DoAll(SaveArg<2>(&userDataB), Return(CURLSHE_OK)))
         .WillRepeatedly(Return(CURLSHE_OK));
 
-    GetHandleForHost("t1-host-a.example.com");
-    GetHandleForHost("t1-host-b.example.com");
+    CURL *t1HandleA = GetHandleForHost("t1-host-a.example.com");
+    CURL *t1HandleB = GetHandleForHost("t1-host-b.example.com");
 
     ASSERT_NE(userDataA, nullptr);
     ASSERT_NE(userDataB, nullptr);
     EXPECT_NE(userDataA, userDataB)
         << "Each host must have its own per-host lock (VPAAMP-558 regression)";
+
+    // Return handles so mCurlStoreUserCount drops to 0; prevents cross-test
+    // coupling via the process-lifetime singleton CurlStore.
+    ReturnHandleForHost("t1-host-a.example.com", t1HandleA);
+    ReturnHandleForHost("t1-host-b.example.com", t1HandleB);
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +228,7 @@ TEST_F(CurlStoreTests, LockCallback_WorksWhileEntryIsAlive)
         .WillRepeatedly(Return(CURLSHE_OK));
 
     // Create entry; mCurlStoreUserCount = 1 (still alive)
-    GetHandleForHost("t2-host.example.com");
+    CURL *t2Handle = GetHandleForHost("t2-host.example.com");
 
     ASSERT_NE(capturedUserData,  nullptr) << "USERDATA must be non-null";
     ASSERT_NE(capturedLockFn,   nullptr)  << "lock callback must be non-null";
@@ -233,6 +238,10 @@ TEST_F(CurlStoreTests, LockCallback_WorksWhileEntryIsAlive)
     // lock is valid so this must not crash.
     capturedLockFn(nullptr, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SHARED, capturedUserData);
     capturedUnlockFn(nullptr, CURL_LOCK_DATA_DNS, capturedUserData);
+
+    // Return the handle so mCurlStoreUserCount drops to 0; prevents cross-test
+    // coupling via the process-lifetime singleton CurlStore.
+    ReturnHandleForHost("t2-host.example.com", t2Handle);
 }
 
 // ---------------------------------------------------------------------------
@@ -269,7 +278,13 @@ TEST_F(CurlStoreTests, ShareCleanup_CalledOnEviction)
     EXPECT_CALL(*g_mockCurl, curl_share_cleanup(reinterpret_cast<CURLSH *>(0x6001)))
         .Times(1);
 
-    GetHandleForHost("t3-trigger.example.com");
+    CURL *t3TriggerHandle = GetHandleForHost("t3-trigger.example.com");
+
+    // Return the trigger handle so mCurlStoreUserCount drops to 0; prevents
+    // cross-test coupling via the process-lifetime singleton CurlStore.
+    // Note: t3-host was already evicted by RemoveCurlSock above, so no return
+    // is needed for it.
+    ReturnHandleForHost("t3-trigger.example.com", t3TriggerHandle);
 }
 
 // ---------------------------------------------------------------------------
@@ -293,7 +308,7 @@ TEST_F(CurlStoreTests, LockCallback_HandlesAllLockDataTypes)
         .WillOnce(DoAll(SaveArg<2>(&capturedUnlockFn), Return(CURLSHE_OK)))
         .WillRepeatedly(Return(CURLSHE_OK));
 
-    GetHandleForHost("t4-host.example.com");
+    CURL *t4Handle = GetHandleForHost("t4-host.example.com");
 
     ASSERT_NE(capturedUserData,  nullptr);
     ASSERT_NE(capturedLockFn,   nullptr);
@@ -311,4 +326,8 @@ TEST_F(CurlStoreTests, LockCallback_HandlesAllLockDataTypes)
         capturedLockFn(nullptr, data, CURL_LOCK_ACCESS_SHARED, capturedUserData);
         capturedUnlockFn(nullptr, data, capturedUserData);
     }
+
+    // Return the handle so mCurlStoreUserCount drops to 0; prevents cross-test
+    // coupling via the process-lifetime singleton CurlStore.
+    ReturnHandleForHost("t4-host.example.com", t4Handle);
 }

--- a/test/utests/tests/AampCurlStore/CurlStoreTests.cpp
+++ b/test/utests/tests/AampCurlStore/CurlStoreTests.cpp
@@ -20,30 +20,35 @@
 /**
  * @file CurlStoreTests.cpp
  *
- * Regression tests for VPAAMP-139: use-after-free in CurlStore lock callbacks.
+ * Regression tests for VPAAMP-139 / follow-up optimisation VPAAMP-558.
  *
- * Root cause: old code heap-allocated a CurlDataShareLock per host entry and
- * passed its address as CURLSHOPT_USERDATA.  On store cleanup the object was
- * deleted while libcurl could still invoke the lock/unlock callbacks with the
- * stale pointer, causing a use-after-free.
+ * VPAAMP-139 root cause: old code heap-allocated a CurlDataShareLock per host
+ * and passed its address as CURLSHOPT_USERDATA.  Cleanup freed the object while
+ * libcurl could still invoke the lock callbacks with the stale pointer.
+ * VPAAMP-139 fix: a single static CurlStore::mSharedCurlLock with process
+ * lifetime replaced per-host heap allocations — eliminating the UAF but
+ * serialising DNS/SSL cache operations for every CDN hostname on one mutex.
  *
- * Fix: a single static CurlDataShareLock (CurlStore::mSharedCurlLock) with
- * process lifetime is now used for all CURLSH handles.
+ * VPAAMP-558 optimisation: replace the single static lock with a per-host
+ * CurlDataShareLock embedded directly in curlstorestruct (mShareLock).
+ * Lifetime safety is preserved because every cleanup path calls
+ * curl_share_cleanup before SAFE_DELETE(CurlSock), so the embedded lock is
+ * always alive when libcurl needs it.
+ * The non-store path (CurlInit when the curl store is disabled) now passes
+ * &gCurlShLock (file-scope static) as CURLSHOPT_USERDATA instead of NULL.
  *
  * Test strategy:
- *   T1 - Two different hostnames must receive the SAME CURLSHOPT_USERDATA
- *        pointer.  On old code they each got a distinct heap allocation so
- *        the pointers differed; on fixed code both equal &mSharedCurlLock.
+ *   T1 - Two different hostname entries must receive DISTINCT CURLSHOPT_USERDATA
+ *        pointers.  If they share the same pointer, DNS/SSL cache operations
+ *        for different CDNs serialise (the VPAAMP-139 state).
  *
- *   T2 - After a store entry is evicted and the same hostname is re-added,
- *        the new CURLSHOPT_USERDATA must be identical to the original.  On old
- *        code a fresh heap allocation produced a different address.
+ *   T2 - Lock/unlock callbacks work correctly while the store entry is alive
+ *        (mCurlStoreUserCount > 0).  The embedded lock is valid; no crash.
  *
- *   T3 - (ASAN regression) After a store entry is evicted — the path where
- *        old code freed the per-entry lock — invoking the captured lock
- *        callback with the captured USERDATA must not crash or trigger an
- *        AddressSanitizer use-after-free report.  On fixed code USERDATA
- *        points to the static object which is never freed.
+ *   T3 - When a store entry is evicted, curl_share_cleanup is called for its
+ *        CURLSH handle before the struct is deleted.  This verifies the
+ *        cleanup order that guarantees the embedded lock is alive during
+ *        curl_share_cleanup.
  *
  *   T4 - Lock/unlock callbacks handle all three CURL_LOCK_DATA_* cases
  *        (DNS, SSL, default/generic) without crashing.
@@ -166,85 +171,47 @@ protected:
 };
 
 // ---------------------------------------------------------------------------
-// T1: Two different hostnames must receive the SAME CURLSHOPT_USERDATA pointer.
+// T1: Two different hostname entries must receive DISTINCT CURLSHOPT_USERDATA pointers.
 //
-// Regression: old code did `new curldatasharelock()` per host, so two hosts
-// got different heap addresses and this test would FAIL.
-// Fixed code passes &mSharedCurlLock for every host → addresses are equal.
+// VPAAMP-558: each curlstorestruct embeds its own CurlDataShareLock (mShareLock)
+// so DNS/SSL cache operations for different CDN hosts use independent mutexes.
+//
+// Regression: if all hosts share one lock (VPAAMP-139 state), the addresses
+// are equal and this test would FAIL.
 // ---------------------------------------------------------------------------
-TEST_F(CurlStoreTests, CreateCurlStore_UserDataIsSameStaticPointerAcrossHosts)
+TEST_F(CurlStoreTests, CreateCurlStore_UserDataDiffersAcrossHosts)
 {
     void *userDataA = nullptr;
     void *userDataB = nullptr;
 
-    // Capture the first CURLSHOPT_USERDATA call (host A) then the second (host B)
+    // Capture the CURLSHOPT_USERDATA for host A then host B
     EXPECT_CALL(*g_mockCurl, curl_share_setopt_ptr(_, CURLSHOPT_USERDATA, _))
         .WillOnce(DoAll(SaveArg<2>(&userDataA), Return(CURLSHE_OK)))
         .WillOnce(DoAll(SaveArg<2>(&userDataB), Return(CURLSHE_OK)))
-        .WillRepeatedly(Return(CURLSHE_OK)); // allow further calls from prior-test evictions
+        .WillRepeatedly(Return(CURLSHE_OK));
 
     GetHandleForHost("t1-host-a.example.com");
     GetHandleForHost("t1-host-b.example.com");
 
     ASSERT_NE(userDataA, nullptr);
     ASSERT_NE(userDataB, nullptr);
-    EXPECT_EQ(userDataA, userDataB)
-        << "CURLSHOPT_USERDATA must be the same static lock for all hosts";
+    EXPECT_NE(userDataA, userDataB)
+        << "Each host must have its own per-host lock (VPAAMP-558 regression)";
 }
 
 // ---------------------------------------------------------------------------
-// T2: After a store entry is evicted and its hostname re-added, the new
-// CURLSHOPT_USERDATA must equal the original one.
+// T2: Lock/unlock callbacks work correctly while a store entry is alive.
 //
-// Regression: old code allocated a fresh lock on each CreateCurlStore call,
-// so the second allocation produced a different address → test FAIL.
-// Fixed code always uses &mSharedCurlLock → addresses are equal.
+// The per-host embedded lock (mShareLock) is valid for the lifetime of its
+// curlstorestruct.  When mCurlStoreUserCount > 0 the entry is live and
+// invoking the captured lock/unlock callbacks must not crash.
 // ---------------------------------------------------------------------------
-TEST_F(CurlStoreTests, CreateCurlStore_UserDataSameAfterEntryRecreation)
+TEST_F(CurlStoreTests, LockCallback_WorksWhileEntryIsAlive)
 {
-    void *userDataFirst  = nullptr;
-    void *userDataSecond = nullptr;
+    void                *capturedUserData  = nullptr;
+    curl_lock_function   capturedLockFn    = nullptr;
+    curl_unlock_function capturedUnlockFn  = nullptr;
 
-    // We expect three CreateCurlStore calls: t2-orig, t2-trigger (causes
-    // eviction of t2-orig), t2-orig again.  Capture 1st and 3rd USERDATA.
-    EXPECT_CALL(*g_mockCurl, curl_share_setopt_ptr(_, CURLSHOPT_USERDATA, _))
-        .WillOnce(DoAll(SaveArg<2>(&userDataFirst),  Return(CURLSHE_OK))) // t2-orig created
-        .WillOnce(Return(CURLSHE_OK))                                       // t2-trigger created
-        .WillOnce(DoAll(SaveArg<2>(&userDataSecond), Return(CURLSHE_OK))) // t2-orig re-created
-        .WillRepeatedly(Return(CURLSHE_OK));
-
-    CURL *handleOrig = GetHandleForHost("t2-orig.example.com");
-    // Return handle to store so mCurlStoreUserCount = 0, enabling eviction
-    ReturnHandleForHost("t2-orig.example.com", handleOrig);
-    // Adding a new host triggers RemoveCurlSock which evicts t2-orig
-    GetHandleForHost("t2-trigger.example.com");
-    // Re-add t2-orig: should call CreateCurlStore again with the same USERDATA
-    GetHandleForHost("t2-orig.example.com");
-
-    ASSERT_NE(userDataFirst,  nullptr);
-    ASSERT_NE(userDataSecond, nullptr);
-    EXPECT_EQ(userDataFirst, userDataSecond)
-        << "CURLSHOPT_USERDATA must be the same static lock after re-creation";
-}
-
-// ---------------------------------------------------------------------------
-// T3 (ASAN regression): Invoke the captured lock callback with the captured
-// USERDATA *after* the owning store entry has been evicted.
-//
-// Old code: cleanup called SAFE_DELETE(pstShareLocks) — the heap object pointed
-// to by USERDATA was freed.  Invoking the callback after that is use-after-free;
-// AddressSanitizer would report it.
-//
-// Fixed code: USERDATA = &mSharedCurlLock (static, never freed).  Invoking the
-// callback after eviction is safe.  This test passes cleanly under ASAN.
-// ---------------------------------------------------------------------------
-TEST_F(CurlStoreTests, LockCallback_SafeToCallAfterStoreEviction)
-{
-    void               *capturedUserData  = nullptr;
-    curl_lock_function  capturedLockFn    = nullptr;
-    curl_unlock_function capturedUnlockFn = nullptr;
-
-    // Capture the lock-related setopt arguments from CreateCurlStore("t3-evict")
     EXPECT_CALL(*g_mockCurl, curl_share_setopt_ptr(_, CURLSHOPT_USERDATA, _))
         .WillOnce(DoAll(SaveArg<2>(&capturedUserData), Return(CURLSHE_OK)))
         .WillRepeatedly(Return(CURLSHE_OK));
@@ -255,25 +222,54 @@ TEST_F(CurlStoreTests, LockCallback_SafeToCallAfterStoreEviction)
         .WillOnce(DoAll(SaveArg<2>(&capturedUnlockFn), Return(CURLSHE_OK)))
         .WillRepeatedly(Return(CURLSHE_OK));
 
-    // Step 1: create store entry for t3-evict, capture its USERDATA and callbacks
-    CURL *handleEvict = GetHandleForHost("t3-evict.example.com");
+    // Create entry; mCurlStoreUserCount = 1 (still alive)
+    GetHandleForHost("t2-host.example.com");
 
     ASSERT_NE(capturedUserData,  nullptr) << "USERDATA must be non-null";
-    ASSERT_NE(capturedLockFn,   nullptr) << "lock callback must be non-null";
-    ASSERT_NE(capturedUnlockFn, nullptr) << "unlock callback must be non-null";
+    ASSERT_NE(capturedLockFn,   nullptr)  << "lock callback must be non-null";
+    ASSERT_NE(capturedUnlockFn, nullptr)  << "unlock callback must be non-null";
 
-    // Step 2: return the handle so mCurlStoreUserCount drops to 0
-    ReturnHandleForHost("t3-evict.example.com", handleEvict);
-
-    // Step 3: adding a new host triggers RemoveCurlSock which evicts t3-evict.
-    // On old code this would have deleted the heap lock (USERDATA now dangling).
-    // On fixed code the static lock is untouched.
-    GetHandleForHost("t3-trigger.example.com");
-
-    // Step 4: invoke the production lock callback with the captured USERDATA.
-    // With ASAN: use-after-free is detected here on old code; passes on fixed code.
+    // Invoke the production callbacks while the entry is alive — the embedded
+    // lock is valid so this must not crash.
     capturedLockFn(nullptr, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SHARED, capturedUserData);
     capturedUnlockFn(nullptr, CURL_LOCK_DATA_DNS, capturedUserData);
+}
+
+// ---------------------------------------------------------------------------
+// T3: curl_share_cleanup is called for the evicted entry's CURLSH handle.
+//
+// VPAAMP-558 safety invariant: in every cleanup path the order is
+//   (1) curl_share_cleanup(mCurlShared)   — share teardown, lock may fire
+//   (2) SAFE_DELETE(CurlSock)             — destroys embedded mShareLock
+// This test verifies step (1) actually happens (via mock expectation) so that
+// the embedded lock is guaranteed alive whenever libcurl needs it.
+//
+// Mechanism: RemoveCurlSock fires when CreateCurlStore finds the map at or
+// above MaxCurlSockStore (== 0 in tests).  It evicts the entry with the
+// oldest timestamp and mCurlStoreUserCount == 0.
+// ---------------------------------------------------------------------------
+TEST_F(CurlStoreTests, ShareCleanup_CalledOnEviction)
+{
+    // Give distinct CURLSH handles to each curl_share_init call so we can
+    // identify which entry is cleaned up.
+    uintptr_t shareSeq = 0x6001;
+    EXPECT_CALL(*g_mockCurl, curl_share_init())
+        .WillOnce(Return(reinterpret_cast<CURLSH *>(0x6001))) // t3-host
+        .WillOnce(Return(reinterpret_cast<CURLSH *>(0x6002))) // t3-trigger
+        .WillRepeatedly(Return(reinterpret_cast<CURLSH *>(0x6003)));
+    (void)shareSeq;
+
+    CURL *hdl = GetHandleForHost("t3-host.example.com");
+    // mCurlStoreUserCount = 1 after GetHandleForHost; drop to 0 so evictable
+    ReturnHandleForHost("t3-host.example.com", hdl);
+
+    // When GetHandleForHost("t3-trigger") calls CreateCurlStore, RemoveCurlSock
+    // must call curl_share_cleanup on t3-host's CURLSH handle (0x6001) before
+    // deleting the struct.  Exactly one call is expected.
+    EXPECT_CALL(*g_mockCurl, curl_share_cleanup(reinterpret_cast<CURLSH *>(0x6001)))
+        .Times(1);
+
+    GetHandleForHost("t3-trigger.example.com");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Issue 1 (medium risk -- per-host DNS/SSL lock granularity):

  Embed CurlDataShareLock mShareLock directly in curlstorestruct as a
  value member.  CURLSHOPT_USERDATA is now set to &CurlSock->mShareLock
  so each CDN hostname gets its own three-way mutex (DNS / SSL / general),
  restoring the parallelism lost by the VPAAMP-139 single-static-lock fix.

  Safety: every cleanup path (RemoveCurlSock, ~CurlStore,
  FlushCurlSockForHost) follows the order:
    1. curl_easy_cleanup all queued handles (no further easy-hdl callbacks)
    2. curl_share_cleanup(mCurlShared)      (share teardown; lock may fire)
    3. SAFE_DELETE(CurlSock)               (destroys embedded mShareLock)
  The embedded lock is therefore always alive when curl_share_cleanup
  calls it, eliminating the original use-after-free without leaking memory.

  Removes: CurlStore::mSharedCurlLock (static class member, no longer
  needed) and the old large IMPORTANT comment block.

Issue 2 (low risk -- non-store path USERDATA=NULL inconsistency):

  Replace static std::mutex gCurlShMutex with static CurlDataShareLock
  gCurlShLock.  CurlInit (non-store path) now passes &gCurlShLock as
  CURLSHOPT_USERDATA instead of NULL, giving DNS/SSL/general lock
  granularity parity with the store path.  The defensive else branches
  in curl_lock/unlock_callback are updated accordingly.

Test updates (CurlStoreTests.cpp):

  T1 CreateCurlStore_UserDataDiffersAcrossHosts
     Flipped from SAME to DIFFERENT: two hostname entries must now
     receive distinct CURLSHOPT_USERDATA pointers (per-host lock).

  T2 LockCallback_WorksWhileEntryIsAlive
     Replaced: captures callbacks while entry is alive (count > 0) and
     invokes them; verifies the embedded lock is functional.

  T3 ShareCleanup_CalledOnEviction
     Replaced: verifies that curl_share_cleanup is called with the
     correct CURLSH handle when RemoveCurlSock evicts an entry, testing
     the cleanup-order invariant that guarantees lock safety.

  T4 LockCallback_HandlesAllLockDataTypes
     Unchanged (still exercises DNS/SSL/generic branches).