### PR TITLE
VPAAMP-667: Live-edge ABR ramp-up bypass for buffer-deadlock recovery

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -2271,6 +2271,22 @@ void StreamAbstractionAAMP::GetDesiredProfileOnSteadyState(int currProfileIndex,
 				mABRHighBufferCounter = 0;
 			}
 		}
+		else if(mIsAtLivePoint && bufferValue > mABRMinBuffer && bufferValue <= mABRMaxBuffer)
+		{
+			mABRHighBufferCounter++;
+			mABRLowBufferCounter = 0;
+			if(mABRHighBufferCounter > mMaxBufferCountCheck)
+			{
+				int nProfileIdx = aamp->mhAbrManager.getRampedUpProfileIndex(currProfileIndex);
+				long newBandwidth = GetStreamInfo(nProfileIdx)->bandwidthBitsPerSecond;
+				ABRManager::BitrateChangeReason mhBitrateReason;
+				mhBitrateReason = (ABRManager::BitrateChangeReason) mBitrateReason;
+				aamp->mhAbrManager.CheckRampupFromSteadyState(currProfileIndex,newProfileIndex,nwBandwidth,bufferValue,newBandwidth,mhBitrateReason,mMaxBufferCountCheck);
+				mBitrateReason = (BitrateChangeReason) mhBitrateReason;
+				mABRHighBufferCounter = 0;
+				AAMPLOG_WARN("Live-edge ABR bypass: buffer %f in deadlock band [%d,%d], attempting ramp-up from profile %d",bufferValue,mABRMinBuffer,mABRMaxBuffer,currProfileIndex);
+			}
+		}
 		// steady state ,with no ABR cache available to determine actual bandwidth
 		// this state can happen due to timeouts
 		// Adding delta check: When bandwidth is higher than currentprofile bandwidth but insufficient to download both audio and video simultaneously, a delta less than 2000 kbps indicates a need for steady state rampdown.

--- a/test/utests/fakes/FakeABR.cpp
+++ b/test/utests/fakes/FakeABR.cpp
@@ -186,6 +186,10 @@ int ABRManager::getProfileIndexByBitrateRampUpOrDown(int currentProfileIndex, Bi
 
 int ABRManager::getRampedUpProfileIndex(int currentProfileIndex, const std::string& periodId)
 {
+	if (g_mockABRManager)
+	{
+		return g_mockABRManager->getRampedUpProfileIndex(currentProfileIndex, periodId);
+	}
 	return 0;
 }
 
@@ -244,6 +248,11 @@ void ABRManager::GetDesiredProfileOnBuffer(int currProfileIndex,int &newProfileI
 
 void ABRManager::CheckRampupFromSteadyState(int currProfileIndex, int &newProfileIndex, BitsPerSecond nwBandwidth, double bufferValue, BitsPerSecond newBandwidth, BitrateChangeReason &mhBitrateReason, int &mMaxBufferCountCheck, const std::string& periodId)
 {
+	if (g_mockABRManager)
+	{
+		g_mockABRManager->CheckRampupFromSteadyState(currProfileIndex, newProfileIndex, nwBandwidth, bufferValue, newBandwidth, mhBitrateReason, mMaxBufferCountCheck, periodId);
+		return;
+	}
 	(void)currProfileIndex;
 	(void)newProfileIndex;
 	(void)nwBandwidth;

--- a/test/utests/mocks/MockABRManager.h
+++ b/test/utests/mocks/MockABRManager.h
@@ -42,6 +42,7 @@ public:
 	MOCK_METHOD(int, getLowestIframeProfile, ());
 	MOCK_METHOD(int, getProfileIndexByBitrateRampUpOrDown, (int currentProfileIndex, BitsPerSecond currentBandwidth, BitsPerSecond networkBandwidth, int nwConsistencyCnt, const std::string& periodId));
 	MOCK_METHOD(int, getRampedUpProfileIndex, (int currentProfileIndex, const std::string& periodId));
+	MOCK_METHOD(void, CheckRampupFromSteadyState, (int currProfileIndex, int &newProfileIndex, BitsPerSecond nwBandwidth, double bufferValue, BitsPerSecond newBandwidth, ABRManager::BitrateChangeReason &mhBitrateReason, int &mMaxBufferCountCheck, const std::string& periodId));
 	MOCK_METHOD(bool, isProfileIndexBitrateLowest, (int currentProfileIndex, const std::string& periodId));
 };
 

--- a/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP/FunctionalTests.cpp
@@ -29,6 +29,7 @@
 #include "MockPrivateInstanceAAMP.h"
 #include "MockMediaTrack.h"
 #include "MockMediaProcessor.h"
+#include "MockABRManager.h"
 
 using ::testing::_;
 using ::testing::An;
@@ -102,6 +103,28 @@ protected:
 			return GetBufferValue(track);
 		}
 
+		void testGetDesiredProfileOnSteadyState(int curr, int &desired, long nwBW)
+		{
+			GetDesiredProfileOnSteadyState(curr, desired, nwBW);
+		}
+
+		void testSetABRMinBuffer(int v) { mABRMinBuffer = v; }
+		void testSetABRMaxBuffer(int v) { mABRMaxBuffer = v; }
+		void testSetMaxBufferCountCheck(int v) { mMaxBufferCountCheck = v; }
+		void testSetABRHighBufferCounter(int v) { mABRHighBufferCounter = v; }
+		void testSetABRLowBufferCounter(int v) { mABRLowBufferCounter = v; }
+		int testGetABRHighBufferCounter() { return mABRHighBufferCounter; }
+
+		StreamInfo mStreamInfos[8];
+		int mStreamInfoCount = 0;
+
+		virtual StreamInfo* GetStreamInfo(int idx) override
+		{
+			if(idx >= 0 && idx < mStreamInfoCount)
+				return &mStreamInfos[idx];
+			return nullptr;
+		}
+
 		MOCK_METHOD(void, clearFirstPTS, (), (override));
 
 	};
@@ -118,6 +141,11 @@ protected:
 			gpGlobalConfig =  new AampConfig();
 		}
 		g_mockAampConfig = std::make_shared<NiceMock<MockAampConfig>>();
+
+		if (g_mockABRManager == nullptr)
+		{
+			g_mockABRManager = std::make_shared<NiceMock<MockABRManager>>();
+		}
 
 		if (g_mockPrivateInstanceAAMP == nullptr)
 		{
@@ -160,6 +188,8 @@ protected:
 
 		delete gpGlobalConfig;
 		gpGlobalConfig = nullptr;
+
+		g_mockABRManager.reset();
 
 		g_mockAampConfig.reset();
 
@@ -449,4 +479,249 @@ TEST_F(StreamAbstractionAAMP_Test, GetBufferValue_ClampsToZero_WhenLiveEdgeDelta
 
 	EXPECT_DOUBLE_EQ(0.0, mStreamAbstractionAAMP->testGetBufferValue(
 		mStreamAbstractionAAMP->mMockVideoTrack));
+}
+
+/**
+ * @brief Verify live-edge bypass fires ramp-up when buffer is in the deadlock band.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_FiresInDeadlockBand)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = true;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(6);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(10);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(1);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mStreamAbstractionAAMP->mStreamInfoCount = 3;
+	mStreamAbstractionAAMP->mStreamInfos[0].bandwidthBitsPerSecond = 1000000;
+	mStreamAbstractionAAMP->mStreamInfos[1].bandwidthBitsPerSecond = 3000000;
+	mStreamAbstractionAAMP->mStreamInfos[2].bandwidthBitsPerSecond = 5000000;
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = false;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillRepeatedly(Return(8.0));
+
+	EXPECT_CALL(*g_mockABRManager, getRampedUpProfileIndex(0, _))
+		.WillRepeatedly(Return(1));
+
+	EXPECT_CALL(*g_mockABRManager, CheckRampupFromSteadyState(0, _, _, _, _, _, _, _))
+		.WillOnce(DoAll(SetArgReferee<1>(1)));
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+
+	EXPECT_GT(newProfile, currProfile);
+}
+
+/**
+ * @brief Verify live-edge bypass does NOT fire when not at the live point.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_DoesNotFire_NotAtLivePoint)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = false;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(6);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(10);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(1);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = false;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillRepeatedly(Return(8.0));
+
+	EXPECT_CALL(*g_mockABRManager, getRampedUpProfileIndex(_, _)).Times(0);
+	EXPECT_CALL(*g_mockABRManager, CheckRampupFromSteadyState(_, _, _, _, _, _, _, _)).Times(0);
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	for (int i = 0; i < 5; i++)
+	{
+		mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	}
+
+	EXPECT_EQ(newProfile, currProfile);
+}
+
+/**
+ * @brief Verify live-edge bypass does NOT fire when buffer is below mABRMinBuffer.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_DoesNotFire_BufferBelowMinBuffer)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = true;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(6);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(10);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(1);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = false;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillRepeatedly(Return(4.0));
+
+	EXPECT_CALL(*g_mockABRManager, getRampedUpProfileIndex(_, _)).Times(0);
+	EXPECT_CALL(*g_mockABRManager, CheckRampupFromSteadyState(_, _, _, _, _, _, _, _)).Times(0);
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+
+	EXPECT_EQ(mStreamAbstractionAAMP->testGetABRHighBufferCounter(), 0);
+}
+
+/**
+ * @brief Verify that when buffer is above mABRMaxBuffer and not in lowLatencyMode,
+ *        the normal high-buffer path fires instead of the bypass.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_DoesNotFire_BufferAboveMaxBuffer)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = true;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(6);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(10);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(1);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mStreamAbstractionAAMP->mStreamInfoCount = 3;
+	mStreamAbstractionAAMP->mStreamInfos[0].bandwidthBitsPerSecond = 1000000;
+	mStreamAbstractionAAMP->mStreamInfos[1].bandwidthBitsPerSecond = 3000000;
+	mStreamAbstractionAAMP->mStreamInfos[2].bandwidthBitsPerSecond = 5000000;
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = false;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillRepeatedly(Return(12.0));
+
+	EXPECT_CALL(*g_mockABRManager, getRampedUpProfileIndex(0, _))
+		.WillRepeatedly(Return(1));
+
+	EXPECT_CALL(*g_mockABRManager, CheckRampupFromSteadyState(0, _, _, _, _, _, _, _))
+		.WillOnce(DoAll(SetArgReferee<1>(1)));
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+
+	EXPECT_GT(newProfile, currProfile);
+}
+
+/**
+ * @brief Verify live-edge bypass fires for LLDASH in its deadlock band.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_LLDASH_FiresInDeadlockBand)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = true;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(3);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(4);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(1);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mStreamAbstractionAAMP->mStreamInfoCount = 3;
+	mStreamAbstractionAAMP->mStreamInfos[0].bandwidthBitsPerSecond = 1000000;
+	mStreamAbstractionAAMP->mStreamInfos[1].bandwidthBitsPerSecond = 3000000;
+	mStreamAbstractionAAMP->mStreamInfos[2].bandwidthBitsPerSecond = 5000000;
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = true;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillRepeatedly(Return(3.5));
+
+	EXPECT_CALL(*g_mockABRManager, getRampedUpProfileIndex(0, _))
+		.WillRepeatedly(Return(1));
+
+	EXPECT_CALL(*g_mockABRManager, CheckRampupFromSteadyState(0, _, _, _, _, _, _, _))
+		.WillOnce(DoAll(SetArgReferee<1>(1)));
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+
+	EXPECT_GT(newProfile, currProfile);
+}
+
+/**
+ * @brief Verify the patience counter requires N+1 segments before ramp-up fires.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_PatientCounter_RequiresNSegments)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = true;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(6);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(10);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(3);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mStreamAbstractionAAMP->mStreamInfoCount = 3;
+	mStreamAbstractionAAMP->mStreamInfos[0].bandwidthBitsPerSecond = 1000000;
+	mStreamAbstractionAAMP->mStreamInfos[1].bandwidthBitsPerSecond = 3000000;
+	mStreamAbstractionAAMP->mStreamInfos[2].bandwidthBitsPerSecond = 5000000;
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = false;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillRepeatedly(Return(8.0));
+
+	EXPECT_CALL(*g_mockABRManager, getRampedUpProfileIndex(0, _))
+		.WillRepeatedly(Return(1));
+
+	EXPECT_CALL(*g_mockABRManager, CheckRampupFromSteadyState(0, _, _, _, _, _, _, _))
+		.WillOnce(DoAll(SetArgReferee<1>(1)));
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	for (int i = 0; i < 3; i++)
+	{
+		mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+		EXPECT_EQ(newProfile, currProfile);
+	}
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	EXPECT_GT(newProfile, currProfile);
+}
+
+/**
+ * @brief Verify mABRHighBufferCounter resets when ramp-down path is entered.
+ */
+TEST_F(StreamAbstractionAAMP_Test, GetDesiredProfileOnSteadyState_LiveEdgeBypass_CounterResets_OnRampdown)
+{
+	mStreamAbstractionAAMP->mIsAtLivePoint = true;
+	mStreamAbstractionAAMP->testSetABRMinBuffer(6);
+	mStreamAbstractionAAMP->testSetABRMaxBuffer(10);
+	mStreamAbstractionAAMP->testSetMaxBufferCountCheck(5);
+	mStreamAbstractionAAMP->testSetABRHighBufferCounter(0);
+	mStreamAbstractionAAMP->testSetABRLowBufferCounter(0);
+
+	mPrivateInstanceAAMP->GetLLDashServiceData()->lowLatencyMode = true;
+
+	EXPECT_CALL(*mStreamAbstractionAAMP->mMockVideoTrack, GetBufferedDuration())
+		.WillOnce(Return(8.0))
+		.WillOnce(Return(8.0))
+		.WillOnce(Return(4.0));
+
+	int currProfile = 0;
+	int newProfile = 0;
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	EXPECT_EQ(mStreamAbstractionAAMP->testGetABRHighBufferCounter(), 1);
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, 5000000);
+	EXPECT_EQ(mStreamAbstractionAAMP->testGetABRHighBufferCounter(), 2);
+
+	mStreamAbstractionAAMP->testGetDesiredProfileOnSteadyState(currProfile, newProfile, -1);
+	EXPECT_EQ(mStreamAbstractionAAMP->testGetABRHighBufferCounter(), 0);
 }


### PR DESCRIPTION
Add an else-if branch in GetDesiredProfileOnSteadyState() that allows ABR ramp-up when the player is at the live point and the buffer is in the deadlock band (above mABRMinBuffer but at or below mABRMaxBuffer).

Previously, after curl timeouts dropped the profile to index 0, the buffer would stabilise at ~6-9s during standard-latency live. The live edge means downloads arrive at approximately the same rate they are consumed, so the buffer could never grow above the 10s mABRMaxBuffer gate required for ramp-up. For LLDASH the same structural deadlock exists because the steady-state ramp-up path is skipped by the !lowLatencyMode guard.

The new branch uses the same patience counter (mABRHighBufferCounter / mMaxBufferCountCheck) and the same CheckRampupFromSteadyState 30% headroom rule as the existing high-buffer path. VOD playback is unaffected (mIsAtLivePoint == false). Both LLDASH and standard-latency live benefit.

Unit tests: 7 new test cases covering the bypass firing in the deadlock band, LLDASH deadlock band, patience counter, counter reset on ramp-down, and negative cases (not at live point, buffer below min, buffer above max).

Test infrastructure: FakeABR.cpp getRampedUpProfileIndex and CheckRampupFromSteadyState now delegate to g_mockABRManager when available. MockABRManager.h gains a CheckRampupFromSteadyState mock.