### PR TITLE
VPLAY-12287 - Defer CC Enable / Disable to avoid Stop delays

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -190,7 +190,9 @@ PlayerInstanceAAMP::~PlayerInstanceAAMP()
 		mScheduler.RemoveAllTasks();
 		if (state != eSTATE_IDLE && state != eSTATE_RELEASED)
 		{
+			//AAMPLOG_WARN("+ ~PlayerInstanceAAMP Stop- GNP");
 			aamp->Stop(false); // Don't send state change events during destruction
+			//AAMPLOG_WARN("- ~PlayerInstanceAAMP Stop- GNP");
 		}
 		std::lock_guard<std::mutex> lock (mPrvAampMtx);
 		aamp = NULL;
@@ -257,6 +259,8 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 {
 	if (aamp)
 	{
+		AAMPLOG_WARN("+StopJSt");
+		auto playerStopStartTime=NOW_STEADY_TS_MS;
 		UsingPlayerId playerId(aamp->mPlayerId);
 		AAMPPlayerState state = aamp->GetState();
 
@@ -264,7 +268,10 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 		// 2. Check for state ,if already in Idle / Released , ignore stopInternal
 		// 3. Restart the scheduler , needed if same instance is used for tune again
 
+		auto suspendSchedulerStartTime=NOW_STEADY_TS_MS;
 		mScheduler.SuspendScheduler();
+		auto suspendSchedulerEndTime=NOW_STEADY_TS_MS;
+		//AAMPLOG_WARN("*StopJSt");
 		mScheduler.RemoveAllTasks();
 
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
@@ -282,7 +289,14 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 			aamp->mDRMLicenseManager->clearFailedKeyIds();
 		}
 		//Release lock
+		auto resumeSchedulerStartTime=NOW_STEADY_TS_MS;
 		mScheduler.ResumeScheduler();
+		auto resumeSchedulerEndTime=NOW_STEADY_TS_MS;
+		AAMPLOG_WARN("-StopJSt      ;  SuspendScheduler = %u ms, ResumeScheduler = %u, Total = %u",
+				(unsigned)(suspendSchedulerEndTime-suspendSchedulerStartTime),
+				(unsigned)(resumeSchedulerStartTime-resumeSchedulerEndTime),
+				(unsigned)(resumeSchedulerEndTime-playerStopStartTime)
+			);
 	}
 }
 
@@ -357,6 +371,7 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 										)
 {
 	if(aamp){
+		AAMPLOG_WARN("+TuneJSt");
 		UsingPlayerId playerId(aamp->mPlayerId);
 
 	/* Set single pipeline according to the configuration */
@@ -379,11 +394,13 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 
 		if ((state != eSTATE_IDLE) && (state != eSTATE_RELEASED) && (!IsOTAtoOTA))
 		{
+			AAMPLOG_WARN("*TuneJSt - calling StopInternal from TuneInternal");
 			//Calling tune without closing previous tune
 			StopInternal(true, false);
 		}
 		aamp->getAampCacheHandler()->StartPlaylistCache();
 		aamp->Tune(mainManifestUrl, autoPlay, contentType, bFirstAttempt, bFinalAttempt, traceUUID, audioDecoderStreamSync, refreshManifestUrl, mpdStitchingMode, std::move(sid),manifestData);
+		AAMPLOG_WARN("-TuneJSt");
 	}
 }
 
@@ -2598,7 +2615,9 @@ std::string PlayerInstanceAAMP::GetPreferredTextProperties()
  */
 void PlayerInstanceAAMP::SetPreferredLanguages(const char *languageList, const char *preferredRendition, const char *preferredType, const char* codecList, const char* labelList, const Accessibility *accessibilityItem, const char *preferredName)
 {
+	//AAMPLOG_WARN("+SetPreferredLanguagesJSt");
 	aamp->SetPreferredLanguages(languageList, preferredRendition, preferredType, codecList, labelList, accessibilityItem, preferredName);
+	//AAMPLOG_WARN("-SetPreferredLanguagesJSt");
 }
 
 /**
@@ -2919,7 +2938,14 @@ int PlayerInstanceAAMP::GetTextTrack()
  */
 void PlayerInstanceAAMP::SetCCStatus(bool enabled)
 {
+	//AAMPLOG_WARN("+SetCCStatusJSt");
+	auto setCCStartTime=NOW_STEADY_TS_MS;
 	aamp->SetCCStatus(enabled);
+	auto setCCDuration = (unsigned)(NOW_STEADY_TS_MS - setCCStartTime);
+	//if (setCCDuration > 0)
+	//{		
+		AAMPLOG_WARN("-SetCCStatusJSt  ;      Total = %u", setCCDuration);
+	//}
 }
 
 /**

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -190,9 +190,7 @@ PlayerInstanceAAMP::~PlayerInstanceAAMP()
 		mScheduler.RemoveAllTasks();
 		if (state != eSTATE_IDLE && state != eSTATE_RELEASED)
 		{
-			//AAMPLOG_WARN("+ ~PlayerInstanceAAMP Stop- GNP");
 			aamp->Stop(false); // Don't send state change events during destruction
-			//AAMPLOG_WARN("- ~PlayerInstanceAAMP Stop- GNP");
 		}
 		std::lock_guard<std::mutex> lock (mPrvAampMtx);
 		aamp = NULL;
@@ -259,7 +257,6 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 {
 	if (aamp)
 	{
-		AAMPLOG_WARN("+StopJSt");
 		auto playerStopStartTime=NOW_STEADY_TS_MS;
 		UsingPlayerId playerId(aamp->mPlayerId);
 		AAMPPlayerState state = aamp->GetState();
@@ -271,7 +268,6 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 		auto suspendSchedulerStartTime=NOW_STEADY_TS_MS;
 		mScheduler.SuspendScheduler();
 		auto suspendSchedulerEndTime=NOW_STEADY_TS_MS;
-		//AAMPLOG_WARN("*StopJSt");
 		mScheduler.RemoveAllTasks();
 
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
@@ -289,12 +285,10 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 			aamp->mDRMLicenseManager->clearFailedKeyIds();
 		}
 		//Release lock
-		auto resumeSchedulerStartTime=NOW_STEADY_TS_MS;
 		mScheduler.ResumeScheduler();
 		auto resumeSchedulerEndTime=NOW_STEADY_TS_MS;
-		AAMPLOG_WARN("-StopJSt      ;  SuspendScheduler = %u ms, ResumeScheduler = %u, Total = %u",
+		AAMPLOG_WARN("-Stop (player) ; SuspendScheduler took %u ms, Total %u ms",
 				(unsigned)(suspendSchedulerEndTime-suspendSchedulerStartTime),
-				(unsigned)(resumeSchedulerStartTime-resumeSchedulerEndTime),
 				(unsigned)(resumeSchedulerEndTime-playerStopStartTime)
 			);
 	}
@@ -371,7 +365,6 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 										)
 {
 	if(aamp){
-		AAMPLOG_WARN("+TuneJSt");
 		UsingPlayerId playerId(aamp->mPlayerId);
 
 	/* Set single pipeline according to the configuration */
@@ -394,13 +387,11 @@ void PlayerInstanceAAMP::TuneInternal(const char *mainManifestUrl,
 
 		if ((state != eSTATE_IDLE) && (state != eSTATE_RELEASED) && (!IsOTAtoOTA))
 		{
-			AAMPLOG_WARN("*TuneJSt - calling StopInternal from TuneInternal");
 			//Calling tune without closing previous tune
 			StopInternal(true, false);
 		}
 		aamp->getAampCacheHandler()->StartPlaylistCache();
 		aamp->Tune(mainManifestUrl, autoPlay, contentType, bFirstAttempt, bFinalAttempt, traceUUID, audioDecoderStreamSync, refreshManifestUrl, mpdStitchingMode, std::move(sid),manifestData);
-		AAMPLOG_WARN("-TuneJSt");
 	}
 }
 
@@ -2615,9 +2606,7 @@ std::string PlayerInstanceAAMP::GetPreferredTextProperties()
  */
 void PlayerInstanceAAMP::SetPreferredLanguages(const char *languageList, const char *preferredRendition, const char *preferredType, const char* codecList, const char* labelList, const Accessibility *accessibilityItem, const char *preferredName)
 {
-	//AAMPLOG_WARN("+SetPreferredLanguagesJSt");
 	aamp->SetPreferredLanguages(languageList, preferredRendition, preferredType, codecList, labelList, accessibilityItem, preferredName);
-	//AAMPLOG_WARN("-SetPreferredLanguagesJSt");
 }
 
 /**
@@ -2938,14 +2927,8 @@ int PlayerInstanceAAMP::GetTextTrack()
  */
 void PlayerInstanceAAMP::SetCCStatus(bool enabled)
 {
-	//AAMPLOG_WARN("+SetCCStatusJSt");
-	auto setCCStartTime=NOW_STEADY_TS_MS;
 	aamp->SetCCStatus(enabled);
 	auto setCCDuration = (unsigned)(NOW_STEADY_TS_MS - setCCStartTime);
-	//if (setCCDuration > 0)
-	//{		
-		AAMPLOG_WARN("-SetCCStatusJSt  ;      Total = %u", setCCDuration);
-	//}
 }
 
 /**

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -2928,7 +2928,6 @@ int PlayerInstanceAAMP::GetTextTrack()
 void PlayerInstanceAAMP::SetCCStatus(bool enabled)
 {
 	aamp->SetCCStatus(enabled);
-	auto setCCDuration = (unsigned)(NOW_STEADY_TS_MS - setCCStartTime);
 }
 
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -708,7 +708,7 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 	}
 	else
 	{
-		AAMPLOG_WARN("interrupted");
+		AAMPLOG_WARN("interrupted for type %d", context->mediaType);
 	}
 	return ret;
 }
@@ -1247,6 +1247,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, bitrateList()
 	, userProfileStatus(false)
 	, mApplyCachedVideoMute(false)
+	, mApplyCachedCCStatus(false)
 	, mFirstProgress(false)
 	, mTsbSessionRequestUrl()
 	, mcurrent_keyIdArray()
@@ -5627,6 +5628,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 					sink->SetVideoMute(video_muted.load());
 				}
 				SetCCStatusInternal();
+				mApplyCachedCCStatus = false;
 				sink->SetAudioVolume(volume);
 				if (mbPlayEnabled)
 				{
@@ -6230,12 +6232,19 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 			//These two fns are being called in PlayerInstanceAAMP::SetVideoMute
 			SetVideoMuteInternal(video_muted.load());
 			SetCCStatusInternal();
+			mApplyCachedCCStatus=false;
 		}
 		else
 		{
 			AAMPLOG_ERR("mpStreamAbstractionAAMP is NULL, cannot apply cached video mute");
 		}
 	}
+	else if (mApplyCachedCCStatus.load())
+	{
+		SetCCStatusInternal();
+		mApplyCachedCCStatus=false;
+	}
+	AAMPLOG_WARN("GNP - release stream lock !!!!");
 	ReleaseStreamLock();
 
 	// To check and apply stored video rectangle properties
@@ -7649,6 +7658,8 @@ bool PrivateInstanceAAMP::IsLiveStream()
 void PrivateInstanceAAMP::Stop( bool isDestructing )
 {
 	auto stopStartTime = NOW_STEADY_TS_MS;
+	//AAMPLOG_WARN(" + PrivateInstanceAAMP: GNP");
+	mApplyCachedCCStatus = false;
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
 	mEventManager->FlushPendingEvents();
 	if( !isDestructing )
@@ -7713,10 +7724,14 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 	// so downloads are disabled among other things
 	SetLocalAAMPTsb(false);
 	SetLocalAAMPTsbInjection(false);
-	// Stopping the playback, release all DRM context
+	auto streamLockStartTime = NOW_STEADY_TS_MS;
+	auto streamLockStopTime = NOW_STEADY_TS_MS;
+	auto licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
+	auto licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;	// Stopping the playback, release all DRM context
 	if (mpStreamAbstractionAAMP)
 	{
 		AcquireStreamLock();
+		streamLockStopTime = NOW_STEADY_TS_MS;
 		if (mDRMLicenseManager)
 		{
 			ReleaseDynamicDRMToUpdateWait();
@@ -7725,7 +7740,9 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 			// StreamAbstractionAamp object from TeardownStream(). Otherwise it can
 			// lead to crash as PreFetchThread can call UpdateFailedDRMStatus
 			// of StreamAbstractionAamp.
+			licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
 			mDRMLicenseManager->SetLicenseFetcher(nullptr);
+			licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;
 		}
 		if (HasSidecarData())
 		{ // has sidecar data
@@ -7733,7 +7750,9 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		}
 		ReleaseStreamLock();
 	}
+	auto tearDownStartTime = NOW_STEADY_TS_MS;
 	TeardownStream(true,true); //disable download as well
+	auto tearDownEndTime = NOW_STEADY_TS_MS;
 
 	// stop the mpd update immediately after Stream abstraction delete
 	if(mMPDDownloaderInstance != nullptr)
@@ -7858,9 +7877,12 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 
 	AampStreamSinkManager::GetInstance().DeactivatePlayer(this, true);
 	unsigned int mLastStopDurationMs = (unsigned)(NOW_STEADY_TS_MS - stopStartTime);
-	AAMPLOG_WARN("AAMP Stop took %u ms",mLastStopDurationMs);
-	profiler.mStopDurationMs = mLastStopDurationMs;
-
+	AAMPLOG_WARN("AAMP Stop took %u ms; streamLock %u, SetLicenceFetcher %u, Teardown %u",
+		mLastStopDurationMs,
+		(unsigned int)(streamLockStopTime - streamLockStartTime),
+		(unsigned int)(licenseAquisitionLockStopTime- licenseAquisitionLockStartTime),
+		(unsigned int)(tearDownEndTime - tearDownStartTime)	);
+	//AAMPLOG_WARN(" - PrivateInstanceAAMP: GNP");
 }
 
 const std::vector<TimedMetadata> & PrivateInstanceAAMP::GetTimedMetadata( void ) const
@@ -11187,40 +11209,70 @@ int PrivateInstanceAAMP::GetTextTrack()
 void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 {
 	AAMPLOG_INFO("enabled %s", enabled?"true":"false");
-	AcquireStreamLock();
 	// Set subtitles_muted flag to the value requested by the app
-	subtitles_muted = !enabled;
+	subtitles_muted = !enabled; 	// this is atomic - StreamLock not required
 	SetCCStatusInternal();
-	ReleaseStreamLock();
 }
 
 void PrivateInstanceAAMP::SetCCStatusInternal(void)
 {
-	// StreamLock is recursive, so it is fine to call this method with it locked.
-	AcquireStreamLock();
-	if (mpStreamAbstractionAAMP)
-	{
-		// Mute subtitles if either video is muted or subtitles are muted
-		bool mute_subtitles_applied = video_muted.load() || subtitles_muted.load();
-		bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
-		AAMPLOG_TRACE("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
-					  mIsInbandCC, isGstSubtecEnabled, mute_subtitles_applied, video_muted.load(), subtitles_muted.load());
+	auto playerState=GetState();
+	bool streamLockTaken=false;
+	// This process will be blocking if we've already entered a playback state.
+	// This is a workaround where SetCCStatus is called whilst Tune is in progress (StreamLock held) from an EPG Stop call.
+	// Note: CC status can be changed at any time during playback and we do not want to ignore this if StreamLock is currently taken.
+	// The alternative would be to allow TryStreamLock() to have a timeout ~1s, but this might be less predictable.
+	bool allowDeferredApplication =	
+					((playerState == eSTATE_IDLE)         ||
+					 (playerState == eSTATE_INITIALIZING) ||
+					 (playerState == eSTATE_INITIALIZED)  ||
+					 (playerState == eSTATE_PREPARING)    ||
+					 (playerState == eSTATE_PREPARED)     ||
+					 (playerState == eSTATE_STOPPING)     ||
+					 (playerState == eSTATE_STOPPED)
+					);
 
-		if (mIsInbandCC || !isGstSubtecEnabled)
-		{
-			PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
-		}
-		else
-		{
-			mpStreamAbstractionAAMP->MuteSubtitles(mute_subtitles_applied);
-			if (HasSidecarData())
-			{ // has sidecar data
-				mpStreamAbstractionAAMP->MuteSidecarSubtitles(mute_subtitles_applied);
-			}
-			SetSubtitleMuteInternal(mute_subtitles_applied);
-		}
+	if(allowDeferredApplication)
+	{
+		streamLockTaken=TryStreamLock();
 	}
-	ReleaseStreamLock();
+	else
+	{
+		AcquireStreamLock();
+		streamLockTaken=true;
+	}
+	if (streamLockTaken)
+	{
+		if (mpStreamAbstractionAAMP)
+		{
+			// Mute subtitles if either video is muted or subtitles are muted
+			bool mute_subtitles_applied = video_muted.load() || subtitles_muted.load();
+			bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
+			AAMPLOG_TRACE("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
+						mIsInbandCC, isGstSubtecEnabled, mute_subtitles_applied, video_muted.load(), subtitles_muted.load());
+
+			if (mIsInbandCC || !isGstSubtecEnabled)
+			{
+				PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
+			}
+			else
+			{
+				mpStreamAbstractionAAMP->MuteSubtitles(mute_subtitles_applied);
+				if (HasSidecarData())
+				{ // has sidecar data
+					mpStreamAbstractionAAMP->MuteSidecarSubtitles(mute_subtitles_applied);
+				}
+				SetSubtitleMuteInternal(mute_subtitles_applied);
+			}
+        }
+		mApplyCachedCCStatus=false;
+		ReleaseStreamLock();
+	}
+	else
+	{
+		AAMPLOG_WARN("CC status value has been cached, subtitles_muted = %d, playerState=%d", subtitles_muted.load(), playerState);
+		mApplyCachedCCStatus=true; // can't do it now, but remember that we want to apply this
+	}
 }
 
 /**

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -708,7 +708,7 @@ size_t PrivateInstanceAAMP::HandleSSLWriteCallback ( char *ptr, size_t size, siz
 	}
 	else
 	{
-		AAMPLOG_WARN("interrupted for type %d", context->mediaType);
+		AAMPLOG_WARN("interrupted");
 	}
 	return ret;
 }
@@ -6244,7 +6244,6 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 		SetCCStatusInternal();
 		mApplyCachedCCStatus=false;
 	}
-	AAMPLOG_WARN("GNP - release stream lock !!!!");
 	ReleaseStreamLock();
 
 	// To check and apply stored video rectangle properties
@@ -7658,7 +7657,6 @@ bool PrivateInstanceAAMP::IsLiveStream()
 void PrivateInstanceAAMP::Stop( bool isDestructing )
 {
 	auto stopStartTime = NOW_STEADY_TS_MS;
-	//AAMPLOG_WARN(" + PrivateInstanceAAMP: GNP");
 	mApplyCachedCCStatus = false;
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
 	mEventManager->FlushPendingEvents();
@@ -7727,7 +7725,8 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 	auto streamLockStartTime = NOW_STEADY_TS_MS;
 	auto streamLockStopTime = NOW_STEADY_TS_MS;
 	auto licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
-	auto licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;	// Stopping the playback, release all DRM context
+	auto licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;
+	// Stopping the playback, release all DRM context
 	if (mpStreamAbstractionAAMP)
 	{
 		AcquireStreamLock();
@@ -7882,7 +7881,6 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		(unsigned int)(streamLockStopTime - streamLockStartTime),
 		(unsigned int)(licenseAquisitionLockStopTime- licenseAquisitionLockStartTime),
 		(unsigned int)(tearDownEndTime - tearDownStartTime)	);
-	//AAMPLOG_WARN(" - PrivateInstanceAAMP: GNP");
 }
 
 const std::vector<TimedMetadata> & PrivateInstanceAAMP::GetTimedMetadata( void ) const

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1177,6 +1177,7 @@ public:
 	bool playerStartedWithTrickPlay; 			/**< To indicate player switch happened in trickplay rate */
 	bool userProfileStatus; 				/**< Select profile based on user list*/
 	bool mApplyCachedVideoMute;				/**< To apply video mute() operations if it has been cached due to tune in progress */
+	std::atomic_bool mApplyCachedCCStatus;				/**< To apply () operations if it has been cached due to tune in progress */
 	std::vector<uint8_t> mcurrent_keyIdArray;		/**< Current KeyID for DRM license */
 	DynamicDrmInfo mDynamicDrmDefaultconfig;		/**< Init drmConfig stored as default config */
 	std::vector<std::string> mDynamicDrmCache;


### PR DESCRIPTION
VPLAY-12287 - Defer CC Enable / Disable to avoid Stop delays
Reason for change:
This change avoids SetCCStatus delays during stop sequencing causing timeouts.
Note: This still blocks if in a playing state to reduce risk of mute not being applied.
This also includes some useful debug for improving stop handling later.

Test Procedure: Check that subtitles still  work. Check blanking works on pin popup. Check no issues with video/subtitle muting.
Check SetCCStatus executes without delays on streamLock during channel zapping sequences and gets applied later if StreamLock is not available.