### PR TITLE
VPAAMP-773: Fix uveExecuter not landing in build/Debug/ on macOS

### DIFF
--- a/scripts/install_jsbindings.sh
+++ b/scripts/install_jsbindings.sh
@@ -24,7 +24,10 @@ function jsbindings_install_build_darwin_fn()
     cd $AAMP_DIR/build
 
     xcodebuild -scheme aampjsbindings build
-    xcodebuild -scheme uveExecuter build
+    # Override SYMROOT so uveExecuter lands in build/Debug/ where aamp-uve.sh expects it.
+    # The cmake configure step sets SYMROOT=XcodeDerivedData which would redirect the binary
+    # to XcodeDerivedData/Debug/uveExecuter instead.
+    xcodebuild -scheme uveExecuter SYMROOT="$AAMP_DIR/build" build
 }
 
 function jsbindings_install_build_linux_fn()

--- a/scripts/install_jsbindings.sh
+++ b/scripts/install_jsbindings.sh
@@ -24,9 +24,9 @@ function jsbindings_install_build_darwin_fn()
     cd "${AAMP_DIR}/build" || { echo "Failed to change to build directory: ${AAMP_DIR}/build"; return 1; }
 
     xcodebuild -scheme aampjsbindings build
-    # Override SYMROOT so uveExecuter lands in build/Debug/ where aamp-uve.sh expects it.
-    # The cmake configure step sets SYMROOT=XcodeDerivedData which would redirect the binary
-    # to XcodeDerivedData/Debug/uveExecuter instead.
+    # Override SYMROOT so uveExecuter lands in build/Debug/uveExecuter.
+    # CMake config sets SYMROOT to "${AAMP_DIR}/build/XcodeDerivedData", which would
+    # otherwise place the binary in build/XcodeDerivedData/Debug/uveExecuter.
     xcodebuild -scheme uveExecuter SYMROOT="$AAMP_DIR/build" build
 }
 

--- a/scripts/install_jsbindings.sh
+++ b/scripts/install_jsbindings.sh
@@ -21,7 +21,7 @@
 function jsbindings_install_build_darwin_fn()
 {   
     echo "Build aamp-jsbindings"
-    cd $AAMP_DIR/build
+    cd "${AAMP_DIR}/build" || { echo "Failed to change to build directory: ${AAMP_DIR}/build"; return 1; }
 
     xcodebuild -scheme aampjsbindings build
     # Override SYMROOT so uveExecuter lands in build/Debug/ where aamp-uve.sh expects it.


### PR DESCRIPTION
The cmake configure step bakes SYMROOT=XcodeDerivedData into the Xcode project. The previous xcodebuild invocation for uveExecuter inherited that setting, placing the binary in XcodeDerivedData/Debug/ instead of build/Debug/ where aamp-uve.sh expects it.

Fix: pass SYMROOT="$AAMP_DIR/build" explicitly when building uveExecuter so the binary always lands at build/Debug/uveExecuter.