### PR TITLE
VPAAMP-394:[VIPA - TS DAI][cDVR on XiOne/Llama] Ads are not played on cdvr asset and getting "Error: Ad fetch failed"

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -4130,7 +4130,13 @@ AAMPStatusType StreamAbstractionAAMP_MPD::Init(TuneType tuneType)
 			AAMPLOG_WARN("mCurrentPeriod  is null");  //CID:84770 - Null Return
 		}
 		mBasePeriodOffset = offsetFromStart;
-		onAdEvent(AdEvent::INIT, offsetFromStart);
+		//Avoid calling onAdEvent during a new tune to prevent ad processing at tune start.
+		if ((tuneType != eTUNETYPE_NEW_NORMAL) &&
+			(tuneType != eTUNETYPE_NEW_SEEK) &&
+			(tuneType != eTUNETYPE_NEW_END))
+		{
+			onAdEvent(AdEvent::INIT, offsetFromStart);
+		}
 
 		UpdateLanguageList();
 
@@ -5470,7 +5476,6 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 								eventInfo.duration = 0;
 							}
 							eventStartTime = 0;
-
 						}
 					}
 					else
@@ -5479,34 +5484,19 @@ bool StreamAbstractionAAMP_MPD::ProcessEventStream(uint64_t startMS, int64_t sta
 					}
 					AAMPLOG_INFO("SCTEDBG adjust start time %" PRIu64 " -> %" PRIu64 " (duration %d)", eventInfo.presentationTime, eventStartTime, eventInfo.duration);
 				}
+				// Update event break to AAMP's CDAI object so that ad reservations can be processed later.
+				aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
 
-				//for livestream send the timedMetadata only., because at init, control does not come here
-				if(mIsLiveManifest && ! ISCONFIGSET(eAAMPConfig_BulkTimedMetaReportLive))
+				// Report the event break info to application as timed metadata. This will be done for both live and recorded content.
+				// Save the event for later reporting. De-duplication happens in ReportTimedMetadata() (non-bulk mode only).
+				if(reportBulkMeta)
 				{
-					// The current process relies on enabling eAAMPConfig_EnableClientDai and that may not be desirable
-					// for our requirements. We'll just skip this and use the VOD process to send events
-					bool modifySCTEProcessing = ISCONFIGSET(eAAMPConfig_EnableSCTE35PresentationTime);
-					if (modifySCTEProcessing)
-					{
-						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
-					}
-					else
-					{
-						aamp->FoundEventBreak(prdId, eventStartTime, eventInfo);
-					}
+					AAMPLOG_INFO("Saving timedMetadata event %s for the period, %s", eventInfo.name.c_str(), prdId.c_str());
+					aamp->SaveTimedMetadata(eventStartTime, eventInfo.name.c_str() , eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
 				}
 				else
 				{
-					//for vod, send TimedMetadata only when bulkmetadata is not enabled
-					if(reportBulkMeta)
-					{
-						AAMPLOG_INFO("Saving timedMetadata for VOD %s event for the period, %s", eventInfo.name.c_str(), prdId.c_str());
-						aamp->SaveTimedMetadata(eventStartTime, eventInfo.name.c_str() , eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
-					}
-					else
-					{
-						aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
-					}
+					aamp->SaveNewTimedMetadata(eventStartTime, eventInfo.name.c_str(), eventInfo.payload.c_str(), (int)eventInfo.payload.size(), prdId.c_str(), eventInfo.duration);
 				}
 			}
 			ret = true;

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -10271,17 +10271,7 @@ void PrivateInstanceAAMP::FoundEventBreak(const std::string &adBreakId, uint64_t
 			std::string url("");
 			mCdaiObject->SetAlternateContents(adBreakId, adId, url, startMS, brInfo.duration);	//A placeholder to avoid multiple scte35 event firing for the same adbreak
 		}
-		//Ignoring past SCTE events.
-		//mFogTSBEnabled check is added to ensure the change won't effect IPVOD
-		AAMPLOG_INFO("[CDAI] mTuneCompleted:%d mFogTSBEnabled:%d", mTuneCompleted, mFogTSBEnabled);
-		if (mTuneCompleted || !mFogTSBEnabled)
-		{
-			SaveNewTimedMetadata((long long) startMS, brInfo.name.c_str(), brInfo.payload.c_str(), (int)brInfo.payload.size(), adBreakId.c_str(), brInfo.duration);
-		}
-		else
-		{
-			AAMPLOG_WARN("[CDAI] Discarding SCTE event for period:%s  since tune is not completed",adBreakId.c_str());
-		}
+
 	}
 }
 

--- a/test/utests/fakes/FakePrivateInstanceAAMP.cpp
+++ b/test/utests/fakes/FakePrivateInstanceAAMP.cpp
@@ -992,6 +992,10 @@ void PrivateInstanceAAMP::ResumeTrackInjection(AampMediaType type)
 
 void PrivateInstanceAAMP::SaveTimedMetadata(long long timeMilliseconds, const char* szName, const char* szContent, int nb, const char* id, double durationMS)
 {
+	if(g_mockPrivateInstanceAAMP != nullptr)
+	{
+		g_mockPrivateInstanceAAMP->SaveTimedMetadata(timeMilliseconds, szName, id, durationMS);
+	}
 }
 
 void PrivateInstanceAAMP::SendEvent(AAMPEventPtr eventData, AAMPEventMode eventMode)

--- a/test/utests/mocks/MockPrivateInstanceAAMP.h
+++ b/test/utests/mocks/MockPrivateInstanceAAMP.h
@@ -65,6 +65,7 @@ public:
 	MOCK_METHOD(void, NotifyFirstVideoFrameDisplayed, ());
 	MOCK_METHOD(void, FoundEventBreak, (const std::string &adBreakId, uint64_t startMS, EventBreakInfo brInfo));
 	MOCK_METHOD(void, SaveNewTimedMetadata, (long long timeMS, const char* id, double durationMS));
+	MOCK_METHOD(void, SaveTimedMetadata, (long long timeMS, const char* szName, const char* id, double durationMS));
 	MOCK_METHOD(bool, DownloadsAreEnabled, ());
 	MOCK_METHOD(void, SendAdResolvedEvent, (const std::string &adId, bool status, uint64_t startMS, uint64_t durationMs, AAMPCDAIError errorCode));
 	MOCK_METHOD(uint32_t, GetAudTimeScale, ());

--- a/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdFallbackTests/FunctionalTests.cpp
@@ -439,7 +439,13 @@ TEST_F(AdFallbackTests, AdInitFailureTest)
 	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, false, _, _, _))
 		.WillRepeatedly(Return(true)); // Media fragments
 
-	TuneType tuneType = TuneType::eTUNETYPE_NEW_NORMAL;
+	// eTUNETYPE_RETUNE is required here because Init() has a guard that skips onAdEvent(INIT)
+	// for eTUNETYPE_NEW_NORMAL and eTUNETYPE_NEW_SEEK and eTUNETYPE_NEW_END.
+	// Skipping onAdEvent(INIT) means the CDAI state never transitions to IN_ADBREAK_AD_PLAYING
+	// during Init(), so StreamSelection() does not set the ad manifest URL and no ad init fragment
+	// is fetched. eTUNETYPE_RETUNE bypasses that guard, allowing onAdEvent(INIT) to run
+	// and the ad init path to be exercised as intended.
+	TuneType tuneType = TuneType::eTUNETYPE_RETUNE;
 	// Will start fetching the ad, but fails in ad init fragment and should fallback to source period and its init fragment
 	status = Init(tuneType);
 	EXPECT_EQ(status, eAAMPSTATUS_OK);

--- a/test/utests/tests/PrivAampTests/PrivAampTests.cpp
+++ b/test/utests/tests/PrivAampTests/PrivAampTests.cpp
@@ -3866,6 +3866,66 @@ TEST_F(PrivAampTests,FoundEventBreakTest)
 	EXPECT_FALSE(p_aamp->mFogTSBEnabled);
 }
 
+// FoundEventBreak with CDAI enabled and isDAIEvent=true must call SetAlternateContents to register the ad break.
+TEST_F(PrivAampTests, FoundEventBreak_CdaiEnabled_IsDAIEvent_CallsSetAlternateContents)
+{
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableClientDai))
+		.WillRepeatedly(Return(true));
+
+	CDAIObjectMPD *cdaiObj = new CDAIObjectMPD(p_aamp);
+	p_aamp->mCdaiObject = cdaiObj;
+
+	EventBreakInfo info;
+	info.payload = "payload";
+	info.name = "sampleTest";
+	info.duration = 15000;
+	info.presentationTime = 0;
+	info.isDAIEvent = true;
+
+	EXPECT_CALL(*g_MockPrivateCDAIObjectMPD, SetAlternateContents(_, _, _)).Times(1);
+	p_aamp->FoundEventBreak("Period-1", 0, info);
+
+	// mCdaiObject ownership transferred to p_aamp; cleaned up in destructor.
+}
+ 
+// FoundEventBreak with CDAI enabled but isDAIEvent=false must not register an ad break — SetAlternateContents not called.
+TEST_F(PrivAampTests, FoundEventBreak_CdaiEnabled_NotDAIEvent_NoSetAlternateContents)
+{
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableClientDai))
+		.WillRepeatedly(Return(true));
+
+	CDAIObjectMPD *cdaiObj = new CDAIObjectMPD(p_aamp);
+	p_aamp->mCdaiObject = cdaiObj;
+
+	EventBreakInfo info;
+	info.payload = "payload";
+	info.name = "sampleTest";
+	info.duration = 15000;
+	info.presentationTime = 0;
+	info.isDAIEvent = false;
+
+	EXPECT_CALL(*g_MockPrivateCDAIObjectMPD, SetAlternateContents(_, _, _)).Times(0);
+	p_aamp->FoundEventBreak("Period-1", 0, info);
+
+	// mCdaiObject ownership transferred to p_aamp; cleaned up in destructor.
+}
+ 
+// FoundEventBreak with CDAI disabled must take no action — SetAlternateContents must not be called.
+TEST_F(PrivAampTests, FoundEventBreak_CdaiDisabled_NoSetAlternateContents)
+{
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_EnableClientDai))
+		.WillRepeatedly(Return(false));
+	EventBreakInfo info;
+	info.payload = "payload";
+	info.name = "sampleTest";
+	info.duration = 15000;
+	info.presentationTime = 0;
+	info.isDAIEvent = true;
+
+	EXPECT_CALL(*g_MockPrivateCDAIObjectMPD, SetAlternateContents(_, _, _)).Times(0);
+	p_aamp->FoundEventBreak("Period-1", 0, info);
+}
+
 TEST_F(PrivAampTests,SetAlternateContentsTest)
 {
 	EXPECT_CALL(*g_MockPrivateCDAIObjectMPD, SetAlternateContents(_, _, _)).Times(0);
@@ -6194,7 +6254,7 @@ TEST_F(PrivAampTests, IsLatencyExceedingTrickplayThreshold_ReturnsTrue_WhenAbove
  */
 TEST_F(PrivAampPrivTests, StartLatencyMonitor_LiveLatencyCorrection_StartsMonitor)
 {
-	// Make the stream appear live.
+	// We are dealing with live manifest, so set the appropriate flags.
 	testp_aamp->SetIsLive(true);
 	testp_aamp->SetIsLiveStream(true);
 

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/FunctionalTests.cpp
@@ -5125,3 +5125,95 @@ R"(<?xml version="1.0" encoding="utf-8"?>
 	EXPECT_EQ(bitrates[0], 1000000);
 }
 
+/**
+ * @brief Parameterized test class for CDAI Init tests with different TuneTypes.
+ *
+ * Tests Init() behavior with various TuneType values:
+ * - NEW tune types (NEW_NORMAL, NEW_SEEK, NEW_END) should NOT call CheckForAdStart (CDAI skipped)
+ * - Non-NEW tune types (SEEK, RETUNE, SEEKTOLIVE, SEEKTOEND) SHOULD call CheckForAdStart (CDAI continues)
+ *
+ * Parameter: pair<TuneType, bool> where bool indicates if CheckForAdStart should be called.
+ */
+class CDAIInitTuneTypeTests : public FunctionalTestsBase,
+							  public ::testing::TestWithParam<std::pair<TuneType, bool>>
+{
+protected:
+	void SetUp() override
+	{
+		FunctionalTestsBase::SetUp();
+	}
+
+	void TearDown() override
+	{
+		FunctionalTestsBase::TearDown();
+	}
+};
+
+// Test Init() CDAI behavior based on TuneType
+TEST_P(CDAIInitTuneTypeTests, VerifiesCheckForAdStartBehavior)
+{
+	static const char *manifest =
+R"(<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" minBufferTime="PT2S" type="static"
+	mediaPresentationDuration="PT1M0S"
+	profiles="urn:mpeg:dash:profile:isoff-live:2011">
+	<Period id="p0" duration="PT1M0S">
+		<AdaptationSet contentType="video" mimeType="video/mp4">
+			<SegmentTemplate timescale="2500" initialization="video_init.mp4"
+							media="video_$Number$.m4s" startNumber="1"
+							duration="2500"/>
+			<Representation id="1" bandwidth="1000000" codecs="avc1.640028"
+							width="640" height="360" frameRate="25"/>
+		</AdaptationSet>
+	</Period>
+</MPD>
+)";
+	auto params = GetParam();
+	TuneType tuneType = params.first;
+	bool shouldCallCheckForAdStart = params.second;
+
+	mBoolConfigSettings[eAAMPConfig_EnableClientDai] = true;
+	g_MockPrivateCDAIObjectMPD = std::make_shared<NiceMock<MockPrivateCDAIObjectMPD>>();
+
+	// Set expectation based on parameter
+	if (shouldCallCheckForAdStart)
+	{
+		// Non-NEW tune types: CheckForAdStart SHOULD be called
+		EXPECT_CALL(*g_MockPrivateCDAIObjectMPD, CheckForAdStart(_, _, _, _, _, _)).Times(::testing::AtLeast(1));
+	}
+	else
+	{
+		// NEW tune types: CheckForAdStart should NOT be called
+		EXPECT_CALL(*g_MockPrivateCDAIObjectMPD, CheckForAdStart(_, _, _, _, _, _)).Times(0);
+	}
+
+	EXPECT_CALL(*g_mockMediaStreamContext, CacheFragment(_, _, _, _, _, true, _, _, _))
+		.WillRepeatedly(Return(true));
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, SetLLDashChunkMode(_));
+
+	AAMPStatusType status = InitializeMPD(manifest, tuneType);
+	EXPECT_EQ(status, eAAMPSTATUS_OK);
+
+	g_MockPrivateCDAIObjectMPD.reset();
+}
+
+/**
+ * @brief Instantiate CDAI Init tests with all TuneType variants.
+ *
+ * Format: pair<TuneType, shouldCallCheckForAdStart>
+ * - NEW tune types have shouldCallCheckForAdStart = false (skip CDAI)
+ * - Non-NEW tune types have shouldCallCheckForAdStart = true (continue CDAI)
+ */
+INSTANTIATE_TEST_SUITE_P(AllTuneTypes,
+						CDAIInitTuneTypeTests,
+						::testing::Values(
+							// NEW tune types - CheckForAdStart should NOT be called
+							std::make_pair(eTUNETYPE_NEW_NORMAL, false),
+							std::make_pair(eTUNETYPE_NEW_SEEK, false),
+							std::make_pair(eTUNETYPE_NEW_END, false),
+							// Non-NEW tune types - CheckForAdStart SHOULD be called
+							std::make_pair(eTUNETYPE_SEEK, true),
+							std::make_pair(eTUNETYPE_SEEKTOLIVE, true),
+							std::make_pair(eTUNETYPE_RETUNE, true),
+							std::make_pair(eTUNETYPE_SEEKTOEND, true)
+						));

--- a/test/utests/tests/fragmentcollector_mpd/FindTimedMetadataTests.cpp
+++ b/test/utests/tests/fragmentcollector_mpd/FindTimedMetadataTests.cpp
@@ -243,10 +243,12 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     // LiveManifest=true and init=false
     ResetCDAIAdObject();
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 27120))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),27120.0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 
     // Duplicate Periods are not processed
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,_)).Times(0);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,_,_)).Times(0);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 }
 
@@ -285,17 +287,22 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     // LiveManifest=false and init=true
     InitializeMPD(manifest);
     mStreamAbstractionAAMP_MPD->SetIsLiveManifest(false);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 0))).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, true, false);
 
     // LiveManifest=false and init=false
     ResetCDAIAdObject();
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 0))).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 
     // Duplicate Periods are not processed
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,_)).Times(0);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,_,_)).Times(0);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
 }
@@ -341,5 +348,46 @@ R"(<?xml version="1.0" encoding="UTF-8"?>
     mStreamAbstractionAAMP_MPD->SetIsLiveManifest(true);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 27120))).Times(1);
     EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),27120.0)).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
     mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, false);
+}
+
+TEST_F(FindTimedMetadataTests, BulkMetaReporting_CallsSaveTimedMetadata)
+{
+    static const char *manifest =
+R"(<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:scte35="urn:scte:scte35:2014:xml+bin" type="dynamic" id="test" profiles="urn:mpeg:dash:profile:isoff-live:2011" minBufferTime="PT1S" availabilityStartTime="1970-01-01T00:00:00.000Z" timeShiftBufferDepth="PT30M">
+  <Period id="Period-1" start="PT477586H51M45.467S">
+    <EventStream schemeIdUri="urn:scte:scte35:2014:xml+bin" timescale="90000" presentationTimeOffset="79441464098">
+      <Event presentationTime="79441464098" duration="2440800">
+        <scte35:Signal><scte35:Binary>/DAsAAAQdSsYAP/wBQb+3zKJFQAWAhRDVUVJAAAkQn/AAABOcUAAACIAAJR2FfM=</scte35:Binary></scte35:Signal>
+      </Event>
+      <Event presentationTime="79455172898" duration="2700000">
+        <scte35:Signal><scte35:Binary>/DAnAAAQdSsYAP/wBQb+34D6VQARAg9DVUVJAAAkQn+AAAAjAAAJmX3z</scte35:Binary></scte35:Signal>
+      </Event>
+    </EventStream>
+    <AdaptationSet id="track-1" contentType="video" mimeType="video/mp4">
+      <SegmentTemplate initialization="init.mp4" media="seg-$Time$.mp4" timescale="240000" presentationTimeOffset="79455172898">
+        <SegmentTimeline><S t="79476480098" d="460800" r="10"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="track-2" bandwidth="500000" codecs="avc1.640028" width="640" height="360"/>
+    </AdaptationSet>
+  </Period>
+</MPD>
+)";
+    std::string adBreakId = "Period-1";
+    EXPECT_CALL(*g_mockAampUtils, parseAndValidateSCTE35(_)).WillRepeatedly(Return(true));
+
+    InitializeMPD(manifest);
+    mStreamAbstractionAAMP_MPD->SetIsLiveManifest(true);
+
+    // FoundEventBreak must be called for both events regardless of reportBulkMeta.
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 27120))).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, FoundEventBreak(adBreakId,_,Field(&EventBreakInfo::duration, 30000))).Times(1);
+    // With reportBulkMeta=true, SaveTimedMetadata is called instead of SaveNewTimedMetadata.
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveTimedMetadata(_,_,StrEq(adBreakId.c_str()),27120.0)).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveTimedMetadata(_,_,StrEq(adBreakId.c_str()),30000.0)).Times(1);
+    EXPECT_CALL(*g_mockPrivateInstanceAAMP, SaveNewTimedMetadata(_,_,_)).Times(0);
+    mStreamAbstractionAAMP_MPD->InvokeFindTimedMetadata(mMPD, mRootNode, false, true);
 }


### PR DESCRIPTION
Reason for change: Invoke FoundEventBreak for both static and dynamic manifests when CDAI is enabled to support CDAI on cold CDVR. Avoid calling onAdEvent from init() to prevent processing DAI events during the tune-time period for a new tune.Added L1s.
Test Procedure: Refer jira ticket VPAAMP-394
Priority: P1