### PR TITLE
Feature/vplay 11407 1 (#659)

### DIFF
--- a/AampEventManager.cpp
+++ b/AampEventManager.cpp
@@ -121,7 +121,10 @@ void AampEventManager::AddListenerForAllEvents(EventListener* eventListener)
 {
 	if(eventListener != NULL)
 	{
-		AddEventListener(AAMP_EVENT_ALL_EVENTS,eventListener);
+		std::shared_ptr<EventListener> sharedListener(eventListener, [](EventListener* ptr) {
+			// No-op deleter to avoid accidental deletion
+		});
+		AddEventListener(AAMP_EVENT_ALL_EVENTS,sharedListener);
 	}
 	else
 	{
@@ -136,7 +139,10 @@ void AampEventManager::RemoveListenerForAllEvents(EventListener* eventListener)
 {
 	if(eventListener != NULL)
 	{
-		RemoveEventListener(AAMP_EVENT_ALL_EVENTS,eventListener);
+		std::shared_ptr<EventListener> sharedListener(eventListener, [](EventListener* ptr) {
+		// No-op deleter to avoid accidental deletion
+		});
+		RemoveEventListener(AAMP_EVENT_ALL_EVENTS,sharedListener);
 	}
 	else
 	{
@@ -146,15 +152,15 @@ void AampEventManager::RemoveListenerForAllEvents(EventListener* eventListener)
 
 /**
  * @brief AddEventListener - Register  listener for one eventtype
- */ 
-void AampEventManager::AddEventListener(AAMPEventType eventType, EventListener* eventListener)
+ */
+void AampEventManager::AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 	if ((eventListener != NULL) && (eventType >= AAMP_EVENT_ALL_EVENTS) && (eventType < AAMP_MAX_NUM_EVENTS))
 	{
 		ListenerData* pListener = new ListenerData;
 		if (pListener)
 		{
-			AAMPLOG_INFO("EventType:%d, Listener %p new %p", eventType, eventListener, pListener);
+			AAMPLOG_INFO("EventType:%d, Listener %p new %p", eventType, eventListener.get(), pListener);
 			std::lock_guard<std::mutex> guard(mMutexVar);
 			pListener->eventListener = eventListener;
 			pListener->pNext = mEventListeners[eventType];
@@ -170,7 +176,7 @@ void AampEventManager::AddEventListener(AAMPEventType eventType, EventListener* 
 /**
  * @brief RemoveEventListener - Remove one listener registration for one event
  */
-void AampEventManager::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener)
+void AampEventManager::RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 	// listener instance is cleared here , but created outside
 	if ((eventListener != NULL) && (eventType >= AAMP_EVENT_ALL_EVENTS) && (eventType < AAMP_MAX_NUM_EVENTS))
@@ -183,7 +189,7 @@ void AampEventManager::RemoveEventListener(AAMPEventType eventType, EventListene
 			if (pListener->eventListener == eventListener)
 			{
 				*ppLast = pListener->pNext;
-				AAMPLOG_INFO("Eventtype:%d %p delete %p", eventType, eventListener, pListener);
+				AAMPLOG_INFO("Eventtype:%d %p delete %p usecount = %d", eventType, eventListener.get(), pListener, (int)eventListener.use_count());
 				SAFE_DELETE(pListener);
 				return;
 			}
@@ -378,7 +384,6 @@ void AampEventManager::SendEventSync(const AAMPEventPtr &eventData)
 				eventData->GetSessionId().c_str());
 		}
 	}
-
 	// Build list of registered event listeners.
 	ListenerData* pList = NULL;
 	ListenerData* pListener = mEventListeners[eventType];

--- a/AampEventManager.h
+++ b/AampEventManager.h
@@ -42,7 +42,7 @@
  * @brief  Structure of the event listener list
  */
 struct ListenerData {
-	EventListener* eventListener;   /**< Event listener */
+	std::shared_ptr<EventListener> eventListener;   /**< Event listener */
 	ListenerData* pNext;            /**< Next listener */
 };
 
@@ -164,22 +164,25 @@ public:
 	 * @fn RemoveListenerForAllEvents
 	 * @param eventListener - listener for events
 	 * @return void
-	 */	
+	 */
 	void RemoveListenerForAllEvents(EventListener* eventListener);
 	/**
 	 * @fn AddEventListener
 	 * @param eventType - Aamp Event type
-	 * @param eventListener - listener for events
+	 * @param eventListener - shared pointer to listener for events
 	 * @return void
 	 */
-	void AddEventListener(AAMPEventType eventType, EventListener* eventListener);
+	void AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener);
+
 	/**
 	 * @fn RemoveEventListener
 	 * @param eventType - Aamp Event type
 	 * @param eventListener - listener for events
 	 * @return void
 	 */
-	void RemoveEventListener(AAMPEventType eventType, EventListener* eventListener);
+	void RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener);
+
+
 	/**
 	 * @fn IsEventListenerAvailable - Check if any listeners present for this event
 	 * @param eventType - Aamp Event Type

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -48,7 +48,7 @@ extern "C"
 	JSObjectRef AAMP_JS_AddEventTypeClass(JSGlobalContextRef context);
 	void aamp_ApplyPageHttpHeaders(PlayerInstanceAAMP *);
 }
-
+class AAMP_JSListener;
 /**
  * @struct AAMP_JS
  * @brief Data structure of AAMP object
@@ -57,7 +57,7 @@ struct AAMP_JS
 {
 	JSGlobalContextRef _ctx;
 	class PlayerInstanceAAMP* _aamp;
-	class AAMP_JSListener* _listeners;
+	std::shared_ptr<AAMP_JSListener> _listeners;
 	int  iPlayerId; /*An int variable iPlayerID to store Playerid */
         bool bInfoEnabled; /*A bool variable bInfoEnabled for INFO logging check*/
 	JSObjectRef _eventType;
@@ -705,7 +705,7 @@ public:
 	AAMP_JS*			_aamp;
 	AAMPEventType		_type;
 	JSObjectRef			_jsCallback;
-	AAMP_JSListener*	_pNext;
+	std::shared_ptr<AAMP_JSListener>	_pNext;
 };
 
 /**
@@ -2116,128 +2116,128 @@ void AAMP_JSListener::AddEventListener(AAMP_JS* aamp, AAMPEventType type, JSObje
 {
         LOG_TRACE("(%p, %d, %p)", aamp, type, jsCallback);
 
-	AAMP_JSListener* pListener = 0;
+	std::shared_ptr<AAMP_JSListener> pListener = NULL;
 
 	if(type == AAMP_EVENT_PROGRESS)
 	{
-		pListener = new AAMP_JSListener_Progress(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_Progress>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_SPEED_CHANGED)
 	{
-		pListener = new AAMP_JSListener_SpeedChanged(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_SpeedChanged>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_CC_HANDLE_RECEIVED)
 	{
-		pListener = new AAMP_JSListener_CCHandleReceived(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_CCHandleReceived>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_MEDIA_METADATA)
 	{
-		pListener = new AAMP_JSListener_VideoMetadata(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_VideoMetadata>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_TUNE_FAILED)
 	{
-		pListener = new AAMP_JSListener_TuneFailed(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_TuneFailed>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_BITRATE_CHANGED)
 	{
-		pListener = new AAMP_JSListener_BitRateChanged(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_BitRateChanged>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_BULK_TIMED_METADATA)
 	{
-		pListener = new AAMP_JSListener_BulkTimedMetadata(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_BulkTimedMetadata>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_TIMED_METADATA)
 	{
-		pListener = new AAMP_JSListener_TimedMetadata(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_TimedMetadata>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_CONTENT_GAP)
 	{
-		pListener = new AAMP_JSListener_ContentGap(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_ContentGap>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_STATE_CHANGED)
 	{
-		pListener = new AAMP_JSListener_StatusChanged(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_StatusChanged>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_SPEEDS_CHANGED)
 	{
-		pListener = new AAMP_JSListener_SpeedsChanged(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_SpeedsChanged>(aamp, type, jsCallback);
 	}
 	else if (type == AAMP_EVENT_REPORT_ANOMALY)
 	{
-		pListener = new AAMP_JSListener_AnomalyReport(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AnomalyReport>(aamp, type, jsCallback);
 	}
 	else if (type == AAMP_EVENT_REPORT_METRICS_DATA)
 	{
-		pListener = new AAMP_JSListener_MetricsData(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_MetricsData>(aamp, type, jsCallback);
 	}
 	else if (type == AAMP_EVENT_DRM_METADATA)
 	{
-		pListener = new AAMP_JSListener_DRMMetadata(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_DRMMetadata>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_RESOLVED)
 	{
-		pListener = new AAMP_JSListener_AdResolved(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdResolved>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_RESERVATION_START)
 	{
-		pListener = new AAMP_JSListener_AdReservationStart(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdReservationStart>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_RESERVATION_END)
 	{
-		pListener = new AAMP_JSListener_AdReservationEnd(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdReservationEnd>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_PLACEMENT_START)
 	{
-		pListener = new AAMP_JSListener_AdPlacementStart(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdPlacementStart>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_PLACEMENT_END)
 	{
-		pListener = new AAMP_JSListener_AdPlacementEnd(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdPlacementEnd>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_PLACEMENT_PROGRESS)
 	{
-		pListener = new AAMP_JSListener_AdProgress(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdProgress>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_AD_PLACEMENT_ERROR)
 	{
-		pListener = new AAMP_JSListener_AdPlacementEror(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_AdPlacementEror>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_BUFFERING_CHANGED)
 	{
-		pListener = new AAMP_JSListener_BufferingChanged(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_BufferingChanged>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_ID3_METADATA)
 	{
-		pListener = new AAMP_JSListener_Id3Metadata(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_Id3Metadata>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_DRM_MESSAGE)
 	{
-		pListener = new AAMP_JSListener_DrmMessage(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_DrmMessage>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE)
 	{
-		pListener = new AAMP_JSListener_ContentProtectionData(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_ContentProtectionData>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_MANIFEST_REFRESH_NOTIFY)
 	{
-		pListener = new AAMP_JSListener_DashManifestRefreshNotify(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_DashManifestRefreshNotify>(aamp, type, jsCallback);
 	}
 	else if(type == AAMP_EVENT_TUNE_TIME_METRICS)
 	{
-		pListener = new AAMP_JSListener_TuneMetricData(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_TuneMetricData>(aamp, type, jsCallback);
 	}
 	else if (type == AAMP_EVENT_MONITORAV_STATUS)
 	{
-		pListener = new AAMP_JSListener_MonitorAVStatus(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener_MonitorAVStatus>(aamp, type, jsCallback);
 	}
 	else
 	{
-		pListener = new AAMP_JSListener(aamp, type, jsCallback);
+		pListener = std::make_shared<AAMP_JSListener>(aamp, type, jsCallback);
 	}
 
 	pListener->_pNext = aamp->_listeners;
 	aamp->_listeners = pListener;
-	aamp->_aamp->AddEventListener(type, pListener);
+	aamp->_aamp->AddEventListener(type, std::static_pointer_cast<EventListener>(pListener));
 }
 
 /**
@@ -2302,16 +2302,15 @@ static JSValueRef AAMP_removeEventListener(JSContextRef context, JSObjectRef fun
 void AAMP_JSListener::RemoveEventListener(AAMP_JS* aamp, AAMPEventType type, JSObjectRef jsCallback)
 {
         LOG_TRACE("(%p, %d, %p)", aamp, type, jsCallback);
-	AAMP_JSListener** ppListener = &aamp->_listeners;
+	std::shared_ptr<AAMP_JSListener>* ppListener = &aamp->_listeners;
 	while (*ppListener != NULL)
 	{
-		AAMP_JSListener* pListener = *ppListener;
+		std::shared_ptr<AAMP_JSListener>& pListener = *ppListener;
 		if ((pListener->_type == type) && (pListener->_jsCallback == jsCallback))
 		{
 			*ppListener = pListener->_pNext;
-                        LOG_WARN_EX(" type=%d,pListener= %p", type, pListener);
-			aamp->_aamp->RemoveEventListener(type, pListener);
-			SAFE_DELETE(pListener);
+			LOG_WARN_EX(" type=%d,pListener= %p", type, pListener.get());
+			aamp->_aamp->RemoveEventListener(type, std::static_pointer_cast<EventListener>(pListener));
 			return;
 		}
 		ppListener = &pListener->_pNext;

--- a/jsbindings/jsbindings.h
+++ b/jsbindings/jsbindings.h
@@ -48,7 +48,7 @@ struct PrivAAMPStruct_JS {
 	JSGlobalContextRef _ctx;
 	PlayerInstanceAAMP* _aamp;
 
-	std::multimap<AAMPEventType, void*> _listeners;
+	std::multimap<AAMPEventType, std::shared_ptr<void>> _listeners;
 };
 
 /**

--- a/jsbindings/jseventlistener.cpp
+++ b/jsbindings/jseventlistener.cpp
@@ -1813,112 +1813,126 @@ void AAMP_JSEventListener::AddEventListener(PrivAAMPStruct_JS* obj, AAMPEventTyp
 {
 	LOG_TRACE("(%p, %d, %p)", obj, type, jsCallback);
 
-	AAMP_JSEventListener* pListener = NULL;
+    // Check for duplicate: see if jsCallback is already registered for this event type
+	if (obj->_listeners.count(type) > 0)
+	{
+		auto range = obj->_listeners.equal_range(type);
+		for (auto iter = range.first; iter != range.second; ++iter)
+		{
+			auto listener = std::static_pointer_cast<AAMP_JSEventListener>(iter->second);
+			if (listener->p_jsCallback == jsCallback)
+			{
+				// Listener already registered for this type and callback, ignore registration
+				LOG_WARN_EX("Duplicate event listener registration ignored for type %d and callback %p", type, jsCallback);
+				return;
+			}
+		}
+	}
+	std::shared_ptr<AAMP_JSEventListener> pListener = NULL;
 
 	switch(type)
 	{
 		case AAMP_EVENT_STATE_CHANGED:
-			pListener = new AAMP_Listener_PlaybackStateChanged(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_PlaybackStateChanged>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_PROGRESS:
-			pListener = new AAMP_Listener_ProgressUpdate(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_ProgressUpdate>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_SPEED_CHANGED:
-			pListener = new AAMP_Listener_SpeedChanged(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_SpeedChanged>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_BUFFERING_CHANGED:
-			pListener = new AAMP_Listener_BufferingChanged(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_BufferingChanged>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_TUNE_FAILED:
-			pListener = new AAMP_Listener_PlaybackFailed(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_PlaybackFailed>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_MEDIA_METADATA:
-			pListener = new AAMP_Listener_MediaMetadata(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_MediaMetadata>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_SPEEDS_CHANGED:
-			pListener = new AAMP_Listener_SpeedsChanged(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_SpeedsChanged>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_SEEKED:
-			pListener = new AAMP_Listener_Seeked(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_Seeked>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_TUNE_PROFILING:
-			pListener = new AAMP_Listener_TuneProfiling(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_TuneProfiling>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_CC_HANDLE_RECEIVED:
-			pListener = new AAMP_Listener_CCHandleAvailable(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_CCHandleAvailable>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_DRM_METADATA:
-			pListener = new AAMP_Listener_DRMMetadata(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_DRMMetadata>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_REPORT_ANOMALY:
-			pListener = new AAMP_Listener_AnomalyReport(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AnomalyReport>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_WEBVTT_CUE_DATA:
-			pListener = new AAMP_Listener_VTTCueData(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_VTTCueData>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_BULK_TIMED_METADATA:
-			pListener = new AAMP_Listener_BulkTimedMetadata(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_BulkTimedMetadata>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_TIMED_METADATA:
-			pListener = new AAMP_Listener_TimedMetadata(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_TimedMetadata>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_HTTP_RESPONSE_HEADER:
-			pListener = new AAMP_Listener_HTTPResponseHeader(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_HTTPResponseHeader>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_BITRATE_CHANGED:
-			pListener = new AAMP_Listener_BitrateChanged(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_BitrateChanged>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_RESOLVED:
-			pListener = new AAMP_Listener_AdResolved(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AdResolved>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_RESERVATION_START:
-			pListener = new AAMP_Listener_AdReservationStart(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AdReservationStart>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_RESERVATION_END:
-			pListener = new AAMP_Listener_AdReservationEnd(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AdReservationEnd>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_PLACEMENT_START:
-			pListener = new AAMP_Listener_AdPlacementStart(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AdPlacementStart>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_PLACEMENT_END:
-			pListener = new AAMP_Listener_AdPlacementEnd(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AdPlacementEnd>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_PLACEMENT_PROGRESS:
-			pListener = new AAMP_Listener_AdProgress(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_AdProgress>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_AD_PLACEMENT_ERROR:
-			pListener = new AAMP_Listener_AdPlacementError(obj, type, jsCallback);
-			break;
+			pListener = std::make_shared<AAMP_Listener_AdPlacementError>(obj, type, jsCallback);				break;
 		case AAMP_EVENT_ID3_METADATA:
-			pListener = new AAMP_Listener_Id3Metadata(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_Id3Metadata>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_BLOCKED:
-			pListener = new AAMP_Listener_Blocked(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_Blocked>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_CONTENT_GAP:
-			pListener = new AAMP_Listener_ContentGap(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_ContentGap>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_WATERMARK_SESSION_UPDATE:
-			pListener = new AAMP_Listener_WatermarkSessionUpdate(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_WatermarkSessionUpdate>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE:
-			pListener = new AAMP_Listener_ContentProtectionData(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_ContentProtectionData>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_MANIFEST_REFRESH_NOTIFY:
-			pListener = new AAMP_Listener_DashManifestRefreshNotify(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_DashManifestRefreshNotify>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_TUNE_TIME_METRICS:
-			pListener = new AAMP_Listener_TuneMetricData(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_TuneMetricData>(obj, type, jsCallback);
 			break;
 		case AAMP_EVENT_MONITORAV_STATUS:
-			pListener = new AAMP_Listener_MonitorAVStatus(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_MonitorAVStatus>(obj, type, jsCallback);
 			break;
 		// Following events are not having payload and hence falls under default case
 		// AAMP_EVENT_EOS, AAMP_EVENT_TUNED, AAMP_EVENT_ENTERING_LIVE,
 		// AAMP_EVENT_AUDIO_TRACKS_CHANGED, AAMP_EVENT_TEXT_TRACKS_CHANGED, AAMP_EVENT_NEED_MANIFEST_DATA
 		default:
 			// pListener = new AAMP_JSEventListener(obj, type, jsCallback);
-			pListener = new AAMP_Listener_DefaultEvent(obj, type, jsCallback);
+			pListener = std::make_shared<AAMP_Listener_DefaultEvent>(obj, type, jsCallback);
 			break;
 	}
 
@@ -1927,7 +1941,7 @@ void AAMP_JSEventListener::AddEventListener(PrivAAMPStruct_JS* obj, AAMPEventTyp
 		obj->_aamp->AddEventListener(type, pListener);
 	}
 
-	obj->_listeners.insert({type, (void *)pListener});
+	obj->_listeners.insert({type,(pListener)});
 }
 
 
@@ -1937,15 +1951,14 @@ void AAMP_JSEventListener::AddEventListener(PrivAAMPStruct_JS* obj, AAMPEventTyp
 void AAMP_JSEventListener::RemoveEventListener(PrivAAMPStruct_JS* obj, AAMPEventType type, JSObjectRef jsCallback)
 {
         LOG_TRACE("(%p, %d, %p)", obj, type, jsCallback);
-
 	if (obj->_listeners.count(type) > 0)
 	{
 
-		typedef std::multimap<AAMPEventType, void*>::iterator listenerIter_t;
+		typedef std::multimap<AAMPEventType, std::shared_ptr<void>>::iterator listenerIter_t;
 		std::pair<listenerIter_t, listenerIter_t> range = obj->_listeners.equal_range(type);
 		for(listenerIter_t iter = range.first; iter != range.second; )
 		{
-			AAMP_JSEventListener *listener = (AAMP_JSEventListener *)iter->second;
+			auto listener = std::static_pointer_cast<AAMP_JSEventListener>((iter->second));
 			if (listener->p_jsCallback == jsCallback)
 			{
 				if (obj->_aamp != NULL)
@@ -1953,7 +1966,6 @@ void AAMP_JSEventListener::RemoveEventListener(PrivAAMPStruct_JS* obj, AAMPEvent
 					obj->_aamp->RemoveEventListener(iter->first, listener);
 				}
 				iter = obj->_listeners.erase(iter);
-				SAFE_DELETE(listener);
 			}
 			else
 			{
@@ -1974,13 +1986,12 @@ void AAMP_JSEventListener::RemoveAllEventListener(PrivAAMPStruct_JS * obj)
 
 	for (auto listenerIter = obj->_listeners.begin(); listenerIter != obj->_listeners.end();)
 	{
-		AAMP_JSEventListener *listener = (AAMP_JSEventListener *)listenerIter->second;
+		auto listener = std::static_pointer_cast<AAMP_JSEventListener>((listenerIter->second));
 		if (obj->_aamp != NULL)
 		{
 			obj->_aamp->RemoveEventListener(listenerIter->first, listener);
 		}
 		listenerIter = obj->_listeners.erase(listenerIter);
-		SAFE_DELETE(listener);
 	}
 
 	obj->_listeners.clear();

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -1670,20 +1670,42 @@ void PlayerInstanceAAMP::UnloadJS(void* context)
 /**
  *  @brief Support multiple listeners for multiple event type
  */
+void PlayerInstanceAAMP::AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener> eventListener)
+{
+	if(aamp){
+		aamp->AddEventListener(eventType, eventListener);
+	}
+}
+
+/**
+ * @brief Support multiple listeners for multiple event type - raw pointer version
+ */
 void PlayerInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListener* eventListener)
 {
 	if(aamp){
-	aamp->AddEventListener(eventType, eventListener);
+		std::shared_ptr<EventListener> sharedListener(eventListener, [](EventListener* ptr) { /* do nothing, non-owning */ });
+		aamp->AddEventListener(eventType, sharedListener);
 	}
 }
 
 /**
  *  @brief Remove event listener for eventType.
  */
+void PlayerInstanceAAMP::RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener> eventListener)
+{
+	if(aamp){
+		aamp->RemoveEventListener(eventType, eventListener);
+	}
+}
+
+ /**
+  * @brief Remove event listener for eventType - raw pointer version
+  */
 void PlayerInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener)
 {
 	if(aamp){
-	aamp->RemoveEventListener(eventType, eventListener);
+		std::shared_ptr<EventListener> sharedListener(eventListener, [](EventListener* ptr) { /* do nothing, non-owning */ });
+		aamp->RemoveEventListener(eventType, sharedListener);
 	}
 }
 

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -354,6 +354,15 @@ public:
 	 *   @param[in]  eventListener - listener for the eventType.
 	 *   @return void
 	 */
+	void AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener> eventListener);
+
+	/**
+	 *   @fn AddEventListener
+	 *
+	 *   @param[in]  eventType - type of event.
+	 *   @param[in]  eventListener - listener for the eventType - raw pointer.
+	 *   @return void
+	 */
 	void AddEventListener(AAMPEventType eventType, EventListener* eventListener);
 
 	/**
@@ -363,8 +372,16 @@ public:
 	 *   @param[in]  eventListener - listener to be removed for the eventType.
 	 *   @return void
 	 */
-	void RemoveEventListener(AAMPEventType eventType, EventListener* eventListener);
+	void RemoveEventListener(AAMPEventType eventType,std::shared_ptr<EventListener> eventListener);
 
+	/**
+	 *   @fn RemoveEventListener
+	 *
+	 *   @param[in]  eventType - type of event.
+	 *   @param[in]  eventListener - listener to be removed for the eventType - raw pointer.
+	 *   @return void
+	 */
+	void RemoveEventListener(AAMPEventType eventType, EventListener* eventListener);
 	/**
 	 *   @fn IsLive
 	 *

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -2539,7 +2539,7 @@ void PrivateInstanceAAMP::UpdateCullingState(double culledSecs)
 /**
  * @brief Add listener to aamp events
  */
-void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListener* eventListener)
+void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 	mEventManager->AddEventListener(eventType,eventListener);
 }
@@ -2548,7 +2548,7 @@ void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListene
 /**
  * @brief Deregister event lister, Remove listener to aamp events
  */
-void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener)
+void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType,std::shared_ptr<EventListener>& eventListener)
 {
 	mEventManager->RemoveEventListener(eventType,eventListener);
 }

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1053,7 +1053,7 @@ public:
         double mProgramDateTime;
 	std::vector<PeriodInfo> mMPDPeriodsInfo;
 	float maxRefreshPlaylistIntervalSecs;
-	EventListener* mEventListener;
+	std::shared_ptr<EventListener> mEventListener;
 	long long prevFirstPeriodStartTime;
 
 	//updated by ReportProgress() and used by PlayerInstanceAAMP::SetRateInternal() to update seek_pos_seconds
@@ -1416,7 +1416,7 @@ public:
 	 * @param[in] eventListener - Event handler
 	 * @return void
 	 */
-	void AddEventListener(AAMPEventType eventType, EventListener* eventListener);
+	void AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener);
 
 	/**
 	 * @fn RemoveEventListener
@@ -1425,7 +1425,7 @@ public:
 	 * @param[in] eventListener - Event handler
 	 * @return void
 	 */
-	void RemoveEventListener(AAMPEventType eventType, EventListener* eventListener);
+	void RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener);
 	/**
 	 * @fn IsEventListenerAvailable
 	 *
@@ -2103,7 +2103,15 @@ public:
 	 */
 	void RegisterEvent(AAMPEventType type, EventListener* listener)
 	{
-		mEventManager->AddEventListener(type, listener);
+		if (!listener)
+		{
+			AAMPLOG_WARN("Received a null listener.");
+			return;
+		}
+		std::shared_ptr<EventListener> sharedListener(listener, [](EventListener* ptr) {
+			// No-op deleter to avoid accidental deletion
+		});
+		mEventManager->AddEventListener(type, sharedListener);
 	}
 
 	/**

--- a/test/aampcli/AampcliSet.cpp
+++ b/test/aampcli/AampcliSet.cpp
@@ -915,11 +915,11 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						if (sscanf(cmd, "set %s %d", command, &id3MetadataEventsEnabled) == 2){
 							if (id3MetadataEventsEnabled)
 							{
-								playerInstanceAamp->AddEventListener(AAMP_EVENT_ID3_METADATA, lAampcli.mEventListener);
+								playerInstanceAamp->AddEventListener(AAMP_EVENT_ID3_METADATA, std::shared_ptr<EventListener>(lAampcli.mEventListener));
 							}
 							else
 							{
-								playerInstanceAamp->RemoveEventListener(AAMP_EVENT_ID3_METADATA, lAampcli.mEventListener);
+								playerInstanceAamp->RemoveEventListener(AAMP_EVENT_ID3_METADATA, std::shared_ptr<EventListener>(lAampcli.mEventListener));
 							}
 
 						}
@@ -938,11 +938,11 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						if (sscanf(cmd, "set %s %d", command, &mediaMetadataEventsEnabled) == 2){
 							if (mediaMetadataEventsEnabled)
 							{
-								playerInstanceAamp->AddEventListener(AAMP_EVENT_MEDIA_METADATA, lAampcli.mEventListener);
+								playerInstanceAamp->AddEventListener(AAMP_EVENT_MEDIA_METADATA, std::shared_ptr<EventListener>(lAampcli.mEventListener));
 							}
 							else
 							{
-								playerInstanceAamp->RemoveEventListener(AAMP_EVENT_MEDIA_METADATA, lAampcli.mEventListener);
+								playerInstanceAamp->RemoveEventListener(AAMP_EVENT_MEDIA_METADATA, std::shared_ptr<EventListener>(lAampcli.mEventListener));
 							}
 						}
 						else
@@ -1228,7 +1228,7 @@ bool Set::execute( const char *cmd, PlayerInstanceAAMP *playerInstanceAamp)
 						if (sscanf(cmd, "set %s %d", command, &timeout) == 2)
 						{
 							AAMPCLI_PRINTF("[AAMPCLI] Enabling AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE event registration");
-							playerInstanceAamp->AddEventListener(AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE, lAampcli.mEventListener);
+							playerInstanceAamp->AddEventListener(AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE, std::shared_ptr<EventListener>(lAampcli.mEventListener));
 							playerInstanceAamp->SetContentProtectionDataUpdateTimeout(timeout);
 						}
 						else

--- a/test/utests/drm/mocks/aampMocks.cpp
+++ b/test/utests/drm/mocks/aampMocks.cpp
@@ -346,11 +346,11 @@ void PrivateInstanceAAMP::SetAudioVolume(int volume)
 {
 }
 
-void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListener *eventListener)
+void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType,  std::shared_ptr<EventListener>& eventListener)
 {
 }
 
-void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListener *eventListener)
+void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 }
 

--- a/test/utests/fakes/FakeAampEventManager.cpp
+++ b/test/utests/fakes/FakeAampEventManager.cpp
@@ -50,11 +50,11 @@ void AampEventManager::FlushPendingEvents()
 {
 }
 
-void AampEventManager::AddEventListener(AAMPEventType eventType, EventListener* eventListener)
+void AampEventManager::AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 }
 
-void AampEventManager::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener)
+void AampEventManager::RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 }
 

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -72,8 +72,8 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 	void PlayerInstanceAAMP::SubscribeResponseHeaders(std::vector<std::string> responseHeaders) {  }
 	void PlayerInstanceAAMP::LoadJS(void* context) {  }
 	void PlayerInstanceAAMP::UnloadJS(void* context) {  }
-	void PlayerInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListener* eventListener) {  }
-	void PlayerInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener) {  }
+	void PlayerInstanceAAMP::AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener> eventListener) {  }
+	void PlayerInstanceAAMP::RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener> eventListener) {  }
 	void PlayerInstanceAAMP::InsertAd(const char *url, double  positionSeconds) {  }
 	void PlayerInstanceAAMP::AddPageHeaders(std::map<std::string, std::string> customHttpHeaders) {  }
 	void PlayerInstanceAAMP::AddCustomHTTPHeader(std::string headerName, std::vector<std::string> headerValue, bool isLicenseHeader) {  }

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -389,11 +389,11 @@ void PrivateInstanceAAMP::SetAudioVolume(int volume)
 {
 }
 
-void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType, EventListener* eventListener)
+void PrivateInstanceAAMP::AddEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 }
 
-void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, EventListener* eventListener)
+void PrivateInstanceAAMP::RemoveEventListener(AAMPEventType eventType, std::shared_ptr<EventListener>& eventListener)
 {
 }
 

--- a/test/utests/tests/AampEventManagerTests/AampEventManagerTests.cpp
+++ b/test/utests/tests/AampEventManagerTests/AampEventManagerTests.cpp
@@ -63,13 +63,14 @@ protected:
     };
     void SetUp() override {
         handler = new TestableAampEventManager();
+        eventListener = std::make_shared<AbstractEventListener>();
     }
     void TearDown() override {
     delete handler;
     handler = nullptr;
     }
 public:
-	EventListener* eventListener;
+    std::shared_ptr<EventListener> eventListener;
 
     TestableAampEventManager *handler;
 
@@ -177,7 +178,7 @@ TEST_F(AampEventManagerTest, SetPlayerStateTest)
 TEST_F(AampEventManagerTest,AddListenerForAllEventsTest1)
 {
 	//Arrange:declare the variable with size
-	handler->AddListenerForAllEvents(eventListener);
+	handler->AddListenerForAllEvents(eventListener.get());
 }
 TEST_F(AampEventManagerTest,AddListenerForAllEventsTest2)
 {
@@ -192,7 +193,7 @@ TEST_F(AampEventManagerTest, RemoveListenerForAllEventsTest1)
 {
 	//Act: call the removeEventlistener function
     eventListener = nullptr;
-	handler->RemoveListenerForAllEvents(eventListener);
+	handler->RemoveListenerForAllEvents(eventListener.get());
 }
 TEST_F(AampEventManagerTest, RemoveListenerForAllEventsTest2)
 { 
@@ -202,7 +203,7 @@ TEST_F(AampEventManagerTest,FlushPendingEventsTest)
 {
 
     //Arrange:declare the variable with size
-    handler->AddListenerForAllEvents(eventListener);
+    handler->AddListenerForAllEvents(eventListener.get());
 
     for(int i= AAMP_EVENT_ALL_EVENTS ; i< AAMP_MAX_NUM_EVENTS ;i++)
     {
@@ -242,7 +243,7 @@ TEST_F(AampEventManagerTest, SendEventTest_2)
 TEST_F(AampEventManagerTest, RemoveListenerForAllEventsTest_1)
 {
     //Act: call the removeEventlistener function
-    handler->RemoveListenerForAllEvents(eventListener);
+    handler->RemoveListenerForAllEvents(eventListener.get());
 
     for(int i= AAMP_EVENT_ALL_EVENTS ; i< AAMP_MAX_NUM_EVENTS ;i++)
     {

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -703,7 +703,7 @@ TEST_F(PlayerInstanceAAMPTests, SubscribeResponseHeadersTest) {
 
 TEST_F(PlayerInstanceAAMPTests, AddEventListenerTest) {
     AAMPEventType eventType = AAMP_EVENT_TUNED;
-    EventListener* eventListener = nullptr ;
+    std::shared_ptr<EventListener> eventListener = nullptr;
 
     // Call the method to be tested
    mPlayerInstance->AddEventListener(eventType,eventListener);
@@ -712,7 +712,7 @@ TEST_F(PlayerInstanceAAMPTests, AddEventListenerTest) {
 
 TEST_F(PlayerInstanceAAMPTests, RemoveEventListenerTest) {
     AAMPEventType eventType = AAMP_EVENT_TUNED;
-    EventListener* eventListener = nullptr;
+    std::shared_ptr<EventListener> eventListener = nullptr;
 
     // Call the method to be tested
    mPlayerInstance->RemoveEventListener(eventType,eventListener);

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -1004,9 +1004,22 @@ TEST_F(PrivAampTests,UpdateCullingStateTest)
 	EXPECT_FALSE(p_aamp->mAutoResumeTaskPending);
 }
 
+/**
+ * @class TestEventListener
+ * @brief Test implementation of EventListener for unit tests
+ */
+class TestEventListener : public EventListener
+{
+public:
+	void SendEvent(const AAMPEventPtr &event) override
+	{
+		// Empty implementation for testing
+	}
+};
+
 TEST_F(PrivAampTests,AddEventListenerTest)
 {
-	EventListener* eventListener;
+	std::shared_ptr<EventListener> eventListener = std::make_shared<TestEventListener>();
 	p_aamp->AddEventListener(AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE,eventListener);
 	p_aamp->RemoveEventListener(AAMP_EVENT_CONTENT_PROTECTION_DATA_UPDATE,eventListener);
 


### PR DESCRIPTION
VPLAY-11407 : Migrate AAMP Eventlisteners to shared_ptr for better memory handling

Reason for change: improve the memory handling,move the AAMPEventListener object cached in AAMP to be of shared_ptr
Test Procedure: Updated in the ticket
Risks: Low

VPAAMP-568 Prevent SelectSubtitleTrack changing tracks, and clearing the in band CC flag
VPAAMP-565: Deprecate ceaFormat from AAMP Config
    
Reason for change : fix cc selection when both in-band and out-band cc is present as part of stream
Test procedure : see ticket
risks: Low
