### PR TITLE
VPAAMP-501: Follow-up for VPAAMP-477

### DIFF
--- a/AAMP-Retry-Timeout-Internals.md
+++ b/AAMP-Retry-Timeout-Internals.md
@@ -161,7 +161,7 @@ After all per-download retries are exhausted, the track-level download loop cont
 |---|---|---|---|
 | `segDLFailCount` (media segments) | `eAAMPConfig_FragmentDownloadFailThreshold` | `MAX_SEG_DOWNLOAD_FAIL_COUNT` = **10** | `SendDownloadErrorEvent(AAMP_TUNE_FRAGMENT_DOWNLOAD_FAILURE)` |
 | `manifestDLFailCount` (HLS sub-manifest) | `MAX_MANIFEST_DOWNLOAD_RETRY` | **3** (`fragmentcollector_hls.h`) | `SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED)` |
-| MPD manifest failures | `MAX_MANIFEST_DOWNLOAD_RETRY_MPD` | **2** (`fragmentcollector_mpd.h`) | Same error event |
+| MPD manifest refresh failures (DASH live) | `eAAMPConfig_ManifestRefreshFailEventThreshold` | **0** (`AampConfig.cpp`) | While retries continue, suppress `AAMP_TUNE_MANIFEST_REQ_FAILED`; emit once after N consecutive failures when threshold `> 0` |
 | Ad segment failures | `MAX_AD_SEG_DOWNLOAD_FAIL_COUNT` | **2** (`AampDefine.h`) | Ad playback failure event |
 
 ---
@@ -178,3 +178,20 @@ After all per-download retries are exhausted, the track-level download loop cont
 | `fragmentcollector_mpd.cpp` | DASH manifest failure counting |
 | `AampDefine.h` | All default timeout and retry constants |
 | `priv_aamp.h` | Internal partial-download error codes (130–133) |
+
+---
+
+## DASH Live Manifest Refresh Event Policy
+
+For DASH live MPD refresh callbacks:
+
+- `AampMPDDownloader` keeps retrying refreshes after transient download failures
+	(including curl 56 / `CURLE_RECV_ERROR`).
+- `fragmentcollector_mpd.cpp` tracks consecutive refresh-download failures.
+- By default (`manifestRefreshFailEventThreshold = 0`),
+	`AAMP_TUNE_MANIFEST_REQ_FAILED` is suppressed while retries are in progress,
+	to avoid apps treating a recoverable refresh hiccup as a terminal stream
+	failure.
+- If `manifestRefreshFailEventThreshold` is set to `N > 0`, AAMP emits
+	`AAMP_TUNE_MANIFEST_REQ_FAILED` once after `N` consecutive refresh failures,
+	then waits for a successful refresh to reset the streak.

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -439,6 +439,7 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{DEFAULT_LLD_CACHED_FRAGMENTS_PER_TRACK,"downloadBufferChunks",eAAMPConfig_MaxLLDFragmentCached,false,eCONFIG_RANGE_FRAGMENT_CACHE},
 	{DEFAULT_AAMP_ABR_CHUNK_THRESHOLD_SIZE,"abrChunkThresholdSize",eAAMPConfig_ABRChunkThresholdSize,false},
 	{MAX_SEG_DOWNLOAD_FAIL_COUNT,"fragmentDownloadFailThreshold",eAAMPConfig_FragmentDownloadFailThreshold,false,eCONFIG_RANGE_DOWNLOAD_ERROR_THRESHOLD },
+	{0,"manifestRefreshFailEventThreshold",eAAMPConfig_ManifestRefreshFailEventThreshold,false,eCONFIG_RANGE_ANY },
 	{MAX_INIT_FRAGMENT_CACHE_PER_TRACK,"maxInitFragCachePerTrack",eAAMPConfig_MaxInitFragCachePerTrack,true, eCONFIG_RANGE_INIT_FRAGMENT_CACHE },
 	{FOG_MAX_CONCURRENT_DOWNLOADS,"fogMaxConcurrentDownloads",eAAMPConfig_FogMaxConcurrentDownloads, false },
 	{DEFAULT_CONTENT_PROTECTION_DATA_UPDATE_TIMEOUT,"contentProtectionDataUpdateTimeout",eAAMPConfig_ContentProtectionDataUpdateTimeout,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -289,6 +289,7 @@ typedef enum
 	eAAMPConfig_MaxLLDFragmentCached,           				/**< LLD fragment cache length */
 	eAAMPConfig_ABRChunkThresholdSize,                			/**< AAMP ABR Chunk threshold size*/
 	eAAMPConfig_FragmentDownloadFailThreshold, 				/**< Retry attempts for non-init fragment curl timeout failures*/
+	eAAMPConfig_ManifestRefreshFailEventThreshold,			/**< Consecutive manifest refresh download failures before raising AAMP_TUNE_MANIFEST_REQ_FAILED; 0 suppresses event while retries continue */
 	eAAMPConfig_MaxInitFragCachePerTrack,					/**< Max no of Init fragment cache per track */
 	eAAMPConfig_FogMaxConcurrentDownloads,                                  /**< Concurrent download posted to fog from player*/
 	eAAMPConfig_ContentProtectionDataUpdateTimeout,				/**< Default Timeout For ContentProtectionData Update in milliseconds */

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -133,7 +133,7 @@ static constexpr const char* GetAdReservationEndReason(bool adFailed, bool adCan
 StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *aamp, double seek_pos, float rate, id3_callback_t id3Handler)
 	: StreamAbstractionAAMP(aamp, std::move(id3Handler)),
 	mLangList(), seekPosition(seek_pos), mPlayRate(rate), fragmentCollectorThreadID(),tsbReaderThreadID(),
-	mpd(NULL), mNumberOfTracks(0), mCurrentPeriodIdx(0), mEndPosition(0), mIsLiveStream(true), mIsLiveManifest(true),mManifestDnldRespPtr(nullptr),mManifestUpdateHandleFlag(false), mUpdateManifestState(false),
+	mpd(NULL), mNumberOfTracks(0), mCurrentPeriodIdx(0), mEndPosition(0), mIsLiveStream(true), mIsLiveManifest(true),mManifestDnldRespPtr(nullptr),mManifestUpdateHandleFlag(false), mManifestRefreshFailureCount(0), mManifestRefreshHardFailureEventSent(false), mUpdateManifestState(false),
 	mStreamInfo(), mPrevStartTimeSeconds(0), mPrevLastSegurlMedia(""), mPrevLastSegurlOffset(0),
 	mPeriodEndTime(0), mPeriodStartTime(0), mPeriodDuration(0), mMinUpdateDurationMs(DEFAULT_INTERVAL_BETWEEN_MPD_UPDATES_MS),
 	mLastPlaylistDownloadTimeMs(0), mFirstPTS(0), mStartTimeOfFirstPTS(0), mAudioType(eAUDIO_UNKNOWN),
@@ -4621,6 +4621,8 @@ void StreamAbstractionAAMP_MPD::MPDUpdateCallbackExec()
 	if(tmpManifestDnldRespPtr->mMPDStatus == AAMPStatusType::eAAMPSTATUS_OK)
 	{
 		mNetworkDownDetected = false;
+		mManifestRefreshFailureCount = 0;
+		mManifestRefreshHardFailureEventSent = false;
 		ProcessMetadataFromManifest(tmpManifestDnldRespPtr , false);
 		AampMPDParseHelperPtr	mMPDParser = tmpManifestDnldRespPtr->GetMPDParseHelper();
 
@@ -4646,6 +4648,28 @@ void StreamAbstractionAAMP_MPD::MPDUpdateCallbackExec()
 		// Failure from the manifest download during refresh --- fire , what to do ??
 		// Check if the App only insisted to stop the download resulting in partial failure ?
 		int http_error	=	tmpManifestDnldRespPtr->mMPDDownloadResponse->iHttpRetValue;
+		int manifestRefreshFailEventThreshold = GETCONFIGVALUE(eAAMPConfig_ManifestRefreshFailEventThreshold);
+
+		auto shouldRaiseManifestRefreshFailureEvent = [&]() -> bool
+		{
+			if(manifestRefreshFailEventThreshold <= 0)
+			{
+				return false;
+			}
+
+			if(mManifestRefreshHardFailureEventSent)
+			{
+				return false;
+			}
+
+			if(mManifestRefreshFailureCount < manifestRefreshFailEventThreshold)
+			{
+				return false;
+			}
+
+			mManifestRefreshHardFailureEventSent = true;
+			return true;
+		};
 
 		if (aamp->DownloadsAreEnabled())
 		{
@@ -4655,7 +4679,17 @@ void StreamAbstractionAAMP_MPD::MPDUpdateCallbackExec()
 			{
 				//Skip this for first ever update mpd request
 				mNetworkDownDetected = true;
-				AAMPLOG_WARN("Ignore curl timeout");
+				mManifestRefreshFailureCount++;
+				if (shouldRaiseManifestRefreshFailureEvent())
+				{
+					aamp->SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, http_error);
+					AAMPLOG_ERR("manifest download failed after %d consecutive refresh failures", mManifestRefreshFailureCount);
+				}
+				else
+				{
+					AAMPLOG_WARN("Suppress manifest refresh failure event while retrying (%d consecutive failures, threshold=%d)",
+						mManifestRefreshFailureCount, manifestRefreshFailEventThreshold);
+				}
 			}
 			else
 			{
@@ -4689,8 +4723,17 @@ void StreamAbstractionAAMP_MPD::MPDUpdateCallbackExec()
 				}
 				else
 				{
-					aamp->SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, http_error);
-					AAMPLOG_ERR("manifest download failed");
+					mManifestRefreshFailureCount++;
+					if (shouldRaiseManifestRefreshFailureEvent())
+					{
+						aamp->SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, http_error);
+						AAMPLOG_ERR("manifest download failed after %d consecutive refresh failures", mManifestRefreshFailureCount);
+					}
+					else
+					{
+						AAMPLOG_WARN("Suppress manifest refresh failure event while retrying (%d consecutive failures, threshold=%d)",
+							mManifestRefreshFailureCount, manifestRefreshFailEventThreshold);
+					}
 				}
 			}
 		}

--- a/fragmentcollector_mpd.h
+++ b/fragmentcollector_mpd.h
@@ -1139,6 +1139,8 @@ protected:
 	std::thread tsbReaderThreadID;
 	ManifestDownloadResponsePtr mManifestDnldRespPtr ;
 	bool    mManifestUpdateHandleFlag;
+	int mManifestRefreshFailureCount;
+	bool mManifestRefreshHardFailureEventSent;
 	AampMPDParseHelperPtr	mMPDParseHelper;
 	bool mLowLatencyMode;
 	dash::mpd::IMPD *mpd;

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -527,6 +527,11 @@ protected:
 			return FetchDashManifest();
 		}
 
+		void CallMPDUpdateCallbackExec()
+		{
+			MPDUpdateCallbackExec();
+		}
+
 		void CallFindTimedMetadata(dash::mpd::MPD *mpd, Node *root, bool init, bool reportBulkMet)
 		{
 			FindTimedMetadata(mpd, root, init, reportBulkMet);
@@ -4472,6 +4477,88 @@ TEST_F(StreamAbstractionAAMP_MPDTest, FetchDashManifest_ConnectTimeout_WithManif
 	// Execute test
 	AAMPStatusType result = mStreamAbstractionAAMP_MPD->CallFetchDashManifest();
 	EXPECT_EQ(result, AAMPStatusType::eAAMPSTATUS_MANIFEST_DOWNLOAD_ERROR);
+}
+
+// Verify default option-2 behavior: suppress manifest refresh failure events
+// while retries are in progress.
+TEST_F(StreamAbstractionAAMP_MPDTest, MPDUpdateCallbackExec_SuppressesManifestFailureEventByDefault)
+{
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT0H10M54.00S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264">
+	<Period duration="PT1M0S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.640028" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1000000">
+				<SegmentTemplate timescale="2500" media="video_$Time$.mp4" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="5000" r="29" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	mIntConfigSettings[eAAMPConfig_ManifestRefreshFailEventThreshold] = 0;
+	AAMPStatusType status = InitializeMPD(manifest);
+	ASSERT_EQ(status, AAMPStatusType::eAAMPSTATUS_OK);
+
+	EXPECT_CALL(*g_mockAampMPDDownloader, GetManifest(_, _, _))
+		.WillOnce(WithArgs<2>(Invoke([this](int errorSimulation) {
+			return this->GetManifestForMPDDownloaderTimeout(CURLE_RECV_ERROR);
+		})));
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.WillOnce(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, CURLE_RECV_ERROR))
+		.Times(0);
+
+	mStreamAbstractionAAMP_MPD->CallMPDUpdateCallbackExec();
+}
+
+// Verify threshold behavior for option-2: emit hard failure once after N
+// consecutive refresh failures, then suppress repeats until recovery.
+TEST_F(StreamAbstractionAAMP_MPDTest, MPDUpdateCallbackExec_RaisesManifestFailureAfterThresholdOnce)
+{
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static" mediaPresentationDuration="PT0H10M54.00S" profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash264">
+	<Period duration="PT1M0S">
+		<AdaptationSet maxWidth="1920" maxHeight="1080" maxFrameRate="25" par="16:9">
+			<Representation id="1" mimeType="video/mp4" codecs="avc1.640028" width="640" height="360" frameRate="25" sar="1:1" bandwidth="1000000">
+				<SegmentTemplate timescale="2500" media="video_$Time$.mp4" initialization="video_init.mp4">
+					<SegmentTimeline>
+						<S d="5000" r="29" />
+					</SegmentTimeline>
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+
+	mIntConfigSettings[eAAMPConfig_ManifestRefreshFailEventThreshold] = 2;
+	AAMPStatusType status = InitializeMPD(manifest);
+	ASSERT_EQ(status, AAMPStatusType::eAAMPSTATUS_OK);
+
+	EXPECT_CALL(*g_mockAampMPDDownloader, GetManifest(_, _, _))
+		.Times(3)
+		.WillRepeatedly(WithArgs<2>(Invoke([this](int errorSimulation) {
+			return this->GetManifestForMPDDownloaderTimeout(CURLE_RECV_ERROR);
+		})));
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.Times(3)
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+		SendDownloadErrorEvent(AAMP_TUNE_MANIFEST_REQ_FAILED, CURLE_RECV_ERROR))
+		.Times(1);
+
+	mStreamAbstractionAAMP_MPD->CallMPDUpdateCallbackExec();
+	mStreamAbstractionAAMP_MPD->CallMPDUpdateCallbackExec();
+	mStreamAbstractionAAMP_MPD->CallMPDUpdateCallbackExec();
 }
 
 /**


### PR DESCRIPTION
Reson for change: Add suppressing send download
failure event while retry in progress
Test Procedure: updated in ticket
Risks: Medium