### PR TITLE
VPLAY-12287 - Fix Stop profiling

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -7884,6 +7884,8 @@ void PrivateInstanceAAMP::Stop( bool isDestructing )
 		(unsigned int)(streamLockStopTime - streamLockStartTime),
 		(unsigned int)(licenseAquisitionLockStopTime- licenseAquisitionLockStartTime),
 		(unsigned int)(tearDownEndTime - tearDownStartTime)	);
+	profiler.mStopDurationMs = mLastStopDurationMs;
+
 }
 
 const std::vector<TimedMetadata> & PrivateInstanceAAMP::GetTimedMetadata( void ) const


### PR DESCRIPTION
Reason for change: Repair accidental breakage of stop profiling.

Test Procedure: Check IP_AAMP_TUNETIME stop timing output.

Risk: Low