### PR TITLE
RDKEMW-20121:[8.3p15s2,8.3p16s1]  WPEWebProcess crashed with fingerprint 80095400

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -69,7 +69,7 @@ static const char* GstPluginNameVMX = "aampverimatrixdecryptor";
 InterfacePlayerRDK::InterfacePlayerRDK() : mPlayerName(),
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
 mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL),
-mProgressCallbackContext(std::make_shared<ProgressCallbackContext>(this))
+mProgressCallbackContext(std::make_shared<ProgressCallbackContext>(this)), mStopInProgress(false)
 {
 	gstPrivateContext = new GstPlayerPriv();
 	m_gstConfigParam = new Configs();
@@ -689,8 +689,29 @@ gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
 			return G_SOURCE_REMOVE;
 		}
 		callbackContext->activeCallbacks++;
+		callbackContext->callbackThreadId = std::this_thread::get_id();
 		pInterfacePlayerRDK = callbackContext->player;
 	}
+
+	// RAII guard: decrements activeCallbacks, clears callbackThreadId, and
+	// notifies waiters on every exit path, including exceptions.
+	struct ActiveCallbackGuard
+	{
+		std::shared_ptr<ProgressCallbackContext> &ctx;
+		~ActiveCallbackGuard()
+		{
+			std::lock_guard<std::mutex> lock(ctx->mutex);
+			ctx->activeCallbacks--;
+			ctx->callbackThreadId = std::thread::id{};
+			// Unconditional: notify any waiter whenever the count reaches zero,
+			// regardless of the cancelled flag, so WaitForProgressCallbackCompletion
+			// always wakes even if it was called without a prior cancel signal.
+			if (0 == ctx->activeCallbacks)
+			{
+				ctx->cv.notify_all();
+			}
+		}
+	} guard{callbackContext};
 
 	if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
 	{
@@ -699,15 +720,10 @@ gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
 	pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
 	MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId);
 
-	{
-		std::lock_guard<std::mutex> lock(callbackContext->mutex);
-		callbackContext->activeCallbacks--;
-		if (callbackContext->cancelled && (0 == callbackContext->activeCallbacks))
-		{
-			callbackContext->cv.notify_all();
-		}
-	}
-	return G_SOURCE_CONTINUE;
+	// Re-check cancellation: if Stop() ran while we were in MonitorAV/TriggerEvent,
+	// return G_SOURCE_REMOVE so GLib does not attempt to re-arm an already-removed source.
+	std::lock_guard<std::mutex> lock(callbackContext->mutex);
+	return callbackContext->cancelled ? G_SOURCE_REMOVE : G_SOURCE_CONTINUE;
 }
 
 /**
@@ -729,6 +745,11 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 			reportProgressInterval *= 1000; //convert s to ms
 
 			auto callbackContext = pInterfacePlayerRDK->GetOrCreateProgressCallbackContext();
+			if (!callbackContext)
+			{
+    			MW_LOG_ERR("Failed to create progress callback context");
+    			return G_SOURCE_REMOVE;
+			}
 			auto *timerUserData = new std::weak_ptr<ProgressCallbackContext>(callbackContext);
 			GSourceFunc timerFunc = ProgressCallbackOnTimeout;
 			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId, timerUserData, "periodicProgressCallbackIdleTask", DestroyProgressCallbackUserData);
@@ -1314,7 +1335,17 @@ void InterfacePlayerRDK::TearDownStream(GstMediaType mediaType)
 
 void InterfacePlayerRDK::Stop(bool keepLastFrame)
 {
-	std::lock_guard<std::mutex> lock(mMutex);
+	std::unique_lock<std::mutex> lock(mMutex);
+	// Guard against double teardown: this flag is set while Stop() is executing
+	// teardown under mMutex. A concurrent Stop() on another thread, or a
+	// re-entrant Stop() called from the progress callback, will see this flag
+	// and return immediately rather than running teardown twice.
+	if (mStopInProgress)
+	{
+		MW_LOG_WARN("InterfacePlayerRDK::Stop called re-entrantly or concurrently - teardown already in progress, ignoring.");
+		return;
+	}
+	mStopInProgress = true;
 	/*  make the execution of this function more deterministic and
 	 *  reduce scope for potential pipeline lockups*/
 
@@ -1323,8 +1354,14 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	// Stop async worker before removing idle/timer tasks to prevent
 	// new tasks from being scheduled concurrently during teardown.
 	mScheduler.StopScheduler();
-	std::unique_lock<std::mutex> sourceSetupLock(mSourceSetupMutex);
-	mSourceSetupCV.notify_all();
+	{
+		// Scope the sourceSetupLock so it is released immediately after
+		// notify_all. Holding it longer blocks WaitForSourceSetup() callers
+		// from waking if the progress callback itself triggers buffer injection
+		// while we are blocked in WaitForProgressCallbackCompletion.
+		std::unique_lock<std::mutex> sourceSetupLock(mSourceSetupMutex);
+		mSourceSetupCV.notify_all();
+	}
 	if(gstPrivateContext->bus)
 	{
 		gst_bus_remove_watch(gstPrivateContext->bus);           /* Remove the watch from bus so that gstreamer no longer sends messages to it */
@@ -1338,7 +1375,18 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	}
 	this->IdleTaskRemove(gstPrivateContext->firstProgressCallbackIdleTask);
 
-	CancelProgressCallbackContext();
+	// Signal cancellation (fast, non-blocking) while still holding mMutex.
+	// Capture the returned context so that WaitForProgressCallbackCompletion
+	// operates on the exact same snapshot (no TOCTOU race).
+	auto progressCtx = SignalCancelProgressCallback();
+
+	// Release mMutex before blocking on the wait so that any in-flight progress
+	// callback that calls back into InterfacePlayerRDK under mMutex can complete
+	// without deadlocking.
+	lock.unlock();
+	WaitForProgressCallbackCompletion(progressCtx);
+	lock.lock();
+
 	if (gstPrivateContext->bufferingTimeoutTimerId)
 	{
 		MW_LOG_MIL("InterfacePlayerRDK: Remove bufferingTimeoutTimerId %d", gstPrivateContext->bufferingTimeoutTimerId);
@@ -1418,6 +1466,7 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 
 	// Restart scheduler so the same InterfacePlayerRDK instance can be reused.
 	mScheduler.StartScheduler();
+	mStopInProgress = false;
 }
 
 void InterfacePlayerRDK::ResetGstEvents()
@@ -3509,6 +3558,20 @@ std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::GetOrCreateProgress
 
 void InterfacePlayerRDK::CancelProgressCallbackContext()
 {
+	// Called from the destructor where mMutex is not held, so it is safe
+	// to call both phases in sequence without any unlock/relock dance.
+	auto ctx = SignalCancelProgressCallback();
+	WaitForProgressCallbackCompletion(ctx);
+}
+
+// Marks the current progress callback context as cancelled, removes the
+// GLib timer, and returns the snapshotted shared_ptr so the caller can pass
+// the exact same context to WaitForProgressCallbackCompletion() without a
+// second TaskControlMutex acquisition (eliminates the TOCTOU window).
+// This function is intentionally non-blocking so it can be called while
+// holding mMutex without risking deadlock.
+std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::SignalCancelProgressCallback()
+{
 	std::shared_ptr<ProgressCallbackContext> callbackContext;
 	{
 		std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
@@ -3517,7 +3580,7 @@ void InterfacePlayerRDK::CancelProgressCallbackContext()
 
 	if (!callbackContext)
 	{
-		return;
+		return nullptr;
 	}
 
 	{
@@ -3527,14 +3590,48 @@ void InterfacePlayerRDK::CancelProgressCallbackContext()
 	}
 
 	this->TimerRemove(gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
+	return callbackContext;
+}
 
-	std::unique_lock<std::mutex> lock(callbackContext->mutex);
-	if (!callbackContext->cv.wait_for(lock, std::chrono::seconds(5), [&callbackContext]() {
-		return 0 == callbackContext->activeCallbacks;
-	})) {
-		MW_LOG_WARN("Teardown timeout: callback context still has active callbacks (%zu). Possible I/O blockage or deadlock detected.", callbackContext->activeCallbacks);
+// Blocks until the progress callback context has no active invocations and
+// then resets mProgressCallbackContext.
+//
+// MUST NOT be called while mMutex is held except when called re-entrantly
+// from within the progress callback itself (e.g. the app calls Stop() from
+// inside its progress callback). In that re-entrant case the current thread
+// already owns the active invocation that we would be waiting for, so waiting
+// would deadlock permanently. We detect this with callbackThreadId and return
+// immediately; the RAII guard in ProgressCallbackOnTimeout will decrement
+// activeCallbacks and reset the context once the callback stack unwinds.
+//
+// The caller must pass the shared_ptr returned by SignalCancelProgressCallback()
+// so that both functions operate on the same snapshot and avoid a TOCTOU race.
+void InterfacePlayerRDK::WaitForProgressCallbackCompletion(std::shared_ptr<ProgressCallbackContext> callbackContext)
+{
+	if (!callbackContext)
+	{
+		return;
 	}
-	lock.unlock();
+
+	{
+		std::unique_lock<std::mutex> lock(callbackContext->mutex);
+		// Re-entrancy guard: if the calling thread is the same thread that is
+		// currently executing the progress callback, waiting would deadlock
+		// because the RAII guard that decrements activeCallbacks lives above us
+		// on this very call stack.
+		if (callbackContext->callbackThreadId == std::this_thread::get_id())
+		{
+			MW_LOG_WARN("WaitForProgressCallbackCompletion called re-entrantly from the progress callback thread. "
+				"Stop() must not be called from within a progress callback. Skipping wait; "
+				"cleanup will complete when the callback stack unwinds.");
+			return;
+		}
+		// Indefinite wait: safe because mMutex is NOT held here, so any
+		// re-entrant callbacks that acquire mMutex will complete normally.
+		callbackContext->cv.wait(lock, [&callbackContext]() {
+			return 0 == callbackContext->activeCallbacks;
+		});
+	}
 
 	std::lock_guard<std::mutex> taskLock(gstPrivateContext->TaskControlMutex);
 	if (mProgressCallbackContext == callbackContext)

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -69,7 +69,7 @@ static const char* GstPluginNameVMX = "aampverimatrixdecryptor";
 InterfacePlayerRDK::InterfacePlayerRDK() : mPlayerName(),
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
 mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL),
-mProgressCallbackContext(std::make_shared<ProgressCallbackContext>(this)), mStopInProgress(false)
+mStopInProgress(false), mProgressCallbackContext(nullptr)
 {
 	gstPrivateContext = new GstPlayerPriv();
 	m_gstConfigParam = new Configs();
@@ -664,7 +664,8 @@ void MonitorAV( InterfacePlayerRDK *pInterfacePlayerRDK )
 
 /**
  * @brief Timer's callback to notify playback progress event
- * @param[in] user_data pointer to InterfacePlayerRDK instance
+ * @param[in] user_data pointer to std::weak_ptr<ProgressCallbackContext>
+ *            allocated in IdleCallback and released via destroy notify
  * @retval G_SOURCE_CONTINUE, this function to be called periodically
  */
 gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
@@ -3602,7 +3603,7 @@ std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::SignalCancelProgres
 // already owns the active invocation that we would be waiting for, so waiting
 // would deadlock permanently. We detect this with callbackThreadId and return
 // immediately; the RAII guard in ProgressCallbackOnTimeout will decrement
-// activeCallbacks and reset the context once the callback stack unwinds.
+// activeCallbacks and notify waiters once the callback stack unwinds.
 //
 // The caller must pass the shared_ptr returned by SignalCancelProgressCallback()
 // so that both functions operate on the same snapshot and avoid a TOCTOU race.

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -68,7 +68,8 @@ static const char* GstPluginNameVMX = "aampverimatrixdecryptor";
 /*InterfacePlayerRDK constructor*/
 InterfacePlayerRDK::InterfacePlayerRDK() : mPlayerName(),
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
-mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL)
+mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL),
+mProgressCallbackContext(std::make_shared<ProgressCallbackContext>(this))
 {
 	gstPrivateContext = new GstPlayerPriv();
 	m_gstConfigParam = new Configs();
@@ -84,6 +85,7 @@ mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSys
 /* InterfacePlayerRDK destructor*/
 InterfacePlayerRDK::~InterfacePlayerRDK()
 {
+	CancelProgressCallbackContext();
 	DestroyPipeline();
 	if (mDrmSystem)
 	{
@@ -667,15 +669,43 @@ void MonitorAV( InterfacePlayerRDK *pInterfacePlayerRDK )
  */
 gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
 {
-	InterfacePlayerRDK *pInterfacePlayerRDK = (InterfacePlayerRDK *)user_data;
-	if (pInterfacePlayerRDK)
+	auto *weakContext = static_cast<std::weak_ptr<ProgressCallbackContext> *>(user_data);
+	if (!weakContext)
 	{
-		if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
+		return G_SOURCE_REMOVE;
+	}
+
+	auto callbackContext = weakContext->lock();
+	if (!callbackContext)
+	{
+		return G_SOURCE_REMOVE;
+	}
+
+	InterfacePlayerRDK *pInterfacePlayerRDK = nullptr;
+	{
+		std::unique_lock<std::mutex> lock(callbackContext->mutex);
+		if (callbackContext->cancelled || !callbackContext->player)
 		{
-			MonitorAV(pInterfacePlayerRDK);
+			return G_SOURCE_REMOVE;
 		}
-		pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
-		MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+		callbackContext->activeCallbacks++;
+		pInterfacePlayerRDK = callbackContext->player;
+	}
+
+	if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
+	{
+		MonitorAV(pInterfacePlayerRDK);
+	}
+	pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
+	MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+
+	{
+		std::lock_guard<std::mutex> lock(callbackContext->mutex);
+		callbackContext->activeCallbacks--;
+		if (callbackContext->cancelled && (0 == callbackContext->activeCallbacks))
+		{
+			callbackContext->cv.notify_all();
+		}
 	}
 	return G_SOURCE_CONTINUE;
 }
@@ -698,8 +728,10 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 			double  reportProgressInterval = pInterfacePlayerRDK->m_gstConfigParam->progressTimer;
 			reportProgressInterval *= 1000; //convert s to ms
 
+			auto callbackContext = pInterfacePlayerRDK->GetOrCreateProgressCallbackContext();
+			auto *timerUserData = new std::weak_ptr<ProgressCallbackContext>(callbackContext);
 			GSourceFunc timerFunc = ProgressCallbackOnTimeout;
-			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId, user_data, "periodicProgressCallbackIdleTask");
+			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId, timerUserData, "periodicProgressCallbackIdleTask", DestroyProgressCallbackUserData);
 		}
 		else
 		{
@@ -1288,6 +1320,9 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 
 	gstPrivateContext->syncControl.disable();
 	gstPrivateContext->aSyncControl.disable();
+	// Stop async worker before removing idle/timer tasks to prevent
+	// new tasks from being scheduled concurrently during teardown.
+	mScheduler.StopScheduler();
 	std::unique_lock<std::mutex> sourceSetupLock(mSourceSetupMutex);
 	mSourceSetupCV.notify_all();
 	if(gstPrivateContext->bus)
@@ -1303,7 +1338,7 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	}
 	this->IdleTaskRemove(gstPrivateContext->firstProgressCallbackIdleTask);
 
-	this->TimerRemove(gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
+	CancelProgressCallbackContext();
 	if (gstPrivateContext->bufferingTimeoutTimerId)
 	{
 		MW_LOG_MIL("InterfacePlayerRDK: Remove bufferingTimeoutTimerId %d", gstPrivateContext->bufferingTimeoutTimerId);
@@ -1380,6 +1415,9 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	gstPrivateContext->videoMuted = false;
 	gstPrivateContext->subtitleMuted = false;
 	gstPrivateContext->audioVolume = 1.0;
+
+	// Restart scheduler so the same InterfacePlayerRDK instance can be reused.
+	mScheduler.StartScheduler();
 }
 
 void InterfacePlayerRDK::ResetGstEvents()
@@ -3446,24 +3484,106 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
 /**
  *  @brief TimerAdd - add a new glib timer in thread safe manner
  */
-void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName)
+std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::GetOrCreateProgressCallbackContext()
+{
+	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+	bool createNewContext = false;
+	if (!mProgressCallbackContext)
+	{
+		createNewContext = true;
+	}
+	else
+	{
+		std::lock_guard<std::mutex> contextLock(mProgressCallbackContext->mutex);
+		if (mProgressCallbackContext->cancelled)
+		{
+			createNewContext = true;
+		}
+	}
+	if (createNewContext)
+	{
+		mProgressCallbackContext = std::make_shared<ProgressCallbackContext>(this);
+	}
+	return mProgressCallbackContext;
+}
+
+void InterfacePlayerRDK::CancelProgressCallbackContext()
+{
+	std::shared_ptr<ProgressCallbackContext> callbackContext;
+	{
+		std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+		callbackContext = mProgressCallbackContext;
+	}
+
+	if (!callbackContext)
+	{
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(callbackContext->mutex);
+		callbackContext->cancelled = true;
+		callbackContext->player = nullptr;
+	}
+
+	this->TimerRemove(gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
+
+	std::unique_lock<std::mutex> lock(callbackContext->mutex);
+	if (!callbackContext->cv.wait_for(lock, std::chrono::seconds(5), [&callbackContext]() {
+		return 0 == callbackContext->activeCallbacks;
+	})) {
+		MW_LOG_WARN("Teardown timeout: callback context still has active callbacks (%zu). Possible I/O blockage or deadlock detected.", callbackContext->activeCallbacks);
+	}
+	lock.unlock();
+
+	std::lock_guard<std::mutex> taskLock(gstPrivateContext->TaskControlMutex);
+	if (mProgressCallbackContext == callbackContext)
+	{
+		mProgressCallbackContext.reset();
+	}
+}
+
+void InterfacePlayerRDK::DestroyProgressCallbackUserData(gpointer user_data)
+{
+	delete static_cast<std::weak_ptr<ProgressCallbackContext> *>(user_data);
+}
+
+void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName, GDestroyNotify destroyNotify)
 {
 	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
 	if (funcPtr && user_data)
 	{
 		if (0 == taskId)
 		{
-			/* Sets the function pointed by functPtr to be called at regular intervals of repeatTimeout, supplying user_data to the function */
-			taskId = g_timeout_add(repeatTimeout, funcPtr, user_data);
+			if (destroyNotify)
+			{
+				taskId = g_timeout_add_full(G_PRIORITY_DEFAULT, repeatTimeout, funcPtr, user_data, destroyNotify);
+				if (0 == taskId)
+				{
+					destroyNotify(user_data);
+				}
+			}
+			else
+			{
+				taskId = g_timeout_add(repeatTimeout, funcPtr, user_data);
+			}
 			MW_LOG_INFO("InterfacePlayerRDK: Added timer '%.50s', %d", (nullptr!=timerName) ? timerName : "unknown" , taskId);
 		}
 		else
 		{
+			if (destroyNotify)
+			{
+				destroyNotify(user_data);
+			}
 			MW_LOG_INFO("InterfacePlayerRDK: Timer '%.50s' already added, taskId=%d", (nullptr!=timerName) ? timerName : "unknown", taskId);
 		}
 	}
 	else
 	{
+		if (destroyNotify && user_data)
+		{
+			destroyNotify(user_data);
+		}
 		MW_LOG_ERR("Bad pointer. funcPtr = %p, user_data=%p",funcPtr,user_data);
 	}
 }
@@ -3616,7 +3736,7 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 {
 	auto it = callbackMap.find(event);
-	if (it != callbackMap.end())
+	if ((it != callbackMap.end()) && it->second)
 	{
 		it->second();
 	}
@@ -3628,7 +3748,7 @@ void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event, int data)
 {
 	auto it = setupStreamCallbackMap.find(event);
-	if (it != setupStreamCallbackMap.end())
+	if ((it != setupStreamCallbackMap.end()) && it->second)
 	{
 		it->second(data);
 	}

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -740,7 +740,9 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 		pInterfacePlayerRDK->TriggerEvent(InterfaceCB::idleCb);
 		pInterfacePlayerRDK->IdleTaskClearFlags(pInterfacePlayerRDK->gstPrivateContext->firstProgressCallbackIdleTask);
 
-		if ( !(pInterfacePlayerRDK->TimerIsRunning( pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId)) && (pInterfacePlayerRDK->callbackMap[InterfaceCB::progressCb] != nullptr) )
+		auto progressCbIt = pInterfacePlayerRDK->callbackMap.find(InterfaceCB::progressCb);
+		const bool hasProgressCb = (progressCbIt != pInterfacePlayerRDK->callbackMap.end()) && (progressCbIt->second != nullptr);
+		if ( !(pInterfacePlayerRDK->TimerIsRunning( pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId)) && hasProgressCb )
 		{
 			double  reportProgressInterval = pInterfacePlayerRDK->m_gstConfigParam->progressTimer;
 			reportProgressInterval *= 1000; //convert s to ms
@@ -3834,14 +3836,19 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 {
 	auto it = callbackMap.find(event);
-	if ((it != callbackMap.end()) && it->second)
+	if (it == callbackMap.end())
 	{
-		it->second();
+		MW_LOG_ERR("Unknown event %d - callback key not registered", static_cast<int>(event));
+		return;
 	}
-	else
+
+	if (!it->second)
 	{
-		MW_LOG_ERR("Unknown event - No callback registered!");
+		MW_LOG_TRACE("Event %d callback intentionally unset; skipping invocation", static_cast<int>(event));
+		return;
 	}
+
+	it->second();
 }
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event, int data)
 {

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -38,6 +38,7 @@
 #include <condition_variable>
 #include <chrono>
 #include <memory>
+#include <thread>
 #include "GstUtils.h"
 #include <any>
 #include "SocUtils.h"
@@ -51,9 +52,13 @@ struct ProgressCallbackContext
 	InterfacePlayerRDK *player;
 	bool cancelled;
 	size_t activeCallbacks;
+	// Tracks the thread currently executing the progress callback so that
+	// WaitForProgressCallbackCompletion() can detect re-entrant Stop() calls
+	// from within the callback and avoid a self-deadlock.
+	std::thread::id callbackThreadId;
 
 	explicit ProgressCallbackContext(InterfacePlayerRDK *playerInstance)
-		: player(playerInstance), cancelled(false), activeCallbacks(0)
+		: player(playerInstance), cancelled(false), activeCallbacks(0), callbackThreadId()
 	{
 	}
 };
@@ -377,12 +382,17 @@ class InterfacePlayerRDK
 private:
 	bool trickTeardown;
 	std::mutex mMutex;
+	// Prevents double teardown when Stop() is called concurrently or
+	// re-entrantly from the progress callback. Protected by mMutex.
+	bool mStopInProgress;
 	std::map<std::string, int> configMap;
 	PlayerScheduler mScheduler;
 	std::shared_ptr<ProgressCallbackContext> mProgressCallbackContext;
 
 	std::shared_ptr<ProgressCallbackContext> GetOrCreateProgressCallbackContext();
 	void CancelProgressCallbackContext();
+	std::shared_ptr<ProgressCallbackContext> SignalCancelProgressCallback();
+	void WaitForProgressCallbackCompletion(std::shared_ptr<ProgressCallbackContext> callbackContext);
 	static void DestroyProgressCallbackUserData(gpointer user_data);
 
 public:

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -1083,6 +1083,9 @@ public:
 	 * @param[in] repeatTimeout timeout between calls in ms
 	 * @param[in] user_data data to pass to the timer function
 	 * @param[in] timerName name of the timer being added
+	 * @param[in] destroyNotify cleanup callback for user_data ownership. It is
+	 *            passed to GLib when the timer is created, and is invoked
+	 *            immediately by TimerAdd if the timer cannot be added.
 	 * @param[out] taskId id of the timer to be returned
 	 */
 	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr, GDestroyNotify destroyNotify = nullptr);

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -37,9 +37,26 @@
 #include <functional>
 #include <condition_variable>
 #include <chrono>
+#include <memory>
 #include "GstUtils.h"
 #include <any>
 #include "SocUtils.h"
+
+class InterfacePlayerRDK;
+
+struct ProgressCallbackContext
+{
+	std::mutex mutex;
+	std::condition_variable cv;
+	InterfacePlayerRDK *player;
+	bool cancelled;
+	size_t activeCallbacks;
+
+	explicit ProgressCallbackContext(InterfacePlayerRDK *playerInstance)
+		: player(playerInstance), cancelled(false), activeCallbacks(0)
+	{
+	}
+};
 
 /**
  * @enum eGstPlayFlags
@@ -362,6 +379,11 @@ private:
 	std::mutex mMutex;
 	std::map<std::string, int> configMap;
 	PlayerScheduler mScheduler;
+	std::shared_ptr<ProgressCallbackContext> mProgressCallbackContext;
+
+	std::shared_ptr<ProgressCallbackContext> GetOrCreateProgressCallbackContext();
+	void CancelProgressCallbackContext();
+	static void DestroyProgressCallbackUserData(gpointer user_data);
 
 public:
 	std::shared_ptr<SocInterface> socInterface;
@@ -1053,7 +1075,7 @@ public:
 	 * @param[in] timerName name of the timer being added
 	 * @param[out] taskId id of the timer to be returned
 	 */
-	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr);
+	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr, GDestroyNotify destroyNotify = nullptr);
 	/**
 	 * @fn TimerIsRunning
 	 * @param[in] taskId id of the timer to be removed

--- a/middleware/PlayerScheduler.cpp
+++ b/middleware/PlayerScheduler.cpp
@@ -173,23 +173,38 @@ void PlayerScheduler::RemoveAllTasks()
 void PlayerScheduler::StopScheduler()
 {
 	MW_LOG_WARN("Stopping Async Worker Thread");
+	const bool calledFromSchedulerThread =
+		(mSchedulerThread.joinable() && (std::this_thread::get_id() == mSchedulerThread.get_id()));
+	bool suspendedHere = false;
+
+	if (calledFromSchedulerThread)
+	{
+		MW_LOG_WARN("StopScheduler invoked from scheduler thread; skipping SuspendScheduler and join to avoid self-deadlock");
+	}
+
 	// Clean up things in queue
 	mSchedulerRunning = false;
 
 	//allow StopScheduler() to be called without warning from a nonsuspended state and
 	//not cause an error in ResumeScheduler() below due to trying to unlock an unlocked lock
-	if(!mLockOut)
+	if(!calledFromSchedulerThread && !mLockOut)
 	{
 		SuspendScheduler();
+		suspendedHere = true;
 	}
 
 	RemoveAllTasks();
 
 	//prevent possible deadlock where mSchedulerThread is waiting for mExLock/mExMutex
-	ResumeScheduler();
+	if (suspendedHere)
+	{
+		ResumeScheduler();
+	}
 	mQCond.notify_one();
-    if (mSchedulerThread.joinable())
-        mSchedulerThread.join();
+	if (mSchedulerThread.joinable() && !calledFromSchedulerThread)
+	{
+		mSchedulerThread.join();
+	}
 }
 
 /**

--- a/test/utests/fakes/FakeGLib.cpp
+++ b/test/utests/fakes/FakeGLib.cpp
@@ -234,7 +234,14 @@ int g_strcmp0(const char *str1, const char *str2)
 
 guint g_timeout_add_full(gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify)
 {
-	return 0;
+	guint retval = 0;
+
+	if (g_mockGLib != nullptr)
+	{
+		retval = g_mockGLib->g_timeout_add_full(priority, interval, function, data, notify);
+	}
+
+	return retval;
 }
 
 void g_usleep(gulong microseconds)

--- a/test/utests/fakes/FakePlayerExternalsInterface.cpp
+++ b/test/utests/fakes/FakePlayerExternalsInterface.cpp
@@ -110,8 +110,10 @@ bool PlayerExternalsInterface::IsActiveStreamingInterfaceWifi(void)
 /**
  * @brief initilaize IARM
  */
-void PlayerExternalsInterface::IARMInit(const char* processName)
+void PlayerExternalsInterface::IARMInit(const char* processName, bool powerEvt)
 {
+    (void)processName;
+    (void)powerEvt;
 }
 
 /**

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -29,7 +29,7 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 }
 
 
-	PlayerInstanceAAMP::PlayerInstanceAAMP(StreamSink* streamSink, std::function< void(const unsigned char *, int, int, int) > exportFrames) {  }
+	PlayerInstanceAAMP::PlayerInstanceAAMP(StreamSink* streamSink, std::function< void(const unsigned char *, int, int, int) > exportFrames, bool powerEvt) { (void)streamSink; (void)exportFrames; (void)powerEvt; }
 	PlayerInstanceAAMP::~PlayerInstanceAAMP() {  }
 
 	void PlayerInstanceAAMP::Tune(const char *mainManifestUrl,

--- a/test/utests/mocks/MockGLib.h
+++ b/test/utests/mocks/MockGLib.h
@@ -31,6 +31,7 @@ class MockGLib
 public:
 	MOCK_METHOD(GParamSpec*, g_object_class_find_property, (GObjectClass* oclass, const gchar* property_name));
 	MOCK_METHOD(guint, g_timeout_add, (guint interval, GSourceFunc function, gpointer data));
+	MOCK_METHOD(guint, g_timeout_add_full, (gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify));
 	MOCK_METHOD(gboolean, g_source_remove, (guint tag));
 	MOCK_METHOD(gpointer, g_malloc, (gsize n_bytes));
 	MOCK_METHOD(void, g_free, (gpointer mem));

--- a/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
+++ b/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
@@ -86,7 +86,13 @@ protected:
 
 	void TearDown() override
 	{
-		ReleaseCapturedTimerUserData();
+		// Free timer user_data allocated in IdleCallback via captured destroy notify.
+		if (capturedDestroyNotify && capturedUserData)
+		{
+			capturedDestroyNotify(capturedUserData);
+			capturedUserData = nullptr;
+			capturedDestroyNotify = nullptr;
+		}
 
 		// Clean up player
 		// Note: We delete m_gstConfigParam because we allocated it in SetUp
@@ -120,18 +126,21 @@ protected:
 	 */
 	void SetupTimerMocks()
 {
-    ON_CALL(*g_mockGLib, g_timeout_add(_, _, _))
-        .WillByDefault(Invoke([this](guint interval,
-                                     GSourceFunc function,
-                                     void* userData) -> guint
-        {
-            // Capture the callback and user data
-            capturedTimerFunc = function;
-            capturedUserData = userData;
+	ON_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, _, _))
+		.WillByDefault(Invoke([this](gint,
+		                             guint,
+		                             GSourceFunc function,
+		                             gpointer userData,
+		                             GDestroyNotify notify) -> guint
+		{
+			// Capture timer callback and cleanup hook for explicit test teardown.
+			capturedTimerFunc = function;
+			capturedUserData = userData;
+			capturedDestroyNotify = notify;
 
-            // Return a unique timer ID
-            return ++capturedTimerId;
-        }));
+			// Return a unique timer ID
+			return ++capturedTimerId;
+		}));
 }
 
 
@@ -208,7 +217,11 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
 	// Expect that timer is added exactly once
 	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
 		.Times(1)
-		.WillOnce(Return(123)); // Fake timer ID
+		.WillOnce(DoAll(
+			SaveArg<2>(&capturedTimerFunc),
+			SaveArg<3>(&capturedUserData),
+			SaveArg<4>(&capturedDestroyNotify),
+			Return(123))); // Fake timer ID
 
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
@@ -235,7 +248,11 @@ TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullProgressCb_
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
-		.WillOnce(Return(123));
+		.WillOnce(DoAll(
+			SaveArg<2>(&capturedTimerFunc),
+			SaveArg<3>(&capturedUserData),
+			SaveArg<4>(&capturedDestroyNotify),
+			Return(123)));
 	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
 	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
 
@@ -280,7 +297,11 @@ TEST_F(InterfacePlayerRDKCallbackTest, CallbacksUnregistered_ThenTriggered_DoesN
 		.WillRepeatedly(Return(FALSE));
 	SetupTimerMocks();
 	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
-		.WillOnce(Return(123));
+		.WillOnce(DoAll(
+			SaveArg<2>(&capturedTimerFunc),
+			SaveArg<3>(&capturedUserData),
+			SaveArg<4>(&capturedDestroyNotify),
+			Return(123)));
 
 	// Schedule while callbacks are still registered
 	gboolean idleResult = InterfacePlayerRDK::IdleCallback(m_player);
@@ -337,7 +358,11 @@ TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_AfterStop_Remov
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(TRUE));
 	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
-		.WillOnce(Return(123));
+		.WillOnce(DoAll(
+			SaveArg<2>(&capturedTimerFunc),
+			SaveArg<3>(&capturedUserData),
+			SaveArg<4>(&capturedDestroyNotify),
+			Return(123)));
 
 	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
 	m_player->Stop(false);

--- a/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
+++ b/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
@@ -58,7 +58,8 @@ protected:
 	guint capturedTimerId;
 	GSourceFunc capturedTimerFunc;
 	gpointer capturedUserData;
-	
+	GDestroyNotify capturedDestroyNotify;
+
 	void SetUp() override
 	{
 		// Setup mocks
@@ -80,10 +81,13 @@ protected:
 		capturedTimerId = 0;
 		capturedTimerFunc = nullptr;
 		capturedUserData = nullptr;
+		capturedDestroyNotify = nullptr;
 	}
-	
+
 	void TearDown() override
 	{
+		ReleaseCapturedTimerUserData();
+
 		// Clean up player
 		// Note: We delete m_gstConfigParam because we allocated it in SetUp
 		if (m_player)
@@ -150,9 +154,9 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_NullProgressCb_DoesNotSetupT
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	
-	// Expect that g_timeout_add_full is NOT called (no timer should be added)
-	EXPECT_CALL(*g_mockGLib, g_timeout_add(_, _, _)) .Times(0);
-	
+	// Expect that no timer should be added
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, _, _)).Times(0);
+
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
 	
@@ -201,17 +205,18 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	
-	// Expect that timer is added exactly once using the available mock method 
-	EXPECT_CALL(*g_mockGLib, g_timeout_add(_,_, NotNull()))
+	// Expect that timer is added exactly once
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
 		.Times(1)
 		.WillOnce(Return(123)); // Fake timer ID
-	
+
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
-	
+
 	// Assert: Timer function should be captured
 	EXPECT_NE(capturedTimerFunc, nullptr);
-	EXPECT_EQ(capturedUserData, m_player);
+	EXPECT_NE(capturedUserData, nullptr);
+	EXPECT_NE(capturedDestroyNotify, nullptr);
 	EXPECT_EQ(result, G_SOURCE_REMOVE);
 }
 
@@ -224,15 +229,22 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
  */
 TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullProgressCb_DoesNotCrash)
 {
-	// Arrange: Set progressCb to nullptr (simulating unregistered callback)
+	// Arrange: Schedule timer while callback is registered, then unregister it
+	m_player->callbackMap[InterfaceCB::progressCb] = []() {};
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
+		.WillRepeatedly(Return(FALSE));
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
 	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
-	
+
 	// Disable AV monitoring to simplify test
 	m_player->m_gstConfigParam->monitorAV = false;
-	
-	// Act: Call ProgressCallbackOnTimeout - should not crash
-	gboolean result = InterfacePlayerRDK::ProgressCallbackOnTimeout(m_player);
-	
+
+	// Act: Fire the already-scheduled timeout
+	gboolean result = capturedTimerFunc(capturedUserData);
+
 	// Assert: Should return G_SOURCE_CONTINUE (periodic timer continues)
 	EXPECT_EQ(result, G_SOURCE_CONTINUE);
 }
@@ -260,22 +272,24 @@ TEST_F(InterfacePlayerRDKCallbackTest, CallbacksUnregistered_ThenTriggered_DoesN
 		idleCalled = true;
 	};
 	
-	// Simulate callbacks being unregistered (as would happen in UnregisterFirstFrameCallbacks)
-	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
-	m_player->callbackMap[InterfaceCB::idleCb] = nullptr;
-	
 	// Disable AV monitoring
 	m_player->m_gstConfigParam->monitorAV = false;
-	
+
 	// Mock timer operations
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
-	
-	// Act: Trigger callbacks that might have been scheduled before unregistration
-	// This should not crash even though callbacks are now nullptr
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+
+	// Schedule while callbacks are still registered
 	gboolean idleResult = InterfacePlayerRDK::IdleCallback(m_player);
-	gboolean progressResult = InterfacePlayerRDK::ProgressCallbackOnTimeout(m_player);
-	
+	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
+	m_player->callbackMap[InterfaceCB::idleCb] = nullptr;
+
+	// Act: Trigger a timeout that was already scheduled before unregistration
+	gboolean progressResult = capturedTimerFunc(capturedUserData);
+
 	// Assert: Both should return without crashing
 	EXPECT_EQ(idleResult, G_SOURCE_REMOVE);
 	EXPECT_EQ(progressResult, G_SOURCE_CONTINUE);
@@ -306,9 +320,30 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_NullPlayer_DoesNotCrash)
  */
 TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullPlayer_DoesNotCrash)
 {
-	// Act: Call with nullptr player
+	// Act: Call with nullptr user data
 	gboolean result = InterfacePlayerRDK::ProgressCallbackOnTimeout(nullptr);
-	
-	// Assert: Should return G_SOURCE_CONTINUE safely
-	EXPECT_EQ(result, G_SOURCE_CONTINUE);
+
+	// Assert: Should remove the timer safely
+	EXPECT_EQ(result, G_SOURCE_REMOVE);
+}
+
+TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_AfterStop_RemovesTimerSafely)
+{
+	bool progressCalled = false;
+	m_player->callbackMap[InterfaceCB::progressCb] = [&progressCalled]() {
+		progressCalled = true;
+	};
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
+		.WillRepeatedly(Return(TRUE));
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+
+	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
+	m_player->Stop(false);
+
+	gboolean result = capturedTimerFunc(capturedUserData);
+
+	EXPECT_EQ(result, G_SOURCE_REMOVE);
+	EXPECT_FALSE(progressCalled);
 }


### PR DESCRIPTION
RDKEMW-20121:[8.3p15s2,8.3p16s1]  WPEWebProcess crashed with fingerprint 80095400
Reason for change : Added fix for the race condition by using weakpointer instead of raw pointer
Priority : P1
Test Steps: Mentioned in ticket
Signed off by : Nejuma T N <nejumatn28@gmail.com>