### PR TITLE
VPAAMP-683 : add log to to check time taken between first frame to pi…

### DIFF
--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -784,6 +784,7 @@ void AAMPGstPlayer::Stream()
 {
 }
 
+
 /**
  * @brief Configure pipeline based on A/V formats
  */

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -103,6 +103,7 @@ static void InitializePlayerConfigs(AAMPGstPlayer *_this, void *playerInstance)
 	interfacePlayer->m_gstConfigParam->gstreamerSubsEnabled = _this->aamp->IsGstreamerSubsEnabled();
 	interfacePlayer->m_gstConfigParam->media = _this->aamp->GetMediaFormatTypeEnum();
 	interfacePlayer->m_gstConfigParam->useMp4Demux = config->IsConfigSet(eAAMPConfig_UseMp4Demux);
+	interfacePlayer->m_gstConfigParam->isNewTune = _this->aamp->isNewTune;
 }
 
 /*
@@ -782,7 +783,6 @@ bool AAMPGstPlayer::SendTransfer(AampMediaType mediaType, void *ptr, size_t len,
 void AAMPGstPlayer::Stream()
 {
 }
-
 
 /**
  * @brief Configure pipeline based on A/V formats

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4309,7 +4309,7 @@ static gboolean bus_message(GstBus * bus, GstMessage * msg, InterfacePlayerRDK *
 					std::string newState(gst_element_state_get_name(new_state));
 					if(oldState == "PAUSED" && newState == "PLAYING")
 					{
-						long long playingStartTimeInMS = NOW_SYSTEM_TS_MS - pInterfacePlayerRDK->mFirstFrameTimeInMS;
+						long long playingStartTimeInMS = NOW_STEADY_TS_MS  - pInterfacePlayerRDK->mFirstFrameTimeInMS;
 						MW_LOG_WARN("Time taken from First Frame to PLAYING state %.3f seconds", (double)playingStartTimeInMS / 1000.00f);
 						pInterfacePlayerRDK->mFirstFrameTimeInMS = 0;
 						pInterfacePlayerRDK->m_gstConfigParam->isNewTune = false;

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -3805,7 +3805,9 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 
 	if (eGST_MEDIATYPE_VIDEO == mediaType)
 	{
-		MW_LOG_MIL("OnFirstVideoFrame. got First Video Frame");
+		
+		mFirstFrameTimeInMS = NOW_STEADY_TS_MS;
+		MW_LOG_MIL("OnFirstVideoFrame. got First Video Frame at %lld seconds", mFirstFrameTimeInMS / 1000);
 
 		if (!interfacePlayerPriv->gstPrivateContext->decoderHandleNotified)
 		{
@@ -4690,6 +4692,11 @@ static gboolean buffering_timeout (gpointer data)
 				
 				privatePlayer->gstPrivateContext->buffering_in_progress = false;
 				isPlayerReady = true;
+
+				long long currentTimeInMS = NOW_SYSTEM_TS_MS;
+				long long playingStartTimeInMS = currentTimeInMS - pInterfacePlayerRDK->mFirstFrameTimeInMS;
+				MW_LOG_WARN("time taken from first frame to PLAYING state %.5f seconds",(double)playingStartTimeInMS / 1000.00f);
+				pInterfacePlayerRDK->mFirstFrameTimeInMS = 0;	
 			}
 		}
 		if (!privatePlayer->gstPrivateContext->buffering_in_progress)

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -4303,15 +4303,16 @@ static gboolean bus_message(GstBus * bus, GstMessage * msg, InterfacePlayerRDK *
 						   gst_element_state_get_name(new_state),
 						   gst_element_state_get_name(pending_state));
 
-				if(pInterfacePlayerRDK->mFirstFrameTimeInMS > 0)
+				if(pInterfacePlayerRDK->mFirstFrameTimeInMS > 0 && pInterfacePlayerRDK->m_gstConfigParam->isNewTune )
 				{
 					std::string oldState(gst_element_state_get_name(old_state));
 					std::string newState(gst_element_state_get_name(new_state));
 					if(oldState == "PAUSED" && newState == "PLAYING")
 					{
 						long long playingStartTimeInMS = NOW_SYSTEM_TS_MS - pInterfacePlayerRDK->mFirstFrameTimeInMS;
-						MW_LOG_WARN("Time taken from first frame to PLAYING state %.3f seconds", (double)playingStartTimeInMS / 1000.00f);
+						MW_LOG_WARN("Time taken from First Frame to PLAYING state %.3f seconds", (double)playingStartTimeInMS / 1000.00f);
 						pInterfacePlayerRDK->mFirstFrameTimeInMS = 0;
+						pInterfacePlayerRDK->m_gstConfigParam->isNewTune = false;
 					}
 				}
 				

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -3805,9 +3805,8 @@ void InterfacePlayerRDK::NotifyFirstFrame(int mediaType)
 
 	if (eGST_MEDIATYPE_VIDEO == mediaType)
 	{
-		
 		mFirstFrameTimeInMS = NOW_STEADY_TS_MS;
-		MW_LOG_MIL("OnFirstVideoFrame. got First Video Frame at %lld seconds", mFirstFrameTimeInMS / 1000);
+		MW_LOG_MIL("OnFirstVideoFrame. got First Video Frame");
 
 		if (!interfacePlayerPriv->gstPrivateContext->decoderHandleNotified)
 		{
@@ -4304,6 +4303,18 @@ static gboolean bus_message(GstBus * bus, GstMessage * msg, InterfacePlayerRDK *
 						   gst_element_state_get_name(new_state),
 						   gst_element_state_get_name(pending_state));
 
+				if(pInterfacePlayerRDK->mFirstFrameTimeInMS > 0)
+				{
+					std::string oldState(gst_element_state_get_name(old_state));
+					std::string newState(gst_element_state_get_name(new_state));
+					if(oldState == "PAUSED" && newState == "PLAYING")
+					{
+						long long playingStartTimeInMS = NOW_SYSTEM_TS_MS - pInterfacePlayerRDK->mFirstFrameTimeInMS;
+						MW_LOG_WARN("Time taken from first frame to PLAYING state %.3f seconds", (double)playingStartTimeInMS / 1000.00f);
+						pInterfacePlayerRDK->mFirstFrameTimeInMS = 0;
+					}
+				}
+				
 				if(isPlaybinStateChangeEvent && privatePlayer->gstPrivateContext->pauseOnStartPlayback && (new_state == GST_STATE_PAUSED))
 				{
 					GstElement *video_sink = privatePlayer->gstPrivateContext->video_sink;
@@ -4692,11 +4703,6 @@ static gboolean buffering_timeout (gpointer data)
 				
 				privatePlayer->gstPrivateContext->buffering_in_progress = false;
 				isPlayerReady = true;
-
-				long long currentTimeInMS = NOW_SYSTEM_TS_MS;
-				long long playingStartTimeInMS = currentTimeInMS - pInterfacePlayerRDK->mFirstFrameTimeInMS;
-				MW_LOG_WARN("time taken from first frame to PLAYING state %.5f seconds",(double)playingStartTimeInMS / 1000.00f);
-				pInterfacePlayerRDK->mFirstFrameTimeInMS = 0;	
 			}
 		}
 		if (!privatePlayer->gstPrivateContext->buffering_in_progress)

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -162,6 +162,7 @@ class InterfacePlayerRDK
 		void *mDRMSessionManager;
 		std::map<InterfaceCB, std::function<void()>> callbackMap;
 		std::map<InterfaceCB, std::function<void(int)>> setupStreamCallbackMap;
+		long long mFirstFrameTimeInMS;
         
 		PlayerScheduler mScheduler;
 		InterfacePlayerRDK(bool isRialto = false);

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -128,6 +128,7 @@ struct Configs
 	int monitorAvsyncThresholdNegativeMs;
 	int monitorAvJumpThresholdMs;
 	bool useMp4Demux;
+	bool isNewTune;
 };
 
 

--- a/middleware/PlayerUtils.h
+++ b/middleware/PlayerUtils.h
@@ -38,7 +38,7 @@
 #define MW_SAFE_DELETE(ptr) { delete(ptr); ptr = NULL; }
 //Delete Array object
 #define MW_SAFE_DELETE_ARRAY(ptr) { delete [] ptr; ptr = NULL; }
-
+#define NOW_SYSTEM_TS_MS std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()     /**< Getting current system clock in milliseconds */
 
 #define WRITE_HASCII( DST, BYTE ) \
 { \

--- a/middleware/PlayerUtils.h
+++ b/middleware/PlayerUtils.h
@@ -38,7 +38,7 @@
 #define MW_SAFE_DELETE(ptr) { delete(ptr); ptr = NULL; }
 //Delete Array object
 #define MW_SAFE_DELETE_ARRAY(ptr) { delete [] ptr; ptr = NULL; }
-#define NOW_SYSTEM_TS_MS std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count()     /**< Getting current system clock in milliseconds */
+
 
 #define WRITE_HASCII( DST, BYTE ) \
 { \

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1300,6 +1300,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, mIsFlushOperationInProgress(false)
 	, mThumbnailLastProgramDateTime(0)
 	, mLastSleThumbnailInfo()
+	, isNewTune(false)
 {
 	AAMPLOG_MIL("Create Private Player %d", mPlayerId);
 	mAampCacheHandler = new AampCacheHandler(mPlayerId);
@@ -3538,6 +3539,7 @@ void PrivateInstanceAAMP::TuneFail(bool fail)
 	{
 		SendTuneMetricsEvent(tuneData);
 	}
+	isNewTune = false;
 	AdditionalTuneFailLogEntries();
 }
 
@@ -3546,6 +3548,7 @@ void PrivateInstanceAAMP::TuneFail(bool fail)
  */
 void PrivateInstanceAAMP::LogTuneComplete(void)
 {
+	isNewTune = false;
 	TuneEndMetrics mTuneMetrics = {0, 0, 0,0,0,0,0,0,0,(ContentType)0};
 
 	mTuneMetrics.success 		 	 = true;
@@ -6229,6 +6232,7 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 	{
 		char tuneStrPrefix[64];
 		mTsbSessionRequestUrl.clear();
+		isNewTune = true;
 		memset(tuneStrPrefix, '\0', sizeof(tuneStrPrefix));
 		if (!mAppName.empty())
 		{

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1219,6 +1219,7 @@ public:
 
 	bool mIsFlushFdsInCurlStore;	/**< Mark to clear curl store instance in case of playback stopped due to download Error */
 	bool mIsFlushOperationInProgress;		/**< Flag to indicate pipeline flush operation is going on */
+	bool isNewTune;		/**< Flag to indicate it is new tune */
 
 	/**
 	 * @fn ProcessID3Metadata


### PR DESCRIPTION
…peline moved to PLAYING state

Reason for change :A new log has been added to report the time elapsed between the first frame and the PLAYING state Test Procedure: See ticket
Risks: low