### PR TITLE
VPAAMP-512-follow-up: Remove premature eosReached reset that breaks EOS validation

### DIFF
--- a/streamabstraction.cpp
+++ b/streamabstraction.cpp
@@ -1497,8 +1497,6 @@ bool MediaTrack::SignalIfEOSReached()
 			{
 				pContext->StopUnderflowMonitor();
 			}
-			// Reset the EOS flag so that we don't send EOS again if the injector is restarted
-			eosReached = false;
 			ret = true;
 		}
 		else


### PR DESCRIPTION
Root cause:
The "Reset eosReached flag after signalling EndOfStream" change (commit bf697dd6) added `eosReached = false` in SignalIfEOSReached() after calling EndOfStreamReached().

This causes a race condition:
1. FetcherLoop sets eosReached=true on tracks
2. Injector calls SignalIfEOSReached() → sends EOS to GStreamer → resets eosReached=false
3. GStreamer fires GST_MESSAGE_EOS back to AAMP
4. NotifyEOSReached() validates via IsEOSReached() → calls IsAtEndOfTrack() which returns eosReached (now false!)
5. EOS is discarded as "Bogus" (priv_aamp.cpp:3742) → AAMP_EVENT_EOS never fires

Impact:
All L2 tests waiting for EOS/COMPLETE time out:
- 1025 (SegmentBase VOD EOS)
- 7002 (Trickplay BOS auto-resume)
- 8004 (CDAI ad playback EOS)
- 8015 (CDAI split period trickplay)
- 13006 (Codec change EOS)

Fix:
Remove the eosReached=false reset. Duplicate-EOS prevention is already handled by videoEosSubmitted/audioEosSubmitted guards in fragmentcollector_mpd.cpp (lines 10538-10548, 10561-10571).

Change-Id: I$(uuidgen | tr -d '-' | cut -c1-40)