### PR TITLE
VPAAMP-603 Revert wrong commit from Copilot to VPAAMP-457

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1323,11 +1323,8 @@ void MediaTrack::ProcessAndInjectFragment(CachedFragment *cachedFragment, bool f
 							// down into the subtec parser and forward the buffer unchanged. The
 							// subtec channel applies the offset to media_PTS so cue display time
 							// aligns with the restamped video PTS.
-											const std::string_view vttView{ptr, len};
-											const bool mpegtsIsZero = (vttView.find("MPEGTS:0") != std::string_view::npos);
-											mSubtitleParser->setPtsOffset(mpegtsIsZero ? 0.0 : cachedFragment->PTSOffsetSec);
-											mSubtitleParser->processData(
-												ptr, len, cachedFragment->position, cachedFragment->duration);
+							mSubtitleParser->setPtsOffset(cachedFragment->PTSOffsetSec);
+							mSubtitleParser->processData(ptr, len, cachedFragment->position, cachedFragment->duration);
 						}
 						break;
 					}
@@ -4119,13 +4116,13 @@ void StreamAbstractionAAMP::InitializeMediaProcessor(bool passThroughMode)
 				if (i != eMEDIATYPE_SUBTITLE)
 				{
 					track->playContext = std::make_shared<AampMp4Demuxer>(aamp, (AampMediaType)i, ISCONFIGSET(eAAMPConfig_EnablePTSReStamp));
-					
+
 					// Set playback rate
 					track->playContext->setRate(aamp->rate, PlayMode_normal);
-					
+
 					// Set trickplay FPS for the demuxer
 					int trickPlayFPS = aamp->mConfig->GetConfigValue(eAAMPConfig_VODTrickPlayFPS);
-					
+
 					track->playContext->setFrameRateForTM(trickPlayFPS);
 				}
 				else
@@ -4745,3 +4742,4 @@ void StreamAbstractionAAMP::ReinitializeInjection(double rate)
 		}
 	}
 }
+


### PR DESCRIPTION
When VPAAMP-457 was being delivered copilot made a bad suggestion that was accepted, this PR reverts that suggestion