### PR TITLE
VPAAMP-582 AAMP middleware L1 fake used for L2 tests and aamp-cli

### DIFF
--- a/middleware/CMakeLists.txt
+++ b/middleware/CMakeLists.txt
@@ -191,17 +191,13 @@ set(SOURCES
 	PlayerUtils.cpp
 	drm/processProtectionHls.cpp
 	ProcessHandler.cpp
+	vendor/amlogic/AmlogicSocInterface.cpp
+	vendor/realtek/RealtekSocInterface.cpp
+	vendor/brcm/BrcmSocInterface.cpp
+	vendor/mtk/MtkSocInterface.cpp
+	vendor/default/DefaultSocInterface.cpp
+	vendor/SocInterface.cpp
 	)
-if(NOT CMAKE_PLATFORM_UBUNTU AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    list(APPEND SOURCES vendor/amlogic/AmlogicSocInterface.cpp
-						vendor/realtek/RealtekSocInterface.cpp
-						vendor/brcm/BrcmSocInterface.cpp
-						vendor/mtk/MtkSocInterface.cpp
-						vendor/default/DefaultSocInterface.cpp
-						vendor/SocInterface.cpp)
-else()
-	list(APPEND SOURCES test/utests/fakes/FakeSocInterface.cpp)
-endif()
 set(LIBPLAYERGSTINTERFACE_DRM_SOURCES drm/PlayerHlsDrmSessionInterface.cpp
 	drm/DrmSessionManager.cpp
 	drm/DrmSession.cpp


### PR DESCRIPTION
Reason for Change: Avoid confusion and dependencies between L1 and L2

Summary of Changes:
- Include the vendor files unconditionally when building AAMP

Test Procedure: Build AAMP simulator on ubuntu and Mac

Priority: P2

Risks: Low