### PR TITLE
VPAAMP-568 Prevent SelectSubtitleTrack changing tracks, and clearing …

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -411,7 +411,6 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{AAMP_HIGH_BUFFER_BEFORE_RAMPUP,"maxABRBufferRampup",eAAMPConfig_MaxABRNWBufferRampUp,false},
 	{DEFAULT_PREBUFFER_COUNT,"preplayBuffercount",eAAMPConfig_PrePlayBufferCount,false},
 	{0,"preCachePlaylistTime",eAAMPConfig_PreCachePlaylistTime,false},
-	{-1, "ceaFormat",eAAMPConfig_CEAPreferred,false, eCONFIG_RANGE_CEA_PREFERRED},
 	{DEFAULT_STALL_ERROR_CODE,"stallErrorCode",eAAMPConfig_StallErrorCode,false},
 	{DEFAULT_STALL_DETECTION_TIMEOUT,"stallTimeout",eAAMPConfig_StallTimeoutMS,false},
 	{DEFAULT_MINIMUM_INIT_CACHE_SECONDS,"initialBuffer",eAAMPConfig_InitialBuffer,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -254,7 +254,6 @@ typedef enum
 	eAAMPConfig_MaxABRNWBufferRampUp,					/**< Maximum ABR Buffer for Rampup*/
 	eAAMPConfig_PrePlayBufferCount, 					/**< Count of segments to be downloaded until play state */
 	eAAMPConfig_PreCachePlaylistTime,					/**< Max time to complete PreCaching .In Minutes  */
-	eAAMPConfig_CEAPreferred,						/**< To force 608/708 track selection in CC manager */
 	eAAMPConfig_StallErrorCode,
 	eAAMPConfig_StallTimeoutMS,
 	eAAMPConfig_InitialBuffer,

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6438,7 +6438,6 @@ void StreamAbstractionAAMP_MPD::SelectSubtitleTrack(bool newTune, std::vector<Te
 	TextTrackInfo preferredTextTrack;
 	std::vector<AudioTrackInfo> aTracks;//aTracks is only used for calling ParseTrackInformation
 	bool isFrstAvailableTxtTrackSelected = false;
-	bool isinbandCCAlsoPresent = false;
 
 	class MediaStreamContext *pMediaStreamContext = mMediaStreamContext[eMEDIATYPE_SUBTITLE];
 	mMediaStreamContext[eMEDIATYPE_SUBTITLE]->enabled = false;
@@ -6449,14 +6448,12 @@ void StreamAbstractionAAMP_MPD::SelectSubtitleTrack(bool newTune, std::vector<Te
 		return;
 	}
 
-	// Fix A: if the application explicitly selected an in-band CC track via
-	// SetTextTrack, do not auto-pick a subtitle adaptation set here. Doing so
-	// would clobber aamp->mIsInbandCC to false on every retune (e.g. trickplay
-	// exit) and break the RestoreCC gate in TuneHelper. Leave the subtitle
-	// MediaStreamContext disabled and keep mIsInbandCC as the user set it.
-	if (aamp->mAppSelectedInbandCC)
+	// Skip OOB subtitle scoring on seek/trickplay resume when the app
+	// explicitly selected a CC track. mPreferredTextTrack
+	// is reset in Stop(), so this guard is inactive on a new tune.
+	if (aamp->GetPreferredTextTrack().isCC)
 	{
-		AAMPLOG_WARN("App-selected in-band CC active; skipping subtitle auto-pick to preserve mIsInbandCC=%d", aamp->mIsInbandCC);
+		AAMPLOG_INFO("SelectSubtitleTrack: CC track explicitly selected, skipping OOB subtitle selection");
 		return;
 	}
 
@@ -6473,22 +6470,6 @@ void StreamAbstractionAAMP_MPD::SelectSubtitleTrack(bool newTune, std::vector<Te
 		if (mMPDParseHelper->IsContentType(adaptationSet,eMEDIATYPE_SUBTITLE))
 		{
 			ParseTrackInformation(adaptationSet, iAdaptationSet,eMEDIATYPE_SUBTITLE , aTracks, tTracks);
-			for (int j = 0; j < tTracks.size(); j++)
-			{
-				if (!tTracks[j].isCC)
-					{
-						AAMPLOG_INFO("Available subs - mime %s lang %s index %s isCC %d",
-											 tTracks[j].instreamId.c_str(), tTracks[j].language.c_str(), tTracks[j].index.c_str(),tTracks[j].isCC);
-					}
-					else
-					{
-						AAMPLOG_INFO("Available subs - mime %s lang %s index %s isCC %d",
-								 tTracks[j].instreamId.c_str(), tTracks[j].language.c_str(), tTracks[j].index.c_str(),tTracks[j].isCC);
-						isinbandCCAlsoPresent = true;
-						memset(&preferredTextTrack, 0, sizeof(preferredTextTrack)); // Clear any preferred text track selection if in-band CC is present, as in-band CC will be preferred over subtitle tracks
-						break;
-					}
-			 }
 			if (AAMP_NORMAL_PLAY_RATE == rate)
 			{
 				if (selAdaptationSetIndex == -1 || isFrstAvailableTxtTrackSelected)
@@ -6531,13 +6512,7 @@ void StreamAbstractionAAMP_MPD::SelectSubtitleTrack(bool newTune, std::vector<Te
 						// 3. Not set
 						selectedTextTrack = (nullptr != firstAvailTextTrack) ? *firstAvailTextTrack : aamp->GetPreferredTextTrack();
 					}
-					if(isinbandCCAlsoPresent)
-					{
-				 		//break the loop here so that gst TTML will not be created
-						AAMPLOG_INFO("Inband CC track is also present in the stream, mIsInbandCC=%d", aamp->mIsInbandCC);
-				 		aamp->mIsInbandCC = true;
-						break;
-					}
+
 					if (!selectedTextTrack.index.empty())
 					{
 						if (IsMatchingLanguageAndMimeType(eMEDIATYPE_SUBTITLE, selectedTextTrack.language, adaptationSet, selRepresentationIndex))

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -498,8 +498,7 @@ static bool AAMP_setProperty_preferredCEAFormat(JSContextRef context, JSObjectRe
 		return false;
 	}
 	preferredCEAFormat = (int)JSValueToNumber(context, value, exception);
-        LOG_WARN(pAAMP,"_aamp->SetCEAFormat context=%p  value=%d exception=%p ",context, preferredCEAFormat, exception);
-	pAAMP->_aamp->SetCEAFormat(preferredCEAFormat);
+        LOG_WARN(pAAMP,"_aamp->SetCEAFormat context=%p  value=%d exception=%p(deprecated )",context, preferredCEAFormat, exception);
 	return true;
 }
 

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2964,16 +2964,6 @@ void PlayerInstanceAAMP::SetInitRampdownLimit(int limit)
 	SETCONFIGVALUE(AAMP_APPLICATION_SETTING,eAAMPConfig_InitRampDownLimit,limit);
 }
 
-
-/**
- *  @brief Set the CEA format for force setting
- */
-void PlayerInstanceAAMP::SetCEAFormat(int format)
-{
-	SETCONFIGVALUE(AAMP_APPLICATION_SETTING,eAAMPConfig_CEAPreferred,format);
-}
-
-
 /**
  *   @brief To get the available bitrates for thumbnails.
  */

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -1197,14 +1197,6 @@ public:
 	void SetLanguageFormat(LangCodePreference preferredFormat, bool useRole = false);
 
 	/**
-	 *   @brief Set the CEA format for force setting
-	 *
-	 *   @param[in] format - 0 for 608, 1 for 708
-	 *   @return void
-	 */
-	void SetCEAFormat(int format);
-
-	/**
 	 *   @brief Set the session token for player
 	 *
 	 *   @param[in]string -  sessionToken

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -10851,6 +10851,7 @@ void PrivateInstanceAAMP::SetTextTrack(int trackId, char *data)
 				{
 					mIsInbandCC = true;
 					SetPreferredTextTrack(track);
+					SetCCStatusInternal();
 					if (!track.instreamId.empty())
 					{
 						CCFormat format = eCLOSEDCAPTION_FORMAT_DEFAULT;
@@ -10990,8 +10991,16 @@ int PrivateInstanceAAMP::GetTextTrack()
 void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 {
 	AAMPLOG_INFO("enabled %s", enabled?"true":"false");
-	AcquireStreamLock();
-	subtitles_muted = !enabled;
+	{
+		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
+		// Set subtitles_muted flag to the value requested by the app
+		subtitles_muted = !enabled;
+		SetCCStatusInternal();
+	}
+}
+
+void PrivateInstanceAAMP::SetCCStatusInternal(void)
+{
 	// Mute subtitles if either video is muted or subtitles are muted
 	bool mute_subtitles_applied = video_muted || subtitles_muted;
 	bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
@@ -11015,7 +11024,6 @@ void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 		}
 	}
 	SetSubtitleMute(mute_subtitles_applied);
-	ReleaseStreamLock();
 }
 
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1261,7 +1261,6 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, mVideoRect{}
 	, mData()
 	, mIsInbandCC(true)
-	, mAppSelectedInbandCC(false)
 	, bitrateList()
 	, userProfileStatus(false)
 	, mApplyCachedVideoMute(false)
@@ -5869,12 +5868,6 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	// Reset current audio/text track index
 	mCurrentAudioTrackIndex = -1;
 	mCurrentTextTrackIndex = -1;
-	// A new asset is being tuned: forget any previously app-selected in-band
-	// CC choice so the new manifest's text tracks are configured from scratch.
-	// Mid-session retunes (TuneHelper without going through Tune()) leave
-	// this flag intact so the user's CC choice persists across trickplay /
-	// seek-induced retunes.
-	mAppSelectedInbandCC = false;
 	SetPauseOnStartPlayback(false);
 
 	mSchemeIdUriDai = GETCONFIGVALUE_PRIV(eAAMPConfig_SchemeIdUriDaiStream);
@@ -8019,17 +8012,7 @@ void PrivateInstanceAAMP::ReportContentGap(long long timeMilliseconds, std::stri
 void PrivateInstanceAAMP::InitializeCC(unsigned long decoderHandle)
 {
 	PlayerCCManager::GetInstance()->Init((void *)decoderHandle);
-	if (ISCONFIGSET_PRIV(eAAMPConfig_NativeCCRendering))
-	{
-		int overrideCfg = GETCONFIGVALUE_PRIV(eAAMPConfig_CEAPreferred);
-		if (overrideCfg == 0)
-		{
-			AAMPLOG_WARN("PrivateInstanceAAMP: CC format override to 608 present, selecting 608CC");
-			PlayerCCManager::GetInstance()->SetTrack("CC1");
-		}
-	}
 }
-
 /**
  *  @brief Notify first frame is displayed. Sends CC handle event to listeners.
  */
@@ -10848,9 +10831,6 @@ void PrivateInstanceAAMP::SetTextTrack(int trackId, char *data)
 		// Passing in -1 as the track ID mutes subs
 		if (MUTE_SUBTITLES_TRACKID == trackId)
 		{
-			// User is muting all text rendering; clear the in-band CC
-			// preference so a subsequent retune does not auto-restore CC.
-			mAppSelectedInbandCC = false;
 			SetCCStatus(false);
 			if (data != NULL)
 			{
@@ -10870,11 +10850,7 @@ void PrivateInstanceAAMP::SetTextTrack(int trackId, char *data)
 				if (track.isCC)
 				{
 					mIsInbandCC = true;
-					// Remember that the application explicitly chose an in-band
-					// CC track so MPD SelectSubtitleTrack can skip its
-					// "auto-pick first subtitle adaptation" path on the next
-					// retune and avoid clobbering mIsInbandCC back to false.
-					mAppSelectedInbandCC = true;
+					SetPreferredTextTrack(track);
 					if (!track.instreamId.empty())
 					{
 						CCFormat format = eCLOSEDCAPTION_FORMAT_DEFAULT;
@@ -10892,13 +10868,6 @@ void PrivateInstanceAAMP::SetTextTrack(int trackId, char *data)
 							}
 						}
 
-						// preferredCEA708 overrides whatever we infer from track. USE WITH CAUTION
-						int overrideCfg = GETCONFIGVALUE_PRIV(eAAMPConfig_CEAPreferred);
-						if (overrideCfg != -1)
-						{
-							format = (CCFormat)(overrideCfg & 1);
-							AAMPLOG_WARN("PrivateInstanceAAMP: CC format override present, override format to: %d", format);
-						}
 						PlayerCCManager::GetInstance()->SetTrack(track.instreamId, format);
 					}
 					else
@@ -10909,7 +10878,6 @@ void PrivateInstanceAAMP::SetTextTrack(int trackId, char *data)
 				else
 				{
 					mIsInbandCC = false;
-					mAppSelectedInbandCC = false;
 					//Unmute subtitles
 					SetCCStatus(true);
 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1160,7 +1160,6 @@ public:
 	double mLLActualOffset;				/**< Actual Offset After Seeking in LL Mode*/
 	bool mIsStream4K;                  /**< Identify whether live playing stream is 4K or not; reset on every retune*/
 	bool mIsInbandCC;                   /** Indicate inband cc or out of band cc is selected*/
-	bool mAppSelectedInbandCC;          /**< True when the application explicitly selected an in-band CC track via SetTextTrack; persists across retunes so MPD SelectSubtitleTrack will not overwrite the user's choice with an auto-picked subtitle adaptation set. */
 	std::string mFogDownloadFailReason; /** Identify Fog Manifest Download Failure Reason*/
 	int mBufferFor4kRampup; 		    /** Max Buffer for rampup used for 4k stream */
 	int mBufferFor4kRampdown; 	    /** Min Buffer for rampdown used for 4k Stream */

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -4208,5 +4208,12 @@ private:
 	void SetCMCDTrackData(AampMediaType mediaType);
 	std::vector<float> getSupportedPlaybackSpeeds(void);
 	bool IsFogUrl(const char *mainManifestUrl);
+
+	/**
+	 *   @fn SetCCStatusInternal
+	 *   @brief Set CC visibility on/off according to the current values of
+	 *          video_muted and subtitle_muted.
+	 */
+	void SetCCStatusInternal(void);
 };
 #endif // PRIVAAMP_H


### PR DESCRIPTION
…the in band CC flag

VPAAMP-565: Deprecate ceaFormat from AAMP Config

Reason for change : fix cc selection when both in-band and out-band cc is present as part of stream
Test procedure : see ticket
risks: Low