### PR TITLE
VPAAMP-418: Negative Audio buffer values logged with HLS linear playback

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3741,7 +3741,7 @@ double StreamAbstractionAAMP::GetBufferedAudioDurationSec()
 	{
 		bufferValue = GetBufferValue(audio);
 	}
-	else
+	else if(IsMuxedStream())
 	{
 		// Audio is muxed into the video track; report video buffer duration instead
 		MediaTrack *video = GetMediaTrack(eTRACK_VIDEO);

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3737,9 +3737,18 @@ double StreamAbstractionAAMP::GetBufferedAudioDurationSec()
 		return bufferValue;
 	}
 	MediaTrack *audio = GetMediaTrack(eTRACK_AUDIO);
-	if(audio)
+	if(audio && audio->enabled)
 	{
 		bufferValue = GetBufferValue(audio);
+	}
+	else
+	{
+		// Audio is muxed into the video track; report video buffer duration instead
+		MediaTrack *video = GetMediaTrack(eTRACK_VIDEO);
+		if(video)
+		{
+			bufferValue = GetBufferValue(video);
+		}
 	}
 	return bufferValue;
 }

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -3743,7 +3743,7 @@ double StreamAbstractionAAMP::GetBufferedAudioDurationSec()
 	}
 	else if(IsMuxedStream())
 	{
-		// Audio is muxed into the video track; report video buffer duration instead
+		// For muxed A/V playback, report video buffer duration as audio buffer duration
 		MediaTrack *video = GetMediaTrack(eTRACK_VIDEO);
 		if(video)
 		{

--- a/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
@@ -281,3 +281,39 @@ TEST_F(StreamAbstractionAAMP_Test, UpdateTSAfterFetchStats_DoesNotRestoreLatency
 
         EXPECT_FALSE(mStreamAbstractionAAMP->mSavedLatencyMonitorState);
 }
+
+/**
+ * @brief Verify GetBufferedAudioDurationSec() reports audio track buffer
+ *        duration when the audio track is enabled.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetBufferedAudioDurationSec_ReturnsAudioBuffer_WhenAudioTrackEnabled)
+{
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mStreamAbstractionAAMP->mMockAudioTrack->enabled = true;
+	mStreamAbstractionAAMP->mMockVideoTrack->enabled = true;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockAudioTrack, GetBufferedDuration())
+		.WillOnce(Return(12.5));
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.Times(0);
+
+	EXPECT_DOUBLE_EQ(12.5, mStreamAbstractionAAMP->GetBufferedAudioDurationSec());
+}
+
+/**
+ * @brief Verify GetBufferedAudioDurationSec() falls back to video buffer
+ *        duration when audio is muxed and the audio track is disabled.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetBufferedAudioDurationSec_ReturnsVideoBuffer_WhenAudioTrackDisabled)
+{
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mStreamAbstractionAAMP->mMockAudioTrack->enabled = false;
+	mStreamAbstractionAAMP->mMockVideoTrack->enabled = true;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockAudioTrack, GetBufferedDuration())
+		.Times(0);
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillOnce(Return(8.75));
+
+	EXPECT_DOUBLE_EQ(8.75, mStreamAbstractionAAMP->GetBufferedAudioDurationSec());
+}

--- a/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
@@ -317,3 +317,23 @@ TEST_F(StreamAbstractionAAMP_Test, GetBufferedAudioDurationSec_ReturnsVideoBuffe
 
 	EXPECT_DOUBLE_EQ(8.75, mStreamAbstractionAAMP->GetBufferedAudioDurationSec());
 }
+
+/**
+ * @brief Verify GetBufferedAudioDurationSec() does not fall back to video
+ *        when AudioOnlyPlayback is enabled.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetBufferedAudioDurationSec_ReturnsSentinel_WhenAudioOnlyPlaybackEnabled)
+{
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mStreamAbstractionAAMP->mMockAudioTrack->enabled = false;
+	mStreamAbstractionAAMP->mMockVideoTrack->enabled = true;
+
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_AudioOnlyPlayback))
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockAudioTrack, GetBufferedDuration())
+		.Times(0);
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.Times(0);
+
+	EXPECT_DOUBLE_EQ(-1.0, mStreamAbstractionAAMP->GetBufferedAudioDurationSec());
+}


### PR DESCRIPTION
Reason for change: Modified GetBufferedAudioDurationSec() to return the video track's buffer value for HLS muxed streams. Added L1 test as well.