### PR TITLE
VPAAMP-766 Fix GetStreamFormat() premature pipeline setup for HLS-MP4 with UseMp4Demux

### DIFF
--- a/fragmentcollector_hls.cpp
+++ b/fragmentcollector_hls.cpp
@@ -5061,7 +5061,8 @@ void StreamAbstractionAAMP_HLS::Stop(bool clearChannelData)
 void StreamAbstractionAAMP_HLS::GetStreamFormat(StreamOutputFormat &primaryOutputFormat, StreamOutputFormat &audioOutputFormat, StreamOutputFormat &subOutputFormat)
 {
 	if (ISCONFIGSET(eAAMPConfig_UseMp4Demux) &&
-		(aamp->mMediaFormat == eMEDIAFORMAT_HLS_MP4))
+		(aamp->mMediaFormat == eMEDIAFORMAT_HLS_MP4 ||
+		 trackState[eMEDIATYPE_VIDEO]->streamOutputFormat == FORMAT_ISO_BMFF))
 	{
 		// Mp4Demuxer will set the format later once the init fragment is parsed
 		// format is only used for video and audio formats. Subtitle should be unaffected

--- a/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
+++ b/test/utests/tests/StreamAbstractionAAMP_HLS/FunctionalTests.cpp
@@ -333,6 +333,50 @@ TEST_F(StreamAbstractionAAMP_HLSTest, GetStreamFormat_UseMp4DemuxAndHlsMp4_Retur
 	EXPECT_EQ(subtitleOutputFormat, FORMAT_SUBTITLE_WEBVTT);
 }
 
+TEST_F(StreamAbstractionAAMP_HLSTest, GetStreamFormat_UseMp4DemuxHlsNotYetPromoted_VideoISOBMFF_ReturnsUnknownForAv)
+{
+	if (mStreamAbstractionAAMP_HLS->trackState[eTRACK_VIDEO] == nullptr)
+	{
+		mStreamAbstractionAAMP_HLS->trackState[eTRACK_VIDEO] =
+			new TrackState(eTRACK_VIDEO, mStreamAbstractionAAMP_HLS,
+				mPrivateInstanceAAMP, "video");
+	}
+	if (mStreamAbstractionAAMP_HLS->trackState[eTRACK_AUDIO] == nullptr)
+	{
+		mStreamAbstractionAAMP_HLS->trackState[eTRACK_AUDIO] =
+			new TrackState(eTRACK_AUDIO, mStreamAbstractionAAMP_HLS,
+				mPrivateInstanceAAMP, "audio");
+	}
+	if (mStreamAbstractionAAMP_HLS->trackState[eTRACK_SUBTITLE] == nullptr)
+	{
+		mStreamAbstractionAAMP_HLS->trackState[eTRACK_SUBTITLE] =
+			new TrackState(eTRACK_SUBTITLE, mStreamAbstractionAAMP_HLS,
+				mPrivateInstanceAAMP, "subtitle");
+	}
+
+	// mMediaFormat not yet promoted (still HLS), but Init() has set video/audio
+	// tracks to FORMAT_ISO_BMFF after detecting EXT-X-MAP fMP4 segments.
+	// GetStreamFormat() must return UNKNOWN for both so Configure() defers
+	// pipeline setup to SetStreamCaps() from AampMp4Demuxer.
+	mPrivateInstanceAAMP->mMediaFormat = eMEDIAFORMAT_HLS;
+	mStreamAbstractionAAMP_HLS->trackState[eTRACK_VIDEO]->streamOutputFormat = FORMAT_ISO_BMFF;
+	mStreamAbstractionAAMP_HLS->trackState[eTRACK_AUDIO]->streamOutputFormat = FORMAT_ISO_BMFF;
+	mStreamAbstractionAAMP_HLS->trackState[eTRACK_SUBTITLE]->streamOutputFormat = FORMAT_SUBTITLE_WEBVTT;
+
+	EXPECT_CALL(*g_mockAampConfig, IsConfigSet(eAAMPConfig_UseMp4Demux))
+		.WillOnce(Return(true));
+
+	StreamOutputFormat primaryOutputFormat{};
+	StreamOutputFormat audioOutputFormat{};
+	StreamOutputFormat subtitleOutputFormat{};
+	mStreamAbstractionAAMP_HLS->GetStreamFormat(primaryOutputFormat,
+		audioOutputFormat, subtitleOutputFormat);
+
+	EXPECT_EQ(primaryOutputFormat, FORMAT_UNKNOWN);
+	EXPECT_EQ(audioOutputFormat, FORMAT_UNKNOWN);
+	EXPECT_EQ(subtitleOutputFormat, FORMAT_SUBTITLE_WEBVTT);
+}
+
 TEST_F(StreamAbstractionAAMP_HLSTest, GetStreamFormat_UseMp4DemuxAndHlsTs_ReturnsTrackFormats)
 {
 	if (mStreamAbstractionAAMP_HLS->trackState[eTRACK_VIDEO] == nullptr)


### PR DESCRIPTION
Reason for Change: AAMP-TRICKPLAY-7002 L2 tests failing with
  "qtdemux0: This file contains no playable streams".
  When UseMp4Demux=true, Init() sets both video and audio track
  streamOutputFormat to FORMAT_ISO_BMFF after detecting EXT-X-MAP
  in the HLS playlist.  GetStreamFormat() was then called in
  TuneHelper() before mMediaFormat was promoted from eMEDIAFORMAT_HLS
  to eMEDIAFORMAT_HLS_MP4 (promotion happens at the call site after
  GetStreamFormat() returns).  With mMediaFormat still HLS, the
  UseMp4Demux guard was skipped and GetStreamFormat() returned
  FORMAT_ISO_BMFF for both tracks.  This caused Configure() to set
  up a qtdemux-based GStreamer pipeline immediately.  When
  AampMp4Demuxer subsequently parsed the audio init fragment and
  called SetStreamCaps() to switch audio to raw AAC ES, the pipeline
  became inconsistent (qtdemux on video, raw AAC ES on audio),
  resulting in the "no playable streams" error.
  This regression was exposed by VPAAMP-733 which correctly tightened
  the UseMp4Demux guard to require mMediaFormat==HLS_MP4, but that
  tightening removed the accidental protection for the pre-promotion
  window.

Summary of Changes:
- fragmentcollector_hls.cpp: extend GetStreamFormat() UseMp4Demux guard to also fire when the video track streamOutputFormat is FORMAT_ISO_BMFF, regardless of whether mMediaFormat has been promoted yet.  This matches the signal used by the TuneHelper() call site to perform the promotion itself, and is safe for HLS-TS (video format is FORMAT_MPEGTS, not FORMAT_ISO_BMFF).
- FunctionalTests.cpp: add regression test covering the pre-promotion scenario (mMediaFormat=HLS, video=FORMAT_ISO_BMFF, UseMp4Demux=true) asserting FORMAT_UNKNOWN is returned for both A/V.

Test Procedure:
- Run StreamAbstractionAAMP_HLS unit tests.
- Re-run AAMP-TRICKPLAY-7002 L2 tests and confirm pass.

Priority: P1
Risks: Low - one-line condition extension; HLS-TS path unaffected.