### PR TITLE
VPAAMP-621 Fix AAMP L1 test build failure on Ubuntu

### DIFF
--- a/scripts/install_middleware_interfaces.sh
+++ b/scripts/install_middleware_interfaces.sh
@@ -48,7 +48,12 @@ function sync_internal_middleware_headers_fn()
         local base
         base=$(basename "${installed}")
         local src
-        src=$(find "${middleware_dir}" -maxdepth 4 -name "${base}" 2>/dev/null | head -1)
+        # Search only the middleware source tree, pruning the .libs build
+        # artifact directory.  .libs holds vendored third-party build outputs
+        # (e.g. glib, protobuf) whose headers share common basenames such as
+        # config.h.  Matching those by basename would overwrite unrelated
+        # installed headers (e.g. libdash/config.h), breaking the build.
+        src=$(find "${middleware_dir}" -maxdepth 4 -name .libs -prune -o -name "${base}" -print 2>/dev/null | head -1)
         if [[ -n "${src}" ]] && ! diff -q "${installed}" "${src}" > /dev/null 2>&1; then
             echo "Refreshing stale header: ${base}"
             cp "${src}" "${installed}" || {


### PR DESCRIPTION
Reason for Change: Fix AAMP L1 test build failure on Ubuntu

Root cause:
libdash uses the wrong header because of a basename-collision bug in sync_internal_middleware_headers_fn in `install_middleware_interfaces.sh:47`.

That function walks every *.h/*.hpp already in [include] (including [config.h]) and refreshes each from `middleware` matched by bare basename:
`src=$(find "${middleware_dir}" -maxdepth 4 -name "${base}" 2>/dev/null | head -1)`
`config.h` is an extremely common name. `.libs` is a git-ignored build-artifact tree with 3207 vendored headers (GLib, protobuf), and the find picked `config.h` — GLib's Meson-autogenerated `config.h` with no <stdint.h> — and overwrote libdash's. That caused uint64_t to be undeclared.

Summary of Changes:
- Update the script to install the middleware interfaces

Test Procedure: Build AAMP L1 tests

Priority: P2

Risks: Low