### PR TITLE
VPLAY-12287 - Defer CC Enable / Disable to avoid Stop delays (#1717)

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -293,6 +293,7 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent)
 {
 	if (aamp)
 	{
+		auto playerStopStartTime=NOW_STEADY_TS_MS;
 		UsingPlayerId playerId(aamp->mPlayerId);
 		AAMPPlayerState state = aamp->GetState();
 
@@ -300,7 +301,9 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent)
 		// 2. Check for state ,if already in Idle / Released , ignore stopInternal
 		// 3. Restart the scheduler , needed if same instance is used for tune again
 
+		auto suspendSchedulerStartTime=NOW_STEADY_TS_MS;
 		mScheduler.SuspendScheduler();
+		auto suspendSchedulerEndTime=NOW_STEADY_TS_MS;
 		mScheduler.RemoveAllTasks();
 
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
@@ -311,6 +314,11 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent)
 
 		//Release lock
 		mScheduler.ResumeScheduler();
+		auto resumeSchedulerEndTime=NOW_STEADY_TS_MS;
+		AAMPLOG_WARN("-Stop (player) ; SuspendScheduler took %u ms, Total %u ms",
+				(unsigned)(suspendSchedulerEndTime-suspendSchedulerStartTime),
+				(unsigned)(resumeSchedulerEndTime-playerStopStartTime)
+			);
 	}
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1245,6 +1245,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, bitrateList()
 	, userProfileStatus(false)
 	, mApplyCachedVideoMute(false)
+	, mApplyCachedCCStatus(false)
 	, mFirstProgress(false)
 	, mTsbSessionRequestUrl()
 	, mcurrent_keyIdArray()
@@ -5667,6 +5668,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 					sink->SetVideoMute(video_muted.load());
 				}
 				SetCCStatusInternal();
+				mApplyCachedCCStatus = false;
 				sink->SetAudioVolume(volume);
 				if (mbPlayEnabled)
 				{
@@ -6273,11 +6275,17 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 			//These two fns are being called in PlayerInstanceAAMP::SetVideoMute
 			SetVideoMuteInternal(video_muted.load());
 			SetCCStatusInternal();
+			mApplyCachedCCStatus=false;
 		}
 		else
 		{
 			AAMPLOG_ERR("mpStreamAbstractionAAMP is NULL, cannot apply cached video mute");
 		}
+	}
+	else if (mApplyCachedCCStatus.load())
+	{
+		SetCCStatusInternal();
+		mApplyCachedCCStatus=false;
 	}
 	ReleaseStreamLock();
 
@@ -7697,6 +7705,7 @@ bool PrivateInstanceAAMP::IsLiveStream()
 void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 {
 	auto stopStartTime = NOW_STEADY_TS_MS;
+	mApplyCachedCCStatus = false;
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
 	mEventManager->FlushPendingEvents();
 	// Set state to STOPPING irrespective of sending state change event or not
@@ -7758,10 +7767,13 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	// so downloads are disabled among other things
 	SetLocalAAMPTsb(false);
 	SetLocalAAMPTsbInjection(false);
+	auto streamLockStartTime = NOW_STEADY_TS_MS;
+	auto streamLockStopTime = NOW_STEADY_TS_MS;
 	// Stopping the playback, release all DRM context
 	if (mpStreamAbstractionAAMP)
 	{
 		AcquireStreamLock();
+		streamLockStopTime = NOW_STEADY_TS_MS;
 		if (mDRMLicenseManager)
 		{
 			ReleaseDynamicDRMToUpdateWait();
@@ -7773,7 +7785,9 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 		}
 		ReleaseStreamLock();
 	}
+	auto tearDownStartTime = NOW_STEADY_TS_MS;
 	TeardownStream(true,true); //disable download as well
+	auto tearDownEndTime = NOW_STEADY_TS_MS;
 
 	// stop the mpd update immediately after Stream abstraction delete
 	if(mMPDDownloaderInstance != nullptr)
@@ -7891,7 +7905,10 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 
 	AampStreamSinkManager::GetInstance().DeactivatePlayer(this, true);
 	unsigned int mLastStopDurationMs = (unsigned)(NOW_STEADY_TS_MS - stopStartTime);
-	AAMPLOG_WARN("AAMP Stop took %u ms",mLastStopDurationMs);
+	AAMPLOG_WARN("AAMP Stop took %u ms; streamLock %u, Teardown %u",
+		mLastStopDurationMs,
+		(unsigned int)(streamLockStopTime - streamLockStartTime),
+		(unsigned int)(tearDownEndTime - tearDownStartTime)	);
 	profiler.mStopDurationMs = mLastStopDurationMs;
 
 }
@@ -11153,40 +11170,70 @@ int PrivateInstanceAAMP::GetTextTrack()
 void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 {
 	AAMPLOG_INFO("enabled %s", enabled?"true":"false");
-	AcquireStreamLock();
 	// Set subtitles_muted flag to the value requested by the app
-	subtitles_muted = !enabled;
+	subtitles_muted = !enabled; 	// this is atomic - StreamLock not required
 	SetCCStatusInternal();
-	ReleaseStreamLock();
 }
 
 void PrivateInstanceAAMP::SetCCStatusInternal(void)
 {
-	// StreamLock is recursive, so it is fine to call this method with it locked.
-	AcquireStreamLock();
-	if (mpStreamAbstractionAAMP)
-	{
-		// Mute subtitles if either video is muted or subtitles are muted
-		bool mute_subtitles_applied = video_muted.load() || subtitles_muted.load();
-		bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
-		AAMPLOG_INFO("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
-					  mIsInbandCC, isGstSubtecEnabled, mute_subtitles_applied, video_muted.load(), subtitles_muted.load());
+	auto playerState=GetState();
+	bool streamLockTaken=false;
+	// This process will be blocking if we've already entered a playback state.
+	// This is a workaround where SetCCStatus is called whilst Tune is in progress (StreamLock held) from an EPG Stop call.
+	// Note: CC status can be changed at any time during playback and we do not want to ignore this if StreamLock is currently taken.
+	// The alternative would be to allow TryStreamLock() to have a timeout ~1s, but this might be less predictable.
+	bool allowDeferredApplication =	
+					((playerState == eSTATE_IDLE)         ||
+					 (playerState == eSTATE_INITIALIZING) ||
+					 (playerState == eSTATE_INITIALIZED)  ||
+					 (playerState == eSTATE_PREPARING)    ||
+					 (playerState == eSTATE_PREPARED)     ||
+					 (playerState == eSTATE_STOPPING)     ||
+					 (playerState == eSTATE_STOPPED)
+					);
 
-		if (mIsInbandCC || !isGstSubtecEnabled)
-		{
-			PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
-		}
-		else
-		{
-			mpStreamAbstractionAAMP->MuteSubtitles(mute_subtitles_applied);
-			if (HasSidecarData())
-			{ // has sidecar data
-				mpStreamAbstractionAAMP->MuteSidecarSubtitles(mute_subtitles_applied);
-			}
-			SetSubtitleMuteInternal(mute_subtitles_applied);
-		}
+	if(allowDeferredApplication)
+	{
+		streamLockTaken=TryStreamLock();
 	}
-	ReleaseStreamLock();
+	else
+	{
+		AcquireStreamLock();
+		streamLockTaken=true;
+	}
+	if (streamLockTaken)
+	{
+		if (mpStreamAbstractionAAMP)
+		{
+			// Mute subtitles if either video is muted or subtitles are muted
+			bool mute_subtitles_applied = video_muted.load() || subtitles_muted.load();
+			bool isGstSubtecEnabled = ISCONFIGSET_PRIV(eAAMPConfig_GstSubtecEnabled);
+			AAMPLOG_INFO("mIsInbandCC %d GstSubtecEnabled %d mute_subtitles_applied %d video_muted %d subtitles_muted %d",
+						mIsInbandCC, isGstSubtecEnabled, mute_subtitles_applied, video_muted.load(), subtitles_muted.load());
+
+			if (mIsInbandCC || !isGstSubtecEnabled)
+			{
+				PlayerCCManager::GetInstance()->SetStatus(!mute_subtitles_applied);
+			}
+			else
+			{
+				mpStreamAbstractionAAMP->MuteSubtitles(mute_subtitles_applied);
+				if (HasSidecarData())
+				{ // has sidecar data
+					mpStreamAbstractionAAMP->MuteSidecarSubtitles(mute_subtitles_applied);
+				}
+				SetSubtitleMuteInternal(mute_subtitles_applied);
+			}
+        	}
+		mApplyCachedCCStatus=false;
+		ReleaseStreamLock();
+	}
+	else
+	{
+		AAMPLOG_WARN("CC status value has been cached, subtitles_muted = %d, playerState=%d", subtitles_muted.load(), playerState);
+		mApplyCachedCCStatus=true; // can't do it now, but remember that we want to apply this
+	}
 }
 
 /**

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1187,6 +1187,7 @@ public:
 	bool playerStartedWithTrickPlay; 			/**< To indicate player switch happened in trickplay rate */
 	bool userProfileStatus; 				/**< Select profile based on user list*/
 	bool mApplyCachedVideoMute;				/**< To apply video mute() operations if it has been cached due to tune in progress */
+	std::atomic_bool mApplyCachedCCStatus;				/**< To apply cc/subtitle mute status later if it has been cached due to tune in progress */
 	std::vector<uint8_t> mcurrent_keyIdArray;		/**< Current KeyID for DRM license */
 	DynamicDrmInfo mDynamicDrmDefaultconfig;		/**< Init drmConfig stored as default config */
 	std::vector<std::string> mDynamicDrmCache;


### PR DESCRIPTION
Reason for change: If Streamlock is not available, then apply this setting later. This is to reduce delays during channel zapping, reducing likelihood of EPG timeouts. Note: This still blocks on Streamlock if in a playing related state (e.g. user invoked subtitle change), since deferred settings are applied during tune.

This also includes some useful future debug for stop timings, since fixing this has pushed delays further into stop calls during channel zapping. E.g. Delays now seen acquiring the async task execution mutex during stop when an async task tune is still in progress, i.e. in SuspendScheduler.

Test Procedure: Check that the EPG stop sequence is not timing out. Check subtitle and CC status changes as expected.