### PR TITLE
Revert "VPAAMP-512: Fix EOS marking spam in FetcherLoop"

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -9560,23 +9560,18 @@ bool StreamAbstractionAAMP_MPD::CheckEndOfStream(bool waitForAdBreakCatchup)
 		{
 			AAMPLOG_INFO("EOS Reached. mPlayRate=%f mIterPeriodIndex=%d", mPlayRate, mIterPeriodIndex);
 			auto dashWorkerJob = std::make_shared<AampDashWorkerJob>([this]() {
+				mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
 				mMediaStreamContext[eMEDIATYPE_VIDEO]->AbortWaitForCachedAndFreeFragment(false);
 				AAMPLOG_INFO("Video EOS Marked after checking EOS on manifest");
 			});
 			if(ISCONFIGSET(eAAMPConfig_DashParallelFragDownload))
 			{
-				auto future = aamp->GetAampTrackWorkerManager()->SubmitJob(eMEDIATYPE_VIDEO, dashWorkerJob);
-				if (!future.valid())
-				{
-					AAMPLOG_WARN("Video EOS (CheckEndOfStream): SubmitJob failed, falling back to synchronous Execute");
-    				dashWorkerJob->Execute();
-				}
+				aamp->GetAampTrackWorkerManager()->SubmitJob(eMEDIATYPE_VIDEO , dashWorkerJob);
 			}
 			else
 			{
 				dashWorkerJob->Execute();
 			}
-			mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
 		}
 		ret = true;
 	}
@@ -10369,50 +10364,40 @@ void StreamAbstractionAAMP_MPD::FetcherLoop()
 											((mPlayRate > AAMP_RATE_PAUSE && mMediaStreamContext[eMEDIATYPE_VIDEO]->fragmentTime >= aamp->mAbsoluteEndPosition) || (mPlayRate < AAMP_RATE_PAUSE && mMediaStreamContext[eMEDIATYPE_VIDEO]->fragmentTime <= aamp->culledSeconds && (mMPDParseHelper->mLowerBoundaryPeriod == mCurrentPeriodIdx)))); // For rewinding, EOS does not need to be set unless the current period is a lower period.
 					if ((!mIsLiveManifest || (mPlayRate != AAMP_NORMAL_PLAY_RATE)) && (eosOutSideAd || eosAdPlayback))
 					{
-						if (vEos && !mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached)
+						if (vEos)
 						{
 							auto dashWorkerJob = std::make_shared<AampDashWorkerJob>([this]() {
+								mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
 								mMediaStreamContext[eMEDIATYPE_VIDEO]->AbortWaitForCachedAndFreeFragment(false);
 								AAMPLOG_INFO("Video EOS Marked");
 							});
 							if (ISCONFIGSET(eAAMPConfig_DashParallelFragDownload))
 							{
-								auto future = aamp->GetAampTrackWorkerManager()->SubmitJob(eMEDIATYPE_VIDEO, dashWorkerJob);
-								if (!future.valid())
-								{
-									AAMPLOG_WARN("Video EOS: SubmitJob failed, falling back to synchronous Execute");
-									dashWorkerJob->Execute();
-								}
+								aamp->GetAampTrackWorkerManager()->SubmitJob(eMEDIATYPE_VIDEO , dashWorkerJob);
 							}
 							else
 							{
 								dashWorkerJob->Execute();
 							}
-							mMediaStreamContext[eMEDIATYPE_VIDEO]->eosReached = true;
 							AAMPLOG_INFO("EOS Reached.eosOutSideAd:%d eosAdPlayback:%d", eosOutSideAd, eosAdPlayback);
 						}
 						if (audioEnabled)
 						{
-							if (mMediaStreamContext[eMEDIATYPE_AUDIO]->eos && !mMediaStreamContext[eMEDIATYPE_AUDIO]->eosReached)
+							if (mMediaStreamContext[eMEDIATYPE_AUDIO]->eos)
 							{
 								auto dashWorkerJob = std::make_shared<AampDashWorkerJob>([this]() {
+									mMediaStreamContext[eMEDIATYPE_AUDIO]->eosReached = true;
 									mMediaStreamContext[eMEDIATYPE_AUDIO]->AbortWaitForCachedAndFreeFragment(false);
 									AAMPLOG_INFO("Audio EOS Marked");
 								});
 								if (ISCONFIGSET(eAAMPConfig_DashParallelFragDownload))
 								{
-									auto future = aamp->GetAampTrackWorkerManager()->SubmitJob(eMEDIATYPE_AUDIO, dashWorkerJob);
-									if (!future.valid())
-									{
-										AAMPLOG_WARN("Audio EOS: SubmitJob failed, falling back to synchronous Execute");
-										dashWorkerJob->Execute();
-									}
+									aamp->GetAampTrackWorkerManager()->SubmitJob(eMEDIATYPE_AUDIO, dashWorkerJob);
 								}
 								else
 								{
 									dashWorkerJob->Execute();
 								}
-								mMediaStreamContext[eMEDIATYPE_AUDIO]->eosReached = true;
 							}
 						}
 						else


### PR DESCRIPTION
Reverts rdkcentral/aamp#1550

the !eosReached guard correctly prevents spam, but it also prevents the repeated AbortWaitForCachedAndFreeFragment calls that were keeping the downloader unblocked during normal period-boundary downloading