### PR TITLE
VPAAMP-689 : Fix dangling MediaTrack access in AbortWaitForManifestUpdate after MPD teardown (fingerprint 27847108)

### DIFF
--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -11110,15 +11110,17 @@ void  StreamAbstractionAAMP_MPD::ResumeSubtitleAfterSeek(bool mute, char *data)
  */
 StreamAbstractionAAMP_MPD::~StreamAbstractionAAMP_MPD()
 {
-	for (int iTrack = 0; iTrack < mMaxTracks; iTrack++)
-	{
-		MediaStreamContext *track = mMediaStreamContext[iTrack];
-		SAFE_DELETE(track);
-	}
+	// Unregister the MPD download callback BEFORE deleting tracks.
+	// This ensures the notifier thread cannot fire MPDUpdateCallbackExec()
 
 	AampMPDDownloader *dnldInstance = aamp->GetMPDDownloader();
 	mManifestUpdateHandleFlag       =       false;
 	dnldInstance->UnRegisterCallback();
+
+	for (int iTrack = 0; iTrack < mMaxTracks; iTrack++)
+	{
+		SAFE_DELETE(mMediaStreamContext[iTrack]);  // Delete the MediaStreamContext objects for each track
+	}
 
 	{
 		auto syncLock = aamp->SyncLock();

--- a/fragmentcollector_mpd.cpp
+++ b/fragmentcollector_mpd.cpp
@@ -11119,7 +11119,8 @@ StreamAbstractionAAMP_MPD::~StreamAbstractionAAMP_MPD()
 
 	for (int iTrack = 0; iTrack < mMaxTracks; iTrack++)
 	{
-		SAFE_DELETE(mMediaStreamContext[iTrack]);  // Delete the MediaStreamContext objects for each track
+		// Delete the MediaStreamContext object for this track.
+		SAFE_DELETE(mMediaStreamContext[iTrack]);
 	}
 
 	{

--- a/test/utests/fakes/FakeFragmentCollector_MPD.cpp
+++ b/test/utests/fakes/FakeFragmentCollector_MPD.cpp
@@ -17,7 +17,10 @@
 * limitations under the License.
 */
 
+#include <cstring>
+#include "AampUtils.h"
 #include "fragmentcollector_mpd.h"
+#include "MediaStreamContext.h"
 #include "MockStreamAbstractionAAMP_MPD.h"
 
 TimeSyncClient::TimeSyncClient() = default;
@@ -27,10 +30,15 @@ std::shared_ptr<MockStreamAbstractionAAMP_MPD> g_mockStreamAbstractionAAMP_MPD{}
 StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD(class PrivateInstanceAAMP *aamp,double seek_pos, float rate, id3_callback_t id3Handler)
 	: StreamAbstractionAAMP(aamp), mMinUpdateDurationMs(DEFAULT_INTERVAL_BETWEEN_MPD_UPDATES_MS)
 {
+	memset(mMediaStreamContext, 0, sizeof(mMediaStreamContext));
 }
 
 StreamAbstractionAAMP_MPD::~StreamAbstractionAAMP_MPD()
 {
+	for (int iTrack = 0; iTrack < AAMP_TRACK_COUNT; iTrack++)
+	{
+		SAFE_DELETE(mMediaStreamContext[iTrack]);
+	}
 }
 
 Accessibility StreamAbstractionAAMP_MPD::getAccessibilityNode(AampJsonObject &accessNode)
@@ -92,7 +100,7 @@ double StreamAbstractionAAMP_MPD::GetMidSeekPosOffset() {
 
 double StreamAbstractionAAMP_MPD::GetStartTimeOfFirstPTS() { return 0; }
 
-MediaTrack* StreamAbstractionAAMP_MPD::GetMediaTrack(TrackType type) { return nullptr; }
+MediaTrack* StreamAbstractionAAMP_MPD::GetMediaTrack(TrackType type) { return mMediaStreamContext[type]; }
 
 double StreamAbstractionAAMP_MPD::GetBufferedDuration (void)
 {
@@ -337,6 +345,11 @@ void StreamAbstractionAAMP_MPD::WaitForManifestUpdate(uint32_t counter)
 
 void StreamAbstractionAAMP_MPD::AbortWaitForManifestUpdate()
 {
+	MediaTrack *video = GetMediaTrack(eTRACK_VIDEO);
+	if (video)
+	{
+		video->AbortWaitForManifestUpdate();
+	}
 }
 
 uint32_t StreamAbstractionAAMP_MPD::GetManifestUpdateCounter()

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -19,7 +19,9 @@
 
 #include <gtest/gtest.h>
 #include <algorithm>
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <future>
 #include <thread>
 
@@ -29,6 +31,7 @@
 #include "AampTime.h"
 #include "priv_aamp.h"
 #include "fragmentcollector_mpd.h"
+#include "MediaStreamContext.h"
 
 #include "MockIsoBmffHelper.h"
 #include "MockIsoBmffBuffer.h"
@@ -70,6 +73,17 @@ MATCHER_P(VectorRefEq, vecStdConstRef, "")
 	return arg.size() >= vec.size() &&
 		   std::memcmp(arg.data(), vec.data(), vec.size()) == 0;
 }
+
+// Test helper: exposes protected members of StreamAbstractionAAMP_MPD for the
+// regression test. Allows direct access to mMediaStreamContext[] and
+// AbortWaitForManifestUpdate() without modifying the production header.
+class TestableStreamAbstractionAAMP_MPD : public StreamAbstractionAAMP_MPD
+{
+public:
+	using StreamAbstractionAAMP_MPD::StreamAbstractionAAMP_MPD;
+	using StreamAbstractionAAMP_MPD::mMediaStreamContext;
+	using StreamAbstractionAAMP_MPD::AbortWaitForManifestUpdate;
+};
 
 // MediaTrack is an abstract base class, so must be tested via a derived class
 class TestableMediaTrack : public MediaTrack
@@ -1338,4 +1352,85 @@ TEST_F(MediaTrackTests, CheckForDiscontinuity_FallsThrough_WhenPtsRestampDisable
 
 	// Else branch: isDiscontinuity was not modified, remains true.
 	EXPECT_TRUE(isDiscontinuity);
+}
+
+/**
+ * @brief Regression test for SIGABRT crash in MPD teardown (use-after-free of dwnldMutex).
+ *
+ */
+TEST_F(MediaTrackTests, MPDCallback_Teardown_RaceConditionTest)
+{
+	EXPECT_CALL(*g_mockPrivateInstanceAAMP, DownloadsAreEnabled()).WillRepeatedly(Return(true));
+	// MediaStreamContext and MediaTrack constructors call various GETCONFIGVALUE/ISCONFIGSET.
+	// NiceMock returns 0/false by default. Override the ones that need non-zero values:
+	ON_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxFragmentCached)).WillByDefault(Return(1));
+	ON_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxLLDFragmentCached)).WillByDefault(Return(1));
+	ON_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_MaxDownloadBuffer)).WillByDefault(Return(10));
+
+	
+	auto* testMPD = new TestableStreamAbstractionAAMP_MPD(mPrivateInstanceAAMP, 0, 0);
+
+	auto* videoCtx = new MediaStreamContext(eTRACK_VIDEO, testMPD, mPrivateInstanceAAMP, "video");
+	testMPD->mMediaStreamContext[eTRACK_VIDEO] = videoCtx;
+
+	// Precondition: GetMediaTrack() returns the track from the array.
+	ASSERT_EQ(testMPD->GetMediaTrack(eTRACK_VIDEO), static_cast<MediaTrack*>(videoCtx));
+
+	testMPD->AbortWaitForManifestUpdate(); // Must not crash - track is alive.
+
+
+
+
+	// notifierMtx mirrors mMPDNotifierMtx held by downloadNotifierThread.
+	std::mutex notifierMtx;
+	std::atomic<bool> registered{true};
+	std::atomic<int> callbackCount{0};
+
+	// Notifier thread: holds notifierMtx while calling AbortWaitForManifestUpdate.
+	std::thread notifierThread([&]()
+	{
+		while (registered.load(std::memory_order_acquire))
+		{
+			std::lock_guard<std::mutex> lock(notifierMtx);
+			if (!registered.load(std::memory_order_relaxed)) return;
+			testMPD->AbortWaitForManifestUpdate();
+			callbackCount.fetch_add(1, std::memory_order_relaxed);
+			std::this_thread::yield();
+		}
+	});
+
+	// Wait for at least one callback (proves dwnldMutex path is live).
+	while (callbackCount.load(std::memory_order_acquire) == 0)
+	{
+		std::this_thread::sleep_for(std::chrono::microseconds(100));
+	}
+
+	// FIX 1: UnRegisterCallback() - acquires notifierMtx (= mMPDNotifierMtx).
+	// Guarantees any in-flight callback completes before proceeding.
+	{
+		std::lock_guard<std::mutex> lock(notifierMtx);
+		registered.store(false, std::memory_order_release); //mManifestUpdateHandleFlag = false
+	}
+	notifierThread.join(); 
+
+	const int countAfterUnregistering = callbackCount.load(std::memory_order_acquire);
+
+	// FIX 2 validation: The destructor uses SAFE_DELETE(mMediaStreamContext[iTrack]).
+	// We verify this by calling it and checking the array entry is null afterwards.
+	SAFE_DELETE(testMPD->mMediaStreamContext[eTRACK_VIDEO]);
+
+	//Un-fixed code . If this is uncommented then the test will fail
+	// MediaStreamContext* track = testMPD->mMediaStreamContext[eTRACK_VIDEO];
+    // SAFE_DELETE(track);
+
+	//ASSERTION (Fix 2):
+	ASSERT_EQ(testMPD->GetMediaTrack(eTRACK_VIDEO), nullptr);
+
+	// After fix: AbortWaitForManifestUpdate sees null, bails out safely.
+	testMPD->AbortWaitForManifestUpdate(); // Must not crash.
+
+	// Fix 1 assertion: No callbacks fired after unregistering.
+	ASSERT_EQ(callbackCount.load(), countAfterUnregistering);
+
+	delete testMPD;
 }


### PR DESCRIPTION
Reason for change : The issue is caused by use-after-free for a mutex. As Teardown() is called ~StreamAbstractionAAMP_MPD() results in dangling pointer for mMediaStreamContext tracks. Later AbortWaitForManifestUpdate() called by MPDCallbackExec() , tries to acquire a mutex through the dangling mMediaStreamContext video track. This results in use-after-free for the mutex as the mutex belonged to class MediaTrack.

Test Procedure : Refer ticket

Risk : Medium

