### PR TITLE
VPAAMP-569: Optimize Stop Underflow monitoring logic at VOD EOS

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -521,7 +521,6 @@ static const ConfigLookupEntryFloat mConfigLookupTableFloat[AAMPCONFIG_FLOAT_COU
 	{DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC, "underflowResumeThresholdSec", eAAMPConfig_UnderflowResumeThresholdSec, true},
 	{DEFAULT_UNDERFLOW_LOW_BUFFER_SEC, "underflowLowBufferSec", eAAMPConfig_UnderflowLowBufferSec, true},
 	{DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC, "underflowHighBufferSec", eAAMPConfig_UnderflowHighBufferSec, true},
-	{DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC, "underflowEosEndToleranceSec", eAAMPConfig_UnderflowEosEndToleranceSec, true},
 	{DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC, "bufferLevelToEnableLatencySec", eAAMPConfig_BufferLevelToEnableCorrectionSec, false},
 	{DEFAULT_REBUFFER_LATENCY_STEP_SEC, "rebufferLatencyStepSec", eAAMPConfig_RebufferLatencyStepSec, false},
 	{DEFAULT_REBUFFER_LATENCY_MAX_INCREMENT_SEC, "rebufferLatencyMaxIncrementSec", eAAMPConfig_RebufferLatencyMaxIncrementSec, false},

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -521,6 +521,7 @@ static const ConfigLookupEntryFloat mConfigLookupTableFloat[AAMPCONFIG_FLOAT_COU
 	{DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC, "underflowResumeThresholdSec", eAAMPConfig_UnderflowResumeThresholdSec, true},
 	{DEFAULT_UNDERFLOW_LOW_BUFFER_SEC, "underflowLowBufferSec", eAAMPConfig_UnderflowLowBufferSec, true},
 	{DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC, "underflowHighBufferSec", eAAMPConfig_UnderflowHighBufferSec, true},
+	{DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC, "underflowEosEndToleranceSec", eAAMPConfig_UnderflowEosEndToleranceSec, true},
 	{DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC, "bufferLevelToEnableLatencySec", eAAMPConfig_BufferLevelToEnableCorrectionSec, false},
 	{DEFAULT_REBUFFER_LATENCY_STEP_SEC, "rebufferLatencyStepSec", eAAMPConfig_RebufferLatencyStepSec, false},
 	{DEFAULT_REBUFFER_LATENCY_MAX_INCREMENT_SEC, "rebufferLatencyMaxIncrementSec", eAAMPConfig_RebufferLatencyMaxIncrementSec, false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -362,6 +362,7 @@ typedef enum
 	eAAMPConfig_UnderflowResumeThresholdSec,		/**< Underflow resume threshold in seconds */
 	eAAMPConfig_UnderflowLowBufferSec,				/**< Low buffer threshold in seconds */
 	eAAMPConfig_UnderflowHighBufferSec,				/**< High buffer threshold in seconds */
+	eAAMPConfig_UnderflowEosEndToleranceSec,		/**< EOS end-boundary tolerance for suppressing underflow in seconds */
 	eAAMPConfig_BufferLevelToEnableCorrectionSec,   /**< Buffer level to enable latency correction in seconds */
 	eAAMPConfig_RebufferLatencyStepSec,				/**< Step value for latency increase when rebuffering occurs */
 	eAAMPConfig_RebufferLatencyMaxIncrementSec,		/**< Max latency increment allowed due to rebuffering */

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -362,7 +362,6 @@ typedef enum
 	eAAMPConfig_UnderflowResumeThresholdSec,		/**< Underflow resume threshold in seconds */
 	eAAMPConfig_UnderflowLowBufferSec,				/**< Low buffer threshold in seconds */
 	eAAMPConfig_UnderflowHighBufferSec,				/**< High buffer threshold in seconds */
-	eAAMPConfig_UnderflowEosEndToleranceSec,		/**< EOS end-boundary tolerance for suppressing underflow in seconds */
 	eAAMPConfig_BufferLevelToEnableCorrectionSec,   /**< Buffer level to enable latency correction in seconds */
 	eAAMPConfig_RebufferLatencyStepSec,				/**< Step value for latency increase when rebuffering occurs */
 	eAAMPConfig_RebufferLatencyMaxIncrementSec,		/**< Max latency increment allowed due to rebuffering */

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -157,7 +157,6 @@
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */
-#define DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC 0.25	/**< EOS end-boundary tolerance for suppressing underflow in seconds */
 
 #define DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC 0.0  /*< Default is 0.0 means latency correction is enabled at all buffer values */
 #define DEFAULT_REBUFFER_LATENCY_STEP_SEC 1.0			/*< Step value for latency increase when rebuffering occurs in seconds */

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -158,7 +158,6 @@
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */
-#define DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC 0.25	/**< EOS end-boundary tolerance for suppressing underflow in seconds */
 
 #define DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC 0.0  /*< Default is 0.0 means latency correction is enabled at all buffer values */
 #define DEFAULT_REBUFFER_LATENCY_STEP_SEC 1.0			/*< Step value for latency increase when rebuffering occurs in seconds */

--- a/AampDefine.h
+++ b/AampDefine.h
@@ -157,6 +157,7 @@
 #define DEFAULT_UNDERFLOW_RESUME_THRESHOLD_SEC 1.0		/**< Threshold to resume from underflow in seconds */
 #define DEFAULT_UNDERFLOW_LOW_BUFFER_SEC 5.0			/**< Low buffer threshold in seconds */
 #define DEFAULT_UNDERFLOW_HIGH_BUFFER_SEC 10.0			/**< High buffer threshold in seconds */
+#define DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC 0.25	/**< EOS end-boundary tolerance for suppressing underflow in seconds */
 
 #define DEFAULT_BUFFER_LEVEL_TO_ENABLE_LATENCY_SEC 0.0  /*< Default is 0.0 means latency correction is enabled at all buffer values */
 #define DEFAULT_REBUFFER_LATENCY_STEP_SEC 1.0			/*< Step value for latency increase when rebuffering occurs in seconds */

--- a/AampUnderflowMonitor.cpp
+++ b/AampUnderflowMonitor.cpp
@@ -301,7 +301,7 @@ void AampUnderflowMonitor::Run()
             state == eSTATE_ERROR   || state == eSTATE_IDLE ||
             state == eSTATE_COMPLETE)
         {
-            AAMPLOG_INFO("[video] AampUnderflowMonitor: exiting (state=%d)", static_cast<int>(state));
+			AAMPLOG_INFO("[video] AampUnderflowMonitor: exiting (state=%d)", (int)state);
             break;
         }
 
@@ -341,6 +341,29 @@ void AampUnderflowMonitor::Run()
                 continue;
             }
 
+            // For VOD, suppress underflow when buffered end is already at
+            // content end and the sink/state-complete transition is in flight.
+            if (!mAamp->IsLive())
+            {
+                const long long durationMs = mAamp->GetDurationMs();
+                if (durationMs > 0)
+                {
+                    double eosEndToleranceSec = mAamp->mConfig->GetConfigValue(eAAMPConfig_UnderflowEosEndToleranceSec);
+                    if (eosEndToleranceSec < 0.0)
+                    {
+                        eosEndToleranceSec = DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC;
+                    }
+                    const double durationSec = durationMs / 1000.0;
+                    if (mCurrentEndPosition + eosEndToleranceSec >= durationSec)
+                    {
+                        AAMPLOG_INFO("[video] deadline expired at EOS boundary "
+                                     "(end=%.3f, duration=%.3f); suppressing underflow",
+                                     mCurrentEndPosition, durationSec);
+                        mDeadlineArmed = false;
+                        continue;
+                    }
+                }
+            }
         }
 
         if (!mAamp->GetBufUnderFlowStatus())

--- a/AampUnderflowMonitor.cpp
+++ b/AampUnderflowMonitor.cpp
@@ -301,7 +301,7 @@ void AampUnderflowMonitor::Run()
             state == eSTATE_ERROR   || state == eSTATE_IDLE ||
             state == eSTATE_COMPLETE)
         {
-			AAMPLOG_INFO("[video] AampUnderflowMonitor: exiting (state=%d)", (int)state);
+            AAMPLOG_INFO("[video] AampUnderflowMonitor: exiting (state=%d)", static_cast<int>(state));
             break;
         }
 
@@ -341,29 +341,6 @@ void AampUnderflowMonitor::Run()
                 continue;
             }
 
-            // For VOD, suppress underflow when buffered end is already at
-            // content end and the sink/state-complete transition is in flight.
-            if (!mAamp->IsLive())
-            {
-                const long long durationMs = mAamp->GetDurationMs();
-                if (durationMs > 0)
-                {
-                    double eosEndToleranceSec = mAamp->mConfig->GetConfigValue(eAAMPConfig_UnderflowEosEndToleranceSec);
-                    if (eosEndToleranceSec < 0.0)
-                    {
-                        eosEndToleranceSec = DEFAULT_UNDERFLOW_EOS_END_TOLERANCE_SEC;
-                    }
-                    const double durationSec = durationMs / 1000.0;
-                    if (mCurrentEndPosition + eosEndToleranceSec >= durationSec)
-                    {
-                        AAMPLOG_INFO("[video] deadline expired at EOS boundary "
-                                     "(end=%.3f, duration=%.3f); suppressing underflow",
-                                     mCurrentEndPosition, durationSec);
-                        mDeadlineArmed = false;
-                        continue;
-                    }
-                }
-            }
         }
 
         if (!mAamp->GetBufUnderFlowStatus())

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1682,7 +1682,7 @@ public:
 	 * @brief Stop UnderflowMonitor Thread.
 	 * @return void
 	 */
-	void StopUnderflowMonitor();
+	virtual void StopUnderflowMonitor();
 
 	/**
 	 * @fn IsUnderflowMonitorRunning

--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1682,7 +1682,7 @@ public:
 	 * @brief Stop UnderflowMonitor Thread.
 	 * @return void
 	 */
-	virtual void StopUnderflowMonitor();
+	void StopUnderflowMonitor();
 
 	/**
 	 * @fn IsUnderflowMonitorRunning

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1493,6 +1493,13 @@ bool MediaTrack::SignalIfEOSReached()
 			{
 				aamp->EndOfStreamReached(eMEDIATYPE_AUDIO);
 			}
+			// Stop underflow monitor when video EOS is reached on VOD.
+			// EOS can be signalled from both normal sentinel and aborted-wait
+			// paths, so centralize monitor shutdown here.
+			if (!aamp->IsLive() && type == eTRACK_VIDEO)
+			{
+				pContext->StopUnderflowMonitor();
+			}
 			ret = true;
 		}
 		else

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1445,13 +1445,6 @@ bool MediaTrack::InjectFragment()
 					{
 						aamp->EndOfStreamReached(eMEDIATYPE_AUDIO);
 					}
-					// Stop underflow monitor — all VOD fragments are injected;
-					// the GStreamer EOS bubble is now in flight and no further
-					// fragment arrivals are expected, so underflow detection is invalid.
-					if (!aamp->IsLive() && type == eTRACK_VIDEO)
-					{
-						pContext->StopUnderflowMonitor();
-					}
 				}
 				else
 				{

--- a/test/utests/mocks/MockStreamAbstractionAAMP.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP.h
@@ -107,6 +107,8 @@ public:
 	MOCK_METHOD(void, SetIsAtLivePoint, (bool isAtLivePoint));
 
 	MOCK_METHOD(bool, IsCurrentProfileLowest, ());
+
+	MOCK_METHOD(void, StopUnderflowMonitor, (), (override));
 };
 
 extern std::shared_ptr<MockStreamAbstractionAAMP> g_mockStreamAbstractionAAMP;

--- a/test/utests/mocks/MockStreamAbstractionAAMP.h
+++ b/test/utests/mocks/MockStreamAbstractionAAMP.h
@@ -107,8 +107,6 @@ public:
 	MOCK_METHOD(void, SetIsAtLivePoint, (bool isAtLivePoint));
 
 	MOCK_METHOD(bool, IsCurrentProfileLowest, ());
-
-	MOCK_METHOD(void, StopUnderflowMonitor, (), (override));
 };
 
 extern std::shared_ptr<MockStreamAbstractionAAMP> g_mockStreamAbstractionAAMP;

--- a/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
@@ -153,7 +153,6 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -188,7 +187,6 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest3)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -256,7 +254,6 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -322,7 +319,6 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest7)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -363,7 +359,6 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest8)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -418,7 +413,6 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -473,7 +467,6 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest4)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -503,7 +496,6 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -537,7 +529,6 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest6)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -594,7 +585,6 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -627,7 +617,6 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest3)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -689,7 +678,6 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -723,7 +711,6 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest6)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -761,7 +748,6 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest7)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -819,7 +805,6 @@ TEST_F(SetPreferredLanguagesTests, TypeTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -874,7 +859,6 @@ TEST_F(SetPreferredLanguagesTests, TypeTest4)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -905,7 +889,6 @@ TEST_F(SetPreferredLanguagesTests, TypeTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -939,7 +922,6 @@ TEST_F(SetPreferredLanguagesTests, TypeTest6)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -996,7 +978,6 @@ TEST_F(SetPreferredLanguagesTests, CodecListTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -1029,7 +1010,6 @@ TEST_F(SetPreferredLanguagesTests, CodecListTest3)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 

--- a/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredLanguagesTests.cpp
@@ -153,6 +153,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -187,6 +188,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest3)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -254,6 +256,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -319,6 +322,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest7)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -359,6 +363,7 @@ TEST_F(SetPreferredLanguagesTests, LanguageListTest8)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -413,6 +418,7 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -467,6 +473,7 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest4)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -496,6 +503,7 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -529,6 +537,7 @@ TEST_F(SetPreferredLanguagesTests, RenditionTest6)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -585,6 +594,7 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -617,6 +627,7 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest3)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -678,6 +689,7 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -711,6 +723,7 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest6)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -748,6 +761,7 @@ TEST_F(SetPreferredLanguagesTests, LabelListTest7)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -805,6 +819,7 @@ TEST_F(SetPreferredLanguagesTests, TypeTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -859,6 +874,7 @@ TEST_F(SetPreferredLanguagesTests, TypeTest4)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -889,6 +905,7 @@ TEST_F(SetPreferredLanguagesTests, TypeTest5)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -922,6 +939,7 @@ TEST_F(SetPreferredLanguagesTests, TypeTest6)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -978,6 +996,7 @@ TEST_F(SetPreferredLanguagesTests, CodecListTest2)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 
@@ -1010,6 +1029,7 @@ TEST_F(SetPreferredLanguagesTests, CodecListTest3)
 	 */
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableAudioTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredLanguagesTests::Stop));
 

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -254,6 +254,7 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest2)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -325,6 +326,7 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest4)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -357,6 +359,7 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest5)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -397,6 +400,7 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest6)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	mPrivateInstanceAAMP->SetPreferredTextLanguages("lang1");
@@ -436,6 +440,7 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest7)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -464,6 +469,7 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest1)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -495,6 +501,7 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest2)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -527,6 +534,7 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest3)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -564,6 +572,7 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest4)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -614,6 +623,7 @@ TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest3)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -646,6 +656,7 @@ TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest4)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -679,6 +690,7 @@ TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest5)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -721,6 +733,7 @@ TEST_F(SetPreferredTextLanguagesTests, SetTsbSessionManagerNull)
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
 
 	// This test sets IsLocalAAMPTsb=true, so the mock is not deleted by the code-under-test.
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).WillRepeatedly(Return());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_)).WillRepeatedly(Return());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SetCurrentTextTrackIndex(_))
 		.Times(1);
@@ -776,6 +789,7 @@ TEST_F(SetPreferredTextLanguagesTests, ChangePrefTextLangWithTSB)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
 	// This test sets IsLocalAAMPTsb=true, so the mock is not deleted by the code-under-test.
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(2).WillRepeatedly(Return());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_)).Times(2).WillRepeatedly(Return());
 	// SetCurrentTextTrackIndex is called in TSB scenarios
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SetCurrentTextTrackIndex(_))
@@ -857,6 +871,7 @@ TEST_F(SetPreferredTextLanguagesTests, Accessibility1)
 
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(_))
 		.WillOnce(ReturnRef(tracks));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, getAccessibilityNode(_))
@@ -955,6 +970,7 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenTeardownRacesWithSetPreferredTex
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]), Return(true)));
 
 
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -254,7 +254,6 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest2)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -326,7 +325,6 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest4)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -359,7 +357,6 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest5)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -400,7 +397,6 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest6)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	mPrivateInstanceAAMP->SetPreferredTextLanguages("lang1");
@@ -440,7 +436,6 @@ TEST_F(SetPreferredTextLanguagesTests, LanguageListTest7)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -469,7 +464,6 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest1)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockAampGstPlayer, Flush(_,_,_))
@@ -501,7 +495,6 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest2)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -534,7 +527,6 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest3)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -572,7 +564,6 @@ TEST_F(SetPreferredTextLanguagesTests, RenditionTest4)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -623,7 +614,6 @@ TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest3)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -656,7 +646,6 @@ TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest4)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -690,7 +679,6 @@ TEST_F(SetPreferredTextLanguagesTests, TextTrackNameTest5)
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 
@@ -733,7 +721,6 @@ TEST_F(SetPreferredTextLanguagesTests, SetTsbSessionManagerNull)
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
 
 	// This test sets IsLocalAAMPTsb=true, so the mock is not deleted by the code-under-test.
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).WillRepeatedly(Return());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_)).WillRepeatedly(Return());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SetCurrentTextTrackIndex(_))
 		.Times(1);
@@ -789,7 +776,6 @@ TEST_F(SetPreferredTextLanguagesTests, ChangePrefTextLangWithTSB)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SelectPreferredTextTrack(_))
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]),Return(true)));
 	// This test sets IsLocalAAMPTsb=true, so the mock is not deleted by the code-under-test.
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(2).WillRepeatedly(Return());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_)).Times(2).WillRepeatedly(Return());
 	// SetCurrentTextTrackIndex is called in TSB scenarios
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SetCurrentTextTrackIndex(_))
@@ -871,7 +857,6 @@ TEST_F(SetPreferredTextLanguagesTests, Accessibility1)
 
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(_))
 		.WillOnce(ReturnRef(tracks));
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP_MPD, getAccessibilityNode(_))
@@ -970,7 +955,6 @@ TEST_F(SetPreferredTextLanguagesTests, CrashWhenTeardownRacesWithSetPreferredTex
 		.WillOnce(::testing::DoAll(::testing::SetArgReferee<0>(tracks[0]), Return(true)));
 
 
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor());
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_))
 		.WillOnce(Invoke(this, &SetPreferredTextLanguagesTests::Stop));
 

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -29,6 +29,7 @@
 #include "MockPrivateInstanceAAMP.h"
 #include "MockMediaStreamContext.h"
 #include "MockIsoBmffBuffer.h"
+#include "MockStreamAbstractionAAMP.h"
 
 // #include "fragmentcollector_mpd.h"
 #include "isobmff/isobmffprocessor.h"
@@ -40,6 +41,11 @@ using namespace testing;
 static constexpr uint32_t PLAYBACK_TIMESCALE{90000};
 
 AampConfig *gpGlobalConfig{nullptr};
+
+// Defined here (not via libfakes) so FakeStreamAbstractionAamp.cpp.o is not
+// loaded from the archive — which would cause duplicate-symbol errors with the
+// streamabstraction.cpp that is compiled directly into this test binary.
+std::shared_ptr<MockStreamAbstractionAAMP> g_mockStreamAbstractionAAMP{};
 
 class MediaTrackTest : public MediaTrack
 {
@@ -410,8 +416,7 @@ TEST_F(TrackInjectTests, InjectFragment_VodEos_StopsUnderflowMonitor)
 	// Mark the video track at EOS and prepare the EOS-sentinel slot.
 	// fillCachedFragment increments numberOfFragmentsCached so that
 	// WaitForCachedFragmentAvailable() returns true (not "aborted").
-	// 
-  then clears fragment.capacity() to 0, which is the
+	// then clears fragment.capacity() to 0, which is the
 	// signal InjectFragment uses to trigger the EOS path.
 	mMediaTrack->eosReached = true;
 	mMediaTrack->fillCachedFragment(false, false);

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -29,6 +29,7 @@
 #include "MockPrivateInstanceAAMP.h"
 #include "MockMediaStreamContext.h"
 #include "MockIsoBmffBuffer.h"
+#include "MockStreamAbstractionAAMP.h"
 
 // #include "fragmentcollector_mpd.h"
 #include "isobmff/isobmffprocessor.h"
@@ -40,6 +41,11 @@ using namespace testing;
 static constexpr uint32_t PLAYBACK_TIMESCALE{90000};
 
 AampConfig *gpGlobalConfig{nullptr};
+
+// Defined here (not via libfakes) so FakeStreamAbstractionAamp.cpp.o is not
+// loaded from the archive — which would cause duplicate-symbol errors with the
+// streamabstraction.cpp that is compiled directly into this test binary.
+std::shared_ptr<MockStreamAbstractionAAMP> g_mockStreamAbstractionAAMP{};
 
 class MediaTrackTest : public MediaTrack
 {
@@ -124,6 +130,20 @@ public:
 		cachFragment->type = isInit ? eMEDIATYPE_INIT_VIDEO : eMEDIATYPE_VIDEO;
 		cachFragment->fragment.assign(data, data + sizeof(data));
 		UpdateTSAfterFetch();
+	}
+
+	// Clears the injection slot so InjectFragment() sees an EOS sentinel
+	// (capacity == 0 with eosReached == true).
+	void SetupEosSentinel()
+	{
+		CachedFragment *slot = &mCachedFragment[fragmentIdxToInject];
+		slot->fragment.clear();
+		slot->fragment.shrink_to_fit();
+	}
+
+	void SetAbortInject(bool shouldAbort)
+	{
+		abortInject = shouldAbort;
 	}
 };
 
@@ -370,4 +390,123 @@ TEST_F(TrackInjectTests, RunInjectLoopTestLLDInit)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 
 	mMediaTrack->RunInjectLoop();
+}
+
+/**
+ * Verify that InjectFragment() calls StopUnderflowMonitor() exactly once when
+ * the video track reaches end-of-stream on a VOD asset (eosReached == true,
+ * IsLive() == false) and the injector encounters the EOS-sentinel empty slot.
+ */
+TEST_F(TrackInjectTests, InjectFragment_VodEos_StopsUnderflowMonitor)
+{
+	AampLLDashServiceData llDashData;
+	llDashData.availabilityTimeOffset = 0.0;
+	llDashData.lowLatencyMode = false;
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mPrivateInstanceAAMP->SetLLDashServiceData(llDashData);
+	mPrivateInstanceAAMP->SetIsLive(false); // VOD
+
+	// Attach a MockStreamAbstractionAAMP so StopUnderflowMonitor() can be observed.
+	g_mockStreamAbstractionAAMP = std::make_shared<NiceMock<MockStreamAbstractionAAMP>>(mPrivateInstanceAAMP);
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP.get();
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(false));
+	Initialize();
+
+	// Mark the video track at EOS and prepare the EOS-sentinel slot.
+	// fillCachedFragment increments numberOfFragmentsCached so that
+	// WaitForCachedFragmentAvailable() returns true (not "aborted").
+	// SetupEosSentinel then clears fragment.capacity() to 0, which is the
+	// signal InjectFragment uses to trigger the EOS path.
+	mMediaTrack->eosReached = true;
+	mMediaTrack->fillCachedFragment(false, false);
+	mMediaTrack->SetupEosSentinel();
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData(_, _, _));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.WillOnce(Return(true))
+		.WillRepeatedly(Return(false));
+
+	// The key assertion: StopUnderflowMonitor must be called exactly once.
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(1);
+
+	mMediaTrack->RunInjectLoop();
+
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
+	g_mockStreamAbstractionAAMP.reset();
+}
+
+/**
+ * Verify that InjectFragment() does NOT call StopUnderflowMonitor() when the
+ * track reaches end-of-stream on a LIVE asset.  The live-stream code path must
+ * be unaffected by the VOD fix.
+ */
+TEST_F(TrackInjectTests, InjectFragment_LiveEos_DoesNotStopUnderflowMonitor)
+{
+	AampLLDashServiceData llDashData;
+	llDashData.availabilityTimeOffset = 0.0;
+	llDashData.lowLatencyMode = false;
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mPrivateInstanceAAMP->SetLLDashServiceData(llDashData);
+	mPrivateInstanceAAMP->SetIsLive(true); // LIVE
+
+	g_mockStreamAbstractionAAMP = std::make_shared<NiceMock<MockStreamAbstractionAAMP>>(mPrivateInstanceAAMP);
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP.get();
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(false));
+	Initialize();
+
+	mMediaTrack->eosReached = true;
+	mMediaTrack->fillCachedFragment(false, false);
+	mMediaTrack->SetupEosSentinel();
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData(_, _, _));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.WillOnce(Return(true))
+		.WillRepeatedly(Return(false));
+
+	// StopUnderflowMonitor must NOT be called for live streams.
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(0);
+
+	mMediaTrack->RunInjectLoop();
+
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
+	g_mockStreamAbstractionAAMP.reset();
+}
+
+/**
+ * Verify that InjectFragment() calls StopUnderflowMonitor() on VOD when EOS is
+ * signalled from the aborted WaitForCachedFragmentAvailable() path.
+ */
+TEST_F(TrackInjectTests, InjectFragment_VodEosAbortedWait_StopsUnderflowMonitor)
+{
+	AampLLDashServiceData llDashData;
+	llDashData.availabilityTimeOffset = 0.0;
+	llDashData.lowLatencyMode = false;
+	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
+	mPrivateInstanceAAMP->SetLLDashServiceData(llDashData);
+	mPrivateInstanceAAMP->SetIsLive(false); // VOD
+
+	g_mockStreamAbstractionAAMP = std::make_shared<NiceMock<MockStreamAbstractionAAMP>>(mPrivateInstanceAAMP);
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP.get();
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(false));
+	Initialize();
+
+	// Force WaitForCachedFragmentAvailable() to abort and return false.
+	mMediaTrack->eosReached = true;
+	mMediaTrack->SetAbortInject(true);
+
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData(_, _, _));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
+		.WillOnce(Return(true))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(1);
+
+	mMediaTrack->RunInjectLoop();
+
+	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
+	g_mockStreamAbstractionAAMP.reset();
 }

--- a/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
+++ b/test/utests/tests/TrackInjectTests/TrackInjectTests.cpp
@@ -29,7 +29,6 @@
 #include "MockPrivateInstanceAAMP.h"
 #include "MockMediaStreamContext.h"
 #include "MockIsoBmffBuffer.h"
-#include "MockStreamAbstractionAAMP.h"
 
 // #include "fragmentcollector_mpd.h"
 #include "isobmff/isobmffprocessor.h"
@@ -41,11 +40,6 @@ using namespace testing;
 static constexpr uint32_t PLAYBACK_TIMESCALE{90000};
 
 AampConfig *gpGlobalConfig{nullptr};
-
-// Defined here (not via libfakes) so FakeStreamAbstractionAamp.cpp.o is not
-// loaded from the archive — which would cause duplicate-symbol errors with the
-// streamabstraction.cpp that is compiled directly into this test binary.
-std::shared_ptr<MockStreamAbstractionAAMP> g_mockStreamAbstractionAAMP{};
 
 class MediaTrackTest : public MediaTrack
 {
@@ -130,15 +124,6 @@ public:
 		cachFragment->type = isInit ? eMEDIATYPE_INIT_VIDEO : eMEDIATYPE_VIDEO;
 		cachFragment->fragment.assign(data, data + sizeof(data));
 		UpdateTSAfterFetch();
-	}
-
-	// Clears the injection slot so InjectFragment() sees an EOS sentinel
-	// (capacity == 0 with eosReached == true).
-	void SetupEosSentinel()
-	{
-		CachedFragment *slot = &mCachedFragment[fragmentIdxToInject];
-		slot->fragment.clear();
-		slot->fragment.shrink_to_fit();
 	}
 };
 
@@ -385,88 +370,4 @@ TEST_F(TrackInjectTests, RunInjectLoopTestLLDInit)
 	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
 
 	mMediaTrack->RunInjectLoop();
-}
-
-/**
- * Verify that InjectFragment() calls StopUnderflowMonitor() exactly once when
- * the video track reaches end-of-stream on a VOD asset (eosReached == true,
- * IsLive() == false) and the injector encounters the EOS-sentinel empty slot.
- */
-TEST_F(TrackInjectTests, InjectFragment_VodEos_StopsUnderflowMonitor)
-{
-	AampLLDashServiceData llDashData;
-	llDashData.availabilityTimeOffset = 0.0;
-	llDashData.lowLatencyMode = false;
-	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
-	mPrivateInstanceAAMP->SetLLDashServiceData(llDashData);
-	mPrivateInstanceAAMP->SetIsLive(false); // VOD
-
-	// Attach a MockStreamAbstractionAAMP so StopUnderflowMonitor() can be observed.
-	g_mockStreamAbstractionAAMP = std::make_shared<NiceMock<MockStreamAbstractionAAMP>>(mPrivateInstanceAAMP);
-	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP.get();
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(false));
-	Initialize();
-
-	// Mark the video track at EOS and prepare the EOS-sentinel slot.
-	// fillCachedFragment increments numberOfFragmentsCached so that
-	// WaitForCachedFragmentAvailable() returns true (not "aborted").
-	// SetupEosSentinel then clears fragment.capacity() to 0, which is the
-	// signal InjectFragment uses to trigger the EOS path.
-	mMediaTrack->eosReached = true;
-	mMediaTrack->fillCachedFragment(false, false);
-	mMediaTrack->SetupEosSentinel();
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData(_, _, _));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
-		.WillOnce(Return(true))
-		.WillRepeatedly(Return(false));
-
-	// The key assertion: StopUnderflowMonitor must be called exactly once.
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(1);
-
-	mMediaTrack->RunInjectLoop();
-
-	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
-	g_mockStreamAbstractionAAMP.reset();
-}
-
-/**
- * Verify that InjectFragment() does NOT call StopUnderflowMonitor() when the
- * track reaches end-of-stream on a LIVE asset.  The live-stream code path must
- * be unaffected by the VOD fix.
- */
-TEST_F(TrackInjectTests, InjectFragment_LiveEos_DoesNotStopUnderflowMonitor)
-{
-	AampLLDashServiceData llDashData;
-	llDashData.availabilityTimeOffset = 0.0;
-	llDashData.lowLatencyMode = false;
-	mPrivateInstanceAAMP->rate = AAMP_NORMAL_PLAY_RATE;
-	mPrivateInstanceAAMP->SetLLDashServiceData(llDashData);
-	mPrivateInstanceAAMP->SetIsLive(true); // LIVE
-
-	g_mockStreamAbstractionAAMP = std::make_shared<NiceMock<MockStreamAbstractionAAMP>>(mPrivateInstanceAAMP);
-	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = g_mockStreamAbstractionAAMP.get();
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, GetLLDashChunkMode()).WillRepeatedly(Return(false));
-	Initialize();
-
-	mMediaTrack->eosReached = true;
-	mMediaTrack->fillCachedFragment(false, false);
-	mMediaTrack->SetupEosSentinel();
-
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, BlockUntilGstreamerWantsData(_, _, _));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, IsLocalAAMPTsbInjection()).WillRepeatedly(Return(false));
-	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled())
-		.WillOnce(Return(true))
-		.WillRepeatedly(Return(false));
-
-	// StopUnderflowMonitor must NOT be called for live streams.
-	EXPECT_CALL(*g_mockStreamAbstractionAAMP, StopUnderflowMonitor()).Times(0);
-
-	mMediaTrack->RunInjectLoop();
-
-	mPrivateInstanceAAMP->mpStreamAbstractionAAMP = nullptr;
-	g_mockStreamAbstractionAAMP.reset();
 }


### PR DESCRIPTION
Replace the position-based EOS boundary guard (eosEndToleranceSec config) with a clean fix: call StopUnderflowMonitor() from MediaTrack::SignalIfEOSReached() so it stops for both normal EOS-sentinel injection path and aborted-wait EOS path.