### PR TITLE
RDKEMW-20659: Bring in fix for WPEWebProcess crashed with fingerprint 80095400 to 8.4.

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -69,7 +69,8 @@ static const char* GstPluginNameVMX = "verimatrixdecryptor";
 /*InterfacePlayerRDK constructor*/
 InterfacePlayerRDK::InterfacePlayerRDK(bool isRialto) :
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
-mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL), mDRMSessionManager(NULL)
+mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL),
+mProgressCallbackContext(std::make_shared<ProgressCallbackContext>(this))
 {
 	interfacePlayerPriv = new InterfacePlayerPriv(isRialto);
 	m_gstConfigParam = new Configs();
@@ -84,6 +85,7 @@ mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSys
 /* InterfacePlayerRDK destructor*/
 InterfacePlayerRDK::~InterfacePlayerRDK()
 {
+	CancelProgressCallbackContext();
 	DestroyPipeline();
 	if (mDrmSystem)
 	{
@@ -749,17 +751,43 @@ void MonitorAV( InterfacePlayerRDK *pInterfacePlayerRDK )
  */
 gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
 {
-	InterfacePlayerRDK *pInterfacePlayerRDK = (InterfacePlayerRDK *)user_data;
-	InterfacePlayerPriv* privatePlayer = nullptr;
-	if (pInterfacePlayerRDK)
+	auto *weakContext = static_cast<std::weak_ptr<ProgressCallbackContext> *>(user_data);
+	if (!weakContext)
 	{
-	        privatePlayer = pInterfacePlayerRDK->GetPrivatePlayer();
-		if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
+		return G_SOURCE_REMOVE;
+	}
+
+	auto callbackContext = weakContext->lock();
+	if (!callbackContext)
+	{
+		return G_SOURCE_REMOVE;
+	}
+
+	InterfacePlayerRDK *pInterfacePlayerRDK = nullptr;
+	{
+		std::unique_lock<std::mutex> lock(callbackContext->mutex);
+		if (callbackContext->cancelled || !callbackContext->player)
 		{
-			MonitorAV(pInterfacePlayerRDK);
+			return G_SOURCE_REMOVE;
 		}
-		pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
-		MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+		callbackContext->activeCallbacks++;
+		pInterfacePlayerRDK = callbackContext->player;
+	}
+
+	if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
+	{
+		MonitorAV(pInterfacePlayerRDK);
+	}
+	pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
+	MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+
+	{
+		std::lock_guard<std::mutex> lock(callbackContext->mutex);
+		callbackContext->activeCallbacks--;
+		if (callbackContext->cancelled && (0 == callbackContext->activeCallbacks))
+		{
+			callbackContext->cv.notify_all();
+		}
 	}
 	return G_SOURCE_CONTINUE;
 }
@@ -784,8 +812,10 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 			double  reportProgressInterval = pInterfacePlayerRDK->m_gstConfigParam->progressTimer;
 			reportProgressInterval *= 1000; //convert s to ms
 
+			auto callbackContext = pInterfacePlayerRDK->GetOrCreateProgressCallbackContext();
+			auto *timerUserData = new std::weak_ptr<ProgressCallbackContext>(callbackContext);
 			GSourceFunc timerFunc = ProgressCallbackOnTimeout;
-			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId, user_data, "periodicProgressCallbackIdleTask");
+			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId, timerUserData, "periodicProgressCallbackIdleTask", DestroyProgressCallbackUserData);
 		}
 		else
 		{
@@ -1382,8 +1412,11 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	/*  make the execution of this function more deterministic and
 	 *  reduce scope for potential pipeline lockups*/
 
-	interfacePlayerPriv->gstPrivateContext->syncControl.disable();
-	interfacePlayerPriv->gstPrivateContext->aSyncControl.disable();
+	gstPrivateContext->syncControl.disable();
+	gstPrivateContext->aSyncControl.disable();
+	// Stop async worker before removing idle/timer tasks to prevent
+	// new tasks from being scheduled concurrently during teardown.
+	mScheduler.StopScheduler();
 	std::unique_lock<std::mutex> sourceSetupLock(mSourceSetupMutex);
 	mSourceSetupCV.notify_all();
 	if(interfacePlayerPriv->gstPrivateContext->bus)
@@ -1399,8 +1432,8 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	}
 	IdleTaskRemove(interfacePlayerPriv->gstPrivateContext->firstProgressCallbackIdleTask);
 
-	this->TimerRemove(interfacePlayerPriv->gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
-	if (interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId)
+	CancelProgressCallbackContext();
+	if (gstPrivateContext->bufferingTimeoutTimerId)
 	{
 		MW_LOG_MIL("InterfacePlayerRDK: Remove bufferingTimeoutTimerId %d", interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
 		g_source_remove(interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
@@ -1472,10 +1505,13 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	interfacePlayerPriv->gstPrivateContext->paused = false;
 	interfacePlayerPriv->gstPrivateContext->pipelineState = GST_STATE_NULL;
 	// Reset mute and volume params
-	interfacePlayerPriv->gstPrivateContext->audioMuted = false;
-	interfacePlayerPriv->gstPrivateContext->videoMuted = false;
-	interfacePlayerPriv->gstPrivateContext->subtitleMuted = false;
-	interfacePlayerPriv->gstPrivateContext->audioVolume = 1.0;
+	gstPrivateContext->audioMuted = false;
+	gstPrivateContext->videoMuted = false;
+	gstPrivateContext->subtitleMuted = false;
+	gstPrivateContext->audioVolume = 1.0;
+
+	// Restart scheduler so the same InterfacePlayerRDK instance can be reused.
+	mScheduler.StartScheduler();
 }
 
 void InterfacePlayerRDK::ResetGstEvents()
@@ -3686,24 +3722,106 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
 /**
  *  @brief TimerAdd - add a new glib timer in thread safe manner
  */
-void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName)
+std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::GetOrCreateProgressCallbackContext()
 {
-	std::lock_guard<std::mutex> lock(interfacePlayerPriv->gstPrivateContext->TaskControlMutex);
+	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+	bool createNewContext = false;
+	if (!mProgressCallbackContext)
+	{
+		createNewContext = true;
+	}
+	else
+	{
+		std::lock_guard<std::mutex> contextLock(mProgressCallbackContext->mutex);
+		if (mProgressCallbackContext->cancelled)
+		{
+			createNewContext = true;
+		}
+	}
+	if (createNewContext)
+	{
+		mProgressCallbackContext = std::make_shared<ProgressCallbackContext>(this);
+	}
+	return mProgressCallbackContext;
+}
+
+void InterfacePlayerRDK::CancelProgressCallbackContext()
+{
+	std::shared_ptr<ProgressCallbackContext> callbackContext;
+	{
+		std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+		callbackContext = mProgressCallbackContext;
+	}
+
+	if (!callbackContext)
+	{
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(callbackContext->mutex);
+		callbackContext->cancelled = true;
+		callbackContext->player = nullptr;
+	}
+
+	this->TimerRemove(gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
+
+	std::unique_lock<std::mutex> lock(callbackContext->mutex);
+	if (!callbackContext->cv.wait_for(lock, std::chrono::seconds(5), [&callbackContext]() {
+		return 0 == callbackContext->activeCallbacks;
+	})) {
+		MW_LOG_WARN("Teardown timeout: callback context still has active callbacks (%zu). Possible I/O blockage or deadlock detected.", callbackContext->activeCallbacks);
+	}
+	lock.unlock();
+
+	std::lock_guard<std::mutex> taskLock(gstPrivateContext->TaskControlMutex);
+	if (mProgressCallbackContext == callbackContext)
+	{
+		mProgressCallbackContext.reset();
+	}
+}
+
+void InterfacePlayerRDK::DestroyProgressCallbackUserData(gpointer user_data)
+{
+	delete static_cast<std::weak_ptr<ProgressCallbackContext> *>(user_data);
+}
+
+void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName, GDestroyNotify destroyNotify)
+{
+	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
 	if (funcPtr && user_data)
 	{
 		if (0 == taskId)
 		{
-			/* Sets the function pointed by functPtr to be called at regular intervals of repeatTimeout, supplying user_data to the function */
-			taskId = g_timeout_add(repeatTimeout, funcPtr, user_data);
+			if (destroyNotify)
+			{
+				taskId = g_timeout_add_full(G_PRIORITY_DEFAULT, repeatTimeout, funcPtr, user_data, destroyNotify);
+				if (0 == taskId)
+				{
+					destroyNotify(user_data);
+				}
+			}
+			else
+			{
+				taskId = g_timeout_add(repeatTimeout, funcPtr, user_data);
+			}
 			MW_LOG_INFO("InterfacePlayerRDK: Added timer '%.50s', %d", (nullptr!=timerName) ? timerName : "unknown" , taskId);
 		}
 		else
 		{
+			if (destroyNotify)
+			{
+				destroyNotify(user_data);
+			}
 			MW_LOG_INFO("InterfacePlayerRDK: Timer '%.50s' already added, taskId=%d", (nullptr!=timerName) ? timerName : "unknown", taskId);
 		}
 	}
 	else
 	{
+		if (destroyNotify && user_data)
+		{
+			destroyNotify(user_data);
+		}
 		MW_LOG_ERR("Bad pointer. funcPtr = %p, user_data=%p",funcPtr,user_data);
 	}
 }
@@ -3855,7 +3973,7 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 {
 	auto it = callbackMap.find(event);
-	if (it != callbackMap.end())
+	if ((it != callbackMap.end()) && it->second)
 	{
 		it->second();
 	}
@@ -3867,7 +3985,7 @@ void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event, int data)
 {
 	auto it = setupStreamCallbackMap.find(event);
-	if (it != setupStreamCallbackMap.end())
+	if ((it != setupStreamCallbackMap.end()) && it->second)
 	{
 		it->second(data);
 	}

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -33,41 +33,40 @@
 #include <functional>
 #include <condition_variable>
 #include <chrono>
+#include <memory>
+#include "GstUtils.h"
 #include <any>
 #include "SocUtils.h"
-#include "GstUtils.h"
 
-class InterfacePlayerPriv;
+class InterfacePlayerRDK;
 
-struct MonitorAVState
+struct ProgressCallbackContext
 {
-	int64_t tLastReported;
-	int64_t tLastSampled;
-	const char *description;
-	signed long av_position[2];
-	bool happy;
+	std::mutex mutex;
+	std::condition_variable cv;
+	InterfacePlayerRDK *player;
+	bool cancelled;
+	size_t activeCallbacks;
 
-	MonitorAVState() : tLastReported(0), tLastSampled(0), description(nullptr), happy(false)
+	explicit ProgressCallbackContext(InterfacePlayerRDK *playerInstance)
+		: player(playerInstance), cancelled(false), activeCallbacks(0)
 	{
-		av_position[0] = 0; // Video position
-		av_position[1] = 0; // Audio position
 	}
 };
 
 /**
- * @brief Function pointer for the idle task
- * @param[in] arg - Arguments
- * @return Idle task status
+ * @enum eGstPlayFlags
+ * @brief Enum of configuration flags used by playbin
  */
-typedef int (*BackgroundTask)(void *arg);
 
-struct GstTaskControlData
-{
-        guint taskID;
-        bool taskIsPending;
-        std::string taskName;
-        GstTaskControlData(const char *taskIdent) : taskID(0), taskIsPending(false), taskName(taskIdent ? taskIdent : "undefined") {};
-};
+#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 5
+#define GST_NORMAL_PLAY_RATE 1
+#define GST_TRACK_COUNT 4 /**< internal use - audio+video+sub+aux track */
+#define VIDEO_COORDINATES_SIZE 32
+#define GST_TASK_ID_INVALID 0
+#define GST_NORMAL_PLAY_RATE 1
+#define GST_ERROR_DESCRIPTION_LENGTH 256
+#define NOW_STEADY_TS_MS std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count() /**< Getting current steady clock in milliseconds */
 
 /*
  *@enum msgType
@@ -150,626 +149,755 @@ enum class InterfaceCB
 // Class to encapsulate GStreamer-related functionality
 class InterfacePlayerRDK
 {
-	private:
-		bool trickTeardown;
-		std::mutex mMutex;
-		std::map<std::string, int> configMap;
+private:
+	bool trickTeardown;
+	std::mutex mMutex;
+	std::map<std::string, int> configMap;
+	PlayerScheduler mScheduler;
+	std::shared_ptr<ProgressCallbackContext> mProgressCallbackContext;
 
-	public:
-		Configs *m_gstConfigParam;
-		char *mDrmSystem;
-		void *mEncrypt;
-		void *mDRMSessionManager;
-		std::map<InterfaceCB, std::function<void()>> callbackMap;
-		std::map<InterfaceCB, std::function<void(int)>> setupStreamCallbackMap;
-        
-		PlayerScheduler mScheduler;
-		InterfacePlayerRDK(bool isRialto = false);
-        	~InterfacePlayerRDK();
-		InterfacePlayerPriv* GetPrivatePlayer();
-		/**
-		 * @brief Clears the flags for an idle task.
-		 * @param[in] taskDetails The details of the task to clear flags for.
-		 */
-		void IdleTaskClearFlags(GstTaskControlData &taskDetails);
-		/**
-		 * @brief Removes an idle task from the GStreamer pipeline.
-		 * @param[in] taskDetails The details of the task to be removed.
-		 * @return true if the task is successfully removed, false otherwise.
-		 */
-		bool IdleTaskRemove(GstTaskControlData &taskDetails);
-		/**
-		 * @brief Adds an idle task.
-		 * @param[in] taskDetails The details of the task to be added.
-		 * @param[in] funcPtr The function pointer for the background task.
-		 * @return True if the task was added successfully, false otherwise.
-		 */
-		bool IdleTaskAdd(GstTaskControlData &taskDetails, BackgroundTask funcPtr);
-        	/**
-        	 * @brief Idle callback for the first frame.
-        	 *
-        	 * @param[in] user_data User data passed to the callback.
-        	 * @return TRUE if the callback should be called again, FALSE otherwise.
-        	 */
-        	static gboolean IdleCallbackOnFirstFrame(gpointer user_data);
-        	/**
-        	 * @brief Idle callback for end of stream (EOS).
-        	 *
-        	 * @param[in] user_data User data passed to the callback.
-        	 * @return TRUE if the callback should be called again, FALSE otherwise.
-        	 */
-        	static gboolean IdleCallbackOnEOS(gpointer user_data);
-        	/**
-        	 * @brief Progress callback on timeout.
-        	 *
-        	 * @param[in] user_data User data passed to the callback.
-        	 * @return TRUE if the callback should be called again, FALSE otherwise.
-        	 */
-        	static gboolean ProgressCallbackOnTimeout(gpointer user_data);
-        	/**
-        	 * @brief General idle callback.
-        	 *
-        	 * @param[in] user_data User data passed to the callback.
-        	 * @return TRUE if the callback should be called again, FALSE otherwise.
-        	 */
-        	static gboolean IdleCallback(gpointer user_data);
-        	/**
-        	 * @brief Idle callback for the first video frame displayed.
-        	 *
-        	 * @param[in] user_data User data passed to the callback.
-        	 * @return TRUE if the callback should be called again, FALSE otherwise.
-        	 */
-        	static gboolean IdleCallbackFirstVideoFrameDisplayed(gpointer user_data);
-        	/*Callback function types for various GStreamer events*/
-        	using BusMessageCallback = std::function<void(const BusEventData)>;
-        	using HandleOnGstBufferUnderflowCb = std::function<void(int mediaType)>;
-        	using HandleOnGstDecodeErrorCb = std::function<void(int CbCount)>;
-        	using HandleOnGstPtsErrorCb = std::function<void(bool isVideo, bool isAudioSink)>;
-        	using HandleBuffering_timeoutCb = std::function<void(bool isBufferingTimeoutConditionMet, bool isRateCorrectionDefaultOnPlaying, bool isPlayerReady)>;
-        	using HandleRedButtonCallback = std::function<void(const char *data)>;
-        	using HandleNeedDataCb = std::function<void(int mediaType)>;
-        	using HandleEnoughDataCb = std::function<void(int mediaType)>;
-		/**
-		 * @brief Checks if the pipeline is currently in paused state
-		 * @return true if pipeline is paused, false otherwise
-		 */
-		bool IsPipelinePaused();
-		/**
-		 * @brief Sets a flag indicating that pipeline transition to PLAYING state is pending
-		 */
-		void EnablePendingPlayState();
-        	/*
-        	 *@brief Registers need data callback from application
-        	 */
-        	void RegisterNeedDataCb(const HandleNeedDataCb &callback)
-        	{
-        	        NeedDataCb = callback;
-        	}
-        	/*
-         	*@brief Registers enough data callback from application
-        	 */
-        	void RegisterEnoughDataCb(const HandleEnoughDataCb &callback)
-                {
-                        EnoughDataCb = callback;
-                }
-        	/*
-        	 *@brief register registerHandleBuffering_timeoutCb
-        	 */
-        	void RegisterBufferingTimeoutCb(const HandleBuffering_timeoutCb &callback)
-        	{
-        		OnBuffering_timeoutCb = callback;
-        	}
-        	/*
-        	 *@brief register HandleOnGstPtsErrorCb
-        	 */
-        	void RegisterGstPtsErrorCb(const HandleOnGstPtsErrorCb &callback)
-        	{
-        		OnGstPtsErrorCb = callback;
-        	}
-        	/*
-        	 *@brief register handleOnGstDecodeErrorCb
-        	 */
-        	void RegisterGstDecodeErrorCb(const HandleOnGstDecodeErrorCb &callback)
-        	{
-        		OnGstDecodeErrorCb = callback;
-        	}
-        	/*
-        	 *@brief register OnGstBufferUnderflowCb
-        	 */
-        	void RegisterBufferUnderflowCb(const HandleOnGstBufferUnderflowCb &callback)
-        	{
-        		OnGstBufferUnderflowCb = callback;
-        	}
-        	/*
-        	 *@brief register registerHandleRedButtonCallback
-        	 */
-        	void RegisterHandleRedButtonCallback(const HandleRedButtonCallback &callback)
-        	{
-        		OnHandleRedButtonCallback = callback;
-        	}
-        	/*callback declarations*/
-        	BusMessageCallback busMessageCallback;
-        	HandleOnGstBufferUnderflowCb OnGstBufferUnderflowCb;
-        	HandleOnGstDecodeErrorCb OnGstDecodeErrorCb;
-        	HandleOnGstPtsErrorCb OnGstPtsErrorCb;
-        	HandleBuffering_timeoutCb OnBuffering_timeoutCb;
-        	HandleRedButtonCallback OnHandleRedButtonCallback;
-        	HandleNeedDataCb NeedDataCb;
-        	HandleEnoughDataCb EnoughDataCb;
-        	std::function<void(bool)> stopCallback;
-        	std::function<void(bool, int)> tearDownCb;
-        	std::function<void(int, bool, bool, bool &, bool &)> notifyFirstFrameCallback;
-        	std::function<void(const unsigned char *, int, int, int)> gstCbExportYUVFrame;
-        	pthread_mutex_t mProtectionLock;
-        	bool mFirstFrameRequired;
-        	bool mPauseInjector;
-        	bool mResumeInjector;
-        	bool PipelineSetToReady;				/**< To indicate the pipeline is set to ready forcefully */
-        	std::mutex mSourceSetupMutex;			/**< Protects the source setup state>*/
-        	std::condition_variable mSourceSetupCV; /**< Conditional Variable to notify changes in the source setup status>*/
-        	bool mSchedulerStarted;
-        	/**
-        	 * @brief Creates a GStreamer pipeline.
-        	* @param pipelineName Name of the pipeline.
-        	* @param PipelinePriority Priority of the pipeline.
-        	* @return True if the pipeline is created successfully, false otherwise.
-        	*/
-        	bool CreatePipeline(const char *pipelineName, int PipelinePriority);
-		/**
-        	* @brief Sets the player name.
-        	*
-        	* @param[in] name The name of the player.
-        	*/
-        	void SetPlayerName(std::string name);
-        	/**
-        	 *@brief sets the preferred drm by app
-        	 *@param[in] drmID preferred drm
-        	 */
-        	void SetPreferredDRM(const char *drmID);
-        	/**
-        	 * @brief Configures the GStreamer pipeline.
-        	 * @param format Video format.
-        	 * @param audioFormat Audio format.
-        	 * @param auxFormat Auxiliary format.
-        	 * @param subFormat Whether subtitle format is enabled.
-        	 * @param bESChangeStatus Whether ES change status is enabled.
-        	 * @param forwardAudioToAux Whether audio should be forwarded to the auxiliary output.
-        	 * @param setReadyAfterPipelineCreation Whether to set the player as ready after pipeline creation.
-        	 * @param isSubEnable Whether subtitles are enabled.
-        	 * @param trackId Track ID.
-        	 * @param rate Bitrate.
-        	 * @param pipelineName Pipeline name.
-        	 * @param PipelinePriority Pipeline priority.
-        	 */
-        	void ConfigurePipeline(int, int, int, int, bool, bool, bool, bool, int32_t, gint, const char *, int, bool, std::string url);
-        	/**
-        	 * @brief Enables or disables pausing on playback start.
-        	 * @param enable True to enable pausing, false to disable.
-        	 */
-        	void SetPauseOnStartPlayback(bool enable);
-        	/**
-        	 * @fn ForwardAudioBuffersToAux
-        	 *
-        	 * @return bool - true if audio to be forwarded
-        	 */
-        	bool ForwardAudioBuffersToAux();
-        	/**
-        	 * @brief Flush the track playbin
-        	 * @param[in] pos - position to seek to after flush
-        	 * @param[in] pos - audio delta
-        	 * @param[in] pos - subtitle delta
-        	 */
-        	double FlushTrack(int mediaType, double pos, double audioDelta, double subDelta);
-        	/**
-        	 *   @fn set video zoom
-        	 *
-        	 */
-        	void SetVideoZoom(int zoom_mode);
-        	/**
-        	 *   @fn set video mute
-        	 *
-        	 */
-        	void SetVideoMute(bool muted);
-        	/**
-        	 *    @fn set text style
-        	 *
-        	 */
-        	bool SetTextStyle(const std::string &options);
-        	/**
-        	 *   @fn GetVideoRectangle
-        	 *
-        	 */
-        	std::string GetVideoRectangle();
-        	/**
-        	 * @fn SetSubtitlePtsOffset
-        	 * @param[in] pts_offset pts offset for subs
-        	 */
-        	void SetSubtitlePtsOffset(std::uint64_t pts_offset);
-        	/**
-        	 * @fn SetSubtitleMute
-        	 * @param[in] muted true to mute subtitle otherwise false
-        	 */
-        	void SetSubtitleMute(bool mute);
-        	/**
-        	 * @fn GetPositionMilliseconds
-        	 * @retval playback position in MS
-        	 */
-        	long long GetPositionMilliseconds(void);
-        	/**
-        	 * @fn GetVideoPlaybackQuality
-        	 * returns video playback quality data
-        	 */
-        	GstPlaybackQualityStruct *GetVideoPlaybackQuality(void);
-        	/**
-        	 * @fn GetDurationMilliseconds
-        	 * @retval playback duration in MS
-        	 */
-        	long GetDurationMilliseconds(void);
-        	/**
-        	 * @fn ResetFirstFrame
-        	 */
-        	void ResetFirstFrame(void);
-        	/**
-        	 * @fn GetVideoSize
-        	 * @param[out] w width video width
-        	 * @param[out] h height video height
-        	 */
-        	void GetVideoSize(int &width, int &height);
-        	/**
-        	 * @fn SetVideoRectangle
-        	 * @param[in] x x co-ordinate of display rectangle
-        	 * @param[in] y y co-ordinate of display rectangle
-        	 * @param[in] w width of display rectangle
-        	 * @param[in] h height of display rectangle
-        	 */
-        	void SetVideoRectangle(int x, int y, int w, int h);
-        	/**
-        	 * @brief Un-pauses the pipeline and notifies the player of the buffer end event.
-        	 * @param[in] forceStop True to force stop buffering.
-        	 * @param[out] isPlaying Indicates whether playback is ongoing.
-        	 * @return True if buffering was stopped successfully, false otherwise.
-        	 */
-        	bool StopBuffering(bool forceStop, bool &isPlaying);
-        	/**
-        	 * @brief Gets the CC decoder handle.
-        	 * @return The CC decoder handle.
-        	 */
-        	unsigned long GetCCDecoderHandle(void);
-        	/**
-        	 * @brief Waits for the source setup.
-        	 * @param[in] mediaType The type of media stream.
-        	 * @return True if the source setup was successful, false otherwise.
-        	 */
-        	bool WaitForSourceSetup(int mediaType);
-        	/**
-        	 * @brief Send PTS/DTS to downstream elements.
-        	 * @param[in] type The type of event.
-        	 * @param[in] ptr Pointer to the event data.
-        	 * @param[in] len Length of the event data.
-        	 * @param[in] fpts First PTS value.
-        	 * @param[in] fdts First DTS value.
-        	 * @param[in] fDuration Duration of the event.
-        	 * @param[in] fragmentPTSoffset Offset PTS value.
-        	 * @param[in] copy True to copy the event data.
-        	 * @param[in] initFragment True if this is an initialization fragment.
-        	 * @param[out] discontinuity Indicates whether there is a discontinuity.
-        	 * @param[out] notifyFirstBufferProcessed Indicates whether the first buffer was processed.
-        	 * @param[out] sendNewSegmentEvent Indicates whether to send a new segment event.
-        	 * @param[out] resetTrickUTC Indicates whether to reset the trick UTC.
-        	 * @param[out] firstBufferPushed Indicates whether the first buffer was pushed.
-        	 * @return True if the event was sent successfully, false otherwise.
-        	 */
-        	bool SendHelper(int type, const void *ptr, size_t len, double fpts, double fdts, double fDuration, double fragmentPTSoffset, bool copy, bool initFragment, bool &discontinuity, bool &notifyFirstBufferProcessed, bool &sendNewSegmentEvent, bool &resetTrickUTC, bool &firstBufferPushed);
-        	/**
-        	 * @brief Pauses the injector.
-        	 */
-        	void PauseInjector();
-        	/**
-        	 * @brief Resumes the injector.
-        	 */
-        	void ResumeInjector();
-        	/**
-        	 * @brief Handles the video buffer sent event.
-        	 * @return True if the video buffer was handled successfully, false otherwise.
-        	 */
-        	bool HandleVideoBufferSent();
-        	/**
-        	 * @fn QueueProtectionEvent
-        	 * @param[in] formatType hls/dash format
-        	 * @param[in] protSystemId keysystem to be used
-        	 * @param[in] ptr initData DRM initialization data
-        	 * @param[in] len initDataSize DRM initialization data size
-        	 * @param[in] type Media type
-        	 */
-        	void QueueProtectionEvent(const std::string &formatType, const char *protSystemId, const void *initData, size_t initDataSize, int mediaType);
-        	/**
-        	 * @brief Sets the playback rate in audio and video sink.
-        	 * @param[in] rate The playback rate to set.
-        	 * @return True if the playback rate was set successfully, false otherwise.
-        	 */
-        	bool SetPlayBackRate(double rate);
-        	/**
-        	 * @brief Sets the audio volume or mute/unmute.
-        	 */
-        	void SetVolumeOrMuteUnMute(void);
-        	/**
-        	 * @brief Sets the audio volume.
-        	 * @param[in] volume The volume level to set.
-        	 */
-        	void SetAudioVolume(int volume);
-        	/**
-        	 * @brief Tears down the stream.
-        	 * @param[in] mediaType The type of media stream.
-        	 */
-        	void TearDownStream(int mediaType);
-        	/**
-        	 * @brief Initializes the source for the player.
-        	 * @param[in] PlayerInstance The player instance.
-        	 * @param[in] source The source to initialize.
-        	 * @param[in] eMEDIATYPE_VIDEO The media type for video.
-        	 */
-        	void InitializeSourceForPlayer(void *PlayerInstance, void *source, int mediaType);
-        	/**
-        	 * @brief Setup a Closed Caption control stream.
-        	 */
-        	void SetupClosedCaptionControlStream();
-        	/**
-        	 * @brief Sets up the stream.
-        	 * @param[in] streamId The ID of the stream to set up.
-        	 * @param[in] _this The instance of the player.
-        	 * @param[in] url The URL of the stream.
-        	 * @return An integer indicating the success or failure of the setup.
-        	 */
-        	int SetupStream(int streamId, void *_this, std::string url);
-        	/**
-        	 * @brief Gets the video PTS value.
-        	 * @return The video PTS value.
-        	 */
-        	long long GetVideoPTS(void);
-        	/**
-        	 * @brief Sets the callback for the first frame.
-        	 * @param[in] callback The callback function to be called on the first frame.
-        	 */
-        	void FirstFrameCallback(std::function<void(int, bool, bool, bool &, bool &)> callback);
-        	/**
-        	 * @brief Sets the callback for stopping.
-        	 * @param[in] callback The callback function to be called when stopping.
-        	 */
-        	void StopCallback(std::function<void(bool)> callback);
-        	/**
-        	 * @brief Sets the callback for tearing down.
-        	 * @param[in] callback The callback function to be called when tearing down.
-        	 */
-        	void TearDownCallback(std::function<void(bool, int)> callback);
-        	/**
-        	 * @brief Notifies the first frame.
-        	 * @param[in] mediaType The type of media.
-        	 */
-        	void NotifyFirstFrame(int mediaType);
-        	/**
-        	 * @brief Pauses GStreamer.
-        	 * @param[in] pause Indicates whether to pause or resume.
-        	 * @param[in] forceStopGstreamerPreBuffering Indicates whether to force stop GStreamer pre-buffering.
-        	 * @return True if the operation was successful, false otherwise.
-        	 */
-        	bool Pause(bool pause, bool forceStopGstreamerPreBuffering);
-        	/**
-        	 * @brief Checks for PTS change with a timeout.
-        	 * @param[in] timeout The timeout value in milliseconds.
-        	 * @return True if a PTS change was detected within the timeout, false otherwise.
-        	 */
-        	bool CheckForPTSChangeWithTimeout(long timeout);
-        	/**
-        	 * @brief Checks if the cache is empty for a given media type.
-        	 * @param[in] mediaType The type of media stream.
-        	 * @return True if the cache is empty, false otherwise.
-        	 */
-        	bool IsCacheEmpty(int mediaType);
-        	/**
-        	 * @brief Resets the EOS signalled flag.
-        	 */
-        	void ResetEOSSignalledFlag(void);
-        	/**
-        	 * @brief Checks if the pipeline is configured for a given media type.
-        	 * @param[in] type The type of media stream.
-        	 * @return True if the pipeline is configured, false otherwise.
-        	 */
-        	bool PipelineConfiguredForMedia(int type);
-        	/**
-        	 * @brief Gets buffer control data for a given media type.
-        	 * @param[in] mediaType The type of media stream.
-        	 * @return True if the buffer control data was retrieved successfully, false otherwise.
-        	 */
-        	bool GetBufferControlData(int mediaType);
-        	/**
-        	 * @brief Checks if the stream is ready for a given media type.
-        	 * @param[in] mediaType The type of media stream.
-        	 * @return True if the stream is ready, false otherwise.
-        	 */
-        	bool IsStreamReady(int mediaType);
-        	/**
-        	 * @brief Signals a trick mode discontinuity.
-        	 */
-        	void SignalTrickModeDiscontinuity();
-        	/**
-        	 * @brief Processes discontinuity for a stream type.
-        	 *
-        	 * @param[in] mediaType The type of media stream.
-        	 * @param[in] streamFormat The format of the stream.
-        	 * @param[in] codecChange Indicates whether there is a codec change.
-        	 * @param[out] unblockDiscProcess Indicates whether to unblock the discontinuity process.
-        	 * @param[out] shouldHaltBuffering Indicates whether buffering should be halted.
-        	 * @return True if the discontinuity was processed successfully, false otherwise.
-        	 */
-        	bool CheckDiscontinuity(int mediaType, int streamFormat, bool codecChange, bool &unblockDiscProcess, bool &shouldHaltBuffering);
-        	/**
-        	 * @brief Sets up the stream for the interface player.
-        	 * @param[in] streamId The ID of the stream to set up.
-        	 * @param[in] url The URL of the stream.
-        	 * @return An integer indicating the success or failure of the setup.
-        	 */
-        	int InterfacePlayer_SetupStream(int streamId, std::string url);
-        	/**
-        	 * @brief Triggers an event.
-        	 *
-        	 * This function triggers the specified event with the given data.
-        	 *
-        	 * @param[in] event The event to trigger.
-        	 * @param[in] data The data associated with the event.
-        	 */
-        	void TriggerEvent(InterfaceCB event, int data);
-        	/**
-        	 * @brief Triggers an event.
-        	 * @param[in] event The event to trigger.
-        	 */
-        	void TriggerEvent(InterfaceCB event);
-        	/**
-        	 * @brief Disables the decoder handle notification.
-        	 */
-        	void DisableDecoderHandleNotified();
-        	/*
-        	 *@brief register busMessageCallback
-        	 */
-        	void RegisterBusEvent(const BusMessageCallback &callback)
-        	{
-        		busMessageCallback = callback;
-        	}
-        	/**
-        	 * @fn ClearProtectionEvent
-        	 */
-        	void ClearProtectionEvent();
-        	/**
-        	 * @brief Sets the seek position for the GStreamer pipeline.
-        	 * @param[in] positionSecs The position to seek to, in seconds.
-        	 */
-        	void SetSeekPosition(double positionSecs);
-        	/**
-        	 * @brief Disconnects all signals associated with the GStreamer pipeline.
-        	 */
-        	void DisconnectSignals();
-        	/**
-        	 * @brief Removes a GStreamer timer task.
-        	 * @param[in,out] taskId    Reference to the ID of the task to be removed.
-        	 * @param[in]     timerName The name of the timer to be removed
-        	 */
-        	void TimerRemove(guint &taskId, const char *timerName);
-        	/**
-        	 * @brief get the encryption from application to share it with PlayReadyDecryptor Plugin
-        	 */
-        	void setEncryption(void *mEncrypt, void *mDRMSessionManager);
-        	/**
-        	 * @brief Removes all active GStreamer probes.
-        	 */
-        	void RemoveProbes();
-        	/**
-        	 * @fn RemoveProbe
-        	 * @brief Remove probe for a particular media type
-        	 * @param[in] mediaType The media type for which the probe should be removed
-        	 */
-        	void RemoveProbe(int mediaType);
-        	/**
-        	 * @brief Destroys the GStreamer pipeline.
-        	 */
-        	void DestroyPipeline();
-        	/**
-        	 * @brief Stops the GStreamer pipeline.
-        	 *
-        	 * @param[in] keepLastFrame Whether to retain the last displayed frame.
-        	 */
-        	void Stop(bool keepLastFrame);
-        	/**
-        	 * @brief Sets the pending seek state.
-        	 * @param[in] state True to enable pending seek, false to disable.
-        	 */
-        	void SetPendingSeek(bool state);
-        	/**
-        	 *@brief returns true if using rialto sink
-        	 */
-        	bool IsUsingRialtoSink();
-        	/**
-        	 * @brief Resets GStreamer event states for all tracks.
-        	 * This function updates the internal states for each track,
-        	 * marking the position as reset, disabling pending seeks,
-        	 * and clearing EOS and buffer flags.
-        	 */
-        	void ResetGstEvents();
-        	/**
-        	 * @brief Retrieves the trick play teardown status
-        	 */
-        	bool GetTrickTeardown();
-        	/**
-        	 * @brief Sets the trick play teardown state.
-        	 * @param[in] state True to enable trick play teardown, false to disable.
-        	 */
-        	void SetTrickTearDown(bool state);
-        	/**
-        	 * @brief Flushes the GStreamer pipeline.
-        	 * @param[in] position The position to flush to, in seconds.
-        	 * @param[in] rate The playback rate.
-        	 * @param[in] shouldTearDown Whether to tear down the pipeline.
-        	 * @param[in] GstState The desired GStreamer pipeline state.
-        	 * @param[in] gstMediaFormat The media format for the pipeline.
-        	 */
-        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek);
-        	/**
-        	 * @fn TimerAdd
-        	 * @param[in] funcPtr function to execute on timer expiry
-        	 * @param[in] repeatTimeout timeout between calls in ms
-        	 * @param[in] user_data data to pass to the timer function
-        	 * @param[in] timerName name of the timer being added
-        	 * @param[out] taskId id of the timer to be returned
-        	 */
-        	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr);
-        	/**
-        	 * @fn TimerIsRunning
-        	 * @param[in] taskId id of the timer to be removed
-        	 * @return true - timer is currently running
-        	 */
-        	bool TimerIsRunning(guint &taskId);
-        	/**
-        	 * @fn NotifyEOS
-        	 */
-        	void NotifyEOS();
-        	/**
-        	 * @fn NotifyFragmentCachingComplete
-        	 */
-        	void NotifyFragmentCachingComplete();
-        	/**
-        	 * @fn EndOfStreamReached
-        	 * @param[in] type stream type
-        	 */
-        	void EndOfStreamReached(int mediaType, bool &shouldHaltBuffering);
-        	/**
-        	 * @brief Signals the subtitle clock.
-        	 *
-        	 * @param[in] vPTS The presentation timestamp.
-        	 * @param[in] state The state to set for the subtitle clock.
-        	 * @return True if the operation was successful, false otherwise.
-        	 */
-        	bool SignalSubtitleClock(gint64 vPTS, bool state);
-        	/**
-        	 * @brief Initializes Player GStreamer plugins.
-        	 *
-        	 * This function initializes the necessary plugins for Player GStreamer.
-        	 */
-        	static void InitializePlayerGstreamerPlugins();
-        	/**
-        	 * @brief Dumps diagnostic information.
-        	 */
-        	void DumpDiagnostics();
-        	/**
-        	 * @brief Enables GStreamer debug logging.
-        	 * @param[in] debugLevel The level of debug logging to enable.
-        	 */
-        	void EnableGstDebugLogging(std::string debugLevel);
-		/**Add commentMore actions
-		 * @brief Gets the monitor AV state.
-		 * @return A pointer to the MonitorAVState structure containing the AV status or nullptr.
-		 */
-		const MonitorAVState& GetMonitorAVState();
+	std::shared_ptr<ProgressCallbackContext> GetOrCreateProgressCallbackContext();
+	void CancelProgressCallbackContext();
+	static void DestroyProgressCallbackUserData(gpointer user_data);
 
-	private:
-		InterfacePlayerPriv *interfacePlayerPriv;
+public:
+	std::shared_ptr<SocInterface> socInterface;
+	GstPlayerPriv *gstPrivateContext;
+	Configs *m_gstConfigParam;
+	char *mDrmSystem;
+	void *mEncrypt;
+	std::map<InterfaceCB, std::function<void()>> callbackMap;
+	std::map<InterfaceCB, std::function<void(int)>> setupStreamCallbackMap;
+
+	InterfacePlayerRDK();
+	~InterfacePlayerRDK();
+
+	/**
+	 * @brief Idle callback for the first frame.
+	 *
+	 * @param[in] user_data User data passed to the callback.
+	 * @return TRUE if the callback should be called again, FALSE otherwise.
+	 */
+	static gboolean IdleCallbackOnFirstFrame(gpointer user_data);
+
+	/**
+	 * @brief Idle callback for end of stream (EOS).
+	 *
+	 * @param[in] user_data User data passed to the callback.
+	 * @return TRUE if the callback should be called again, FALSE otherwise.
+	 */
+	static gboolean IdleCallbackOnEOS(gpointer user_data);
+
+	/**
+	 * @brief Progress callback on timeout.
+	 *
+	 * @param[in] user_data User data passed to the callback.
+	 * @return TRUE if the callback should be called again, FALSE otherwise.
+	 */
+	static gboolean ProgressCallbackOnTimeout(gpointer user_data);
+
+	/**
+	 * @brief General idle callback.
+	 *
+	 * @param[in] user_data User data passed to the callback.
+	 * @return TRUE if the callback should be called again, FALSE otherwise.
+	 */
+	static gboolean IdleCallback(gpointer user_data);
+
+	/**
+	 * @brief Idle callback for the first video frame displayed.
+	 *
+	 * @param[in] user_data User data passed to the callback.
+	 * @return TRUE if the callback should be called again, FALSE otherwise.
+	 */
+	static gboolean IdleCallbackFirstVideoFrameDisplayed(gpointer user_data);
+
+	/*Callback function types for various GStreamer events*/
+	using BusMessageCallback = std::function<void(const BusEventData)>;
+	using HandleOnGstBufferUnderflowCb = std::function<void(int mediaType)>;
+	using HandleOnGstDecodeErrorCb = std::function<void(int CbCount)>;
+	using HandleOnGstPtsErrorCb = std::function<void(bool isVideo, bool isAudioSink)>;
+	using HandleBuffering_timeoutCb = std::function<void(bool isBufferingTimeoutConditionMet, bool isRateCorrectionDefaultOnPlaying, bool isPlayerReady)>;
+	using HandleRedButtonCallback = std::function<void(const char *data)>;
+	using HandleNeedDataCb = std::function<void(int mediaType)>;
+	using HandleEnoughDataCb = std::function<void(int mediaType)>;
+
+	/*
+	 *@brief Registers need data callback from application
+	 */
+	void RegisterNeedDataCb(const HandleNeedDataCb &callback)
+	{
+	        NeedDataCb = callback;
+	}
+
+	/*
+ 	*@brief Registers enough data callback from application
+	 */
+	void RegisterEnoughDataCb(const HandleEnoughDataCb &callback)
+        {
+                EnoughDataCb = callback;
+        }
+
+	/*
+	 *@brief register registerHandleBuffering_timeoutCb
+	 */
+	void RegisterBufferingTimeoutCb(const HandleBuffering_timeoutCb &callback)
+	{
+		OnBuffering_timeoutCb = callback;
+	}
+
+	/*
+	 *@brief register HandleOnGstPtsErrorCb
+	 */
+	void RegisterGstPtsErrorCb(const HandleOnGstPtsErrorCb &callback)
+	{
+		OnGstPtsErrorCb = callback;
+	}
+
+	/*
+	 *@brief register handleOnGstDecodeErrorCb
+	 */
+	void RegisterGstDecodeErrorCb(const HandleOnGstDecodeErrorCb &callback)
+	{
+		OnGstDecodeErrorCb = callback;
+	}
+
+	/*
+	 *@brief register OnGstBufferUnderflowCb
+	 */
+	void RegisterBufferUnderflowCb(const HandleOnGstBufferUnderflowCb &callback)
+	{
+		OnGstBufferUnderflowCb = callback;
+	}
+
+	/*
+	 *@brief register registerHandleRedButtonCallback
+	 */
+	void RegisterHandleRedButtonCallback(const HandleRedButtonCallback &callback)
+	{
+		OnHandleRedButtonCallback = callback;
+	}
+
+	/*callback declarations*/
+	BusMessageCallback busMessageCallback;
+	HandleOnGstBufferUnderflowCb OnGstBufferUnderflowCb;
+	HandleOnGstDecodeErrorCb OnGstDecodeErrorCb;
+	HandleOnGstPtsErrorCb OnGstPtsErrorCb;
+	HandleBuffering_timeoutCb OnBuffering_timeoutCb;
+	HandleRedButtonCallback OnHandleRedButtonCallback;
+	HandleNeedDataCb NeedDataCb;
+	HandleEnoughDataCb EnoughDataCb;
+
+	std::function<void(bool)> stopCallback;
+	std::function<void(bool, int)> tearDownCb;
+	std::function<void(GstMediaType, bool, bool, bool &, bool &)> notifyFirstFrameCallback;
+	std::function<void(const unsigned char *, int, int, int)> gstCbExportYUVFrame;
+
+	pthread_mutex_t mProtectionLock;
+	std::string mPlayerName;
+	bool mFirstFrameRequired;
+	bool mPauseInjector;
+	bool mResumeInjector;
+	bool PipelineSetToReady;				/**< To indicate the pipeline is set to ready forcefully */
+	std::mutex mSourceSetupMutex;			/**< Protects the source setup state>*/
+	std::condition_variable mSourceSetupCV; /**< Conditional Variable to notify changes in the source setup status>*/
+	bool mSchedulerStarted;
+
+	/**
+	 * @brief Creates a GStreamer pipeline.
+
+	* @param pipelineName Name of the pipeline.
+	* @param PipelinePriority Priority of the pipeline.
+
+	* @return True if the pipeline is created successfully, false otherwise.
+	 */
+	bool CreatePipeline(const char *pipelineName, int PipelinePriority);
+	/**
+	 * @brief Connects a signal to a handler.
+	 *
+	 * @param[in] instance The instance to connect the signal to.
+	 * @param[in] detailed_signal The detailed signal to connect.
+	 * @param[in] c_handler The callback handler for the signal.
+	 * @param[in] data User data to pass to the callback handler.
+	 */
+	void SignalConnect(gpointer instance, const gchar *detailed_signal, GCallback c_handler, gpointer data);
+
+	/**
+	 * @brief Sets the player name.
+	 *
+	 * @param[in] name The name of the player.
+	 */
+	void SetPlayerName(std::string name);
+
+	/**
+	 *@brief sets the preferred drm by app
+	 *@param[in] drmID preferred drm
+	 */
+	void SetPreferredDRM(const char *drmID);
+	/**
+	 * @fn SendQtDemuxOverrideEvent
+	 * @param[in] mediaType stream type
+	 * @param[in] pts position value of buffer
+	 * @param[in] ptr buffer pointer
+	 * @param[in] len length of buffer
+	 * @ret TRUE if override is enabled, FALSE otherwise
+	 */
+	gboolean SendQtDemuxOverrideEvent(GstMediaType mediaType, GstClockTime pts, const void *ptr = nullptr, size_t len = 0);
+
+	/**
+	 * @brief Configures the GStreamer pipeline.
+	 * @param format Video format.
+	 * @param audioFormat Audio format.
+	 * @param auxFormat Auxiliary format.
+	 * @param subFormat Whether subtitle format is enabled.
+	 * @param bESChangeStatus Whether ES change status is enabled.
+	 * @param forwardAudioToAux Whether audio should be forwarded to the auxiliary output.
+	 * @param setReadyAfterPipelineCreation Whether to set the player as ready after pipeline creation.
+	 * @param isSubEnable Whether subtitles are enabled.
+	 * @param trackId Track ID.
+	 * @param rate Bitrate.
+	 * @param pipelineName Pipeline name.
+	 * @param PipelinePriority Pipeline priority.
+	 */
+	void ConfigurePipeline(int, int, int, int, bool, bool, bool, bool, int32_t, gint, const char *, int, bool, std::string url);
+
+	/**
+	 * @brief Enables or disables pausing on playback start.
+	 * @param enable True to enable pausing, false to disable.
+	 */
+	void SetPauseOnStartPlayback(bool enable);
+
+	/**
+	 * @brief SendGstEvents
+	 * @param[in] mediaType stream type
+	 * @param[in] pts position value of first buffer
+	 */
+	void SendGstEvents(GstMediaType mediaType, GstClockTime pts);
+
+	/**
+	 * @fn ForwardAudioBuffersToAux
+	 *
+	 * @return bool - true if audio to be forwarded
+	 */
+	bool ForwardAudioBuffersToAux();
+
+	/**
+	 * @brief Flush the track playbin
+	 * @param[in] pos - position to seek to after flush
+	 * @param[in] pos - audio delta
+	 * @param[in] pos - subtitle delta
+	 */
+	double FlushTrack(int mediaType, double pos, double audioDelta, double subDelta);
+
+	/**
+	 *   @fn set video zoom
+	 *
+	 */
+	void SetVideoZoom(int zoom_mode);
+	/**
+	 *   @fn set video mute
+	 *
+	 */
+	void SetVideoMute(bool muted);
+	/**
+	 *    @fn set text style
+	 *
+	 */
+	bool SetTextStyle(const std::string &options);
+	/**
+	 *   @fn GetVideoRectangle
+	 *
+	 */
+	std::string GetVideoRectangle();
+
+	/**
+	 * @fn SetSubtitlePtsOffset
+	 * @param[in] pts_offset pts offset for subs
+	 */
+	void SetSubtitlePtsOffset(std::uint64_t pts_offset);
+
+	/**
+	 * @fn SetSubtitleMute
+	 * @param[in] muted true to mute subtitle otherwise false
+	 */
+	void SetSubtitleMute(bool mute);
+
+	/**
+	 * @fn GetPositionMilliseconds
+	 * @retval playback position in MS
+	 */
+	long long GetPositionMilliseconds(void);
+
+	/**
+	 * @fn GetVideoPlaybackQuality
+	 * returns video playback quality data
+	 */
+	GstPlaybackQualityStruct *GetVideoPlaybackQuality(void);
+	/**
+	 * @fn GetDurationMilliseconds
+	 * @retval playback duration in MS
+	 */
+	long GetDurationMilliseconds(void);
+
+	/**
+	 * @fn ResetFirstFrame
+	 */
+	void ResetFirstFrame(void);
+	/**
+	 * @fn GetVideoSize
+	 * @param[out] w width video width
+	 * @param[out] h height video height
+	 */
+	void GetVideoSize(int &width, int &height);
+	/**
+	 * @fn SetVideoRectangle
+	 * @param[in] x x co-ordinate of display rectangle
+	 * @param[in] y y co-ordinate of display rectangle
+	 * @param[in] w width of display rectangle
+	 * @param[in] h height of display rectangle
+	 */
+	void SetVideoRectangle(int x, int y, int w, int h);
+	/**
+	 * @brief Un-pauses the pipeline and notifies the player of the buffer end event.
+	 * @param[in] forceStop True to force stop buffering.
+	 * @param[out] isPlaying Indicates whether playback is ongoing.
+	 * @return True if buffering was stopped successfully, false otherwise.
+	 */
+	bool StopBuffering(bool forceStop, bool &isPlaying);
+
+	/**
+	 * @brief Gets the CC decoder handle.
+	 * @return The CC decoder handle.
+	 */
+	unsigned long GetCCDecoderHandle(void);
+
+	/**
+	 * @brief Waits for the source setup.
+	 * @param[in] mediaType The type of media stream.
+	 * @return True if the source setup was successful, false otherwise.
+	 */
+	bool WaitForSourceSetup(GstMediaType mediaType);
+
+	/**
+	 * @brief Send PTS/DTS to downstream elements.
+	 * @param[in] type The type of event.
+	 * @param[in] ptr Pointer to the event data.
+	 * @param[in] len Length of the event data.
+	 * @param[in] fpts First PTS value.
+	 * @param[in] fdts First DTS value.
+	 * @param[in] fDuration Duration of the event.
+	 * @param[in] fragmentPTSoffset Offset PTS value.
+	 * @param[in] copy True to copy the event data.
+	 * @param[in] initFragment True if this is an initialization fragment.
+	 * @param[out] discontinuity Indicates whether there is a discontinuity.
+	 * @param[out] notifyFirstBufferProcessed Indicates whether the first buffer was processed.
+	 * @param[out] sendNewSegmentEvent Indicates whether to send a new segment event.
+	 * @param[out] resetTrickUTC Indicates whether to reset the trick UTC.
+	 * @param[out] firstBufferPushed Indicates whether the first buffer was pushed.
+	 * @return True if the event was sent successfully, false otherwise.
+	 */
+	bool SendHelper(int type, const void *ptr, size_t len, double fpts, double fdts, double fDuration, double fragmentPTSoffset, bool copy, bool initFragment, bool &discontinuity, bool &notifyFirstBufferProcessed, bool &sendNewSegmentEvent, bool &resetTrickUTC, bool &firstBufferPushed);
+
+	/**
+	 * @brief Pauses the injector.
+	 */
+	void PauseInjector();
+
+	/**
+	 * @brief Resumes the injector.
+	 */
+	void ResumeInjector();
+
+	/**
+	 * @brief Sends a new segment event.
+	 * @param[in] mediaType The type of media stream.
+	 * @param[in] startPts The start PTS value.
+	 * @param[in] stopPts The stop PTS value.
+	 */
+	void SendNewSegmentEvent(GstMediaType mediaType, GstClockTime startPts, GstClockTime stopPts);
+
+	/**
+	 * @brief Handles the video buffer sent event.
+	 * @return True if the video buffer was handled successfully, false otherwise.
+	 */
+	bool HandleVideoBufferSent();
+
+	/**
+	 * @fn QueueProtectionEvent
+	 * @param[in] formatType hls/dash format
+	 * @param[in] protSystemId keysystem to be used
+	 * @param[in] ptr initData DRM initialization data
+	 * @param[in] len initDataSize DRM initialization data size
+	 * @param[in] type Media type
+	 */
+	void QueueProtectionEvent(const std::string &formatType, const char *protSystemId, const void *initData, size_t initDataSize, int mediaType);
+	/**
+	 * @brief Sets the playback rate in audio and video sink.
+	 * @param[in] rate The playback rate to set.
+	 * @return True if the playback rate was set successfully, false otherwise.
+	 */
+	bool SetPlayBackRate(double rate);
+
+	/**
+	 * @brief Sets the audio volume or mute/unmute.
+	 */
+	void SetVolumeOrMuteUnMute(void);
+
+	/**
+	 * @brief Sets the audio volume.
+	 * @param[in] volume The volume level to set.
+	 */
+	void SetAudioVolume(int volume);
+
+	/**
+	 * @brief Tears down the stream.
+	 * @param[in] mediaType The type of media stream.
+	 */
+	void TearDownStream(GstMediaType mediaType);
+
+	/**
+	 * @brief Initializes the source for the player.
+	 * @param[in] PlayerInstance The player instance.
+	 * @param[in] source The source to initialize.
+	 * @param[in] eMEDIATYPE_VIDEO The media type for video.
+	 */
+	void InitializeSourceForPlayer(void *PlayerInstance, void *source, GstMediaType eMEDIATYPE_VIDEO);
+
+	/**
+	 * @brief Gets the app source element for a given media type.
+	 * @param[in] mediaType The type of media stream.
+	 * @return A pointer to the app source element.
+	 */
+	GstElement* GetAppSrc(int mediaType);
+
+	/**
+	 * @brief Sets up the stream.
+	 * @param[in] streamId The ID of the stream to set up.
+	 * @param[in] _this The instance of the player.
+	 * @param[in] url The URL of the stream.
+	 * @return An integer indicating the success or failure of the setup.
+	 */
+	int SetupStream(int streamId, void *_this, std::string url);
+
+	/**
+	 * @brief Callback for handling video samples in Player's GStreamer player.
+	 * @param[in] object The GStreamer element.
+	 * @param[in] _this The instance of the player.
+	 * @return The flow return status.
+	 */
+	static GstFlowReturn InterfacePlayerRDK_OnVideoSample(GstElement *object, void *_this);
+
+	/**
+	 * @brief Gets the video PTS value.
+	 * @return The video PTS value.
+	 */
+	long long GetVideoPTS(void);
+
+	/**
+	 * @brief Clears the flags for an idle task.
+	 * @param[in] taskDetails The details of the task to clear flags for.
+	 */
+	void IdleTaskClearFlags(GstTaskControlData &taskDetails);
+
+	/**
+	 * @brief Sets the callback for the first frame.
+	 * @param[in] callback The callback function to be called on the first frame.
+	 */
+	void FirstFrameCallback(std::function<void(GstMediaType, bool, bool, bool &, bool &)> callback);
+
+	/**
+	 * @brief Sets the callback for stopping.
+	 * @param[in] callback The callback function to be called when stopping.
+	 */
+	void StopCallback(std::function<void(bool)> callback);
+
+	/**
+	 * @brief Sets the callback for tearing down.
+	 * @param[in] callback The callback function to be called when tearing down.
+	 */
+	void TearDownCallback(std::function<void(bool, int)> callback);
+
+	/**
+	 * @brief Notifies the first frame.
+	 * @param[in] mediaType The type of media.
+	 */
+	void NotifyFirstFrame(int mediaType);
+
+	/**
+	 * @brief Adds an idle task.
+	 * @param[in] taskDetails The details of the task to be added.
+	 * @param[in] funcPtr The function pointer for the background task.
+	 * @return True if the task was added successfully, false otherwise.
+	 */
+	bool IdleTaskAdd(GstTaskControlData &taskDetails, BackgroundTask funcPtr);
+
+	/**
+	 * @brief Pauses GStreamer.
+	 * @param[in] pause Indicates whether to pause or resume.
+	 * @param[in] forceStopGstreamerPreBuffering Indicates whether to force stop GStreamer prebuffering.
+	 * @return True if the operation was successful, false otherwise.
+	 */
+	bool Pause(bool pause, bool forceStopGstreamerPreBuffering);
+
+	/**
+	 * @brief Checks for PTS change with a timeout.
+	 * @param[in] timeout The timeout value in milliseconds.
+	 * @return True if a PTS change was detected within the timeout, false otherwise.
+	 */
+	bool CheckForPTSChangeWithTimeout(long timeout);
+
+	/**
+	 * @brief Checks if the cache is empty for a given media type.
+	 * @param[in] mediaType The type of media stream.
+	 * @return True if the cache is empty, false otherwise.
+	 */
+	bool IsCacheEmpty(int mediaType);
+
+	/**
+	 * @brief Resets the EOS signalled flag.
+	 */
+	void ResetEOSSignalledFlag(void);
+
+	/**
+	 * @brief Checks if the pipeline is configured for a given media type.
+	 * @param[in] type The type of media stream.
+	 * @return True if the pipeline is configured, false otherwise.
+	 */
+	bool PipelineConfiguredForMedia(int type);
+
+	/**
+	 * @brief Gets buffer control data for a given media type.
+	 * @param[in] mediaType The type of media stream.
+	 * @return True if the buffer control data was retrieved successfully, false otherwise.
+	 */
+	bool GetBufferControlData(int mediaType);
+
+	/**
+	 * @brief Checks if the stream is ready for a given media type.
+	 * @param[in] mediaType The type of media stream.
+	 * @return True if the stream is ready, false otherwise.
+	 */
+	bool IsStreamReady(int mediaType);
+
+	/**
+	 * @brief Signals a trick mode discontinuity.
+	 */
+	void SignalTrickModeDiscontinuity();
+
+	/**
+	 * @brief Processes discontinuity for a stream type.
+	 *
+	 * @param[in] mediaType The type of media stream.
+	 * @param[in] streamFormat The format of the stream.
+	 * @param[in] codecChange Indicates whether there is a codec change.
+	 * @param[out] unblockDiscProcess Indicates whether to unblock the discontinuity process.
+	 * @param[out] shouldHaltBuffering Indicates whether buffering should be halted.
+	 * @return True if the discontinuity was processed successfully, false otherwise.
+	 */
+	bool CheckDiscontinuity(int mediaType, int streamFormat, bool codecChange, bool &unblockDiscProcess, bool &shouldHaltBuffering);
+
+	/**
+	 * @brief Sets up the stream for the interface player.
+	 * @param[in] streamId The ID of the stream to set up.
+	 * @param[in] url The URL of the stream.
+	 * @return An integer indicating the success or failure of the setup.
+	 */
+	int InterfacePlayer_SetupStream(GstMediaType streamId, std::string url);
+
+	/**
+	 * @brief Triggers an event.
+	 *
+	 * This function triggers the specified event with the given data.
+	 *
+	 * @param[in] event The event to trigger.
+	 * @param[in] data The data associated with the event.
+	 */
+	void TriggerEvent(InterfaceCB event, int data);
+	/**
+	 * @brief Triggers an event.
+	 * @param[in] event The event to trigger.
+	 */
+	void TriggerEvent(InterfaceCB event);
+
+	/**
+	 * @brief Checks if a codec is supported.
+	 * @param[in] codecName The name of the codec to check.
+	 * @return True if the codec is supported, false otherwise.
+	 */
+	static bool IsCodecSupported(const std::string &codecName);
+
+	/**
+	 * @brief Disables the decoder handle notification.
+	 */
+	void DisableDecoderHandleNotified();
+
+	/**
+	 * @fn ForwardBuffersToAuxPipeline
+	 *
+	 * @param[in] buffer - input buffer to be forwarded
+	 */
+	void ForwardBuffersToAuxPipeline(GstBuffer *buffer);
+	/*
+	 *@brief register busMessageCallback
+	 */
+	void RegisterBusEvent(const BusMessageCallback &callback)
+	{
+		busMessageCallback = callback;
+	}
+	/**
+	 * @fn ClearProtectionEvent
+	 */
+	void ClearProtectionEvent();
+
+	/**
+	 * @brief Sets the seek position for the GStreamer pipeline.
+	 * @param[in] positionSecs The position to seek to, in seconds.
+	 */
+	void SetSeekPosition(double positionSecs);
+
+	/**
+	 * @brief Disconnects all signals associated with the GStreamer pipeline.
+	 */
+	void DisconnectSignals();
+
+	/**
+	 * @brief Removes a GStreamer timer task.
+	 * @param[in,out] taskId    Reference to the ID of the task to be removed.
+	 * @param[in]     timerName The name of the timer to be removed
+	 */
+	void TimerRemove(guint &taskId, const char *timerName);
+	/**
+	 * @brief get the encryption from application to share it with PlayReadyDecryptor Plugin
+	 */
+	void setEncryption(void *mEncrypt);
+
+	/**
+	 * @brief Removes all active GStreamer probes.
+	 */
+	void RemoveProbes();
+
+	/**
+	 * @fn RemoveProbe
+	 * @brief Remove probe for a particular media type
+	 * @param[in] mediaType The media type for which the probe should be removed
+	 */
+	void RemoveProbe(GstMediaType mediaType);
+
+	/**
+	 * @brief Destroys the GStreamer pipeline.
+	 */
+	void DestroyPipeline();
+
+	/**
+	 * @brief Stops the GStreamer pipeline.
+	 *
+	 * @param[in] keepLastFrame Whether to retain the last displayed frame.
+	 */
+	void Stop(bool keepLastFrame);
+
+	/**
+	 * @brief Sets the pending seek state.
+	 * @param[in] state True to enable pending seek, false to disable.
+	 */
+	void SetPendingSeek(bool state);
+
+	/**
+	 *@brief returns true if using rialto sink
+	 */
+	bool IsUsingRialtoSink();
+
+	/**
+	 * @brief Resets GStreamer event states for all tracks.
+	 * This function updates the internal states for each track,
+	 * marking the position as reset, disabling pending seeks,
+	 * and clearing EOS and buffer flags.
+	 */
+	void ResetGstEvents();
+
+	/**
+	 * @brief Retrieves the trick play teardown status
+	 */
+	bool GetTrickTeardown();
+
+	/**
+	 * @brief Sets the trick play teardown state.
+	 * @param[in] state True to enable trick play teardown, false to disable.
+	 */
+	void SetTrickTearDown(bool state);
+
+	/**
+	 * @brief Flushes the GStreamer pipeline.
+	 * @param[in] position The position to flush to, in seconds.
+	 * @param[in] rate The playback rate.
+	 * @param[in] shouldTearDown Whether to tear down the pipeline.
+	 * @param[in] GstState The desired GStreamer pipeline state.
+	 * @param[in] gstMediaFormat The media format for the pipeline.
+	 */
+	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek);
+
+	/**
+	 * @brief Removes an idle task from the GStreamer pipeline.
+	 * @param[in] taskDetails The details of the task to be removed.
+	 * @return true if the task is successfully removed, false otherwise.
+	 */
+	bool IdleTaskRemove(GstTaskControlData &taskDetails);
+
+	/**
+	 * @fn TimerAdd
+	 * @param[in] funcPtr function to execute on timer expiry
+	 * @param[in] repeatTimeout timeout between calls in ms
+	 * @param[in] user_data data to pass to the timer function
+	 * @param[in] timerName name of the timer being added
+	 * @param[out] taskId id of the timer to be returned
+	 */
+	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr, GDestroyNotify destroyNotify = nullptr);
+	/**
+	 * @fn TimerIsRunning
+	 * @param[in] taskId id of the timer to be removed
+	 * @return true - timer is currently running
+	 */
+	bool TimerIsRunning(guint &taskId);
+	/**
+	 * @fn NotifyEOS
+	 */
+	void NotifyEOS();
+	/**
+	 * @fn NotifyFragmentCachingComplete
+	 */
+	void NotifyFragmentCachingComplete();
+	/**
+	 * @fn EndOfStreamReached
+	 * @param[in] type stream type
+	 */
+	void EndOfStreamReached(int mediaType, bool &shouldHaltBuffering);
+
+	/**
+	 * @brief Signals the subtitle clock.
+	 *
+	 * @param[in] vPTS The presentation timestamp.
+	 * @param[in] state The state to set for the subtitle clock.
+	 * @return True if the operation was successful, false otherwise.
+	 */
+	bool SignalSubtitleClock(gint64 vPTS, bool state);
+
+	/**
+	 * @brief Initializes Player GStreamer plugins.
+	 *
+	 * This function initializes the necessary plugins for Player GStreamer.
+	 */
+	static void InitializePlayerGstreamerPlugins();
+
+	/**
+	 * @brief Enables GStreamer debug logging.
+	 * @param[in] debugLevel The level of debug logging to enable.
+	 */
+	void EnableGstDebugLogging(std::string debugLevel);
+
+	/**
+	 * @brief Gets the monitor AV state.
+	 * @return A pointer to the MonitorAVState structure containing the AV status or nullptr.
+	 */
+	const MonitorAVState& GetMonitorAVState() const { return gstPrivateContext->monitorAVstate; }
 };
 struct data
 {

--- a/test/utests/fakes/FakeGLib.cpp
+++ b/test/utests/fakes/FakeGLib.cpp
@@ -234,7 +234,14 @@ int g_strcmp0(const char *str1, const char *str2)
 
 guint g_timeout_add_full(gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify)
 {
-	return 0;
+	guint retval = 0;
+
+	if (g_mockGLib != nullptr)
+	{
+		retval = g_mockGLib->g_timeout_add_full(priority, interval, function, data, notify);
+	}
+
+	return retval;
 }
 
 void g_usleep(gulong microseconds)

--- a/test/utests/mocks/MockGLib.h
+++ b/test/utests/mocks/MockGLib.h
@@ -31,6 +31,7 @@ class MockGLib
 public:
 	MOCK_METHOD(GParamSpec*, g_object_class_find_property, (GObjectClass* oclass, const gchar* property_name));
 	MOCK_METHOD(guint, g_timeout_add, (guint interval, GSourceFunc function, gpointer data));
+	MOCK_METHOD(guint, g_timeout_add_full, (gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify));
 	MOCK_METHOD(gboolean, g_source_remove, (guint tag));
 	MOCK_METHOD(gpointer, g_malloc, (gsize n_bytes));
 	MOCK_METHOD(void, g_free, (gpointer mem));

--- a/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
+++ b/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
@@ -58,7 +58,8 @@ protected:
 	guint capturedTimerId;
 	GSourceFunc capturedTimerFunc;
 	gpointer capturedUserData;
-	
+	GDestroyNotify capturedDestroyNotify;
+
 	void SetUp() override
 	{
 		// Setup mocks
@@ -80,10 +81,13 @@ protected:
 		capturedTimerId = 0;
 		capturedTimerFunc = nullptr;
 		capturedUserData = nullptr;
+		capturedDestroyNotify = nullptr;
 	}
-	
+
 	void TearDown() override
 	{
+		ReleaseCapturedTimerUserData();
+
 		// Clean up player
 		// Note: We delete m_gstConfigParam because we allocated it in SetUp
 		if (m_player)
@@ -150,9 +154,9 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_NullProgressCb_DoesNotSetupT
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	
-	// Expect that g_timeout_add_full is NOT called (no timer should be added)
-	EXPECT_CALL(*g_mockGLib, g_timeout_add(_, _, _)) .Times(0);
-	
+	// Expect that no timer should be added
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, _, _)).Times(0);
+
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
 	
@@ -201,17 +205,18 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	
-	// Expect that timer is added exactly once using the available mock method 
-	EXPECT_CALL(*g_mockGLib, g_timeout_add(_,_, NotNull()))
+	// Expect that timer is added exactly once
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
 		.Times(1)
 		.WillOnce(Return(123)); // Fake timer ID
-	
+
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
-	
+
 	// Assert: Timer function should be captured
 	EXPECT_NE(capturedTimerFunc, nullptr);
-	EXPECT_EQ(capturedUserData, m_player);
+	EXPECT_NE(capturedUserData, nullptr);
+	EXPECT_NE(capturedDestroyNotify, nullptr);
 	EXPECT_EQ(result, G_SOURCE_REMOVE);
 }
 
@@ -224,15 +229,22 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
  */
 TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullProgressCb_DoesNotCrash)
 {
-	// Arrange: Set progressCb to nullptr (simulating unregistered callback)
+	// Arrange: Schedule timer while callback is registered, then unregister it
+	m_player->callbackMap[InterfaceCB::progressCb] = []() {};
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
+		.WillRepeatedly(Return(FALSE));
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
 	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
-	
+
 	// Disable AV monitoring to simplify test
 	m_player->m_gstConfigParam->monitorAV = false;
-	
-	// Act: Call ProgressCallbackOnTimeout - should not crash
-	gboolean result = InterfacePlayerRDK::ProgressCallbackOnTimeout(m_player);
-	
+
+	// Act: Fire the already-scheduled timeout
+	gboolean result = capturedTimerFunc(capturedUserData);
+
 	// Assert: Should return G_SOURCE_CONTINUE (periodic timer continues)
 	EXPECT_EQ(result, G_SOURCE_CONTINUE);
 }
@@ -260,22 +272,24 @@ TEST_F(InterfacePlayerRDKCallbackTest, CallbacksUnregistered_ThenTriggered_DoesN
 		idleCalled = true;
 	};
 	
-	// Simulate callbacks being unregistered (as would happen in UnregisterFirstFrameCallbacks)
-	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
-	m_player->callbackMap[InterfaceCB::idleCb] = nullptr;
-	
 	// Disable AV monitoring
 	m_player->m_gstConfigParam->monitorAV = false;
-	
+
 	// Mock timer operations
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
-	
-	// Act: Trigger callbacks that might have been scheduled before unregistration
-	// This should not crash even though callbacks are now nullptr
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+
+	// Schedule while callbacks are still registered
 	gboolean idleResult = InterfacePlayerRDK::IdleCallback(m_player);
-	gboolean progressResult = InterfacePlayerRDK::ProgressCallbackOnTimeout(m_player);
-	
+	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
+	m_player->callbackMap[InterfaceCB::idleCb] = nullptr;
+
+	// Act: Trigger a timeout that was already scheduled before unregistration
+	gboolean progressResult = capturedTimerFunc(capturedUserData);
+
 	// Assert: Both should return without crashing
 	EXPECT_EQ(idleResult, G_SOURCE_REMOVE);
 	EXPECT_EQ(progressResult, G_SOURCE_CONTINUE);
@@ -306,9 +320,30 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_NullPlayer_DoesNotCrash)
  */
 TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullPlayer_DoesNotCrash)
 {
-	// Act: Call with nullptr player
+	// Act: Call with nullptr user data
 	gboolean result = InterfacePlayerRDK::ProgressCallbackOnTimeout(nullptr);
-	
-	// Assert: Should return G_SOURCE_CONTINUE safely
-	EXPECT_EQ(result, G_SOURCE_CONTINUE);
+
+	// Assert: Should remove the timer safely
+	EXPECT_EQ(result, G_SOURCE_REMOVE);
+}
+
+TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_AfterStop_RemovesTimerSafely)
+{
+	bool progressCalled = false;
+	m_player->callbackMap[InterfaceCB::progressCb] = [&progressCalled]() {
+		progressCalled = true;
+	};
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
+		.WillRepeatedly(Return(TRUE));
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+
+	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
+	m_player->Stop(false);
+
+	gboolean result = capturedTimerFunc(capturedUserData);
+
+	EXPECT_EQ(result, G_SOURCE_REMOVE);
+	EXPECT_FALSE(progressCalled);
 }


### PR DESCRIPTION
RDKEMW-20659: Bring in fix for WPEWebProcess crashed with fingerprint 80095400 to 8.4.

Reason for change : Added fix for the race condition by using weakpointer instead of raw pointer
Priority : P1
Test Steps: Mentioned in ticket
Signed off by : Nejuma T N <nejumatn28@gmail.com>