### PR TITLE
VPAAMP-588: Disable pre-tune

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,6 @@ if(CMAKE_EXTERNAL_PLAYER_INTERFACE_DEPENDENCIES)
 	pkg_check_modules(SUBTEC REQUIRED libsubtec)
 endif()	
 
-if(CMAKE_PREINIT_DECODER)
-       message("CMAKE_PREINIT_DECODER Set")
-       set(LIBAAMP_DEFINES "${LIBAAMP_DEFINES} -DUSE_PREINIT_DECODING=1")
-       set(LIBAAMPJSBINDINGS_DEFINES "${LIBAAMPJSBINDINGS_DEFINES} -DUSE_PREINIT_DECODING=1")
-endif()
-
 if(APPLE)
 	# libcurl < 8.5 exhibits memory leaks. On Ubuntu 22.04 can't update beyond 7.81.0-1ubuntu1.16 without building from source
 	pkg_check_modules(CURL REQUIRED libcurl>=8.5)

--- a/middleware/externals/CMakeLists.txt
+++ b/middleware/externals/CMakeLists.txt
@@ -110,13 +110,6 @@ if(CMAKE_USE_SECCLIENT OR CMAKE_USE_SECMANAGER)
 	endif()
 endif()
 
-if(CMAKE_PREINIT_DECODER)
-	message("PLAYER PREINIT_DECODING set")
-	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../support/aampabr)
-	set(LIB_EXT_DEFINES "${LIB_EXT_DEFINES} -DUSE_PREINIT_DECODING=1")
-	list(APPEND LIB_EXT_DEPENDS -lWPEFrameworkPowerController)
-endif()
-
 #IARM/RFC
 if(CMAKE_IARM_MGR)
     message("PLAYER IARM_MGR set")


### PR DESCRIPTION
Reason for Change: fake tune disabled for all versions of AAMP
Test Procedure: refer ticket
Risks: Low
Priority: P1