### PR TITLE
VPAAMP-568 Prevent SelectSubtitleTrack changing tracks, and clearing the in band CC flag

### DIFF
--- a/AAMP-UVE-API.md
+++ b/AAMP-UVE-API.md
@@ -186,7 +186,6 @@ Configuration options are passed to AAMP using the UVE `initConfig()` method. Th
 | rebufferLatencyStepSec | Float | 1.0 | Step size (seconds) added to all three latency thresholds (`lowLatencyMinValue`, `lowLatencyTargetValue`, `lowLatencyMaxValue`) each time the buffer drops below `latencyDangerBufferSec`. Allows the player to tolerate higher latency during poor network conditions. Zero disables the adaptive threshold feature entirely. |
 | playreadyOutputProtection | Boolean | false | Enable/disable HDCP output protection for DASH-PlayReady playback. |
 | preferredDrm | Number | 2 | Preferred DRM for playback. Refer Preferred DRM table below for available values. 0 - No DRM, 1 - Widevine, 2 - PlayReady (Default), 3 - Consec, 4 - AdobeAccess, 5 - Vanilla AES, 6 - ClearKey |
-| ceaFormat | Number | -1 | Preferred CEA option for closed captions. Default is stream-based. 0 - CEA 608, 1 - CEA 708 |
 | preFetchIframePlaylist | Boolean | false | Enable/disable prefetching of I-Frame playlist. |
 | preplayBuffercount | Number | 1 | Count of segments to download until reaching play state. |
 | ptsErrorThreshold | Number | 4 | Maximum number of back-to-back PTS errors before triggering a retune. |

--- a/AampConfig.cpp
+++ b/AampConfig.cpp
@@ -420,7 +420,6 @@ static const ConfigLookupEntryInt mConfigLookupTableInt[AAMPCONFIG_INT_COUNT+CON
 	{AAMP_HIGH_BUFFER_BEFORE_RAMPUP,"maxABRBufferRampup",eAAMPConfig_MaxABRNWBufferRampUp,false},
 	{DEFAULT_PREBUFFER_COUNT,"preplayBuffercount",eAAMPConfig_PrePlayBufferCount,false},
 	{0,"preCachePlaylistTime",eAAMPConfig_PreCachePlaylistTime,false},
-	{-1, "ceaFormat",eAAMPConfig_CEAPreferred,false, eCONFIG_RANGE_CEA_PREFERRED},
 	{DEFAULT_STALL_ERROR_CODE,"stallErrorCode",eAAMPConfig_StallErrorCode,false},
 	{DEFAULT_STALL_DETECTION_TIMEOUT,"stallTimeout",eAAMPConfig_StallTimeoutMS,false},
 	{DEFAULT_MINIMUM_INIT_CACHE_SECONDS,"initialBuffer",eAAMPConfig_InitialBuffer,false},

--- a/AampConfig.h
+++ b/AampConfig.h
@@ -271,7 +271,6 @@ typedef enum
 	eAAMPConfig_MaxABRNWBufferRampUp,					/**< Maximum ABR Buffer for Rampup*/
 	eAAMPConfig_PrePlayBufferCount, 					/**< Count of segments to be downloaded until play state */
 	eAAMPConfig_PreCachePlaylistTime,					/**< Max time to complete PreCaching .In Minutes  */
-	eAAMPConfig_CEAPreferred,						/**< To force 608/708 track selection in CC manager */
 	eAAMPConfig_StallErrorCode,
 	eAAMPConfig_StallTimeoutMS,
 	eAAMPConfig_InitialBuffer,

--- a/README.md
+++ b/README.md
@@ -216,9 +216,6 @@ preferredDrm			Preferred DRM for playback
 					4 - AdobeAccess
 					5 - Vanilla AES
 					6 - ClearKey
-ceaFormat			Preferred CEA option for CC. Default stream based . Override value 
-					0 - CEA 608
-					1 - CEA 708
 maxPlaylistCacheSize            Max Size of Cache to store the VOD Manifest/playlist . Size in KBytes. Default: 3072.
 initRampdownLimit		Maximum number of rampdown/retries for initial playlist retrieval at tune/seek time. Default: 0 (disabled).
 downloadBuffer                  Fragment cache length: Default 3 fragments

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -6354,6 +6354,15 @@ void StreamAbstractionAAMP_MPD::SelectSubtitleTrack(bool newTune, std::vector<Te
 		return;
 	}
 
+	// Skip OOB subtitle scoring on seek/trickplay resume when the app
+	// explicitly selected a CC track. mPreferredTextTrack
+	// is reset in Stop(), so this guard is inactive on a new tune.
+	if (aamp->GetPreferredTextTrack().isCC)
+	{
+		AAMPLOG_INFO("SelectSubtitleTrack: CC track explicitly selected, skipping OOB subtitle selection");
+		return;
+	}
+
 	size_t numAdaptationSets = period->GetAdaptationSets().size();
 	if (AAMP_NORMAL_PLAY_RATE == mPlayRate)
 	{

--- a/jsbindings/jsbindings.cpp
+++ b/jsbindings/jsbindings.cpp
@@ -498,8 +498,6 @@ static bool AAMP_setProperty_preferredCEAFormat(JSContextRef context, JSObjectRe
 		return false;
 	}
 	preferredCEAFormat = (int)JSValueToNumber(context, value, exception);
-        LOG_WARN(pAAMP,"_aamp->SetCEAFormat context=%p  value=%d exception=%p ",context, preferredCEAFormat, exception);
-	pAAMP->_aamp->SetCEAFormat(preferredCEAFormat);
 	return true;
 }
 

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -3043,16 +3043,6 @@ void PlayerInstanceAAMP::SetInitRampdownLimit(int limit)
 	SETCONFIGVALUE(AAMP_APPLICATION_SETTING,eAAMPConfig_InitRampDownLimit,limit);
 }
 
-
-/**
- *  @brief Set the CEA format for force setting
- */
-void PlayerInstanceAAMP::SetCEAFormat(int format)
-{
-	SETCONFIGVALUE(AAMP_APPLICATION_SETTING,eAAMPConfig_CEAPreferred,format);
-}
-
-
 /**
  *   @brief To get the available bitrates for thumbnails.
  */

--- a/main_aamp.h
+++ b/main_aamp.h
@@ -1238,14 +1238,6 @@ public:
 	void SetLanguageFormat(LangCodePreference preferredFormat, bool useRole = false);
 
 	/**
-	 *   @brief Set the CEA format for force setting
-	 *
-	 *   @param[in] format - 0 for 608, 1 for 708
-	 *   @return void
-	 */
-	void SetCEAFormat(int format);
-
-	/**
 	 *   @brief Set the session token for player
 	 *
 	 *   @param[in]string -  sessionToken

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -9021,15 +9021,6 @@ void PrivateInstanceAAMP::ReportContentGap(long long timeMilliseconds, std::stri
 void PrivateInstanceAAMP::InitializeCC(unsigned long decoderHandle)
 {
 	PlayerCCManager::GetInstance()->Init((void *)decoderHandle);
-	if (ISCONFIGSET_PRIV(eAAMPConfig_NativeCCRendering))
-	{
-		int overrideCfg = GETCONFIGVALUE_PRIV(eAAMPConfig_CEAPreferred);
-		if (overrideCfg == 0)
-		{
-			AAMPLOG_WARN("PrivateInstanceAAMP: CC format override to 608 present, selecting 608CC");
-			PlayerCCManager::GetInstance()->SetTrack("CC1");
-		}
-	}
 }
 
 /**
@@ -11904,6 +11895,8 @@ void PrivateInstanceAAMP::SetTextTrack(int trackId, char *data)
 				if (track.isCC)
 				{
 					mIsInbandCC = true;
+					SetPreferredTextTrack(track);
+					SetCCStatusInternal();
 					SetClosedCaptionsFromTextTrack(track);
 				}
 				else
@@ -11999,14 +11992,6 @@ void PrivateInstanceAAMP::SetClosedCaptionsFromTextTrack(TextTrackInfo &track)
 			{
 				format = eCLOSEDCAPTION_FORMAT_708;
 			}
-		}
-
-		// preferredCEA708 overrides whatever we infer from track. USE WITH CAUTION
-		int overrideCfg = GETCONFIGVALUE_PRIV(eAAMPConfig_CEAPreferred);
-		if (overrideCfg != -1)
-		{
-			format = (CCFormat)(overrideCfg & 1);
-			AAMPLOG_WARN("PrivateInstanceAAMP: CC format override present, override format to: %d", format);
 		}
 		AAMPLOG_INFO("instreamId %s format %d", track.instreamId.c_str(), format);
 		PlayerCCManager::GetInstance()->SetTrack(track.instreamId, format);

--- a/test/utests/fakes/FakePlayerInstanceAamp.cpp
+++ b/test/utests/fakes/FakePlayerInstanceAamp.cpp
@@ -150,7 +150,6 @@ const std::vector<TimedMetadata> & PlayerInstanceAAMP::GetTimedMetadata( void ) 
 	    }
     }
 	void PlayerInstanceAAMP::SetLanguageFormat(LangCodePreference preferredFormat, bool useRole) {  }
-	void PlayerInstanceAAMP::SetCEAFormat(int format) {  }
 	void PlayerInstanceAAMP::SetSessionToken(std::string sessionToken) {  }
 	void PlayerInstanceAAMP::SetMaxPlaylistCacheSize(int cacheSize) {  }
 	void PlayerInstanceAAMP::EnableSeekableRange(bool enabled) {  }

--- a/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
+++ b/test/utests/tests/PlayerInstanceAAMP/PlayerInstanceAAMPTestsMain.cpp
@@ -2401,21 +2401,6 @@ TEST_F(PlayerInstanceAAMPTests, ProcessContentProtectionDataConfigTests)
 	mPlayerInstance->ProcessContentProtectionDataConfig(jsonBuffer);
 }
 
-TEST_F(PlayerInstanceAAMPTests,SetCEAFormatTest1)
-{
-	int expectedFormat = 1;
-	mPlayerInstance->SetCEAFormat(expectedFormat);
-}
-TEST_F(PlayerInstanceAAMPTests,SetCEAFormatTest2)
-{
-	int expectedFormat = INT_MIN;
-	mPlayerInstance->SetCEAFormat(expectedFormat);
-}
-TEST_F(PlayerInstanceAAMPTests,SetCEAFormatTest3)
-{
-	int expectedFormat = INT_MAX;
-	mPlayerInstance->SetCEAFormat(expectedFormat);
-}
 TEST_F(PlayerInstanceAAMPTests,IsOOBCCRenderingSupportedTest)
 {
 	mPlayerInstance->IsOOBCCRenderingSupported();

--- a/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
+++ b/test/utests/tests/PreferredLanguages/SetPreferredTextLanguagesTests.cpp
@@ -817,7 +817,7 @@ TEST_F(SetPreferredTextLanguagesTests, ClosedCaptionTest1)
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, GetAvailableTextTracks(_))
 		.WillOnce(ReturnRef(tracks));
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, Stop(_)).Times(0);
-	EXPECT_CALL(*g_mockPlayerCCManager, SetTrack("CC1",eCLOSEDCAPTION_FORMAT_608)).Times(1).WillRepeatedly(Return(0));
+	EXPECT_CALL(*g_mockPlayerCCManager, SetTrack("CC1", eCLOSEDCAPTION_FORMAT_DEFAULT)).Times(1).WillRepeatedly(Return(0));
 	// SetCurrentTextTrackIndex is called for closed caption track changes
 	EXPECT_CALL(*g_mockStreamAbstractionAAMP, SetCurrentTextTrackIndex(_))
 		.Times(1);


### PR DESCRIPTION
VPAAMP-568 Prevent SelectSubtitleTrack changing tracks, and clearing the in band CC flag

VPAAMP-565: Deprecate ceaFormat from AAMP Config

Reason for change : fix cc selection when both in-band and out-band cc is present as part of stream
Test procedure : see ticket
risks: Low