### PR TITLE
Revert "Revert "VPAAMP-417: [World Cup 26] Period transition bug with CDAI""

### DIFF
--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -193,16 +193,24 @@ void PrivateCDAIObjectMPD::PrunePeriodMaps(std::vector<std::string> &newPeriodId
 }
 
 /**
+ * @brief Clear current ad break tracking state
+ */
+void PrivateCDAIObjectMPD::ClearCurrentAdBreak()
+{
+	mCurPlayingBreakId = "";
+	mCurAds = nullptr;
+	mCurAdIdx = -1;
+}
+
+/**
  * @brief Method to reset the state of the CDAI state machine
  */
 void PrivateCDAIObjectMPD::ResetState()
 {
 	 //TODO: Vinod, maybe we can move these playback state variables to PrivateStreamAbstractionMPD
 	 mIsFogTSB = false;
-	 mCurPlayingBreakId = "";
-	 mCurAds = nullptr;
+	 ClearCurrentAdBreak();
 	 std::lock_guard<std::mutex> lock(mDaiMtx);
-	 mCurAdIdx = -1;
 	 mContentSeekOffset = 0;
 	 mAdState = AdState::OUTSIDE_ADBREAK;
 	 // NOTE: mVodAdBreaks and mNextVodBreakToCheck are intentionally NOT cleared here.
@@ -933,6 +941,7 @@ int PrivateCDAIObjectMPD::CheckForAdStart(const float &rate, bool init, const st
 				}
 			}
 		}
+		AAMPLOG_INFO("[CDAI] CheckForAdStart for periodId:%s offset:%.2f found adIdx:%d breakId:%s adOffset:%.2f", periodId.c_str(), offSet, adIdx, breakId.c_str(), adOffset);
 	}
 	return adIdx;
 }

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -138,8 +138,7 @@ enum class AdEvent
 	BASE_OFFSET_CHANGE,         /**< Base period's offset change */
 	AD_FINISHED,                /**< Ad playback finished */
 	AD_FAILED,                  /**< Ad playback failed */
-	PERIOD_CHANGE,              /**< Period changed */
-	DEFAULT = PERIOD_CHANGE     /**< Default event */
+	PERIOD_CHANGE,              /**< Period changed, Default event */
 };
 
 #define OFFSET_ALIGN_FACTOR 2000 /**< Observed minor slacks in the ad durations. Align factor used to place the ads correctly. */
@@ -719,6 +718,14 @@ public:
 	 * @return true if an ad is playing, false otherwise
 	 */
 	bool IsAdPlaying();
+
+	/**
+	 * @brief Clear current ad break tracking state
+	 * 
+	 * Resets the current playing break ID, ads vector, and ad index to initial state.
+	 * This is used when exiting an ad break or when ad playback is invalidated.
+	 */
+	void ClearCurrentAdBreak();
 };
 
 #endif /* ADMANAGER_MPD_H_ */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9494,11 +9494,11 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 				periodChanged = false;
 			}
 			// Calling the function to play ads from first ad break(existing logic).
-			adStateChanged = onAdEvent(AdEvent::DEFAULT);
+			adStateChanged = onAdEvent(AdEvent::PERIOD_CHANGE);
 			if(adStateChanged && AdState::OUTSIDE_ADBREAK_WAIT4ADS == mCdaiObject->mAdState)
 			{
 				// Adbreak was available, but ads were not available and waited for fulfillment. Now, check if ads are available.
-				adStateChanged = onAdEvent(AdEvent::DEFAULT);
+				adStateChanged = onAdEvent(AdEvent::PERIOD_CHANGE);
 			}
 			// endPeriod for the ad break is not available, so wait for the ad break to complete
 			if (AdState::IN_ADBREAK_WAIT2CATCHUP == mCdaiObject->mAdState)
@@ -9539,11 +9539,11 @@ bool StreamAbstractionAAMP_MPD::SelectSourceOrAdPeriod(bool &periodChanged, bool
 					}
 				}
 				// Check if the new period is having ads
-				adStateChanged = onAdEvent(AdEvent::DEFAULT);
+				adStateChanged = onAdEvent(AdEvent::PERIOD_CHANGE);
 				if(adStateChanged && AdState::OUTSIDE_ADBREAK_WAIT4ADS == mCdaiObject->mAdState)
 				{
 					// Adbreak was available, but ads were not available and waited for fulfillment. Now, check if ads are available.
-					adStateChanged = onAdEvent(AdEvent::DEFAULT);
+					adStateChanged = onAdEvent(AdEvent::PERIOD_CHANGE);
 				}
 			}
 
@@ -12231,7 +12231,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 		case AdState::OUTSIDE_ADBREAK:
 		case AdState::OUTSIDE_ADBREAK_WAIT4ADS:
 			// Default event state or Idle event state is OUTSIDE_ADBREAK
-			if(AdEvent::DEFAULT == evt || AdEvent::INIT == evt)
+			if(AdEvent::PERIOD_CHANGE == evt || AdEvent::INIT == evt)
 			{
 				// Getting called from StreamAbstractionAAMP_MPD::Init or from FetcherLoop
 				std::string brkId = "";
@@ -12289,15 +12289,15 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 					else
 					{
 						// On rewind, if the ad is not found at the offset, it could also be a partial ads
-						if (mPlayRate < AAMP_RATE_PAUSE)
+						if (mPlayRate < AAMP_RATE_PAUSE && mCdaiObject->mAdBreaks[brkId].ads)
 						{
 							// This will ensure that we play the ads once the offset reaches a position where ad is available
 							mCdaiObject->mAdState = AdState::IN_ADBREAK_AD_NOT_PLAYING;
 							stateChanged = true;
 						}
-						// If an adbreak exists for this basePeriodId, then ads might be available.
+						// If an adbreak exists for this basePeriodId, then ads might become available.
 						// Only for scenarios where mBasePeriodOffset is zero, we have to wait for the ads to be added by application.
-						// Otherwise for partial ad fill, once the ads are played, we will wait as adIdx will be -1 from CheckForAdStart().
+						// Otherwise for partial ad fill, once the ads are played, we will get adIdx as -1 from CheckForAdStart().
 						else if (mBasePeriodOffset == 0)
 						{
 							// If the adbreak is not invalidated, wait for ads to be added and resolved
@@ -12312,6 +12312,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 									if (mCdaiObject->mAdBreaks[brkId].ads->at(0).invalid)
 									{
 										mCdaiObject->mAdState = AdState::OUTSIDE_ADBREAK;
+										mCdaiObject->ClearCurrentAdBreak();
 									}
 								}
 								else
@@ -12326,6 +12327,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 							{
 								// Ads are not added or ads failed to resolve, invalidate the adbreak
 								AAMPLOG_WARN("[CDAI] AdBreak[%s] is invalidated. Skipping.", mBasePeriodId.c_str());
+								mCdaiObject->ClearCurrentAdBreak();
 								if(AdState::OUTSIDE_ADBREAK_WAIT4ADS == mCdaiObject->mAdState)
 								{
 									stateChanged = true;
@@ -12338,6 +12340,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 				else
 				{
 					AAMPLOG_INFO("[CDAI] No AdBreak found for period[%s] at offset:%lf", mBasePeriodId.c_str(), mBasePeriodOffset);
+					mCdaiObject->ClearCurrentAdBreak();
 					if (AdState::OUTSIDE_ADBREAK_WAIT4ADS == mCdaiObject->mAdState)
 					{
 						stateChanged = true;
@@ -12351,8 +12354,9 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 			{
 				std::string brkId = "";
 				int adIdx = mCdaiObject->CheckForAdStart(mPlayRate, false, mBasePeriodId, mBasePeriodOffset, brkId, adOffset);
-				if(-1 != adIdx && mCdaiObject->mAdBreaks[brkId].ads)
+				if(!brkId.empty() && (adIdx != -1) && mCdaiObject->mAdBreaks[brkId].ads)
 				{
+					mCdaiObject->mCurPlayingBreakId = brkId;
 					if (mPlayRate >= AAMP_NORMAL_PLAY_RATE)
 					{
 						// Wait for some time if the ad is not ready yet.
@@ -12384,13 +12388,15 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 				{
 					AAMPLOG_WARN("[CDAI]: ADBREAK[%s] ENDED. Playing the basePeriod[%s].", mCdaiObject->mCurPlayingBreakId.c_str(), mBasePeriodId.c_str());
 					mCdaiObject->mAdBreaks[mCdaiObject->mCurPlayingBreakId].mAdFailed = false;
-					mCdaiObject->mCurPlayingBreakId = "";
-					mCdaiObject->mCurAds = nullptr;
-					mCdaiObject->mCurAdIdx = -1;
+					mCdaiObject->ClearCurrentAdBreak();
 					//Base content playing already. No need to jump to offset again.
 					mCdaiObject->mAdState = AdState::OUTSIDE_ADBREAK;
 					stateChanged = true;
 				}
+			}
+			else
+			{
+				AAMPLOG_WARN("[CDAI]: Unsupported event[%d] in IN_ADBREAK_AD_NOT_PLAYING state. Ignoring.", static_cast<int>(evt));
 			}
 			break;
 		case AdState::IN_ADBREAK_AD_PLAYING:
@@ -12438,16 +12444,14 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 			{
 				AAMPLOG_WARN("[CDAI]: BUG! BUG!! BUG!!! We should not come here.AdIdx[-1].");
 				mCdaiObject->mAdBreaks[mCdaiObject->mCurPlayingBreakId].mAdFailed = false;
-				mCdaiObject->mCurPlayingBreakId = "";
-				mCdaiObject->mCurAds = nullptr;
-				mCdaiObject->mCurAdIdx = -1;
+				mCdaiObject->ClearCurrentAdBreak();
 				mCdaiObject->mContentSeekOffset = mBasePeriodOffset;
 				mCdaiObject->mAdState = AdState::OUTSIDE_ADBREAK;
 				stateChanged = true;
 				break;
 			}
 			//In every event, we need to check this.But do it only on the beginning of the fetcher loop. Hence it is the default event
-			if(AdEvent::DEFAULT == evt)
+			if(AdEvent::PERIOD_CHANGE == evt)
 			{
 				// For rewind cases, we don't need to wait for the ad to get placed. The below TODO says otherwise,
 				// but not seeing any use of base period offset for rewind in the below logic
@@ -12461,10 +12465,11 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 				mCdaiObject->mAdState = AdState::IN_ADBREAK_AD_READY2PLAY;
 			}
 		case AdState::IN_ADBREAK_AD_READY2PLAY:
-			if(AdEvent::DEFAULT == evt)
+			if(AdEvent::PERIOD_CHANGE == evt)
 			{
 				bool curAdFailed = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).invalid;	//TODO: Vinod, may need to check boundary.
 				bool curAdCancelled = mCdaiObject->mCurAds->at(mCdaiObject->mCurAdIdx).cancelled;
+				int prevAdIdx = mCdaiObject->mCurAdIdx;
 
 				GetNextAdInBreak((mPlayRate >= AAMP_NORMAL_PLAY_RATE) ? 1 : -1);
 
@@ -12503,7 +12508,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 							if (mCdaiObject->mCurAdIdx >= mCdaiObject->mCurAds->size())
 							{
 								// Change to index back to valid range
-								mCdaiObject->mCurAdIdx--;
+								mCdaiObject->mCurAdIdx = prevAdIdx;
 							}
 							stateChanged = false;
 							break;
@@ -12537,9 +12542,7 @@ bool StreamAbstractionAAMP_MPD::onAdEvent(AdEvent evt, double &adOffset)
 					reservationEvt2Send = AAMP_EVENT_AD_RESERVATION_END;
 					reservationEndReason = GetAdReservationEndReason(curAdFailed, curAdCancelled);
 					sendImmediate = curAdFailed;	//Current Ad failed. Hence may not get discontinuity from gstreamer.
-					mCdaiObject->mCurPlayingBreakId = "";
-					mCdaiObject->mCurAds = nullptr;
-					mCdaiObject->mCurAdIdx = -1;
+					mCdaiObject->ClearCurrentAdBreak();
 					mCdaiObject->mAdState = AdState::OUTSIDE_ADBREAK;	//No more offset check needed. Hence, changing to OUTSIDE_ADBREAK
 					stateChanged = true;
 				}

--- a/test/utests/fakes/FakeAdManager.cpp
+++ b/test/utests/fakes/FakeAdManager.cpp
@@ -161,6 +161,10 @@ bool PrivateCDAIObjectMPD::IsAdPlaying()
 	return false;
 }
 
+void PrivateCDAIObjectMPD::ClearCurrentAdBreak()
+{
+}
+
 void CDAIObjectMPD::NotifyReservationComplete(const std::string& reservationId)
 {
 	if (g_MockPrivateCDAIObjectMPD)

--- a/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
+++ b/test/utests/tests/FragmentCollectorAdTests/AdSelectionTests.cpp
@@ -641,14 +641,15 @@ TEST_F(AdSelectionTests, WaitForAdFallbackTest)
 	EXPECT_TRUE(ret);
 	EXPECT_EQ(cdaiObj->mAdBreaks[periodId].invalid, true);
 	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
-	EXPECT_EQ(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT), false);
+	EXPECT_EQ(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE), false);
 }
+
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD with starting state OUTSIDE_ADBREAK and then moves to a 
  * period having adbreak and starts playing ad, with state changing to IN_ADBREAK_AD_PLAYING
+ * Validates - OUTSIDE_ADBREAK -> IN_ADBREAK_AD_PLAYING for AdEvent::PERIOD_CHANGE.
  */
-
 TEST_F(AdSelectionTests, onAdEventTest_1)
 {
 	static const char *adManifest = R"(<?xml version="1.0" encoding="UTF-8"?>
@@ -701,14 +702,19 @@ TEST_F(AdSelectionTests, onAdEventTest_1)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_START, "p1", _, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_START, "adId1", _, _, _, _, _, _)).Times(1);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	// Validate CDAI object values after starting ad playback
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD with starting state OUTSIDE_ADBREAK. Then moves to adbreak,
  * Since ad is not downloaded,it enters the IN_ADBREAK_AD_NOT_PLAYING state
+ * Validates - OUTSIDE_ADBREAK -> IN_ADBREAK_AD_NOT_PLAYING for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_2)
 {
@@ -731,6 +737,7 @@ TEST_F(AdSelectionTests, onAdEventTest_2)
 	cdaiObj->mAdBreaks = {
 	    { adPeriodId, AdBreakObject(30000, std::make_shared<std::vector<AdNode>>(), endPeriodId, 0, 30000) }
 	};
+	// Marking resolved false to simulate the scenario where ad is not downloaded yet
 	cdaiObj->mAdBreaks[adPeriodId].ads->emplace_back(false /*invalid*/, false /*placed*/, false /*resolved*/,
 		"adId1" /*adId*/, "" /*url*/, 30000 /*duration*/, adPeriodId /*basePeriodId*/, 0 /*basePeriodOffset*/, nullptr /*mpd*/);
 	cdaiObj->mPeriodMap[adPeriodId] = Period2AdData(false, adPeriodId, 30000 /*in ms*/,
@@ -743,14 +750,18 @@ TEST_F(AdSelectionTests, onAdEventTest_2)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_START, "p1", _, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
+	// Validate CDAI object values after starting ad playback
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD with adbreak not validated, wait for ads to be added.
- * Remains in OUTSIDE_ADBREAK state
+ * Validates - OUTSIDE_ADBREAK -> OUTSIDE_ADBREAK_WAIT4ADS -> OUTSIDE_ADBREAK for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_3)
 {
@@ -771,6 +782,7 @@ TEST_F(AdSelectionTests, onAdEventTest_3)
 
 	cdaiObj->mPeriodMap[adPeriodId] = Period2AdData();
 	cdaiObj->mPeriodMap[adPeriodId].adBreakId = adPeriodId;
+	// Empty adBreak to denote that we have not received any ads yet.
 	cdaiObj->mAdBreaks = {
 		{ adPeriodId, AdBreakObject() }
 	};
@@ -778,18 +790,28 @@ TEST_F(AdSelectionTests, onAdEventTest_3)
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
-	EXPECT_EQ( cdaiObj->mAdState,  AdState::OUTSIDE_ADBREAK_WAIT4ADS);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK_WAIT4ADS);
 	EXPECT_TRUE(cdaiObj->mAdBreaks[adPeriodId].invalid);
+	// Validate CDAI object values after starting ad playback.
+	// Here, we will set adPeriodId as mCurPlayingBreakId initially.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	// Validate CDAI object values after state transition.
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where the ad is invalid, so switching to
- * source content. State transition happens from OUTSIDE_ADBREAK to IN_ADBREAK_AD_NOT_PLAYING 
+ * source content.
+ * Validates - OUTSIDE_ADBREAK -> IN_ADBREAK_AD_NOT_PLAYING for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_4)
 {
@@ -816,6 +838,7 @@ TEST_F(AdSelectionTests, onAdEventTest_4)
 	};
 
 	cdaiObj->mAdBreaks[adPeriodId].ads = std::make_shared<std::vector<AdNode>>();
+	// Marking invalid true to simulate the scenario.
 	cdaiObj->mAdBreaks[adPeriodId].ads->emplace_back(true /*invalid*/, false /*placed*/, true /*resolved*/,
 		"adId1" /*adId*/, adUrl /*url*/, 30000 /*duration*/, adPeriodId /*basePeriodId*/, 0 /*basePeriodOffset*/, nullptr /*mpd*/);
 	cdaiObj->mPeriodMap[adPeriodId] = Period2AdData(false, adPeriodId, 30000 /*in ms*/,
@@ -828,14 +851,20 @@ TEST_F(AdSelectionTests, onAdEventTest_4)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_START, adPeriodId, _, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
+	// Validate CDAI object values after starting ad playback
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	// Due to invalid, ad details are not populated in the CDAI object
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where ad playback occurs with state IN_ADBREAK_AD_PLAYING.
  * Once ad download finished and waiting to catch up baseperiod, state changes to IN_ADBREAK_WAIT2CATCHUP
+ * Validates - IN_ADBREAK_AD_PLAYING -> IN_ADBREAK_WAIT2CATCHUP for AdEvent::AD_FINISHED.
  */
 TEST_F(AdSelectionTests, onAdEventTest_5)
 {
@@ -884,8 +913,10 @@ TEST_F(AdSelectionTests, onAdEventTest_5)
 	{
 		std::make_pair (0, AdOnPeriod(0, 0)), // for adId1 idx=0, offset=0s
 	});
+	// Update CDAI object to reflect the current ad playback details
 	cdaiObj->mCurAdIdx = 0;
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
+	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
@@ -893,13 +924,18 @@ TEST_F(AdSelectionTests, onAdEventTest_5)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_END, "adId1", _, _, _, _, _, _)).Times(1);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::AD_FINISHED));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	// Validate CDAI object values after starting ad playback
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where period is in adbreak and ad starts playing with state
  * IN_ADBREAK_AD_PLAYING. while playing an ad failure happens and state changes to IN_ADBREAK_AD_NOT_PLAYING 
+ * Validates - IN_ADBREAK_AD_PLAYING -> IN_ADBREAK_AD_NOT_PLAYING for AdEvent::AD_FAILED.
  */
 TEST_F(AdSelectionTests, onAdEventTest_6)
 {
@@ -948,8 +984,10 @@ TEST_F(AdSelectionTests, onAdEventTest_6)
 	{
 		std::make_pair (0, AdOnPeriod(0, 0)), // for adId1 idx=0, offset=0s
 	});
+	// Populate CDAI object with current ad details.
 	cdaiObj->mCurAdIdx = 0;
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
+	cdaiObj->mCurPlayingBreakId = adPeriodId;
 
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
@@ -959,13 +997,18 @@ TEST_F(AdSelectionTests, onAdEventTest_6)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_END, "adId1", _, _, _, _, _, _)).Times(1);
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::AD_FAILED));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
+	// Validate CDAI object values after ad failure
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
+	EXPECT_TRUE(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).invalid);
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where current source period is in adbreak,
- * but no ad opportunities are present. Its a bug case. State transition happens from IN_ADBREAK_WAIT2CATCHUP
- * to OUTSIDE_ADBREAK
+ * but no ad opportunities are present. Its a bug case.
+ * Validates IN_ADBREAK_WAIT2CATCHUP -> OUTSIDE_ADBREAK for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_7)
 {
@@ -1014,14 +1057,20 @@ TEST_F(AdSelectionTests, onAdEventTest_7)
 	{
 		std::make_pair (0, AdOnPeriod(0, 0)), // for adId1 idx=0, offset=0s
 	});
+	// Populate CDAI object with current ad details.
 	cdaiObj->mCurAdIdx = -1;
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
+	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT);
+	mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE);
 	EXPECT_EQ( cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	// Validate CDAI object values after state change
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
@@ -1029,6 +1078,7 @@ TEST_F(AdSelectionTests, onAdEventTest_7)
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where all ads in adbreak finished 
  * and waiting for adbreak to place with state IN_ADBREAK_WAIT2CATCHUP. Once adbreak is placed , state moves
  * to OUTSIDE_ADBREAK 
+ * Validates - IN_ADBREAK_WAIT2CATCHUP -> OUTSIDE_ADBREAK for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_8)
 {
@@ -1080,20 +1130,28 @@ TEST_F(AdSelectionTests, onAdEventTest_8)
 
 	cdaiObj->mCurAdIdx = 0;
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
+	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_END, adPeriodId, _, _, _, _)).Times(1);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	EXPECT_FALSE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_FALSE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	// Validate CDAI object values are unchanged.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
 	// Adbreak is now placed
-	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	cdaiObj->mAdBreaks[cdaiObj->mCurPlayingBreakId].mAdBreakPlaced = true;
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_END, adPeriodId, _, _, _, _)).Times(1);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	// Validate CDAI object values after state change
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
@@ -1101,6 +1159,7 @@ TEST_F(AdSelectionTests, onAdEventTest_8)
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where period 
  * is in adbreak with multiple ads and state is IN_ADBREAK_WAIT2CATCHUP
  * and when ad is available and starts playing, state changes to IN_ADBREAK_AD_PLAYING
+ * Validates - IN_ADBREAK_WAIT2CATCHUP -> IN_ADBREAK_AD_PLAYING for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_9)
 {
@@ -1155,21 +1214,28 @@ TEST_F(AdSelectionTests, onAdEventTest_9)
 	});
 	cdaiObj->mCurAdIdx = 0;
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
+	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_START, "adId2", _, _, _, _, _, _)).Times(1);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	// Validate CDAI object values after starting ad playback
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 1);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId2");
 }
 
 /**
  * @brief onAdEventTest tests.
- * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where period is in adbreak and first ad is not able to 
- * download with state IN_ADBREAK_AD_NOT_PLAYING and moving to next ad which is available and able to download and state 
- * changes to IN_ADBREAK_AD_PLAYING 
+ * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where period is in adbreak with IN_ADBREAK_AD_NOT_PLAYING
+ * and moving to next adbreak which is having ads.
+ * changes to IN_ADBREAK_AD_PLAYING.
+ * Validates - IN_ADBREAK_AD_NOT_PLAYING -> IN_ADBREAK_AD_PLAYING for AdEvent::PERIOD_CHANGE.
+ * Note - AdEvent::BASE_OFFSET_CHANGE is only applicable in case of REW mode.
  */
 TEST_F(AdSelectionTests, onAdEventTest_10)
 {
@@ -1202,6 +1268,7 @@ TEST_F(AdSelectionTests, onAdEventTest_10)
 
 	auto cdaiObj = mStreamAbstractionAAMP_MPD->GetCDAIObject();
 	cdaiObj->mAdState = AdState::IN_ADBREAK_AD_NOT_PLAYING;
+	// CDAI object values are not initialized to confirm the details are updated properly during state transition.
 	std::string adPeriodId = "p1";
 	std::string endPeriodId = "p2"; // landing in p2
 	std::string adUrl = TEST_AD_MANIFEST_URL;
@@ -1226,14 +1293,19 @@ TEST_F(AdSelectionTests, onAdEventTest_10)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(AAMP_EVENT_AD_PLACEMENT_START, "adId1", _, _, _, _, _, _)).Times(1);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::BASE_OFFSET_CHANGE));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	// Validate CDAI object values after starting ad playback.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where state transition happens from 
  * IN_ADBREAK_AD_NOT_PLAYING to OUTSIDE_ADBREAK since adbreak ended with ad not playing
+ * Validates - IN_ADBREAK_AD_NOT_PLAYING -> OUTSIDE_ADBREAK for AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_11)
 {
@@ -1249,19 +1321,28 @@ TEST_F(AdSelectionTests, onAdEventTest_11)
 	EXPECT_EQ(status, eAAMPSTATUS_OK);
 
 	auto cdaiObj = mStreamAbstractionAAMP_MPD->GetCDAIObject();
+	// Populate CDAI object with current adbreak details.
 	cdaiObj->mAdState = AdState::IN_ADBREAK_AD_NOT_PLAYING;
+	cdaiObj->mCurAdIdx = -1;
+	cdaiObj->mCurPlayingBreakId = "p1";
 
 	std::string basePeriodId = "p2";//After adbreak p1, player moves to baseperiod p2 with period change event
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(basePeriodId);
 
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	// Validate CDAI object values after state change
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where ads are there,
- * but one ad is yet to be placed. So adbreak is not placed. State remains in IN_ADBREAK_WAIT2CATCHUP state. 
+ * but one ad is valid and the other invalid. The adbreak is also not placed. State remains in IN_ADBREAK_WAIT2CATCHUP state.
+ * Validates - IN_ADBREAK_WAIT2CATCHUP -> IN_ADBREAK_WAIT2CATCHUP for AdEvent::PERIOD_CHANGE.
+ * Mostly validates GetNextAdInBreak logic to not select invalid ads.
  */
 TEST_F(AdSelectionTests, onAdEventTest_12)
 {
@@ -1316,13 +1397,26 @@ TEST_F(AdSelectionTests, onAdEventTest_12)
 	});
 	cdaiObj->mCurAdIdx = 0;
 	cdaiObj->mCurAds = cdaiObj->mAdBreaks[adPeriodId].ads;
+	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	mStreamAbstractionAAMP_MPD->SetBasePeriodId(adPeriodId);
 
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(_, _, _, _, _, _)).Times(0);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	EXPECT_FALSE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_FALSE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	// Validate CDAI object values after state change.
 	EXPECT_FALSE(cdaiObj->mAdBreaks[adPeriodId].mAdBreakPlaced);
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+
+	// Ad placed now
+	cdaiObj->mAdBreaks[adPeriodId].mAdBreakPlaced = true;
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdReservationEvent(AAMP_EVENT_AD_RESERVATION_END, adPeriodId, _, _, _, _)).Times(1);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	// Validate CDAI object values after state change
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
@@ -1332,6 +1426,7 @@ TEST_F(AdSelectionTests, onAdEventTest_12)
  * IN_ADBREAK_AD_NOT_PLAYING. After reaching the offset,ad is found and starts playing and changing state to IN_ADBREAK_AD_PLAYING.
  * Once ad finishes state moves to IN_ADBREAK_WAIT2CATCHUP. 
  * All ads in adbreak finished and state moves to OUTSIDE_ADBREAK.
+ * Validates rewind with - OUTSIDE_ADBREAK -> IN_ADBREAK_AD_NOT_PLAYING -> IN_ADBREAK_AD_PLAYING -> IN_ADBREAK_WAIT2CATCHUP -> OUTSIDE_ADBREAK for AdEvent::PERIOD_CHANGE and BASE_OFFSET_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_13)
 {
@@ -1381,28 +1476,46 @@ TEST_F(AdSelectionTests, onAdEventTest_13)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SendAdPlacementEvent(_, _, _, _, _, _, _, _)).Times(0);
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_NOT_PLAYING);
+	// Validate CDAI object values after reaching adbreak without valid ad at offset.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 
 	mStreamAbstractionAAMP_MPD->SetBasePeriodoffset(5);
 
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::BASE_OFFSET_CHANGE));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	// Validate CDAI object values after starting ad playback.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::AD_FINISHED));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	// Validate CDAI object values after ad finished and waiting for catchup.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
 	cdaiObj->mCurPlayingBreakId = adPeriodId;
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
+	// Validate CDAI object values after adbreak finished and moving to content period.
+	EXPECT_EQ(cdaiObj->mContentSeekOffset, 0);
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
  * @brief onAdEventTest tests.
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where p1 is the period where ad is present.At first
- * state is OUTSIDE_ADBREAK.  After rewind, position reaches to adbreak in Period p1 . In that adbreak, ad is valid 
+ * state is OUTSIDE_ADBREAK. After rewind, position reaches to adbreak in Period p1 . In that adbreak, ad is valid 
  * and it gets played and moving to state IN_ADBREAK_AD_PLAYING. Once ad finishes state moves to IN_ADBREAK_WAIT2CATCHUP.
  * Since its an adbreak with one ad, and when ad finishes playing state moves to OUTSIDE_ADBREAK 
+ * Validates rewind with - OUTSIDE_ADBREAK -> IN_ADBREAK_AD_PLAYING -> IN_ADBREAK_WAIT2CATCHUP -> OUTSIDE_ADBREAK for AdEvent::PERIOD_CHANGE and BASE_OFFSET_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_14)
 {
@@ -1452,16 +1565,28 @@ TEST_F(AdSelectionTests, onAdEventTest_14)
 	mStreamAbstractionAAMP_MPD->SetBasePeriodoffset(30);
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	// Validate CDAI object values after starting ad playback.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::AD_FINISHED));
 	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	// Validate CDAI object values after ad finished and waiting for catchup.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
 	cdaiObj->mCurPlayingBreakId = adPeriodId;
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
 	EXPECT_EQ(cdaiObj->mContentSeekOffset, 0); // Make sure content seek offset is set to adbreak offset
+	// Validate CDAI object values after adbreak finished and moving to content period.
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**
@@ -1469,7 +1594,10 @@ TEST_F(AdSelectionTests, onAdEventTest_14)
  * The tests verify the onAdEvent method of StreamAbstractionAAMP_MPD where p1 is the period where ad is present.At first
  * state is OUTSIDE_ADBREAK.  After forward, position reaches to adbreak in Period p1 . In that adbreak, ad is valid
  * and it gets played and moving to state IN_ADBREAK_AD_PLAYING. Once ad finishes state moves to IN_ADBREAK_WAIT2CATCHUP.
- * Since its an adbreak with one ad, adbreak is placed and state moves to OUTSIDE_ADBREAK
+ * Since its an adbreak with one ad, adbreak is placed and state moves to OUTSIDE_ADBREAK.
+ * Here ad occupies only 5s in a 30s adbreak.
+ * Validates forward with - OUTSIDE_ADBREAK -> IN_ADBREAK_AD_PLAYING -> IN_ADBREAK_WAIT2CATCHUP -> OUTSIDE_ADBREAK
+ * for AdEvent::INIT, AdEvent::AD_FINISHED, AdEvent::PERIOD_CHANGE.
  */
 TEST_F(AdSelectionTests, onAdEventTest_15)
 {
@@ -1520,16 +1648,27 @@ TEST_F(AdSelectionTests, onAdEventTest_15)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetTSBSessionManager()).WillRepeatedly(Return(nullptr));
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::INIT));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_AD_PLAYING);
+	// Validate CDAI object values after starting ad playback.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
 	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::AD_FINISHED));
-	EXPECT_EQ( cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	EXPECT_EQ(cdaiObj->mAdState, AdState::IN_ADBREAK_WAIT2CATCHUP);
+	// Validate CDAI object values after ad finished and waiting for catchup.
+	EXPECT_EQ(cdaiObj->mCurPlayingBreakId, adPeriodId);
+	EXPECT_EQ(cdaiObj->mCurAdIdx, 0);
+	EXPECT_EQ(cdaiObj->mCurAds->at(cdaiObj->mCurAdIdx).adId, "adId1");
 
-	cdaiObj->mCurPlayingBreakId = adPeriodId;
 	cdaiObj->mAdBreaks[cdaiObj->mCurPlayingBreakId].mAdBreakPlaced = true;
-	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::DEFAULT));
+	EXPECT_TRUE(mStreamAbstractionAAMP_MPD->CallOnAdEvent(AdEvent::PERIOD_CHANGE));
 	EXPECT_EQ(cdaiObj->mAdState, AdState::OUTSIDE_ADBREAK);
 	EXPECT_EQ(cdaiObj->mContentSeekOffset, 5); // Make sure content seek offset is set to adbreak offset
+	// Validate CDAI object values after adbreak finished and moving to content period.
+	EXPECT_TRUE(cdaiObj->mCurPlayingBreakId.empty());
+	EXPECT_EQ(cdaiObj->mCurAdIdx, -1);
+	EXPECT_EQ(cdaiObj->mCurAds, nullptr);
 }
 
 /**


### PR DESCRIPTION
Reverts rdkcentral/aamp#1607

Restoring VPAAMP-417 to sprint; follow-up analysis indicates that can't possible be reason for bulk of the observed failures.