### PR TITLE
VPAAMP-559: Fix memory retention after local TSB I-frame extraction

### DIFF
--- a/isobmff/isobmffhelper.cpp
+++ b/isobmff/isobmffhelper.cpp
@@ -48,7 +48,8 @@ bool IsoBmffHelper::ConvertToKeyFrame(std::vector<uint8_t> &buffer)
 	}
 
 	isoBmffBuffer.truncate();
-	buffer.shrink_to_fit(isoBmffBuffer.getSize());
+	buffer.resize(isoBmffBuffer.getSize());
+	buffer.shrink_to_fit();
 	return true;
 }
 

--- a/isobmff/isobmffhelper.cpp
+++ b/isobmff/isobmffhelper.cpp
@@ -49,7 +49,7 @@ bool IsoBmffHelper::ConvertToKeyFrame(std::vector<uint8_t> &buffer)
 
 	isoBmffBuffer.truncate();
 	buffer.resize(isoBmffBuffer.getSize());
-	buffer.shrink_to_fit();
+	buffer.shrink_to_fit(); // GCC (libstdc++), Clang (libc++), and MSVC (STL) all reallocate to fit.
 	return true;
 }
 

--- a/isobmff/isobmffhelper.cpp
+++ b/isobmff/isobmffhelper.cpp
@@ -48,7 +48,7 @@ bool IsoBmffHelper::ConvertToKeyFrame(std::vector<uint8_t> &buffer)
 	}
 
 	isoBmffBuffer.truncate();
-	buffer.resize(isoBmffBuffer.getSize());
+	buffer.shrink_to_fit(isoBmffBuffer.getSize());
 	return true;
 }
 

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -250,10 +250,7 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 				{
 					// Trickmode: the demuxer yields exactly one sample — the iframe.
 					auto& iframe = samples.front();
-					if (mEnablePtsRestamp)
-					{
-						TrickmodePtsRestamp(iframe, duration, discontinuous);
-					}
+					TrickmodePtsRestamp(iframe, duration, discontinuous);
 					mAamp->SendStreamTransfer(mMediaType, std::move(iframe));
 				}
 				else

--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -248,36 +248,26 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 			{
 				if (mIsTrickMode)
 				{
-					for (auto& sample : samples)
+					// Trickmode: the demuxer yields exactly one sample — the iframe.
+					auto& iframe = samples.front();
+					if (mEnablePtsRestamp)
 					{
-						// In trickmode, only I-frames (key frames) should be sent to the sink.
-						// This mirrors the upstream ConvertToKeyFrame filtering done in the TSB path
-						// and the iframe-track selection in the non-TSB path.
-						if (!sample.mIsKeyFrame)
-						{
-							AAMPLOG_TRACE("[%s] Skipping non-key frame sample in trickmode (pts=%.3f)",
-								GetMediaTypeName(mMediaType), sample.mPts);
-							continue;
-						}
-TrickmodePtsRestamp(sample, duration, discontinuous);
-
-						mAamp->SendStreamTransfer(mMediaType, std::move(sample));
+						TrickmodePtsRestamp(iframe, duration, discontinuous);
 					}
+					mAamp->SendStreamTransfer(mMediaType, std::move(iframe));
 				}
 				else
 				{
 					for (auto& sample : samples)
 					{
-						// Apply PTS offset if restamping is enabled. This modifies the sample timestamps before sending them to AAMP, which will use the adjusted values for playback timing.
 						if (mEnablePtsRestamp)
 						{
-							double beforeDTS = sample.mDts;
+							const double beforeDTS = sample.mDts;
 							sample.mPts += fragmentPTSoffset;
 							sample.mDts += fragmentPTSoffset;
-							// Log the restamping if enabled. This can be helpful for debugging and verifying correct behavior, but may cause log flooding for large segments.
 							if (mEnablePtsRestampLogging)
 							{
-								uint32_t timeScale = mMp4Demux->GetTimeScale();
+								const uint32_t timeScale = mMp4Demux->GetTimeScale();
 								AAMPLOG_INFO("[RestampPts][%s] timeScale %u beforeDTS %.3f afterDTS %.3f duration %.3f",
 								GetMediaTypeName(mMediaType),
 								timeScale,

--- a/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
@@ -61,7 +61,7 @@ protected:
 		g_mockMp4Demux = std::make_shared<NiceMock<MockMp4Demux>>();
 
 		// Create the demuxer instance with mocked AAMP
-		mDemuxer = new AampMp4Demuxer(mPrivateInstanceAAMP, eMEDIATYPE_VIDEO, true);
+		mDemuxer = new AampMp4Demuxer(mPrivateInstanceAAMP, eMEDIATYPE_VIDEO, false);
 	}
 
 	void TearDown() override

--- a/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
+++ b/test/utests/tests/AampMp4DemuxTests/FunctionalTests.cpp
@@ -61,7 +61,7 @@ protected:
 		g_mockMp4Demux = std::make_shared<NiceMock<MockMp4Demux>>();
 
 		// Create the demuxer instance with mocked AAMP
-		mDemuxer = new AampMp4Demuxer(mPrivateInstanceAAMP, eMEDIATYPE_VIDEO, false);
+		mDemuxer = new AampMp4Demuxer(mPrivateInstanceAAMP, eMEDIATYPE_VIDEO, true);
 	}
 
 	void TearDown() override

--- a/test/utests/tests/IsoBmffConvertToKeyFrameTests/IsoBmffConvertToKeyFrameTests.cpp
+++ b/test/utests/tests/IsoBmffConvertToKeyFrameTests/IsoBmffConvertToKeyFrameTests.cpp
@@ -127,6 +127,7 @@ TEST_P(IsoBmffConvertToKeyFrameTestsP, converToIFrame)
 
 	EXPECT_TRUE(helper->ConvertToKeyFrame(src_data));
 	EXPECT_EQ(src_data.size(), td.expected_data_len);
+	EXPECT_EQ(src_data.capacity(), td.expected_data_len);
 	auto memcmp_actual_vs_expected = std::memcmp(src_data.data(), td.expected_data,  td.expected_data_len);
 	EXPECT_EQ(0, memcmp_actual_vs_expected);
 	if (memcmp_actual_vs_expected)


### PR DESCRIPTION
`IsoBmffHelper::ConvertToKeyFrame()` called `resize()` to shrink the buffer to the single I-frame after truncation, but did not release the excess allocated capacity. In the local TSB trickplay path, where this is called per-segment at high frequency, the over-allocated tail of each segment buffer persisted until the vector was destroyed, causing steady memory growth and ultimately the crash reported in VPAAMP-559.

**Changes**

isobmffhelper.cpp — add `shrink_to_fit()` after `resize()` in `ConvertToKeyFrame()` so the segment buffer's capacity matches its logical size after I-frame extraction.

AampMp4Demuxer.cpp — remove the per-sample `mIsKeyFrame` loop in the trickmode branch of `sendSegment()`. By the time a segment reaches the demuxer in trickplay mode it already contains exactly one I-frame, whether that segment was sourced from local AAMP TSB (via `ConvertToKeyFrame()`), or a dedicated I-frame track from a cloud / FOG TSB. Iterating and filtering is therefore redundant. Replace with a direct `samples.front()` reference. Also tighten `const` correctness on `beforeDTS` and `timeScale` in the normal-mode restamp path.

IsoBmffConvertToKeyFrameTests.cpp — extend the existing `converToIFrame` parameterised test with `EXPECT_EQ(src_data.capacity(), td.expected_data_len)` to assert that capacity is released after truncation, not just that size is correct.
