### PR TITLE
RDKEMW-20076: Fix for WPEWebProcess during deepsleep wakeup scenario

### DIFF
--- a/middleware/externals/rdk/IIarm/DeviceIARMInterface.cpp
+++ b/middleware/externals/rdk/IIarm/DeviceIARMInterface.cpp
@@ -240,8 +240,21 @@ void terminatePowerController()
 static void IARM_PowerChangeHandler (const PowerController_PowerState_t currentState,
                                       const PowerController_PowerState_t newState, void* userdata)
 {
+
 	MW_LOG_INFO("Entering IARM_PowerChangeHandler:State Changed currentState: %d, newState: %d",
 			currentState, newState);
+	
+
+	std::shared_ptr<PlayerExternalsRdkInterface> pInstance =
+		PlayerExternalsRdkInterface::GetPlayerExternalsRdkInterfaceInstance();
+	if (newState != POWER_STATE_ON) {
+		pInstance->SetPowerEvent(true);
+		MW_LOG_INFO(" Power transition to non-ON state, blocking HDMI events\n");
+	} else {
+		pInstance->SetPowerEvent(false);
+		MW_LOG_INFO(" Power transition to ON, allowing HDMI events\n");
+	}
+
 	bool isOnOrStandby = (newState == POWER_STATE_STANDBY || newState == POWER_STATE_ON);
 	if((currentState == POWER_STATE_STANDBY_DEEP_SLEEP && isOnOrStandby) || 
         (prevState == POWER_STATE_STANDBY_DEEP_SLEEP && currentState == POWER_STATE_STANDBY_LIGHT_SLEEP && isOnOrStandby))
@@ -408,6 +421,12 @@ static void HDMIEventHandler(const char *owner, IARM_EventId_t eventId, void *da
 {
     std::shared_ptr<PlayerExternalsRdkInterface> pInstance = PlayerExternalsRdkInterface::GetPlayerExternalsRdkInterfaceInstance();
 
+
+    if (pInstance->GetPowerEvent())
+    {
+        MW_LOG_WARN(" Skipping HDMI event processing during power transition\n");
+        return;
+    }
     switch (eventId)
     {
         case IARM_BUS_DSMGR_EVENT_HDMI_HOTPLUG :
@@ -421,6 +440,10 @@ static void HDMIEventHandler(const char *owner, IARM_EventId_t eventId, void *da
 
             pInstance->SetHDMIStatus();
 
+	    // Dispatch to detached worker thread — do NOT block IARM dispatch thread
+            std::thread([pInstance]() {
+                pInstance->SetHDMIStatus();
+            }).detach();
             break;
         }
         case IARM_BUS_DSMGR_EVENT_HDCP_STATUS :
@@ -432,6 +455,9 @@ static void HDMIEventHandler(const char *owner, IARM_EventId_t eventId, void *da
                       hdcpStatus, hdcpStatusStr);
 
             pInstance->SetHDMIStatus();
+	    std::thread([pInstance]() {
+                pInstance->SetHDMIStatus();
+            }).detach();
             break;
         }
         default:

--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.cpp
@@ -154,6 +154,11 @@ void PlayerExternalsRdkInterface::SetResolution(int width, int height)
  */
 void PlayerExternalsRdkInterface::SetHDMIStatus()
 {
+    std::unique_lock<std::mutex> lock(m_hdmiStatusMutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        MW_LOG_WARN("SetHDMIStatus: Already in progress on another thread, skipping\n");
+        return;
+    }
     bool                    isConnected              = false;
     bool                    isHDCPCompliant          = false;
     bool                    isHDCPEnabled            = true;
@@ -229,6 +234,7 @@ void PlayerExternalsRdkInterface::SetHDMIStatus()
     }
     catch (...) {
         MW_LOG_WARN("DeviceSettings exception caught\n");
+	try { device::Manager::DeInitialize(); } catch (...) {} 
     }
 
     m_isHDCPEnabled = isHDCPEnabled;

--- a/middleware/externals/rdk/PlayerExternalsRdkInterface.h
+++ b/middleware/externals/rdk/PlayerExternalsRdkInterface.h
@@ -37,7 +37,7 @@
 #include <memory>
 
 #include "PlayerExternalsInterfaceBase.h"
-
+#include <mutex>
  /*
 IARM Deprecation Note:
 IARM is to be deprecated in favor of DeviceSettings and Firebolt Device API.
@@ -60,6 +60,7 @@ class DeviceInterfaceBase;
 //class representing IARM interface in rdk
 class PlayerExternalsRdkInterface : public PlayerExternalsInterfaceBase
 {
+	std::mutex m_hdmiStatusMutex;
         enum InitState{
             NOT_INITIALIZED,
             FIREBOLT,


### PR DESCRIPTION
Update done to fix the crash that happens in deep sleep wakeup scenario , where the webprocess is unresponsive.


Once the HDMI hotplug event arrived, Instead of blocking the IARM thread with SetHDMIStatus() → dsDisplayInit → broken D-Bus, the callback would have returned immediately.
The spawned worker thread would have blocked on the broken IARM Bus, but this would NOT have caused the WPE watchdog to trigger SIGFPE, because the WebProcess main thread would have remained responsive.
This is the most impactful single fix for preventing the crash scenario observed.