### PR TITLE
VPAAMP-451 Remove duplicated defines from AampCurlDefine.h

### DIFF
--- a/AampDefine.h
+++ b/AampDefine.h
@@ -122,7 +122,7 @@
 #define DEFAULT_PLAYLIST_DL_TIMEOUT 10L	/**< Curl timeout for playlist download */
 #define DEFAULT_CURL_TIMEOUT 5L		/**< Default timeout for Curl downloads */
 #define DEFAULT_CURL_CONNECTTIMEOUT 3L	/**< Curl socket connection timeout */
-#define DEFAULT_DNS_CACHE_TIMEOUT 3*60L	/**< Name resolve results cached for this many seconds (180 s = 3x the libcurl default of 60 s) */
+#define DEFAULT_DNS_CACHE_TIMEOUT (3*60L)	/**< Name resolve results cached for this many seconds (180 s = 3x the libcurl default of 60 s) */
 #define EAS_CURL_TIMEOUT 3L		/**< Curl timeout for EAS manifest downloads */
 #define EAS_CURL_CONNECTTIMEOUT 2L      /**< Curl timeout for EAS connection */
 #define DEFAULT_INTERVAL_BETWEEN_PLAYLIST_UPDATES_MS (6*1000)   /**< Interval between playlist refreshes */

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -122,6 +122,7 @@
 #define DEFAULT_PLAYLIST_DL_TIMEOUT 10L	/**< Curl timeout for playlist download */
 #define DEFAULT_CURL_TIMEOUT 5L		/**< Default timeout for Curl downloads */
 #define DEFAULT_CURL_CONNECTTIMEOUT 3L	/**< Curl socket connection timeout */
+#define DEFAULT_DNS_CACHE_TIMEOUT 3*60L	/**< Name resolve results cached for this many seconds (180 s = 3x the libcurl default of 60 s) */
 #define EAS_CURL_TIMEOUT 3L		/**< Curl timeout for EAS manifest downloads */
 #define EAS_CURL_CONNECTTIMEOUT 2L      /**< Curl timeout for EAS connection */
 #define DEFAULT_INTERVAL_BETWEEN_PLAYLIST_UPDATES_MS (6*1000)   /**< Interval between playlist refreshes */

--- a/AampDownloadInfo.hpp
+++ b/AampDownloadInfo.hpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <curl/curl.h>
 #include "AampConstants.h"
+#include "AampDefine.h"
 #include "AampCurlDefine.h"
 #include "AampMediaType.h"
 #include "AampUtils.h"

--- a/abr/abr.h
+++ b/abr/abr.h
@@ -33,6 +33,7 @@
 #include <atomic>
 #include "AampMediaType.h"
 #include "BandwidthEstimatorBase.h"
+#include "AampDefine.h"
 #include "AampCurlDefine.h"
 #include "AampSpeedCache.h"
 

--- a/downloader/AampCurlDefine.h
+++ b/downloader/AampCurlDefine.h
@@ -29,16 +29,12 @@
 #include <sstream>
 #include <chrono>
 #include <curl/curl.h>
+#include "AampDefine.h"
 
 #define CURL_EASY_SETOPT(curl, CURLoption, option)\
 		if (curl_easy_setopt(curl, CURLoption, option) != 0) {\
 			AAMPLOG_WARN("Failed at curl_easy_setopt ");\
 		}
-
-#define DEFAULT_CURL_TIMEOUT 5L		/**< Default timeout for Curl downloads */
-#define DEFAULT_CURL_CONNECTTIMEOUT 3L	/**< Curl socket connection timeout */
-#define DEFAULT_DNS_CACHE_TIMEOUT 3*60L	/**< Name resolve results cached for this many seconds (180 s = 3x the libcurl default of 60 s) */
-#define MIN_DELAY_BETWEEN_MANIFEST_UPDATE_FOR_502_MS (1000) // 1000mSec
 
 /**
  * @brief Http Header Type

--- a/downloader/AampCurlDownloader.h
+++ b/downloader/AampCurlDownloader.h
@@ -39,6 +39,7 @@
 #include <curl/curl.h>
 #include <chrono>
 #include <memory>
+#include "AampDefine.h"
 #include "AampCurlDefine.h"
 #include "AampMediaType.h"
 


### PR DESCRIPTION
Reason for Change: Conflict including AampDefine.h and AampCurlDefine.h

Summary of Changes:
- Remove defines from AampCurlDefine.h
- Add missing define to AampDefine.h
- Update includes in header files

Test Procedure: Build AAMP

Priority: P2

Risks: Low