### PR TITLE
VPAAMP-651: Trickplay skips incorrectly at cdai ad boundaries

### DIFF
--- a/mp4demux/AampMp4Demuxer.cpp
+++ b/mp4demux/AampMp4Demuxer.cpp
@@ -127,6 +127,20 @@ AampMp4Demuxer::~AampMp4Demuxer()
 }
 
 /**
+ * @brief Advance trickmode restamp timeline on discontinuity boundary.
+ */
+void AampMp4Demuxer::HandleTrickModeDiscontinuity()
+{
+	if (mTrickPhase == Mp4TrickPhase::STEADY)
+	{
+		mRestampedPts += mRestampedDuration;
+		mTrickPhase = Mp4TrickPhase::DISCONTINUITY;
+		AAMPLOG_WARN("[%s] Trickmode discontinuity: advancing restampedPts by %.6f to %.6f",
+			GetMediaTypeName(mMediaType), mRestampedDuration, mRestampedPts);
+	}
+}
+
+/**
  * @brief Apply trickmode PTS restamping to a sample, dynamically adjusting duration based on rate and frame rate
  * Similar to qtdemux approach but with dynamic duration calculation for smoother trickmode playback
  * @param[in,out] sample - Sample to restamp
@@ -141,18 +155,6 @@ void AampMp4Demuxer::TrickmodePtsRestamp(AampMediaSample& sample, double duratio
 	double originalDuration = sample.mDuration;
 	double fragmentPtsDelta = 0.0;
 	double restampedDuration = 0.0;
-
-	// On the first keyframe of a discontinuous segment (while in STEADY state), advance
-	// the output PTS by the last known duration so the stream stays gapless, then switch
-	// to DISCONTINUITY so the switch below reuses that duration instead of computing a
-	// (potentially huge) cross-discontinuity PTS delta.
-	if (discontinuous && mTrickPhase == Mp4TrickPhase::STEADY)
-	{
-		mRestampedPts += mRestampedDuration;
-		mTrickPhase = Mp4TrickPhase::DISCONTINUITY;
-		AAMPLOG_WARN("[%s] Trickmode discontinuity: advancing restampedPts by %.6f to %.6f",
-			GetMediaTypeName(mMediaType), mRestampedDuration, mRestampedPts);
-	}
 
 	// All phase transitions are owned here.
 	switch (mTrickPhase)
@@ -291,6 +293,12 @@ bool AampMp4Demuxer::sendSegment(std::vector<uint8_t>&& buffer, double position,
 				{
 					AAMPLOG_ERR("No samples for type:%d and invalid codec format:%d", mMediaType, codecInfo.mCodecFormat);
 					ret = false;
+				}
+				// Init segments can carry discontinuity without samples.
+				// Pre-mark discontinuity so next data sample avoids cross-period PTS delta spikes.
+				if (ret && mIsTrickMode && isInit && discontinuous)
+				{
+					HandleTrickModeDiscontinuity();
 				}
 			}
 		}

--- a/mp4demux/AampMp4Demuxer.h
+++ b/mp4demux/AampMp4Demuxer.h
@@ -153,6 +153,14 @@ private:
 	void TrickmodePtsRestamp(AampMediaSample& sample, double duration, bool discontinuous);
 
 	/**
+	 * @brief Handle trickmode discontinuity by pre-advancing state machine
+	 * @note Called when a discontinuous init segment arrives to prevent large PTS
+	 *       deltas from being computed when the next data segment is processed.
+	 *       Transitions state from STEADY → DISCONTINUITY if discontinuous=true.
+	 */
+	void HandleTrickModeDiscontinuity();
+
+	/**
 	 * @brief Reset only trickmode state variables.
 	 * Called internally whenever trickmode state must be cleared (e.g. on
 	 * transition back to normal play). Intentionally separate from the public


### PR DESCRIPTION
Reason for change:Init segments at ad boundaries carry discontinuity flag but yield no samples,leaving state machine in STEADY phase. Next ad data segment computes incorrect PTS delta, causing catastrophic position jump to stream end.
Risks: p1

Signed-off-by: varshnie <varshniblue14@gmail.com>