### PR TITLE
RDKEMW-20659: [support/8.4.4.0] Bring in fix for WPEWebProcess crashed with fingerprint 80095400 to 8.4

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -779,7 +779,8 @@ gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
 		MonitorAV(pInterfacePlayerRDK);
 	}
 	pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
-	MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+	InterfacePlayerPriv* privatePlayer = pInterfacePlayerRDK->GetPrivatePlayer();
+	MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId);
 
 	{
 		std::lock_guard<std::mutex> lock(callbackContext->mutex);
@@ -815,7 +816,7 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 			auto callbackContext = pInterfacePlayerRDK->GetOrCreateProgressCallbackContext();
 			auto *timerUserData = new std::weak_ptr<ProgressCallbackContext>(callbackContext);
 			GSourceFunc timerFunc = ProgressCallbackOnTimeout;
-			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId, timerUserData, "periodicProgressCallbackIdleTask", DestroyProgressCallbackUserData);
+			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId, timerUserData, "periodicProgressCallbackIdleTask", DestroyProgressCallbackUserData);
 		}
 		else
 		{
@@ -1433,7 +1434,7 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	IdleTaskRemove(interfacePlayerPriv->gstPrivateContext->firstProgressCallbackIdleTask);
 
 	CancelProgressCallbackContext();
-	if (gstPrivateContext->bufferingTimeoutTimerId)
+	if (interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId)
 	{
 		MW_LOG_MIL("InterfacePlayerRDK: Remove bufferingTimeoutTimerId %d", interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
 		g_source_remove(interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
@@ -3724,7 +3725,7 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
  */
 std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::GetOrCreateProgressCallbackContext()
 {
-	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+	std::lock_guard<std::mutex> lock(interfacePlayerPriv->gstPrivateContext->TaskControlMutex);
 	bool createNewContext = false;
 	if (!mProgressCallbackContext)
 	{
@@ -3749,7 +3750,7 @@ void InterfacePlayerRDK::CancelProgressCallbackContext()
 {
 	std::shared_ptr<ProgressCallbackContext> callbackContext;
 	{
-		std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+		std::lock_guard<std::mutex> lock(interfacePlayerPriv->gstPrivateContext->TaskControlMutex);
 		callbackContext = mProgressCallbackContext;
 	}
 
@@ -3764,7 +3765,7 @@ void InterfacePlayerRDK::CancelProgressCallbackContext()
 		callbackContext->player = nullptr;
 	}
 
-	this->TimerRemove(gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
+	this->TimerRemove(interfacePlayerPriv->gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
 
 	std::unique_lock<std::mutex> lock(callbackContext->mutex);
 	if (!callbackContext->cv.wait_for(lock, std::chrono::seconds(5), [&callbackContext]() {
@@ -3774,7 +3775,7 @@ void InterfacePlayerRDK::CancelProgressCallbackContext()
 	}
 	lock.unlock();
 
-	std::lock_guard<std::mutex> taskLock(gstPrivateContext->TaskControlMutex);
+	std::lock_guard<std::mutex> taskLock(interfacePlayerPriv->gstPrivateContext->TaskControlMutex);
 	if (mProgressCallbackContext == callbackContext)
 	{
 		mProgressCallbackContext.reset();
@@ -3788,7 +3789,7 @@ void InterfacePlayerRDK::DestroyProgressCallbackUserData(gpointer user_data)
 
 void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName, GDestroyNotify destroyNotify)
 {
-	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+	std::lock_guard<std::mutex> lock(interfacePlayerPriv->gstPrivateContext->TaskControlMutex);
 	if (funcPtr && user_data)
 	{
 		if (0 == taskId)

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -69,7 +69,8 @@ static const char* GstPluginNameVMX = "verimatrixdecryptor";
 /*InterfacePlayerRDK constructor*/
 InterfacePlayerRDK::InterfacePlayerRDK(bool isRialto) :
 mProtectionLock(), mPauseInjector(false), mSourceSetupMutex(), stopCallback(NULL), tearDownCb(NULL), notifyFirstFrameCallback(NULL),
-mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL), mDRMSessionManager(NULL)
+mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSystem(NULL), mEncrypt(NULL),
+mProgressCallbackContext(std::make_shared<ProgressCallbackContext>(this))
 {
 	interfacePlayerPriv = new InterfacePlayerPriv(isRialto);
 	m_gstConfigParam = new Configs();
@@ -84,6 +85,7 @@ mSourceSetupCV(), mScheduler(), callbackMap(), setupStreamCallbackMap(), mDrmSys
 /* InterfacePlayerRDK destructor*/
 InterfacePlayerRDK::~InterfacePlayerRDK()
 {
+	CancelProgressCallbackContext();
 	DestroyPipeline();
 	if (mDrmSystem)
 	{
@@ -749,17 +751,43 @@ void MonitorAV( InterfacePlayerRDK *pInterfacePlayerRDK )
  */
 gboolean InterfacePlayerRDK::ProgressCallbackOnTimeout(gpointer user_data)
 {
-	InterfacePlayerRDK *pInterfacePlayerRDK = (InterfacePlayerRDK *)user_data;
-	InterfacePlayerPriv* privatePlayer = nullptr;
-	if (pInterfacePlayerRDK)
+	auto *weakContext = static_cast<std::weak_ptr<ProgressCallbackContext> *>(user_data);
+	if (!weakContext)
 	{
-	        privatePlayer = pInterfacePlayerRDK->GetPrivatePlayer();
-		if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
+		return G_SOURCE_REMOVE;
+	}
+
+	auto callbackContext = weakContext->lock();
+	if (!callbackContext)
+	{
+		return G_SOURCE_REMOVE;
+	}
+
+	InterfacePlayerRDK *pInterfacePlayerRDK = nullptr;
+	{
+		std::unique_lock<std::mutex> lock(callbackContext->mutex);
+		if (callbackContext->cancelled || !callbackContext->player)
 		{
-			MonitorAV(pInterfacePlayerRDK);
+			return G_SOURCE_REMOVE;
 		}
-		pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
-		MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+		callbackContext->activeCallbacks++;
+		pInterfacePlayerRDK = callbackContext->player;
+	}
+
+	if (pInterfacePlayerRDK->m_gstConfigParam->monitorAV)
+	{
+		MonitorAV(pInterfacePlayerRDK);
+	}
+	pInterfacePlayerRDK->TriggerEvent(InterfaceCB::progressCb);
+	MW_LOG_TRACE("current %d, stored %d ", g_source_get_id(g_main_current_source()), pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId);
+
+	{
+		std::lock_guard<std::mutex> lock(callbackContext->mutex);
+		callbackContext->activeCallbacks--;
+		if (callbackContext->cancelled && (0 == callbackContext->activeCallbacks))
+		{
+			callbackContext->cv.notify_all();
+		}
 	}
 	return G_SOURCE_CONTINUE;
 }
@@ -784,8 +812,10 @@ gboolean InterfacePlayerRDK::IdleCallback(gpointer user_data)
 			double  reportProgressInterval = pInterfacePlayerRDK->m_gstConfigParam->progressTimer;
 			reportProgressInterval *= 1000; //convert s to ms
 
+			auto callbackContext = pInterfacePlayerRDK->GetOrCreateProgressCallbackContext();
+			auto *timerUserData = new std::weak_ptr<ProgressCallbackContext>(callbackContext);
 			GSourceFunc timerFunc = ProgressCallbackOnTimeout;
-			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, privatePlayer->gstPrivateContext->periodicProgressCallbackIdleTaskId, user_data, "periodicProgressCallbackIdleTask");
+			pInterfacePlayerRDK->TimerAdd(timerFunc, (int)reportProgressInterval, pInterfacePlayerRDK->gstPrivateContext->periodicProgressCallbackIdleTaskId, timerUserData, "periodicProgressCallbackIdleTask", DestroyProgressCallbackUserData);
 		}
 		else
 		{
@@ -1384,6 +1414,9 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 
 	interfacePlayerPriv->gstPrivateContext->syncControl.disable();
 	interfacePlayerPriv->gstPrivateContext->aSyncControl.disable();
+	// Stop async worker before removing idle/timer tasks to prevent
+	// new tasks from being scheduled concurrently during teardown.
+	mScheduler.StopScheduler();
 	std::unique_lock<std::mutex> sourceSetupLock(mSourceSetupMutex);
 	mSourceSetupCV.notify_all();
 	if(interfacePlayerPriv->gstPrivateContext->bus)
@@ -1399,8 +1432,8 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	}
 	IdleTaskRemove(interfacePlayerPriv->gstPrivateContext->firstProgressCallbackIdleTask);
 
-	this->TimerRemove(interfacePlayerPriv->gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
-	if (interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId)
+	CancelProgressCallbackContext();
+	if (gstPrivateContext->bufferingTimeoutTimerId)
 	{
 		MW_LOG_MIL("InterfacePlayerRDK: Remove bufferingTimeoutTimerId %d", interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
 		g_source_remove(interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
@@ -1476,6 +1509,9 @@ void InterfacePlayerRDK::Stop(bool keepLastFrame)
 	interfacePlayerPriv->gstPrivateContext->videoMuted = false;
 	interfacePlayerPriv->gstPrivateContext->subtitleMuted = false;
 	interfacePlayerPriv->gstPrivateContext->audioVolume = 1.0;
+
+	// Restart scheduler so the same InterfacePlayerRDK instance can be reused.
+	mScheduler.StartScheduler();
 }
 
 void InterfacePlayerRDK::ResetGstEvents()
@@ -3686,24 +3722,106 @@ bool InterfacePlayerRDK::CheckDiscontinuity(int mediaType, int streamFormat , bo
 /**
  *  @brief TimerAdd - add a new glib timer in thread safe manner
  */
-void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName)
+std::shared_ptr<ProgressCallbackContext> InterfacePlayerRDK::GetOrCreateProgressCallbackContext()
 {
-	std::lock_guard<std::mutex> lock(interfacePlayerPriv->gstPrivateContext->TaskControlMutex);
+	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+	bool createNewContext = false;
+	if (!mProgressCallbackContext)
+	{
+		createNewContext = true;
+	}
+	else
+	{
+		std::lock_guard<std::mutex> contextLock(mProgressCallbackContext->mutex);
+		if (mProgressCallbackContext->cancelled)
+		{
+			createNewContext = true;
+		}
+	}
+	if (createNewContext)
+	{
+		mProgressCallbackContext = std::make_shared<ProgressCallbackContext>(this);
+	}
+	return mProgressCallbackContext;
+}
+
+void InterfacePlayerRDK::CancelProgressCallbackContext()
+{
+	std::shared_ptr<ProgressCallbackContext> callbackContext;
+	{
+		std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
+		callbackContext = mProgressCallbackContext;
+	}
+
+	if (!callbackContext)
+	{
+		return;
+	}
+
+	{
+		std::lock_guard<std::mutex> lock(callbackContext->mutex);
+		callbackContext->cancelled = true;
+		callbackContext->player = nullptr;
+	}
+
+	this->TimerRemove(gstPrivateContext->periodicProgressCallbackIdleTaskId, "periodicProgressCallbackIdleTaskId");
+
+	std::unique_lock<std::mutex> lock(callbackContext->mutex);
+	if (!callbackContext->cv.wait_for(lock, std::chrono::seconds(5), [&callbackContext]() {
+		return 0 == callbackContext->activeCallbacks;
+	})) {
+		MW_LOG_WARN("Teardown timeout: callback context still has active callbacks (%zu). Possible I/O blockage or deadlock detected.", callbackContext->activeCallbacks);
+	}
+	lock.unlock();
+
+	std::lock_guard<std::mutex> taskLock(gstPrivateContext->TaskControlMutex);
+	if (mProgressCallbackContext == callbackContext)
+	{
+		mProgressCallbackContext.reset();
+	}
+}
+
+void InterfacePlayerRDK::DestroyProgressCallbackUserData(gpointer user_data)
+{
+	delete static_cast<std::weak_ptr<ProgressCallbackContext> *>(user_data);
+}
+
+void InterfacePlayerRDK::TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint& taskId, gpointer user_data, const char* timerName, GDestroyNotify destroyNotify)
+{
+	std::lock_guard<std::mutex> lock(gstPrivateContext->TaskControlMutex);
 	if (funcPtr && user_data)
 	{
 		if (0 == taskId)
 		{
-			/* Sets the function pointed by functPtr to be called at regular intervals of repeatTimeout, supplying user_data to the function */
-			taskId = g_timeout_add(repeatTimeout, funcPtr, user_data);
+			if (destroyNotify)
+			{
+				taskId = g_timeout_add_full(G_PRIORITY_DEFAULT, repeatTimeout, funcPtr, user_data, destroyNotify);
+				if (0 == taskId)
+				{
+					destroyNotify(user_data);
+				}
+			}
+			else
+			{
+				taskId = g_timeout_add(repeatTimeout, funcPtr, user_data);
+			}
 			MW_LOG_INFO("InterfacePlayerRDK: Added timer '%.50s', %d", (nullptr!=timerName) ? timerName : "unknown" , taskId);
 		}
 		else
 		{
+			if (destroyNotify)
+			{
+				destroyNotify(user_data);
+			}
 			MW_LOG_INFO("InterfacePlayerRDK: Timer '%.50s' already added, taskId=%d", (nullptr!=timerName) ? timerName : "unknown", taskId);
 		}
 	}
 	else
 	{
+		if (destroyNotify && user_data)
+		{
+			destroyNotify(user_data);
+		}
 		MW_LOG_ERR("Bad pointer. funcPtr = %p, user_data=%p",funcPtr,user_data);
 	}
 }
@@ -3855,7 +3973,7 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 {
 	auto it = callbackMap.find(event);
-	if (it != callbackMap.end())
+	if ((it != callbackMap.end()) && it->second)
 	{
 		it->second();
 	}
@@ -3867,7 +3985,7 @@ void InterfacePlayerRDK::TriggerEvent(InterfaceCB event)
 void InterfacePlayerRDK::TriggerEvent(InterfaceCB event, int data)
 {
 	auto it = setupStreamCallbackMap.find(event);
-	if (it != setupStreamCallbackMap.end())
+	if ((it != setupStreamCallbackMap.end()) && it->second)
 	{
 		it->second(data);
 	}

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -33,8 +33,26 @@
 #include <functional>
 #include <condition_variable>
 #include <chrono>
+#include <memory>
+#include "GstUtils.h"
 #include <any>
 #include "SocUtils.h"
+
+class InterfacePlayerRDK;
+
+struct ProgressCallbackContext
+{
+	std::mutex mutex;
+	std::condition_variable cv;
+	InterfacePlayerRDK *player;
+	bool cancelled;
+	size_t activeCallbacks;
+
+	explicit ProgressCallbackContext(InterfacePlayerRDK *playerInstance)
+		: player(playerInstance), cancelled(false), activeCallbacks(0)
+	{
+	}
+};
 #include "GstUtils.h"
 
 class InterfacePlayerPriv;
@@ -154,6 +172,11 @@ class InterfacePlayerRDK
 		bool trickTeardown;
 		std::mutex mMutex;
 		std::map<std::string, int> configMap;
+	std::shared_ptr<ProgressCallbackContext> mProgressCallbackContext;
+
+	std::shared_ptr<ProgressCallbackContext> GetOrCreateProgressCallbackContext();
+	void CancelProgressCallbackContext();
+	static void DestroyProgressCallbackUserData(gpointer user_data);
 
 	public:
 		Configs *m_gstConfigParam;
@@ -719,7 +742,7 @@ class InterfacePlayerRDK
         	 * @param[in] timerName name of the timer being added
         	 * @param[out] taskId id of the timer to be returned
         	 */
-        	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr);
+        	void TimerAdd(GSourceFunc funcPtr, int repeatTimeout, guint &taskId, gpointer user_data, const char *timerName = nullptr, GDestroyNotify destroyNotify = nullptr);
         	/**
         	 * @fn TimerIsRunning
         	 * @param[in] taskId id of the timer to be removed

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -34,10 +34,11 @@
 #include <condition_variable>
 #include <chrono>
 #include <memory>
-#include "GstUtils.h"
 #include <any>
 #include "SocUtils.h"
+#include "GstUtils.h"
 
+class InterfacePlayerPriv;
 class InterfacePlayerRDK;
 
 struct ProgressCallbackContext
@@ -53,9 +54,6 @@ struct ProgressCallbackContext
 	{
 	}
 };
-#include "GstUtils.h"
-
-class InterfacePlayerPriv;
 
 struct MonitorAVState
 {

--- a/test/utests/fakes/FakeGLib.cpp
+++ b/test/utests/fakes/FakeGLib.cpp
@@ -234,7 +234,14 @@ int g_strcmp0(const char *str1, const char *str2)
 
 guint g_timeout_add_full(gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify)
 {
-	return 0;
+	guint retval = 0;
+
+	if (g_mockGLib != nullptr)
+	{
+		retval = g_mockGLib->g_timeout_add_full(priority, interval, function, data, notify);
+	}
+
+	return retval;
 }
 
 void g_usleep(gulong microseconds)

--- a/test/utests/mocks/MockGLib.h
+++ b/test/utests/mocks/MockGLib.h
@@ -31,6 +31,7 @@ class MockGLib
 public:
 	MOCK_METHOD(GParamSpec*, g_object_class_find_property, (GObjectClass* oclass, const gchar* property_name));
 	MOCK_METHOD(guint, g_timeout_add, (guint interval, GSourceFunc function, gpointer data));
+	MOCK_METHOD(guint, g_timeout_add_full, (gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify));
 	MOCK_METHOD(gboolean, g_source_remove, (guint tag));
 	MOCK_METHOD(gpointer, g_malloc, (gsize n_bytes));
 	MOCK_METHOD(void, g_free, (gpointer mem));

--- a/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
+++ b/test/utests/tests/InterfacePlayerRDKTests/InterfacePlayerRDKTestCases.cpp
@@ -58,7 +58,8 @@ protected:
 	guint capturedTimerId;
 	GSourceFunc capturedTimerFunc;
 	gpointer capturedUserData;
-	
+	GDestroyNotify capturedDestroyNotify;
+
 	void SetUp() override
 	{
 		// Setup mocks
@@ -80,10 +81,13 @@ protected:
 		capturedTimerId = 0;
 		capturedTimerFunc = nullptr;
 		capturedUserData = nullptr;
+		capturedDestroyNotify = nullptr;
 	}
-	
+
 	void TearDown() override
 	{
+		ReleaseCapturedTimerUserData();
+
 		// Clean up player
 		// Note: We delete m_gstConfigParam because we allocated it in SetUp
 		if (m_player)
@@ -150,9 +154,9 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_NullProgressCb_DoesNotSetupT
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	
-	// Expect that g_timeout_add_full is NOT called (no timer should be added)
-	EXPECT_CALL(*g_mockGLib, g_timeout_add(_, _, _)) .Times(0);
-	
+	// Expect that no timer should be added
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, _, _)).Times(0);
+
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
 	
@@ -201,17 +205,18 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
 	
-	// Expect that timer is added exactly once using the available mock method 
-	EXPECT_CALL(*g_mockGLib, g_timeout_add(_,_, NotNull()))
+	// Expect that timer is added exactly once
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
 		.Times(1)
 		.WillOnce(Return(123)); // Fake timer ID
-	
+
 	// Act: Call IdleCallback
 	gboolean result = InterfacePlayerRDK::IdleCallback(m_player);
-	
+
 	// Assert: Timer function should be captured
 	EXPECT_NE(capturedTimerFunc, nullptr);
-	EXPECT_EQ(capturedUserData, m_player);
+	EXPECT_NE(capturedUserData, nullptr);
+	EXPECT_NE(capturedDestroyNotify, nullptr);
 	EXPECT_EQ(result, G_SOURCE_REMOVE);
 }
 
@@ -224,15 +229,22 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_ValidProgressCb_SetupsTimer)
  */
 TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullProgressCb_DoesNotCrash)
 {
-	// Arrange: Set progressCb to nullptr (simulating unregistered callback)
+	// Arrange: Schedule timer while callback is registered, then unregister it
+	m_player->callbackMap[InterfaceCB::progressCb] = []() {};
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
+		.WillRepeatedly(Return(FALSE));
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
 	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
-	
+
 	// Disable AV monitoring to simplify test
 	m_player->m_gstConfigParam->monitorAV = false;
-	
-	// Act: Call ProgressCallbackOnTimeout - should not crash
-	gboolean result = InterfacePlayerRDK::ProgressCallbackOnTimeout(m_player);
-	
+
+	// Act: Fire the already-scheduled timeout
+	gboolean result = capturedTimerFunc(capturedUserData);
+
 	// Assert: Should return G_SOURCE_CONTINUE (periodic timer continues)
 	EXPECT_EQ(result, G_SOURCE_CONTINUE);
 }
@@ -260,22 +272,24 @@ TEST_F(InterfacePlayerRDKCallbackTest, CallbacksUnregistered_ThenTriggered_DoesN
 		idleCalled = true;
 	};
 	
-	// Simulate callbacks being unregistered (as would happen in UnregisterFirstFrameCallbacks)
-	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
-	m_player->callbackMap[InterfaceCB::idleCb] = nullptr;
-	
 	// Disable AV monitoring
 	m_player->m_gstConfigParam->monitorAV = false;
-	
+
 	// Mock timer operations
 	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
 		.WillRepeatedly(Return(FALSE));
-	
-	// Act: Trigger callbacks that might have been scheduled before unregistration
-	// This should not crash even though callbacks are now nullptr
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+
+	// Schedule while callbacks are still registered
 	gboolean idleResult = InterfacePlayerRDK::IdleCallback(m_player);
-	gboolean progressResult = InterfacePlayerRDK::ProgressCallbackOnTimeout(m_player);
-	
+	m_player->callbackMap[InterfaceCB::progressCb] = nullptr;
+	m_player->callbackMap[InterfaceCB::idleCb] = nullptr;
+
+	// Act: Trigger a timeout that was already scheduled before unregistration
+	gboolean progressResult = capturedTimerFunc(capturedUserData);
+
 	// Assert: Both should return without crashing
 	EXPECT_EQ(idleResult, G_SOURCE_REMOVE);
 	EXPECT_EQ(progressResult, G_SOURCE_CONTINUE);
@@ -306,9 +320,30 @@ TEST_F(InterfacePlayerRDKCallbackTest, IdleCallback_NullPlayer_DoesNotCrash)
  */
 TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_NullPlayer_DoesNotCrash)
 {
-	// Act: Call with nullptr player
+	// Act: Call with nullptr user data
 	gboolean result = InterfacePlayerRDK::ProgressCallbackOnTimeout(nullptr);
-	
-	// Assert: Should return G_SOURCE_CONTINUE safely
-	EXPECT_EQ(result, G_SOURCE_CONTINUE);
+
+	// Assert: Should remove the timer safely
+	EXPECT_EQ(result, G_SOURCE_REMOVE);
+}
+
+TEST_F(InterfacePlayerRDKCallbackTest, ProgressCallbackOnTimeout_AfterStop_RemovesTimerSafely)
+{
+	bool progressCalled = false;
+	m_player->callbackMap[InterfaceCB::progressCb] = [&progressCalled]() {
+		progressCalled = true;
+	};
+	SetupTimerMocks();
+	EXPECT_CALL(*g_mockGLib, g_source_remove(_))
+		.WillRepeatedly(Return(TRUE));
+	EXPECT_CALL(*g_mockGLib, g_timeout_add_full(_, _, _, NotNull(), NotNull()))
+		.WillOnce(Return(123));
+
+	EXPECT_EQ(InterfacePlayerRDK::IdleCallback(m_player), G_SOURCE_REMOVE);
+	m_player->Stop(false);
+
+	gboolean result = capturedTimerFunc(capturedUserData);
+
+	EXPECT_EQ(result, G_SOURCE_REMOVE);
+	EXPECT_FALSE(progressCalled);
 }


### PR DESCRIPTION
RDKEMW-20659: [support/8.4.4.0] Bring in fix for WPEWebProcess crashed with fingerprint 80095400 to 8.4

Reason for change : Added fix for the race condition by using weakpointer instead of raw pointer
Priority : P1
Test Steps: Mentioned in ticket
Signed off by : Nejuma T N <nejumatn28@gmail.com>