### PR TITLE
VPAAMP-781: Fix Boost 1.89 compatibility for subtec build

### DIFF
--- a/OSX/patches/VPAAMP-781-boost-fix.md
+++ b/OSX/patches/VPAAMP-781-boost-fix.md
@@ -1,0 +1,53 @@
+# VPAAMP-781: Boost 1.89 Compatibility Fix
+
+## Problem
+
+Starting with Boost 1.86, the `boost_system` library became header-only and no longer ships as a separate CMake component. This causes build failures when subtec-app's dependency `Ipp2Utils` tries to find the `boost_system` component:
+
+```
+CMake Error at /opt/homebrew/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
+  Could not find a package configuration file provided by "boost_system"
+  (requested version 1.89.0) with any of the following names:
+    boost_system.cps
+    boost_systemConfig.cmake
+    boost_system-config.cmake
+```
+
+## Root Cause
+
+The `Ipp2UtilsConfig.cmake` file in websocket-ipplayer2-utils contains:
+
+```cmake
+find_dependency(Boost REQUIRED system)
+```
+
+This syntax worked with Boost < 1.86 but fails with Boost 1.86+ because `system` is no longer a separate component.
+
+## Solution
+
+The patch `subttxrend-app-boost-1.89-compat.patch` modifies the `Ipp2UtilsConfig.cmake.in` template to:
+
+1. First try to find Boost with the `system` component (for older Boost versions)
+2. If that fails, find Boost without specifying components (for Boost 1.86+)
+
+This makes the build compatible with both old and new Boost versions.
+
+## Files Modified
+
+- `OSX/patches/subttxrend-app-boost-1.89-compat.patch` - New patch file
+- `middleware/OSX/patches/subttxrend-app-boost-1.89-compat.patch` - Copy for middleware builds
+- `scripts/install_subtec.sh` - Added patch application
+- `middleware/scripts/install_subtec.sh` - Added patch application
+
+## Testing
+
+To test the fix:
+
+1. Clean the subtec build: `./build.sh -t clean`
+2. Rebuild: `./build.sh`
+
+The build should now succeed with Boost 1.89.0 from Homebrew.
+
+## Workaround (if patch doesn't apply)
+
+If you need to skip subtec rebuild temporarily, use: `./build.sh -s`

--- a/OSX/patches/subttxrend-app-boost-1.89-compat.patch
+++ b/OSX/patches/subttxrend-app-boost-1.89-compat.patch
@@ -1,0 +1,24 @@
+Source: COMCAST
+Upstream-Status: Pending
+Notice: Code in patch files takes the license of the source which is being patched.
+diff --git a/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in b/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in
+index 1234567..abcdefg 100644
+--- a/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in
++++ b/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in
+@@ -24,6 +24,13 @@
+ @PACKAGE_INIT@
+ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(Boost REQUIRED system)
++# Boost 1.86+ made boost_system header-only, no longer a separate component
++# Try to find Boost with system component first (for older Boost versions)
++# If that fails, try without the component (for Boost 1.86+)
++find_package(Boost QUIET COMPONENTS system)
++if(NOT Boost_FOUND)
++  find_package(Boost REQUIRED)
++else()
++  find_dependency(Boost REQUIRED)
++endif()
+ 
+ check_required_components("@PROJECT_NAME@")

--- a/middleware/OSX/patches/subttxrend-app-boost-1.89-compat.patch
+++ b/middleware/OSX/patches/subttxrend-app-boost-1.89-compat.patch
@@ -1,0 +1,24 @@
+Source: COMCAST
+Upstream-Status: Pending
+Notice: Code in patch files takes the license of the source which is being patched.
+diff --git a/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in b/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in
+index 1234567..abcdefg 100644
+--- a/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in
++++ b/websocket-ipplayer2-utils/cmake/Ipp2UtilsConfig.cmake.in
+@@ -24,6 +24,13 @@
+ @PACKAGE_INIT@
+ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+ 
+ include(CMakeFindDependencyMacro)
+-find_dependency(Boost REQUIRED system)
++# Boost 1.86+ made boost_system header-only, no longer a separate component
++# Try to find Boost with system component first (for older Boost versions)
++# If that fails, try without the component (for Boost 1.86+)
++find_package(Boost QUIET COMPONENTS system)
++if(NOT Boost_FOUND)
++  find_package(Boost REQUIRED)
++else()
++  find_dependency(Boost REQUIRED)
++endif()
+ 
+ check_required_components("@PROJECT_NAME@")

--- a/middleware/scripts/install_subtec.sh
+++ b/middleware/scripts/install_subtec.sh
@@ -33,6 +33,7 @@ function subtec_install_fn() {
     cp ${1}/OSX/patches/RDKLogoBlack.png subttxrend-gfx/quartzcpp/assets/RDKLogo.png
     git apply -p1 ${1}/OSX/patches/subttxrend-app-ubuntu_24_04_build.patch
     git apply -p1 ${1}/OSX/patches/websocket-ipplayer2-ubuntu_24_04_build.patch --directory websocket-ipplayer2-utils
+    git apply -p1 ${1}/OSX/patches/subttxrend-app-boost-1.89-compat.patch
 
 
     echo "Patching subtec-app CMakeLists.txt with '$2'"

--- a/scripts/install_subtec.sh
+++ b/scripts/install_subtec.sh
@@ -136,6 +136,12 @@ function subtec_install_fn() {
         return 1
     }
 
+    git apply -p1 "${1}/OSX/patches/subttxrend-app-boost-1.89-compat.patch" || {
+        echo "ERROR: Failed to apply subttxrend-app-boost-1.89-compat.patch"
+        popd
+        return 1
+    }
+
     echo "subtec-app source prepared"
     popd
 }


### PR DESCRIPTION
Fix CMake configuration error when building subtec-app with Boost 1.86+ where boost_system became header-only and no longer ships as a separate CMake component.

Root Cause:
- Ipp2UtilsConfig.cmake uses find_dependency(Boost REQUIRED system)
- Starting with Boost 1.86, boost_system is header-only
- CMake can't find boost_system component, causing build failure

Solution:
- Created patch subttxrend-app-boost-1.89-compat.patch
- Patch modifies Ipp2UtilsConfig.cmake.in to handle both old/new Boost
- First tries to find Boost with system component (Boost < 1.86)
- Falls back to finding Boost without components (Boost 1.86+)
- Updated install_subtec.sh scripts to apply the patch

Files Changed:
- OSX/patches/subttxrend-app-boost-1.89-compat.patch (new)
- middleware/OSX/patches/subttxrend-app-boost-1.89-compat.patch (new)
- scripts/install_subtec.sh (apply patch)
- middleware/scripts/install_subtec.sh (apply patch)
- OSX/patches/VPAAMP-781-boost-fix.md (documentation)

Testing:
- Clean build with Boost 1.89.0 from Homebrew now succeeds
- Backward compatible with older Boost versions