### PR TITLE
VPAAMP-565: Deprecate ceaFormat from AAMP Config.

### DIFF
--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -423,7 +423,6 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{AAMP_HIGH_BUFFER_BEFORE_RAMPUP,"maxABRBufferRampup",eAAMPConfig_MaxABRNWBufferRampUp,false},
 	{DEFAULT_PREBUFFER_COUNT,"preplayBuffercount",eAAMPConfig_PrePlayBufferCount,false},
 	{0,"preCachePlaylistTime",eAAMPConfig_PreCachePlaylistTime,false},
-	{-1, "ceaFormat",eAAMPConfig_CEAPreferred,false, eCONFIG_RANGE_CEA_PREFERRED},
 	{DEFAULT_STALL_ERROR_CODE,"stallErrorCode",eAAMPConfig_StallErrorCode,false},
 	{DEFAULT_STALL_DETECTION_TIMEOUT,"stallTimeout",eAAMPConfig_StallTimeoutMS,false},
 	{DEFAULT_MINIMUM_INIT_CACHE_SECONDS,"initialBuffer",eAAMPConfig_InitialBuffer,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -273,7 +273,6 @@ typedef enum
 	eAAMPConfig_MaxABRNWBufferRampUp,					/**< Maximum ABR Buffer for Rampup*/
 	eAAMPConfig_PrePlayBufferCount, 					/**< Count of segments to be downloaded until play state */
 	eAAMPConfig_PreCachePlaylistTime,					/**< Max time to complete PreCaching .In Minutes  */
-	eAAMPConfig_CEAPreferred,						/**< To force 608/708 track selection in CC manager */
 	eAAMPConfig_StallErrorCode,
 	eAAMPConfig_StallTimeoutMS,
 	eAAMPConfig_InitialBuffer,

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -498,8 +498,7 @@ static bool AAMP_setProperty_preferredCEAFormat(JSContextRef context, JSObjectRe
 		return false;
 	}
 	preferredCEAFormat = (int)JSValueToNumber(context, value, exception);
-        LOG_WARN(pAAMP,"_aamp->SetCEAFormat context=%p  value=%d exception=%p ",context, preferredCEAFormat, exception);
-	pAAMP->_aamp->SetCEAFormat(preferredCEAFormat);
+        LOG_WARN(pAAMP,"_aamp->SetCEAFormat context=%p  value=%d exception=%p(deprecated )",context, preferredCEAFormat, exception);
 	return true;
 }
 

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -498,7 +498,7 @@ static bool AAMP_setProperty_preferredCEAFormat(JSContextRef context, JSObjectRe
 		return false;
 	}
 	preferredCEAFormat = (int)JSValueToNumber(context, value, exception);
-        LOG_WARN(pAAMP,"_aamp->SetCEAFormat context=%p  value=%d exception=%p(deprecated )",context, preferredCEAFormat, exception);
+		LOG_WARN(pAAMP, "preferredCEAFormat is deprecated; ignoring (context=%p value=%d exception=%p)", context, preferredCEAFormat, exception);
 	return true;
 }
 

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -3064,16 +3064,6 @@ void PlayerInstanceAAMP::SetInitRampdownLimit(int limit)
 	SETCONFIGVALUE(AAMP_APPLICATION_SETTING,eAAMPConfig_InitRampDownLimit,limit);
 }
 
-
-/**
- *  @brief Set the CEA format for force setting
- */
-void PlayerInstanceAAMP::SetCEAFormat(int format)
-{
-	SETCONFIGVALUE(AAMP_APPLICATION_SETTING,eAAMPConfig_CEAPreferred,format);
-}
-
-
 /**
  *   @brief To get the available bitrates for thumbnails.
  */

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -1254,14 +1254,6 @@ public:
 	void SetLanguageFormat(LangCodePreference preferredFormat, bool useRole = false);
 
 	/**
-	 *   @brief Set the CEA format for force setting
-	 *
-	 *   @param[in] format - 0 for 608, 1 for 708
-	 *   @return void
-	 */
-	void SetCEAFormat(int format);
-
-	/**
 	 *   @brief Set the session token for player
 	 *
 	 *   @param[in]string -  sessionToken

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -8875,15 +8875,6 @@ void PrivateInstanceAAMP::ReportContentGap(long long timeMilliseconds, std::stri
 void PrivateInstanceAAMP::InitializeCC(unsigned long decoderHandle)
 {
 	PlayerCCManager::GetInstance()->Init((void *)decoderHandle);
-	if (ISCONFIGSET_PRIV(eAAMPConfig_NativeCCRendering))
-	{
-		int overrideCfg = GETCONFIGVALUE_PRIV(eAAMPConfig_CEAPreferred);
-		if (overrideCfg == 0)
-		{
-			AAMPLOG_WARN("PrivateInstanceAAMP: CC format override to 608 present, selecting 608CC");
-			PlayerCCManager::GetInstance()->SetTrack("CC1");
-		}
-	}
 }
 
 /**
@@ -11909,14 +11900,6 @@ void PrivateInstanceAAMP::SetClosedCaptionsFromTextTrack(TextTrackInfo &track)
 			{
 				format = eCLOSEDCAPTION_FORMAT_708;
 			}
-		}
-
-		// preferredCEA708 overrides whatever we infer from track. USE WITH CAUTION
-		int overrideCfg = GETCONFIGVALUE_PRIV(eAAMPConfig_CEAPreferred);
-		if (overrideCfg != -1)
-		{
-			format = (CCFormat)(overrideCfg & 1);
-			AAMPLOG_WARN("PrivateInstanceAAMP: CC format override present, override format to: %d", format);
 		}
 		AAMPLOG_INFO("instreamId %s format %d", track.instreamId.c_str(), format);
 		PlayerCCManager::GetInstance()->SetTrack(track.instreamId, format);

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -150,7 +150,6 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 	    }
     }
 	void PlayerInstanceAAMP::SetLanguageFormat(LangCodePreference preferredFormat, bool useRole) {  }
-	void PlayerInstanceAAMP::SetCEAFormat(int format) {  }
 	void PlayerInstanceAAMP::SetSessionToken(std::string sessionToken) {  }
 	void PlayerInstanceAAMP::SetMaxPlaylistCacheSize(int cacheSize) {  }
 	void PlayerInstanceAAMP::EnableSeekableRange(bool enabled) {  }

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2415,21 +2415,6 @@ TEST_F(PlayerInstanceAAMPTests, ProcessContentProtectionDataConfigTests)
 	mPlayerInstance->ProcessContentProtectionDataConfig(jsonBuffer);
 }
 
-TEST_F(PlayerInstanceAAMPTests,SetCEAFormatTest1)
-{
-	int expectedFormat = 1;
-	mPlayerInstance->SetCEAFormat(expectedFormat);
-}
-TEST_F(PlayerInstanceAAMPTests,SetCEAFormatTest2)
-{
-	int expectedFormat = INT_MIN;
-	mPlayerInstance->SetCEAFormat(expectedFormat);
-}
-TEST_F(PlayerInstanceAAMPTests,SetCEAFormatTest3)
-{
-	int expectedFormat = INT_MAX;
-	mPlayerInstance->SetCEAFormat(expectedFormat);
-}
 TEST_F(PlayerInstanceAAMPTests,IsOOBCCRenderingSupportedTest)
 {
 	mPlayerInstance->IsOOBCCRenderingSupported();


### PR DESCRIPTION
Reason for Change: Deprecated ceaFormat from AAMP

Test Procedure: see ticket

Priority: P1

Risks: Low