### PR TITLE
RDKEMW-20975 [Rack][RDKE][8.6][Llama G1/Cello]: Screen got stuck during VOD content playback

### DIFF
--- a/AampStreamSinkInactive.h
+++ b/AampStreamSinkInactive.h
@@ -113,7 +113,7 @@ public:
      *   @fn Flush
 	 *   @brief stub implementation for Inactive aamp instance
 	 */
-	virtual void Flush(double position = 0, int rate = AAMP_NORMAL_PLAY_RATE, bool shouldTearDown = true)
+	virtual void Flush(double position = 0, int rate = AAMP_NORMAL_PLAY_RATE, bool shouldTearDown = true, bool keepPausedSeek = false)
 	{
 		AAMPLOG_WARN("Called AAMPGstPlayer()::%s stub", __FUNCTION__);
 	}

--- a/AampStreamSinkManager.cpp
+++ b/AampStreamSinkManager.cpp
@@ -497,7 +497,7 @@ void AampStreamSinkManager::SetActive(PrivateInstanceAAMP *aamp, double position
 
 	mGstPlayer->ChangeAamp(aamp, mInactiveGstPlayersMap[aamp]->GetID3MetadataHandler());
 	aamp->mIsFlushOperationInProgress = true;
-	mGstPlayer->Flush(position, aamp->rate, true);
+	mGstPlayer->Flush(position, aamp->rate, true,false);
 	aamp->mIsFlushOperationInProgress = false;
 	mGstPlayer->SetSubtitleMute(aamp->subtitles_muted);
 	if(!aamp->IsTuneCompleted() && aamp->IsPlayEnabled() && (mPipelineMode == ePIPELINEMODE_SINGLE))

--- a/AampStreamSinkManager.cpp
+++ b/AampStreamSinkManager.cpp
@@ -497,7 +497,7 @@ void AampStreamSinkManager::SetActive(PrivateInstanceAAMP *aamp, double position
 
 	mGstPlayer->ChangeAamp(aamp, mInactiveGstPlayersMap[aamp]->GetID3MetadataHandler());
 	aamp->mIsFlushOperationInProgress = true;
-	mGstPlayer->Flush(position, aamp->rate, true,false);
+	mGstPlayer->Flush(position, aamp->rate, true, false);
 	aamp->mIsFlushOperationInProgress = false;
 	mGstPlayer->SetSubtitleMute(aamp->subtitles_muted);
 	if(!aamp->IsTuneCompleted() && aamp->IsPlayEnabled() && (mPipelineMode == ePIPELINEMODE_SINGLE))

--- a/StreamSink.h
+++ b/StreamSink.h
@@ -133,9 +133,14 @@ public:
      *   @param[in]  position - playback position
      *   @param[in]  rate - Speed
      *   @param[in]  shouldTearDown - if pipeline is not in a valid state, tear down pipeline
+     *   @param[in]  keepPausedSeek - true only when this Flush is part of an explicit seek-with-keepPaused
+     *                                request. Must NOT be inferred from the pipeline's incidental paused
+     *                                state (which can be true for unrelated reasons such as buffering or
+     *                                fragment caching), since that conflation can permanently block later
+     *                                PLAYING transitions when no explicit resume ever arrives.
      *   @return void
      */
-    virtual void Flush(double position = 0, int rate = AAMP_NORMAL_PLAY_RATE, bool shouldTearDown = true){}
+    virtual void Flush(double position = 0, int rate = AAMP_NORMAL_PLAY_RATE, bool shouldTearDown = true, bool keepPausedSeek = false){}
 
     /**
      *   @brief Flush the audio playbin

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1124,7 +1124,7 @@ void AAMPGstPlayer::SetAudioVolume(int volume)
 /**
  *  @brief Flush cached GstBuffers and set seek position & rate
  */
-void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown)
+void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown, bool keepPausedSeek)
 {
 	if(ISCONFIGSET(eAAMPConfig_SuppressDecode))
 	{
@@ -1136,7 +1136,7 @@ void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown)
 	{
 		isAppSeek = true;
 	}
-	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek);
+	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek, keepPausedSeek);
 	if(ret)
 	{
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)
@@ -1269,7 +1269,7 @@ void AAMPGstPlayer::SeekStreamSink(double position, double rate)
 	// shouldTearDown is set to false, because in case of a new tune pipeline
 	// might not be in a playing/paused state which causes Flush() to destroy
 	// pipeline. This has to be avoided.
-	Flush(position, rate, false);
+	Flush(position, rate, false, false);
 
 }
 

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1136,7 +1136,7 @@ void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown, bool k
 	{
 		isAppSeek = true;
 	}
-	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek /*, keepPausedSeek */);
+	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek, keepPausedSeek);
 	if(ret)
 	{
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -1136,7 +1136,7 @@ void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown, bool k
 	{
 		isAppSeek = true;
 	}
-	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek, keepPausedSeek);
+	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek /*, keepPausedSeek */);
 	if(ret)
 	{
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)

--- a/aampgstplayer.h
+++ b/aampgstplayer.h
@@ -167,8 +167,9 @@ public:
 		 * @param[in] position playback seek position
 		 * @param[in] rate playback rate
 		 * @param[in] shouldTearDown flag indicates if pipeline should be destroyed if in invalid state
+		 * @param[in] keepPausedSeek true only for an explicit seek-with-keepPaused request
 		 */
-	void Flush(double position, int rate, bool shouldTearDown) override;
+	void Flush(double position, int rate, bool shouldTearDown, bool keepPausedSeek) override;
 	/**
 		 * @fn Pause
 		 * @param[in] pause flag to pause/play the pipeline

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -917,26 +917,35 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							{
 								retValue = sink->Pause(false, false);
 							}
-				           //If pipeline failed to reach PLAYING state, do not
-				           // mark mSinkPaused=false and trigger a re-tune to recover
-				           if (!retValue)
-				           {
-				               AAMPLOG_ERR("SetRateInternal: Pipeline resume FAILED Triggering re-tune for recovery.");
-				               aamp->ScheduleRetune(eGST_ERROR_GST_PIPELINE_INTERNAL,
-				                                    eMEDIATYPE_VIDEO);
-				               return;
-				           }
-							// required since buffers are already cached in paused state
-							aamp->NotifyFirstBufferProcessed(sink ? sink->GetVideoRectangle() : std::string());
+							if (sink && !retValue)
+							{
+								// Pipeline resume did not complete (async PAUSED->PLAYING wedged by a
+								// rapid trickplay->seek->resume race - seen on both VOD and FOG-TSB linear).
+								// Recover by re-seeking to the current position: the same mechanism the
+								// local-TSB resume path uses. Works uniformly for VOD, FOG-TSB & local TSB.
+								AAMPLOG_WARN("SetRateInternal: pipeline resume failed (GstState timeout); recovering via re-seek");
+								aamp->SetState(eSTATE_SEEKING);
+								aamp->seek_pos_seconds = aamp->GetPositionSeconds();
+								aamp->rate = AAMP_NORMAL_PLAY_RATE;
+								aamp->mSinkPaused = false;
+								{
+								std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock());
+								aamp->TuneHelper(eTUNETYPE_SEEK, false);
+								}
+								// Skip common notification (like local-TSB path): state -> PLAYING
+								// via NotifyFirstBufferProcessed once fragments arrive.
+								retValue = false;
+								aamp->NotifySpeedChanged(aamp->rate, false);
+							}
+							else
+							{
+								// required since buffers are already cached in paused state
+								aamp->NotifyFirstBufferProcessed(sink ? sink->GetVideoRectangle() : std::string());
+							}
 						}
 					}
 					aamp->mSinkPaused = false;
 					aamp->ResumeDownloads();
-					if (retValue)
-					{
-						aamp->mSinkPaused = false;
-						aamp->ResumeDownloads();
-					}
 				}
 			}
 			else if (rate == 0)

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -917,6 +917,15 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							{
 								retValue = sink->Pause(false, false);
 							}
+				           //If pipeline failed to reach PLAYING state, do not
+				           // mark mSinkPaused=false and trigger a re-tune to recover
+				           if (!retValue)
+				           {
+				               AAMPLOG_ERR("SetRateInternal: Pipeline resume FAILED Triggering re-tune for recovery.");
+				               aamp->ScheduleRetune(eGSTREAMER_PIPELINE_PAUSED_TIMEOUT,
+				                                    eMEDIATYPE_VIDEO);
+				               return;
+				           }
 							// required since buffers are already cached in paused state
 							aamp->NotifyFirstBufferProcessed(sink ? sink->GetVideoRectangle() : std::string());
 						}

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -932,6 +932,11 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 					}
 					aamp->mSinkPaused = false;
 					aamp->ResumeDownloads();
+					if (retValue)
+					{
+						aamp->mSinkPaused = false;
+						aamp->ResumeDownloads();
+					}
 				}
 			}
 			else if (rate == 0)

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -928,10 +928,11 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 								aamp->seek_pos_seconds = aamp->GetPositionSeconds();
 								aamp->rate = AAMP_NORMAL_PLAY_RATE;
 								aamp->mSinkPaused = false;
-								{
-								std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock());
-								aamp->TuneHelper(eTUNETYPE_SEEK, false);
-								}
+									{
+										std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock());
+										aamp->TuneHelper(eTUNETYPE_SEEK, false);
+									}
+
 								// Skip common notification (like local-TSB path): state -> PLAYING
 								// via NotifyFirstBufferProcessed once fragments arrive.
 								retValue = false;

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -922,7 +922,7 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 				           if (!retValue)
 				           {
 				               AAMPLOG_ERR("SetRateInternal: Pipeline resume FAILED Triggering re-tune for recovery.");
-				               aamp->ScheduleRetune(eGSTREAMER_PIPELINE_PAUSED_TIMEOUT,
+				               aamp->ScheduleRetune(eGST_ERROR_GST_PIPELINE_INTERNAL,
 				                                    eMEDIATYPE_VIDEO);
 				               return;
 				           }

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -1565,7 +1565,7 @@ bool InterfacePlayerRDK::IsUsingRialtoSink()
 /**
  *  @brief Flush cached GstBuffers and set seek position & rate
  */
-bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek)
+bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek, bool keepPausedSeek)
 {
 	GstState aud_current;
 	GstState aud_pending;

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -717,7 +717,7 @@ class InterfacePlayerRDK
         	 * @param[in] GstState The desired GStreamer pipeline state.
         	 * @param[in] gstMediaFormat The media format for the pipeline.
         	 */
-        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek);
+        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek, bool keepPausedSeek);
         	/**
         	 * @fn TimerAdd
         	 * @param[in] funcPtr function to execute on timer expiry

--- a/middleware/test/utests/tests/InterfacePlayerTests/InterfacePlayerFunctionTests.cpp
+++ b/middleware/test/utests/tests/InterfacePlayerTests/InterfacePlayerFunctionTests.cpp
@@ -547,7 +547,7 @@ TEST_F(InterfacePlayerTests, GstFlush_PipelineNull)
 	bool shouldTearDown = false;
 	bool isAppSeek = false;
 
-	EXPECT_FALSE(mInterfaceGstPlayer->Flush(position, rate, shouldTearDown, isAppSeek));
+	EXPECT_FALSE(mInterfaceGstPlayer->Flush(position, rate, shouldTearDown, isAppSeek, false));
 }
 
 TEST_F(InterfacePlayerTests, GstFlush_PipelineNotPlayingOrPaused)

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6503,7 +6503,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 				// shouldTearDown is set to false, because in case of a new tune pipeline
 				// might not be in a playing/paused state which causes Flush() to destroy
 				// pipeline. This has to be avoided.
-				sink->Flush(flushPosition, rate, false);
+				sink->Flush(flushPosition, rate, false, seekWhilePaused);
 			}
 		}
 

--- a/test/utests/fakes/FakeAampGstPlayer.cpp
+++ b/test/utests/fakes/FakeAampGstPlayer.cpp
@@ -72,11 +72,11 @@ void AAMPGstPlayer::Stop(bool keepLastFrame)
 {
 }
 
-void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown)
+void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown, bool keepPausedSeek)
 {
 	if (g_mockAampGstPlayer != nullptr)
 	{
-		g_mockAampGstPlayer->Flush(position, rate, shouldTearDown);
+		g_mockAampGstPlayer->Flush(position, rate, shouldTearDown, keepPausedSeek);
 	}
 }
 

--- a/test/utests/mocks/MockAampGstPlayer.h
+++ b/test/utests/mocks/MockAampGstPlayer.h
@@ -39,7 +39,7 @@ public:
 
     MOCK_METHOD(void, ChangeAamp, (PrivateInstanceAAMP *, id3_callback_t));
 
-    MOCK_METHOD(void, Flush, (double position, int rate, bool shouldTearDown), (override));
+    MOCK_METHOD(void, Flush, (double position, int rate, bool shouldTearDown, bool keepPausedSeek), (override));
 
     MOCK_METHOD(void, SetEncryptedAamp, (PrivateInstanceAAMP *));
 


### PR DESCRIPTION
### Race Condition Recovery Handling Summary

To address the playback freeze caused by race conditions, the recovery handling has been implemented across both the Middleware and AAMP layers.

#### Middleware Changes
https://github.com/rdkcentral/middleware-player-interface/pull/200

1. **Propagate Pause() failure**

   * `Pause()` detects the failure through `validateStateWithMsTimeout()`, but the failure was not being propagated to the middleware layer.
   * The fix ensures that the failure is propagated instead of being silently ignored.

2. **Increase timeout budget**

   * The existing retry budget of **5 × 100 ms (500 ms)** was insufficient for TSB seek scenarios with concurrent Widevine DRM renegotiation.
   * Increased the retry count to **10** with adaptive sleep to provide sufficient time for recovery.

3. **Maintain correct sink state**

   * Previously, `mSinkPaused` was being set to `false` unconditionally, even when `Pause()` failed, resulting in a state mismatch that masked the playback freeze during subsequent `SetRate()` calls.
   * The state handling has been corrected to avoid this desynchronization.

#### AAMP Changes

4. **Recover by re-tuning**

   * Once the middleware propagates the `Pause()` failure, AAMP now schedules a recovery by performing a re-tune instead of continuing in a broken state.
   * This ensures playback recovery when the race condition is encountered.

#### Additional Linear Playback Handling

After implementing the above changes, VOD playback recovered successfully with approximately **1 second** recovery time. However, linear playback still exhibited issues.

To address this, the AAMP handling was updated in the **pipeline-unpause** branch:

* When `Pause(false)` fails, trigger recovery using `TuneHelper(eTUNETYPE_SEEK)`, matching the existing Local-TSB recovery path.
* Keep `mSinkPaused = false` and `ResumeDownloads()` unconditional as part of the recovery flow.

#### Result

* **VOD Playback:** Successfully recovers without playback freeze (approximately 1-second recovery).
* **Linear Playback:** Successfully recovers after applying the additional AAMP handling.

**Note:** The recovery logic is implemented collaboratively across both the Middleware and AAMP layers. When the race condition is detected and `Pause()` fails, the failure is propagated and appropriate recovery actions are triggered, allowing both VOD and Linear playback to recover automatically.
