### PR TITLE
RDKEMW-19696: WPEWebProcess crash observed with fingerprint

### DIFF
--- a/middleware/drm/ocdm/opencdmsessionadapter.cpp
+++ b/middleware/drm/ocdm/opencdmsessionadapter.cpp
@@ -80,6 +80,10 @@ OCDMSessionAdapter::OCDMSessionAdapter(DrmHelperPtr drmHelper, DrmCallbacks *cal
 
 	// Get output protection pointer
 	m_pOutputProtection = PlayerExternalsInterface::GetPlayerExternalsInterfaceInstance();
+	MW_LOG_WARN("m_drmHelper addr: %p, use_count: %ld, m_pOutputProtection addr: %p, use_count: %ld",
+            m_drmHelper.get(),
+            m_drmHelper.use_count(), m_pOutputProtection.get(), m_pOutputProtection.use_count());
+
 	MW_LOG_WARN("OCDMSessionAdapter :: exit ");
 }
 
@@ -434,6 +438,20 @@ void OCDMSessionAdapter::setKeyId(const std::vector<uint8_t>& keyId)
 
 bool OCDMSessionAdapter::verifyOutputProtection()
 {
+	
+	MW_LOG_WARN("m_drmHelper addr: %p, use_count: %ld, m_pOutputProtection addr: %p, use_count: %ld",
+            m_drmHelper.get(),
+            m_drmHelper.use_count(), m_pOutputProtection.get(), m_pOutputProtection.use_count());
+
+	if(!m_drmHelper)
+	{
+		MW_LOG_WARN("m_drmHelper is NULL, unable to verify output protection");
+	}
+	if(!m_pOutputProtection)
+	{
+		MW_LOG_WARN("Output Protection interface not present, unable to verify output protection");
+	}
+
 	if (m_drmHelper->isHdcp22Required() && m_pOutputProtection->IsSourceUHD())
 	{
 		// Source material is UHD

--- a/middleware/externals/PlayerExternalsInterface.cpp
+++ b/middleware/externals/PlayerExternalsInterface.cpp
@@ -53,6 +53,7 @@ PlayerExternalsInterface::PlayerExternalsInterface()
  */
 PlayerExternalsInterface::~PlayerExternalsInterface()
 {
+    MW_LOG_WARN(" PlayerExternalsInterface destructor called\n");
     m_pIarmInterface = nullptr;
     s_pPlayerOP = NULL;    
 }

--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
@@ -196,6 +196,7 @@ void PlayerExternalsRdkInterface::OnResolutionPreChange(int width, int height)
 
 PlayerExternalsRdkInterface::~PlayerExternalsRdkInterface()
 {
+    MW_LOG_WARN(" PlayerExternalsRdkInterface destructor called\n");
 #ifdef USE_DS_EVENT_SUPPORTED
 	RemoveDsClientEventHandlers();
 #endif


### PR DESCRIPTION
Reason for change : added debug logs to get the RCA
priority  : P1
Test Procedure : see the ticket
Risks : Low