### PR TITLE
VPAAMP-657 [Nitro] AAMP VOD CDAI [phase 3] optimization: parallel ad manifest downloads pre-stitching

### DIFF
--- a/AampVodStitcher.cpp
+++ b/AampVodStitcher.cpp
@@ -536,9 +536,10 @@ static AdFetchResult FetchOneAdMPD(
 	res.ok                = false;
 
 	auto dnldCfg = std::make_shared<DownloadConfig>();
-	dnldCfg->proxyName       = proxyName;
-	dnldCfg->userAgentString = userAgent;
-	dnldCfg->iDownloadTimeout = DEFAULT_CURL_TIMEOUT;
+	dnldCfg->proxyName            = proxyName;
+	dnldCfg->userAgentString      = userAgent;
+	dnldCfg->iDownloadTimeout     = DEFAULT_CURL_TIMEOUT;
+	dnldCfg->bNeedDownloadMetrics = true;
 
 	auto dnldResp = std::make_shared<DownloadResponse>();
 
@@ -546,14 +547,25 @@ static AdFetchResult FetchOneAdMPD(
 	downloader.Initialize(dnldCfg);
 
 	std::string fetchUrl = url;
+	auto fetchStart = std::chrono::steady_clock::now();
 	int rc = downloader.Download(fetchUrl, dnldResp);
+	double totalPerformRequest = std::chrono::duration<double>(
+		std::chrono::steady_clock::now() - fetchStart).count();
 
 	downloader.CleanupCurlHeaderResources();
 
+	const auto &m = dnldResp->downloadCompleteMetrics;
+	AAMPLOG_MIL("HttpRequestEnd: 3,%d,%d,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%.3f,%g,%ld,%" BITSPERSECOND_FORMAT ",0,%.500s",
+		eMEDIATYPE_MANIFEST, rc,
+		totalPerformRequest, m.total, m.connect, m.startTransfer,
+		m.resolve, m.appConnect, m.preTransfer, m.redirect,
+		m.dlSize, m.reqSize, m.downloadbps,
+		(dnldResp->sEffectiveUrl.empty() ? url : dnldResp->sEffectiveUrl).c_str());
+
 	if (rc < 200 || rc >= 300 || dnldResp->mDownloadData.empty())
 	{
-		AAMPLOG_WARN("[VodStitcher] Failed to fetch ad MPD break=%s url=%s http=%d rc=%d",
-		             breakId.c_str(), url.c_str(), dnldResp->iHttpRetValue, rc);
+		AAMPLOG_WARN("[VodStitcher] Failed to fetch ad MPD break=%s url=%s http=%d",
+		             breakId.c_str(), url.c_str(), rc);
 	}
 	else
 	{
@@ -595,18 +607,14 @@ static std::vector<AdFetchResult> FetchAdMPDsParallel(
 			const VodAdBreakInfo &info = vodIt->second;
 			if (info.cancelled)
 				continue;
-			auto abIt = cdaiObj->mAdBreaks.find(info.breakId);
-			if (abIt == cdaiObj->mAdBreaks.end())
-				continue;
-			const AdBreakObject &abObj = abIt->second;
-			if (!abObj.ads || abObj.ads->empty() || !abObj.ads->at(0).resolved)
+			if (info.adUrl.empty())
 			{
-				AAMPLOG_WARN("[VodStitcher] Break %s has no resolved ad URL — skipping",
+				AAMPLOG_WARN("[VodStitcher] Break %s has no ad URL — skipping",
 				             info.breakId.c_str());
 				continue;
 			}
 			todo.push_back({info.breakId, info.insertionPointSec,
-			                info.breakDurationSec, abObj.ads->at(0).url});
+			                info.breakDurationSec, info.adUrl});
 		}
 	}
 

--- a/AampVodStitcher.cpp
+++ b/AampVodStitcher.cpp
@@ -1,5 +1,6 @@
 /*
  * If not stated otherwise in this file or this component's license file the
+ * following copyright and licenses apply:
  *
  * Copyright 2026 RDK Management
  *
@@ -120,7 +121,7 @@ static double ParseIsoDuration(const std::string &s)
 	while (i < s.size())
 	{
 		size_t j = i;
-		while (j < s.size() && (std::isdigit(s[j]) || s[j] == '.'))
+		while (j < s.size() && (std::isdigit(static_cast<unsigned char>(s[j])) || s[j] == '.'))
 			j++;
 		if (j == i || j >= s.size())
 			break;
@@ -707,7 +708,12 @@ std::string BuildStitchedVodManifest(
 	// Wait until every non-cancelled registered break is resolved or failed.
 	// This ensures midroll/postroll ads are included in the stitched MPD.
 	// Timeout after 10s to avoid blocking playback indefinitely if DAI is slow.
-	if (!cdaiObj->mVodAdBreaks.empty())
+	bool hasBreaks = false;
+	{
+		std::lock_guard<std::recursive_mutex> snapLk(cdaiObj->mDaiMtx);
+		hasBreaks = !cdaiObj->mVodAdBreaks.empty();
+	}
+	if (hasBreaks)
 	{
 		const int kTimeoutMs = 10000;
 		std::unique_lock<std::mutex> lk(cdaiObj->mVodAllAdsResolvedMtx);

--- a/AampVodStitcher.cpp
+++ b/AampVodStitcher.cpp
@@ -40,11 +40,15 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <future>
 #include <map>
 #include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "downloader/AampCurlDownloader.h"
+#include "AampConfig.h"
 
 /* -------------------------------------------------------------------------
  * Internal string helpers  (mirrors manifest-genie GetAttr / SetAttr)
@@ -509,18 +513,72 @@ struct AdFetchResult
 	bool        ok;
 };
 
+/** Maximum number of ad MPDs to fetch concurrently. */
+static constexpr int kMaxParallelAdFetches = 6;
+
 /**
- * @brief Fetch all resolved VOD ad MPDs sequentially and return results.
- *        Sequential (not parallel) to avoid stack-use-after-return in
- *        GetFile's curl xferinfo_callback when sharing the AAMP instance.
+ * @brief Fetch one VOD ad MPD using a private AampCurlDownloader instance.
+ *        Called from std::async threads — each call owns its own CURL* handle
+ *        so there is no shared-handle data race and no stack-use-after-return.
  */
-static std::vector<AdFetchResult> FetchAdMPDsSequential(
+static AdFetchResult FetchOneAdMPD(
+	const std::string &breakId,
+	double             insertionPointSec,
+	double             durationSec,
+	const std::string &url,
+	const std::string &proxyName,
+	const std::string &userAgent)
+{
+	AdFetchResult res;
+	res.breakId           = breakId;
+	res.insertionPointSec = insertionPointSec;
+	res.durationSec       = durationSec;
+	res.ok                = false;
+
+	auto dnldCfg = std::make_shared<DownloadConfig>();
+	dnldCfg->proxyName       = proxyName;
+	dnldCfg->userAgentString = userAgent;
+	dnldCfg->iDownloadTimeout = DEFAULT_CURL_TIMEOUT;
+
+	auto dnldResp = std::make_shared<DownloadResponse>();
+
+	AampCurlDownloader downloader;
+	downloader.Initialize(dnldCfg);
+
+	std::string fetchUrl = url;
+	int rc = downloader.Download(fetchUrl, dnldResp);
+
+	downloader.CleanupCurlHeaderResources();
+
+	if (rc != 0 || dnldResp->iHttpRetValue < 200 || dnldResp->iHttpRetValue >= 300
+	    || dnldResp->mDownloadData.empty())
+	{
+		AAMPLOG_WARN("[VodStitcher] Failed to fetch ad MPD break=%s url=%s http=%d rc=%d",
+		             breakId.c_str(), url.c_str(), dnldResp->iHttpRetValue, rc);
+	}
+	else
+	{
+		res.mpdText      = dnldResp->getString();
+		res.effectiveUrl = dnldResp->sEffectiveUrl.empty() ? url : dnldResp->sEffectiveUrl;
+		res.ok           = true;
+		AAMPLOG_INFO("[VodStitcher] Fetched ad MPD break=%s url=%s size=%zu",
+		             breakId.c_str(), res.effectiveUrl.c_str(), res.mpdText.size());
+	}
+	return res;
+}
+
+/**
+ * @brief Fetch all resolved VOD ad MPDs in parallel (up to kMaxParallelAdFetches
+ *        concurrent downloads) and return results in registration order.
+ *
+ * Each download uses its own AampCurlDownloader instance (and therefore its
+ * own CURL* handle), so there is no shared-handle data race and no
+ * stack-use-after-return hazard from GetFile's curl progress callbacks.
+ */
+static std::vector<AdFetchResult> FetchAdMPDsParallel(
 	PrivateInstanceAAMP  *aamp,
 	PrivateCDAIObjectMPD *cdaiObj)
 {
-	// Collect break metadata in registration order under lock, then fetch without lock.
-	// mVodAdBreakOrder preserves the order breaks were registered, giving deterministic
-	// ad playout sequence regardless of breakId string ordering.
 	struct BreakTodo {
 		std::string breakId;
 		double      insertionPointSec;
@@ -553,39 +611,42 @@ static std::vector<AdFetchResult> FetchAdMPDsSequential(
 		}
 	}
 
+	if (todo.empty())
+		return {};
+
+	// Snapshot proxy and user-agent once; safe to read outside mDaiMtx.
+	std::string proxyName  = aamp->GetNetworkProxy();
+	std::string userAgent  = aamp->mConfig->GetUserAgentString();
+
+	// Launch up to kMaxParallelAdFetches downloads at a time using a sliding
+	// window so we never exceed the concurrency cap.
+	const int n = (int)todo.size();
+	std::vector<std::future<AdFetchResult>> futures(n);
+
+	auto launchFrom = [&](int idx) {
+		const BreakTodo &t = todo[idx];
+		futures[idx] = std::async(std::launch::async,
+			FetchOneAdMPD,
+			t.breakId, t.insertionPointSec, t.durationSec,
+			t.url, proxyName, userAgent);
+	};
+
+	// Seed initial wave
+	int launched = 0;
+	while (launched < n && launched < kMaxParallelAdFetches)
+		launchFrom(launched++);
+
 	std::vector<AdFetchResult> results;
-	results.reserve(todo.size());
-	for (const auto &t : todo)
+	results.reserve(n);
+
+	// Collect results in order; launch next as each slot frees.
+	for (int collected = 0; collected < n; collected++)
 	{
-		AdFetchResult res;
-		res.breakId           = t.breakId;
-		res.insertionPointSec = t.insertionPointSec;
-		res.durationSec       = t.durationSec;
-		res.ok                = false;
-
-		std::vector<uint8_t> data;
-		std::string effectiveUrl = t.url;
-		int httpErr = 0;
-		double dlTime = 0.0;
-
-		bool got = aamp->GetFile(effectiveUrl, eMEDIATYPE_MANIFEST, data,
-		                         effectiveUrl, httpErr, &dlTime, nullptr,
-		                         eCURLINSTANCE_MANIFEST_MAIN);
-		if (!got || data.empty())
-		{
-			AAMPLOG_WARN("[VodStitcher] Failed to fetch ad MPD for break=%s url=%s http=%d",
-			             t.breakId.c_str(), t.url.c_str(), httpErr);
-		}
-		else
-		{
-			res.mpdText      = std::string(reinterpret_cast<const char *>(data.data()), data.size());
-			res.effectiveUrl = effectiveUrl;
-			res.ok           = true;
-			AAMPLOG_INFO("[VodStitcher] Fetched ad MPD break=%s url=%s size=%zu",
-			             t.breakId.c_str(), effectiveUrl.c_str(), data.size());
-		}
-		results.push_back(std::move(res));
+		results.push_back(futures[collected].get());
+		if (launched < n)
+			launchFrom(launched++);
 	}
+
 	return results;
 }
 
@@ -672,9 +733,9 @@ std::string BuildStitchedVodManifest(
 		}
 	}
 
-	// Fetch all ad MPDs sequentially (parallel is unsafe: GetFile registers
-	// a stack-local curl progress context that would be accessed after return)
-	std::vector<AdFetchResult> adResults = FetchAdMPDsSequential(aamp, cdaiObj);
+	// Fetch all ad MPDs in parallel — each download uses its own
+	// AampCurlDownloader (and therefore its own CURL* handle).
+	std::vector<AdFetchResult> adResults = FetchAdMPDsParallel(aamp, cdaiObj);
 
 	// Build insertion map: insertionPointSec -> [AdFetchResult*, ...]
 	// Ordered by insertion point; multiple ads at the same point are chained.

--- a/AampVodStitcher.cpp
+++ b/AampVodStitcher.cpp
@@ -550,8 +550,7 @@ static AdFetchResult FetchOneAdMPD(
 
 	downloader.CleanupCurlHeaderResources();
 
-	if (rc != 0 || dnldResp->iHttpRetValue < 200 || dnldResp->iHttpRetValue >= 300
-	    || dnldResp->mDownloadData.empty())
+	if (rc < 200 || rc >= 300 || dnldResp->mDownloadData.empty())
 	{
 		AAMPLOG_WARN("[VodStitcher] Failed to fetch ad MPD break=%s url=%s http=%d rc=%d",
 		             breakId.c_str(), url.c_str(), dnldResp->iHttpRetValue, rc);

--- a/AampVodStitcher.h
+++ b/AampVodStitcher.h
@@ -23,9 +23,9 @@
  *
  * Produces a single multi-period static DASH MPD by splicing ad-break periods
  * into the main content MPD at registered insertion points. Ad MPDs are
- * fetched sequentially before stitching (see implementation notes) so that
- * tune latency stays bounded without unsafe parallel GetFile() usage.
- * Supported segment addressing: SegmentTemplate + SegmentTimeline only.
+ * fetched in parallel using per-break threads (each with a dedicated curl
+ * handle) so that tune latency is minimised when multiple breaks are
+ * registered. Supported segment addressing: SegmentTemplate + SegmentTimeline only.
  */
 
 #pragma once

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -1570,50 +1570,50 @@ void PrivateCDAIObjectMPD::SetAlternateContents(const std::string &periodId, con
 	}
 	else
 	{
-		bool adCached = false;
-		AAMPCDAIError adErrorCode = eCDAI_ERROR_UNKNOWN;
-		// VOD CDAI: create the AdBreakObject on the first SetAlternateContents
-		// call for a registered VOD break (live CDAI creates it via a prior
-		// placeholder SetAlternateContents("","") call; VOD skips that step).
-		if (!isAdBreakObjectExist(periodId))
+		// VOD CDAI stitching path: store the ad URL directly on VodAdBreakInfo and
+		// mark the AdNode resolved immediately.  The stitcher (BuildStitchedVodManifest /
+		// FetchAdMPDsParallel) will download all ad manifests in parallel at tune time —
+		// FulfillAdLoop is not involved for VOD breaks.
 		{
-			auto posIt = mVodAdBreaks.find(periodId);
-			if (posIt != mVodAdBreaks.end())
+			std::lock_guard<std::recursive_mutex> lock(mDaiMtx);
+			auto vodIt = mVodAdBreaks.find(periodId);
+			if (vodIt != mVodAdBreaks.end() && !vodIt->second.cancelled)
 			{
-				if (!posIt->second.cancelled)
+				VodAdBreakInfo &info = vodIt->second;
+				info.adId  = adId;
+				info.adUrl = url;
+
+				// Ensure mAdBreaks entry exists so AreAllVodAdsResolved() can inspect it.
+				if (!isAdBreakObjectExist(periodId))
 				{
-					uint32_t brkDurMs = (uint32_t)(posIt->second.breakDurationSec * 1000.0);
+					uint32_t brkDurMs = (uint32_t)(info.breakDurationSec * 1000.0);
 					auto adBreakAssets = std::make_shared<std::vector<AdNode>>();
 					mAdBreaks.emplace(periodId,
 						AdBreakObject{brkDurMs, std::move(adBreakAssets), "", 0, 0});
 					AAMPLOG_INFO("[CDAI-VOD] Created AdBreakObject for VOD break id=%s (durMs=%u)",
 						periodId.c_str(), brkDurMs);
 				}
-			}
-		}
-		if(isAdBreakObjectExist(periodId))
-		{
-			auto &adbreakObj = mAdBreaks[periodId];
-			if (adbreakObj.invalid)
-			{
-				adErrorCode = eCDAI_ERROR_DECISIONING_TIMEOUT;
-			}
-			else if (adbreakObj.brkDuration <= adbreakObj.adsDuration)
-			{
-				AAMPLOG_WARN("No more space left in the Adbreak. Rejecting the promise.");
-				adErrorCode = eCDAI_ERROR_INVALID_SPECIFICATION;
+
+				auto &adbreakObj = mAdBreaks[periodId];
+				// Add a pre-resolved AdNode so AreAllVodAdsResolved() sees it as done.
+				// Duration is 0 here; the stitcher will determine real duration from the manifest.
+				adbreakObj.ads->emplace_back(AdNode{false, false, true, adId, url, 0, "", 0, nullptr});
+				adbreakObj.resolved = true;
+				AAMPLOG_INFO("[CDAI-VOD] Queued ad id=%s url=%s for break=%s — stitcher will fetch at tune time",
+					adId.c_str(), url.c_str(), periodId.c_str());
 			}
 			else
 			{
-				//Cache the Ad to be placed later
-				CacheAdData(periodId, adId, url);
-				adCached = true;
+				AAMPLOG_WARN("[CDAI-VOD] SetAlternateContents: no registered (or cancelled) VOD break for id=%s — dropping ad id=%s",
+					periodId.c_str(), adId.c_str());
 			}
 		}
-		// Reject the promise as ad couldn't be resolved
-		if(!adCached)
+
+		// Signal the manifest thread if every registered VOD break now has a URL.
+		if (AreAllVodAdsResolved())
 		{
-			mAamp->SendAdResolvedEvent(adId, false, 0, 0, adErrorCode);
+			AAMPLOG_INFO("[CDAI-VOD] All VOD ads queued — signalling stitcher");
+			mVodAllAdsResolvedCV.notify_all();
 		}
 	}
 }

--- a/admanager_mpd.cpp
+++ b/admanager_mpd.cpp
@@ -1568,7 +1568,7 @@ void PrivateCDAIObjectMPD::SetAlternateContents(const std::string &periodId, con
 			pData.adBreakId = periodId;
 		}
 	}
-	else
+	else if (IsVodAdBreak(periodId))
 	{
 		// VOD CDAI stitching path: store the ad URL directly on VodAdBreakInfo and
 		// mark the AdNode resolved immediately.  The stitcher (BuildStitchedVodManifest /
@@ -1614,6 +1614,54 @@ void PrivateCDAIObjectMPD::SetAlternateContents(const std::string &periodId, con
 		{
 			AAMPLOG_INFO("[CDAI-VOD] All VOD ads queued — signalling stitcher");
 			mVodAllAdsResolvedCV.notify_all();
+		}
+	}
+	else
+	{
+		bool adCached = false;
+		AAMPCDAIError adErrorCode = eCDAI_ERROR_UNKNOWN;
+		// VOD CDAI: create the AdBreakObject on the first SetAlternateContents
+		// call for a registered VOD break (live CDAI creates it via a prior
+		// placeholder SetAlternateContents("","") call; VOD skips that step).
+		if (!isAdBreakObjectExist(periodId))
+		{
+			auto posIt = mVodAdBreaks.find(periodId);
+			if (posIt != mVodAdBreaks.end())
+			{
+				if (!posIt->second.cancelled)
+				{
+					uint32_t brkDurMs = (uint32_t)(posIt->second.breakDurationSec * 1000.0);
+					auto adBreakAssets = std::make_shared<std::vector<AdNode>>();
+					mAdBreaks.emplace(periodId,
+						AdBreakObject{brkDurMs, std::move(adBreakAssets), "", 0, 0});
+					AAMPLOG_INFO("[CDAI-VOD] Created AdBreakObject for VOD break id=%s (durMs=%u)",
+						periodId.c_str(), brkDurMs);
+				}
+			}
+		}
+		if(isAdBreakObjectExist(periodId))
+		{
+			auto &adbreakObj = mAdBreaks[periodId];
+			if (adbreakObj.invalid)
+			{
+				adErrorCode = eCDAI_ERROR_DECISIONING_TIMEOUT;
+			}
+			else if (adbreakObj.brkDuration <= adbreakObj.adsDuration)
+			{
+				AAMPLOG_WARN("No more space left in the Adbreak. Rejecting the promise.");
+				adErrorCode = eCDAI_ERROR_INVALID_SPECIFICATION;
+			}
+			else
+			{
+				//Cache the Ad to be placed later
+				CacheAdData(periodId, adId, url);
+				adCached = true;
+			}
+		}
+		// Reject the promise as ad couldn't be resolved
+		if(!adCached)
+		{
+			mAamp->SendAdResolvedEvent(adId, false, 0, 0, adErrorCode);
 		}
 	}
 }

--- a/admanager_mpd.h
+++ b/admanager_mpd.h
@@ -398,6 +398,8 @@ struct VodAdBreakInfo {
 	bool        cancelled;          /**< true if cancelVodAdBreak() was called for this break */
 	bool        adPodStarted;       /**< true once the ad pod begins playing; prevents re-entry */
 	bool        adPodCompleted;     /**< true once all ads in the pod have finished */
+	std::string adId;               /**< Ad identifier supplied via SetAlternateContents() */
+	std::string adUrl;              /**< Ad manifest URL supplied via SetAlternateContents(); used directly by the VOD stitcher */
 
 	VodAdBreakInfo() : insertionPointSec(0.0), breakDurationSec(0.0), opportunityFired(false), cancelled(false),
 				   adPodStarted(false), adPodCompleted(false) {}

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -5367,11 +5367,18 @@ TEST_F(AdManagerMPDTests, VodCdai_AllAdsResolvedCV_SignalledAfterLastSetAlternat
 
 /**
  * @brief SetAlternateContents for an unknown break (not registered via
- *        RegisterVodAdBreak) must be silently dropped — no crash, no
- *        mAdBreaks entry created.
+ *        RegisterVodAdBreak and no prior placeholder call) falls into the
+ *        linear CDAI else branch, finds no mAdBreaks entry, and rejects the
+ *        ad via SendAdResolvedEvent(false). No mAdBreaks entry is created.
  */
 TEST_F(AdManagerMPDTests, VodCdai_SetAlternateContents_DropsUnknownBreak)
 {
+  // No RegisterVodAdBreak and no prior placeholder call — the linear else branch
+  // finds no mAdBreaks entry and rejects the ad via SendAdResolvedEvent(false).
+  EXPECT_CALL(*g_mockPrivateInstanceAAMP,
+              SendAdResolvedEvent(std::string("ad-X"), false, 0, 0, _))
+      .Times(1);
+
   mPrivateCDAIObjectMPD->SetAlternateContents("non-existent-break", "ad-X",
                                                "https://cdn.example.com/adX.mpd", 0, 0);
 

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -5272,3 +5272,171 @@ TEST_F(AdManagerMPDTests, StaticManifest_AdDownloadFails_NotifyComplete_DoesNotP
   EXPECT_EQ(mPrivateCDAIObjectMPD->mPlacementObj.curAdIdx, -1);
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdtoInsertInNextBreakVec.empty());
 }
+
+// ---------------------------------------------------------------------------
+// VOD CDAI stitching path tests (VPAAMP-657)
+// These tests exercise PrivateCDAIObjectMPD state changes driven by
+// RegisterVodAdBreak + SetAlternateContents without any network access.
+// They verify that:
+//   (a) ad URLs are stored on VodAdBreakInfo (not pushed to FulfillAdLoop)
+//   (b) AreAllVodAdsResolved / mVodAllAdsResolvedCV behave correctly
+//   (c) failed / cancelled breaks are handled gracefully
+//   (d) linear CDAI (no RegisterVodAdBreak calls) is completely unaffected
+// ---------------------------------------------------------------------------
+
+/**
+ * @brief RegisterVodAdBreak then SetAlternateContents stores adId/adUrl on
+ *        VodAdBreakInfo and creates a pre-resolved AdNode — FulfillAdLoop
+ *        queue must remain empty.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_SetAlternateContents_StoresUrlOnVodBreakInfo)
+{
+  const std::string breakId = "preroll-1";
+  const std::string adId    = "ad-001";
+  const std::string adUrl   = "https://cdn.example.com/ads/ad1/manifest.mpd";
+
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{breakId, 0.0, 30.0, "preroll"});
+  mPrivateCDAIObjectMPD->SetAlternateContents(breakId, adId, adUrl);
+
+  // adId and adUrl stored directly on VodAdBreakInfo
+  const auto &info = mPrivateCDAIObjectMPD->mVodAdBreaks.at(breakId);
+  EXPECT_EQ(info.adId,  adId);
+  EXPECT_EQ(info.adUrl, adUrl);
+
+  // mAdBreaks entry created with one pre-resolved AdNode
+  ASSERT_TRUE(mPrivateCDAIObjectMPD->isAdBreakObjectExist(breakId));
+  const auto &abObj = mPrivateCDAIObjectMPD->mAdBreaks.at(breakId);
+  ASSERT_EQ(abObj.ads->size(), 1u);
+  EXPECT_TRUE(abObj.ads->at(0).resolved);
+  EXPECT_EQ(abObj.ads->at(0).adId,  adId);
+  EXPECT_EQ(abObj.ads->at(0).url,   adUrl);
+  EXPECT_EQ(abObj.ads->at(0).mpd,   nullptr);
+
+  // FulfillAdLoop queue must be untouched
+  std::lock_guard<std::mutex> lk(mPrivateCDAIObjectMPD->mAdFulfillMtx);
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mAdFulfillQ.empty())
+      << "VOD ad URLs must NOT be pushed to the FulfillAdLoop queue";
+}
+
+/**
+ * @brief AreAllVodAdsResolved returns false until every registered break has
+ *        received a SetAlternateContents call, then returns true.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_AreAllVodAdsResolved_SignalsAfterAllBreaks)
+{
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"brk-1", 0.0,  15.0, "preroll"});
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"brk-2", 30.0, 15.0, "midroll"});
+
+  EXPECT_FALSE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
+      << "Should be false before any SetAlternateContents";
+
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-1", "ad-1", "https://cdn.example.com/ad1.mpd");
+
+  EXPECT_FALSE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
+      << "Should be false while one break still has no URL";
+
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-2", "ad-2", "https://cdn.example.com/ad2.mpd");
+
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
+      << "Should be true once every break has a URL";
+}
+
+/**
+ * @brief mVodAllAdsResolvedCV is signalled after the last SetAlternateContents
+ *        so that BuildStitchedVodManifest's wait_for returns immediately.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_AllAdsResolvedCV_SignalledAfterLastSetAlternateContents)
+{
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"brk-alpha", 0.0, 10.0, "preroll"});
+
+  // Arm a background thread waiting on the CV before SetAlternateContents.
+  std::atomic<bool> signalled{false};
+  auto fut = std::async(std::launch::async, [&]() {
+    std::unique_lock<std::mutex> lk(mPrivateCDAIObjectMPD->mVodAllAdsResolvedMtx);
+    signalled = mPrivateCDAIObjectMPD->mVodAllAdsResolvedCV.wait_for(
+        lk, std::chrono::seconds(2),
+        [&]{ return mPrivateCDAIObjectMPD->AreAllVodAdsResolved(); });
+  });
+
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-alpha", "ad-alpha", "https://cdn.example.com/ad-alpha.mpd");
+
+  fut.get();
+  EXPECT_TRUE(signalled)
+      << "mVodAllAdsResolvedCV must be signalled by SetAlternateContents";
+}
+
+/**
+ * @brief SetAlternateContents for an unknown break (not registered via
+ *        RegisterVodAdBreak) must be silently dropped — no crash, no
+ *        mAdBreaks entry created.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_SetAlternateContents_DropsUnknownBreak)
+{
+  mPrivateCDAIObjectMPD->SetAlternateContents("non-existent-break", "ad-X",
+                                               "https://cdn.example.com/adX.mpd");
+
+  EXPECT_FALSE(mPrivateCDAIObjectMPD->isAdBreakObjectExist("non-existent-break"));
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mVodAdBreaks.empty());
+}
+
+/**
+ * @brief A cancelled VOD break is skipped by AreAllVodAdsResolved — it must
+ *        not block the stitcher even if no SetAlternateContents is received.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_CancelledBreak_DoesNotBlockResolution)
+{
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"brk-ok",     0.0,  10.0, "preroll"});
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"brk-cancel", 30.0, 10.0, "midroll"});
+
+  // Cancel the second break before any SetAlternateContents
+  mPrivateCDAIObjectMPD->CancelVodAdBreak("brk-cancel");
+
+  // Satisfy only the non-cancelled break
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-ok", "ad-ok", "https://cdn.example.com/ad-ok.mpd");
+
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
+      << "Cancelled breaks must not block AreAllVodAdsResolved";
+}
+
+/**
+ * @brief Linear CDAI (no RegisterVodAdBreak calls) must not be affected by
+ *        the new VOD path.  SetAlternateContents with an empty adId/url
+ *        (linear placeholder) still creates the mAdBreaks entry as before.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_LinearCdai_UnaffectedByVodPath)
+{
+  const std::string periodId = "linear-period-1";
+
+  // Linear CDAI placeholder call (empty adId/url) — must still work
+  mPrivateCDAIObjectMPD->SetAlternateContents(periodId, "", "", 0, 30000);
+
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->isAdBreakObjectExist(periodId))
+      << "Linear CDAI placeholder must still create mAdBreaks entry";
+
+  // mVodAdBreaks must remain empty — no VOD registration happened
+  EXPECT_TRUE(mPrivateCDAIObjectMPD->mVodAdBreaks.empty())
+      << "Linear CDAI must not touch mVodAdBreaks";
+
+  // AreAllVodAdsResolved must be false (no VOD breaks registered)
+  EXPECT_FALSE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
+      << "AreAllVodAdsResolved must return false when no VOD breaks registered";
+}
+
+/**
+ * @brief Registration order recorded in mVodAdBreakOrder is preserved
+ *        regardless of map key ordering, ensuring FetchAdMPDsParallel
+ *        iterates breaks in insertion order.
+ */
+TEST_F(AdManagerMPDTests, VodCdai_BreakRegistrationOrder_Preserved)
+{
+  // Register in a non-lexicographic order
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"zzz-post",  120.0, 10.0, "postroll"});
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"aaa-pre",     0.0, 10.0, "preroll"});
+  mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{"mmm-mid",    60.0, 10.0, "midroll"});
+
+  const auto &order = mPrivateCDAIObjectMPD->mVodAdBreakOrder;
+  ASSERT_EQ(order.size(), 3u);
+  EXPECT_EQ(order[0], "zzz-post");
+  EXPECT_EQ(order[1], "aaa-pre");
+  EXPECT_EQ(order[2], "mmm-mid");
+}

--- a/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
+++ b/test/utests/tests/AdManagerMPDTests/FunctionalTests.cpp
@@ -5296,7 +5296,7 @@ TEST_F(AdManagerMPDTests, VodCdai_SetAlternateContents_StoresUrlOnVodBreakInfo)
   const std::string adUrl   = "https://cdn.example.com/ads/ad1/manifest.mpd";
 
   mPrivateCDAIObjectMPD->RegisterVodAdBreak(VodAdBreakInfo{breakId, 0.0, 30.0, "preroll"});
-  mPrivateCDAIObjectMPD->SetAlternateContents(breakId, adId, adUrl);
+  mPrivateCDAIObjectMPD->SetAlternateContents(breakId, adId, adUrl, 0, 0);
 
   // adId and adUrl stored directly on VodAdBreakInfo
   const auto &info = mPrivateCDAIObjectMPD->mVodAdBreaks.at(breakId);
@@ -5330,12 +5330,12 @@ TEST_F(AdManagerMPDTests, VodCdai_AreAllVodAdsResolved_SignalsAfterAllBreaks)
   EXPECT_FALSE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
       << "Should be false before any SetAlternateContents";
 
-  mPrivateCDAIObjectMPD->SetAlternateContents("brk-1", "ad-1", "https://cdn.example.com/ad1.mpd");
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-1", "ad-1", "https://cdn.example.com/ad1.mpd", 0, 0);
 
   EXPECT_FALSE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
       << "Should be false while one break still has no URL";
 
-  mPrivateCDAIObjectMPD->SetAlternateContents("brk-2", "ad-2", "https://cdn.example.com/ad2.mpd");
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-2", "ad-2", "https://cdn.example.com/ad2.mpd", 0, 0);
 
   EXPECT_TRUE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
       << "Should be true once every break has a URL";
@@ -5358,7 +5358,7 @@ TEST_F(AdManagerMPDTests, VodCdai_AllAdsResolvedCV_SignalledAfterLastSetAlternat
         [&]{ return mPrivateCDAIObjectMPD->AreAllVodAdsResolved(); });
   });
 
-  mPrivateCDAIObjectMPD->SetAlternateContents("brk-alpha", "ad-alpha", "https://cdn.example.com/ad-alpha.mpd");
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-alpha", "ad-alpha", "https://cdn.example.com/ad-alpha.mpd", 0, 0);
 
   fut.get();
   EXPECT_TRUE(signalled)
@@ -5373,7 +5373,7 @@ TEST_F(AdManagerMPDTests, VodCdai_AllAdsResolvedCV_SignalledAfterLastSetAlternat
 TEST_F(AdManagerMPDTests, VodCdai_SetAlternateContents_DropsUnknownBreak)
 {
   mPrivateCDAIObjectMPD->SetAlternateContents("non-existent-break", "ad-X",
-                                               "https://cdn.example.com/adX.mpd");
+                                               "https://cdn.example.com/adX.mpd", 0, 0);
 
   EXPECT_FALSE(mPrivateCDAIObjectMPD->isAdBreakObjectExist("non-existent-break"));
   EXPECT_TRUE(mPrivateCDAIObjectMPD->mVodAdBreaks.empty());
@@ -5392,7 +5392,7 @@ TEST_F(AdManagerMPDTests, VodCdai_CancelledBreak_DoesNotBlockResolution)
   mPrivateCDAIObjectMPD->CancelVodAdBreak("brk-cancel");
 
   // Satisfy only the non-cancelled break
-  mPrivateCDAIObjectMPD->SetAlternateContents("brk-ok", "ad-ok", "https://cdn.example.com/ad-ok.mpd");
+  mPrivateCDAIObjectMPD->SetAlternateContents("brk-ok", "ad-ok", "https://cdn.example.com/ad-ok.mpd", 0, 0);
 
   EXPECT_TRUE(mPrivateCDAIObjectMPD->AreAllVodAdsResolved())
       << "Cancelled breaks must not block AreAllVodAdsResolved";

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/CMakeLists.txt
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/CMakeLists.txt
@@ -44,7 +44,7 @@ set(TEST_SOURCES FunctionalTests.cpp
                  subtitleTests.cpp
                  StreamSelectionTest.cpp)
 
-	 set(AAMP_SOURCES ${AAMP_ROOT}/streamabstraction.cpp ${AAMP_ROOT}/CachedFragment.cpp ${AAMP_ROOT}/fragmentcollector_mpd.cpp ${AAMP_ROOT}/AampMPDParseHelper.cpp ${AAMP_ROOT}/AampMPDUtils.cpp ${AAMP_ROOT}/AampFragmentDescriptor.cpp ${AAMP_ROOT}/downloader/AampCurlDownloader.cpp ${AAMP_ROOT}/AampVodStitcher.cpp ${DASH_PARSER_SOURCES})
+	 set(AAMP_SOURCES ${AAMP_ROOT}/streamabstraction.cpp ${AAMP_ROOT}/CachedFragment.cpp ${AAMP_ROOT}/fragmentcollector_mpd.cpp ${AAMP_ROOT}/AampMPDParseHelper.cpp ${AAMP_ROOT}/AampMPDUtils.cpp ${AAMP_ROOT}/AampFragmentDescriptor.cpp ${AAMP_ROOT}/downloader/AampCurlDownloader.cpp ${AAMP_ROOT}/AampVodStitcher.cpp ${AAMP_ROOT}/admanager_mpd.cpp ${DASH_PARSER_SOURCES})
 
 add_executable(${EXEC_NAME}
                ${TEST_SOURCES}

--- a/test/utests/tests/StreamAbstractionAAMP_MPD/CMakeLists.txt
+++ b/test/utests/tests/StreamAbstractionAAMP_MPD/CMakeLists.txt
@@ -44,7 +44,7 @@ set(TEST_SOURCES FunctionalTests.cpp
                  subtitleTests.cpp
                  StreamSelectionTest.cpp)
 
-	 set(AAMP_SOURCES ${AAMP_ROOT}/streamabstraction.cpp ${AAMP_ROOT}/CachedFragment.cpp ${AAMP_ROOT}/fragmentcollector_mpd.cpp ${AAMP_ROOT}/AampMPDParseHelper.cpp ${AAMP_ROOT}/AampMPDUtils.cpp ${AAMP_ROOT}/AampFragmentDescriptor.cpp ${AAMP_ROOT}/downloader/AampCurlDownloader.cpp ${AAMP_ROOT}/AampVodStitcher.cpp ${AAMP_ROOT}/admanager_mpd.cpp ${DASH_PARSER_SOURCES})
+	 set(AAMP_SOURCES ${AAMP_ROOT}/streamabstraction.cpp ${AAMP_ROOT}/CachedFragment.cpp ${AAMP_ROOT}/fragmentcollector_mpd.cpp ${AAMP_ROOT}/AampMPDParseHelper.cpp ${AAMP_ROOT}/AampMPDUtils.cpp ${AAMP_ROOT}/AampFragmentDescriptor.cpp ${AAMP_ROOT}/downloader/AampCurlDownloader.cpp ${AAMP_ROOT}/AampVodStitcher.cpp ${DASH_PARSER_SOURCES})
 
 add_executable(${EXEC_NAME}
                ${TEST_SOURCES}


### PR DESCRIPTION
Description: At tune time,  BuildStitchedVodManifest fetches ad MPDs one at a time via FetchAdMPDsSequential using a single shared AAMP curl instance (eCURLINSTANCE_MANIFEST_MAIN). For a session with N ad breaks this adds N × (network RTT) to tune latency sequentially.
 
Goal: Fetch all ad MPDs in parallel to reduce tune time proportionally to the slowest single fetch rather than the sum of all fetches.