### PR TITLE
VPAAMP-764 Guard GetBufferStatus against uninitialized mStartTimeStamp before first fragment injection

### DIFF
--- a/StreamAbstractionAAMP.h
+++ b/StreamAbstractionAAMP.h
@@ -1321,6 +1321,13 @@ public:
 	void NotifyFirstFragmentInjected(void);
 
 	/**
+	 *   @fn IsFirstFragmentInjected
+	 *   @brief Thread-safe check whether NotifyFirstFragmentInjected() has been called.
+	 *   @return true if the first fragment has been injected (mStartTimeStamp >= 0).
+	 */
+	bool IsFirstFragmentInjected();
+
+	/**
 	 *   @fn GetElapsedTime
 	 *
 	 *   @return elapsed time.

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -162,6 +162,16 @@ BufferHealthStatus MediaTrack::GetBufferStatus()
 	int CachedFragmentsOrChunks = 0;
 	double thresholdBuffer = AAMP_BUFFER_MONITOR_GREEN_THRESHOLD;
 	class StreamAbstractionAAMP* pContext = GetContext();
+
+	// Guard: before NotifyFirstFragmentInjected(), mStartTimeStamp is -1
+	// which causes GetElapsedTime() to return epoch-scale values, producing
+	// a massive negative bufferedTime.  Buffer monitoring is meaningless
+	// before first fragment injection, so return GREEN immediately.
+	if (pContext && pContext->mStartTimeStamp < 0)
+	{
+		return BUFFER_STATUS_GREEN;
+	}
+
 	double injectedDuration = GetTotalInjectedDuration();
 	if(aamp->GetLLDashServiceData()->lowLatencyMode && pContext)
 	{

--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -167,20 +167,23 @@ BufferHealthStatus MediaTrack::GetBufferStatus()
 	// which causes GetElapsedTime() to return epoch-scale values, producing
 	// a massive negative bufferedTime.  Buffer monitoring is meaningless
 	// before first fragment injection, so return GREEN immediately.
-	if (pContext && pContext->mStartTimeStamp < 0)
+	if (pContext && !pContext->IsFirstFragmentInjected())
 	{
 		return BUFFER_STATUS_GREEN;
 	}
 
 	double injectedDuration = GetTotalInjectedDuration();
+	double elapsedTime = 0.0;
 	if(aamp->GetLLDashServiceData()->lowLatencyMode && pContext)
 	{
 		bufferedTime 	    = pContext->GetBufferedDuration(); /** To align with latency monitor use same API*/
 		thresholdBuffer = AAMP_BUFFER_MONITOR_GREEN_THRESHOLD_LLD;
+		elapsedTime = pContext->GetElapsedTime();
 	}
 	else if (pContext)
 	{
-		bufferedTime 	    = injectedDuration - pContext->GetElapsedTime();
+		elapsedTime = pContext->GetElapsedTime();
+		bufferedTime 	    = injectedDuration - elapsedTime;
 		CachedFragmentsOrChunks = numberOfFragmentsCached;
 	}
 
@@ -189,7 +192,7 @@ BufferHealthStatus MediaTrack::GetBufferStatus()
 		double underflowDetectThreshold = GETCONFIGVALUE(eAAMPConfig_UnderflowDetectThresholdSec);
 		AAMPLOG_MIL("[%s] bufferedTime %f totalInjectedDuration %f elapsed time %f threshold %f",
 					name, bufferedTime, injectedDuration,
-					pContext->GetElapsedTime(), underflowDetectThreshold);
+					elapsedTime, underflowDetectThreshold);
 		if (bufferedTime <= underflowDetectThreshold)
 		{
 			bStatus = BUFFER_STATUS_RED;
@@ -3040,6 +3043,15 @@ void StreamAbstractionAAMP::NotifyFirstFragmentInjected()
 	mLastPausedTimeStamp = -1;
 	mTotalPausedDurationMS = 0;
 	mStartTimeStamp = aamp_GetCurrentTimeMS();
+}
+
+/**
+ *  @brief Thread-safe check whether the first fragment has been injected.
+ */
+bool StreamAbstractionAAMP::IsFirstFragmentInjected()
+{
+	std::lock_guard<std::mutex> guard(mLock);
+	return (mStartTimeStamp >= 0);
 }
 
 /**

--- a/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
+++ b/test/utests/tests/MediaTrackTests/MediaTrackTests.cpp
@@ -1063,6 +1063,8 @@ TEST_F(MediaTrackTests, WaitForManifestUpdateSnapshotRacePreventionTest)
 TEST_F(MediaTrackTests, GetBufferStatus_ReturnsGreen_WhenBufferIsSufficient)
 {
 	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
+	// Simulate first fragment injection so the pre-injection guard is not triggered
+	mStreamAbstractionAAMP_MPD->NotifyFirstFragmentInjected();
 	// Low Latency mode enabled, which doesn't check for cached fragments
 	SetLowLatencyMode(true);
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_UnderflowDetectThresholdSec))
@@ -1080,6 +1082,8 @@ TEST_F(MediaTrackTests, GetBufferStatus_ReturnsGreen_WhenBufferIsSufficient)
 TEST_F(MediaTrackTests, GetBufferStatus_ReturnsYellow_WhenBufferIsBelowThreshold)
 {
 	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
+	// Simulate first fragment injection so the pre-injection guard is not triggered
+	mStreamAbstractionAAMP_MPD->NotifyFirstFragmentInjected();
 	// Low Latency mode enabled, which doesn't check for cached fragments
 	SetLowLatencyMode(true);
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_UnderflowDetectThresholdSec))
@@ -1097,6 +1101,8 @@ TEST_F(MediaTrackTests, GetBufferStatus_ReturnsYellow_WhenBufferIsBelowThreshold
 TEST_F(MediaTrackTests, GetBufferStatus_ReturnsRed_WhenBufferIsBelowUnderflowThreshold)
 {
 	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video", mStreamAbstractionAAMP_MPD};
+	// Simulate first fragment injection so the pre-injection guard is not triggered
+	mStreamAbstractionAAMP_MPD->NotifyFirstFragmentInjected();
 	// Low Latency mode enabled, which doesn't check for cached fragments
 	SetLowLatencyMode(true);
 	EXPECT_CALL(*g_mockAampConfig, GetConfigValue(eAAMPConfig_UnderflowDetectThresholdSec))
@@ -1338,4 +1344,42 @@ TEST_F(MediaTrackTests, CheckForDiscontinuity_FallsThrough_WhenPtsRestampDisable
 
 	// Else branch: isDiscontinuity was not modified, remains true.
 	EXPECT_TRUE(isDiscontinuity);
+}
+
+/**
+ * @brief Before NotifyFirstFragmentInjected() is called, GetBufferStatus() must
+ *        return BUFFER_STATUS_GREEN regardless of other state, because elapsed
+ *        time is undefined and would produce a bogus negative bufferedTime.
+ */
+TEST_F(MediaTrackTests, GetBufferStatus_ReturnsGreen_BeforeFirstFragmentInjected)
+{
+	SetLowLatencyMode(false);
+
+	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video",
+								  mStreamAbstractionAAMP_MPD};
+
+	// mStartTimeStamp defaults to -1, NotifyFirstFragmentInjected() has not been called.
+	EXPECT_EQ(videoTrack.GetBufferStatus(), BUFFER_STATUS_GREEN);
+}
+
+/**
+ * @brief After NotifyFirstFragmentInjected(), GetBufferStatus() must proceed
+ *        with normal buffer health evaluation (not short-circuit to GREEN).
+ */
+TEST_F(MediaTrackTests, GetBufferStatus_EvaluatesNormally_AfterFirstFragmentInjected)
+{
+	SetLowLatencyMode(false);
+
+	TestableMediaTrack videoTrack{eTRACK_VIDEO, mPrivateInstanceAAMP, "video",
+								  mStreamAbstractionAAMP_MPD};
+
+	// Simulate first fragment injection — sets mStartTimeStamp to now.
+	mStreamAbstractionAAMP_MPD->NotifyFirstFragmentInjected();
+
+	// With zero injected duration and a valid (positive) elapsed time,
+	// bufferedTime will be negative, triggering YELLOW or RED depending
+	// on config thresholds.  The key assertion is that the pre-injection
+	// guard does NOT fire — i.e. the result is not GREEN.
+	BufferHealthStatus status = videoTrack.GetBufferStatus();
+	EXPECT_NE(status, BUFFER_STATUS_GREEN);
 }

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -1985,6 +1985,8 @@ TEST_F(TrackStateTests, EnterTimedWaitForPlaylistRefreshTests)
 
 TEST_F(TrackStateTests, GetBufferStatusTest)
 {
+	// Simulate first fragment injection so the pre-injection guard is not triggered
+	mStreamAbstractionAAMP_HLS->NotifyFirstFragmentInjected();
 	// Call the function under test
 	BufferHealthStatus bufferStatus = TrackStateobj->GetBufferStatus();
 	ASSERT_EQ(bufferStatus, BUFFER_STATUS_RED);


### PR DESCRIPTION
MediaTrack::GetBufferStatus() can produce anomalous negative bufferedTime and epoch-scale elapsedTime values when called before NotifyFirstFragmentInjected() has set mStartTimeStamp. This occurs because MonitorBufferHealth may start polling before the fragment injector thread has injected the first fragment, at which point mStartTimeStamp is still -1, causing GetElapsedTime() to compute against epoch (Jan 1 1970).

Root cause: Race between MonitorBufferHealth thread launch and first fragment injection in the fragment injector thread. mStartTimeStamp is initialized to -1 and only set to a valid value in NotifyFirstFragmentInjected().

Fix: Add an early return of BUFFER_STATUS_GREEN in GetBufferStatus() when pContext->mStartTimeStamp < 0. Buffer monitoring is meaningless before first fragment injection, so reporting GREEN is the correct behavior.

Impact: Eliminates spurious buffer underflow warnings and misleading GetBufferStatus log entries during startup. These bogus entries were visible in AutoTriage BufferStatus visualizations as large negative bufferedTime outliers.