### PR TITLE
RDKEMW-20975 [Rack][RDKE][8.6][Llama G1/Cello]: Screen got stuck during VOD content playback

### DIFF
--- a/AampStreamSinkManager.cpp
+++ b/AampStreamSinkManager.cpp
@@ -490,6 +490,7 @@ void AampStreamSinkManager::SetActive(PrivateInstanceAAMP *aamp, double position
 	if(!aamp->IsTuneCompleted() && aamp->IsPlayEnabled() && (mPipelineMode == ePIPELINEMODE_SINGLE))
 	{
 		mGstPlayer->ResetFirstFrame();
+		mGstPlayer->ArmBufferingBeforePlay(aamp->rate);
 	}
 }
 

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -980,6 +980,13 @@ void AAMPGstPlayer::ResetFirstFrame(void)
 {
 	playerInstance->ResetFirstFrame();
 }
+/**
+ * @brief Arm buffering before play
+ */
+void AAMPGstPlayer::ArmBufferingBeforePlay(int rate)
+{
+	playerInstance->ArmBufferingBeforePlay(rate);
+}
 
 /**
  * @brief Set video mute

--- a/aampgstplayer.h
+++ b/aampgstplayer.h
@@ -214,6 +214,10 @@ public:
 		 */
 	void ResetFirstFrame(void);
 	/**
+	 * @fn ArmBufferingBeforePlay
+	 */
+	void ArmBufferingBeforePlay(int rate);
+	/**
 		 * @fn SetVideoMute
 		 * @param[in] muted true to mute video otherwise false
 		 */

--- a/middleware/InterfacePlayerPriv.h
+++ b/middleware/InterfacePlayerPriv.h
@@ -205,6 +205,7 @@ struct GstPlayerPriv
 	gboolean buffering_enabled;                                                              /**< enable buffering based on multiqueue */
 	gboolean buffering_in_progress;                                                  /**< buffering is in progress */
 	guint buffering_timeout_cnt;                                                     /**< make sure buffering_timeout doesn't get stuck */
+	bool armBufferingBeforePlayPending;												/**< Set when ArmBufferingBeforePlay() is requested before the pipeline exists*/
 	GstState buffering_target_state;                                                 /**< the target state after buffering */
 	gint64 lastKnownPTS;                                                                     /**< To store the PTS of last displayed video */
 	long long ptsUpdatedTimeMS;                                                              /**< Timestamp when PTS was last updated */

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -124,7 +124,7 @@ audioVolume(1.0), eosCallbackIdleTaskId(GST_TASK_ID_INVALID), eosCallbackIdleTas
 firstFrameReceived(false), pendingPlayState(false), decoderHandleNotified(false),
 firstFrameCallbackIdleTaskId(GST_TASK_ID_INVALID), firstFrameCallbackIdleTaskPending(false),
 using_westerossink(false), usingRialtoSink(false), usingClosedCaptionsControl(false), pauseOnStartPlayback(false), eosSignalled(false),
-buffering_enabled(FALSE), buffering_in_progress(FALSE), buffering_timeout_cnt(0),
+buffering_enabled(FALSE), buffering_in_progress(FALSE), buffering_timeout_cnt(0), armBufferingBeforePlayPending(FALSE),
 buffering_target_state(GST_STATE_NULL),
 lastKnownPTS(0), ptsUpdatedTimeMS(0), ptsCheckForEosOnUnderflowIdleTaskId(GST_TASK_ID_INVALID),
 numberOfVideoBuffersSent(0), segmentStart(0), positionQuery(NULL),
@@ -4020,6 +4020,15 @@ bool InterfacePlayerRDK::CreatePipeline(const char *pipelineName, int PipelinePr
 			interfacePlayerPriv->gstPrivateContext->buffering_timeout_cnt = DEFAULT_BUFFERING_MAX_CNT;
 			interfacePlayerPriv->gstPrivateContext->buffering_target_state = GST_STATE_NULL;
 			MW_LOG_MIL("%s buffering_enabled %u", GST_ELEMENT_NAME(interfacePlayerPriv->gstPrivateContext->pipeline), interfacePlayerPriv->gstPrivateContext->buffering_enabled);
+			
+			/* A buffering-before-play arm was requested (from SetActive) before this pipeline existed. The pipeline is now created, so apply it here. */
+			if (interfacePlayerPriv->gstPrivateContext->armBufferingBeforePlayPending)
+			{
+				interfacePlayerPriv->gstPrivateContext->armBufferingBeforePlayPending = false;
+				ArmBufferingBeforePlay(GST_NORMAL_PLAY_RATE);
+				MW_LOG_MIL("Triggered ArmBufferingBeforePlay ");
+			}
+		
 			if (interfacePlayerPriv->gstPrivateContext->positionQuery == NULL)
 			{
 
@@ -5380,17 +5389,35 @@ double InterfacePlayerRDK::FlushTrack(int mediaType, double pos, double audioDel
 void InterfacePlayerRDK::ArmBufferingBeforePlay(int rate)
 {
     auto *ctx = interfacePlayerPriv->gstPrivateContext;
-    if (ctx->buffering_enabled && (GST_NORMAL_PLAY_RATE == rate) && !ctx->paused && ctx->pipeline)
-    {
-        ctx->buffering_target_state = GST_STATE_PLAYING;
-        ctx->buffering_in_progress  = true;
-        ctx->buffering_timeout_cnt  = DEFAULT_BUFFERING_MAX_CNT;
-        ctx->pendingPlayState       = false;
-        if (ctx->bufferingTimeoutTimerId == 0)
-        {
-            ctx->bufferingTimeoutTimerId =
-                g_timeout_add(DEFAULT_BUFFERING_TO_MS, buffering_timeout, this);
-        }
-        MW_LOG_MIL("Re-armed buffering-before-play on reactivation");
-    }
+    if (ctx->buffering_enabled && (GST_NORMAL_PLAY_RATE == rate) && !ctx->paused)
+	{
+		if (ctx->pipeline)
+		{
+			ctx->buffering_target_state = GST_STATE_PLAYING;
+			ctx->buffering_in_progress = true;
+			ctx->buffering_timeout_cnt = DEFAULT_BUFFERING_MAX_CNT;
+			ctx->pendingPlayState = false;
+			if (ctx->bufferingTimeoutTimerId == 0)
+			{
+				ctx->bufferingTimeoutTimerId =
+					g_timeout_add(DEFAULT_BUFFERING_TO_MS, buffering_timeout, this);
+			}
+			ctx->armBufferingBeforePlayPending = false;
+			MW_LOG_MIL("Re-armed buffering-before-play on reactivation");
+		}
+		else
+		{
+			/* Single-pipeline reactivation: AampStreamSinkManager::SetActive() calls this 
+			 * before the pipeline is (re)created in CreatePipeline(). Defer the arm so it
+			 * is applied once the pipeline exists. 
+			 */
+			ctx->armBufferingBeforePlayPending = true;
+			MW_LOG_MIL("Deferred buffering-before-play; pipeline not yet created");
+		}
+	}
+	else
+	{
+		if (ctx->buffering_enabled && (GST_NORMAL_PLAY_RATE == rate) && !ctx->paused)
+		MW_LOG_MIL("invalid buffer[%u]rate[%d]pause[%u]",ctx->buffering_enabled,rate,ctx->paused);
+	}
 }

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5373,3 +5373,24 @@ double InterfacePlayerRDK::FlushTrack(int mediaType, double pos, double audioDel
 
 	return rate;
 }
+/**
+ * @brief Arm buffering before play
+ * @param[in] rate - playback rate
+ */
+void InterfacePlayerRDK::ArmBufferingBeforePlay(int rate)
+{
+    auto *ctx = interfacePlayerPriv->gstPrivateContext;
+    if (ctx->buffering_enabled && (GST_NORMAL_PLAY_RATE == rate) && !ctx->paused && ctx->pipeline)
+    {
+        ctx->buffering_target_state = GST_STATE_PLAYING;
+        ctx->buffering_in_progress  = true;
+        ctx->buffering_timeout_cnt  = DEFAULT_BUFFERING_MAX_CNT;
+        ctx->pendingPlayState       = false;
+        if (ctx->bufferingTimeoutTimerId == 0)
+        {
+            ctx->bufferingTimeoutTimerId =
+                g_timeout_add(DEFAULT_BUFFERING_TO_MS, buffering_timeout, this);
+        }
+        MW_LOG_MIL("Re-armed buffering-before-play on reactivation");
+    }
+}

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -767,6 +767,11 @@ class InterfacePlayerRDK
 		 * @return A pointer to the MonitorAVState structure containing the AV status or nullptr.
 		 */
 		const MonitorAVState& GetMonitorAVState();
+		
+		/**	
+		 * @brief Arm buffering before play
+		 */
+		void ArmBufferingBeforePlay(int rate);
 
 	private:
 		InterfacePlayerPriv *interfacePlayerPriv;


### PR DESCRIPTION
Root cause:
"Watch from beginning" = seek(0, keepPause) → the main player is detached and, because position 0 has a DAI pre‑roll ad, a second player (PLAYER[2]) starts on the shared single pipeline.
The auto‑resume ("buffering‑before‑play") is armed only in InterfacePlayerRDK::Configure() via buffering_in_progress=true + buffering_target_state=GST_STATE_PLAYING.
A reused pipeline skips Configure() (not creating GstPlayer for PLAYER[2]); reactivation instead runs AampStreamSinkManager::SetActive → InterfacePlayerRDK::Flush(), which flush‑seeks to PAUSED and removes the buffering timer, but never re‑arms the resume.

Result: pipeline stuck PAUSED, cache full (4/4) but never injected → frozen ~15 min.

The fix (root cause, minimal, no regression)
Re‑arm buffering‑before‑play only on single‑pipeline reactivation, inside the existing guarded block in SetActive (next to ResetFirstFrame()):