### PR TITLE
VPLAY-13653 - Defer CC Enable / Disable to avoid Stop delays

### DIFF
--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -312,7 +312,7 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 {
 	if (aamp)
 	{
-		auto playerStopStartTime=NOW_STEADY_TS_MS;
+		auto playerStopStartTime = NOW_STEADY_TS_MS;
 		UsingPlayerId playerId(aamp->mPlayerId);
 		AAMPPlayerState state = aamp->GetState();
 
@@ -320,9 +320,9 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 		// 2. Check for state ,if already in Idle / Released , ignore stopInternal
 		// 3. Restart the scheduler , needed if same instance is used for tune again
 
-		auto suspendSchedulerStartTime=NOW_STEADY_TS_MS;
+		auto suspendSchedulerStartTime = NOW_STEADY_TS_MS;
 		mScheduler.SuspendScheduler();
-		auto suspendSchedulerEndTime=NOW_STEADY_TS_MS;
+		auto suspendSchedulerEndTime = NOW_STEADY_TS_MS;
 		mScheduler.RemoveAllTasks();
 
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
@@ -341,10 +341,10 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 		}
 		//Release lock
 		mScheduler.ResumeScheduler();
-		auto resumeSchedulerEndTime=NOW_STEADY_TS_MS;
+		auto resumeSchedulerEndTime = NOW_STEADY_TS_MS;
 		AAMPLOG_WARN("-Stop (player) ; SuspendScheduler took %u ms, Total %u ms",
-				(unsigned)(suspendSchedulerEndTime-suspendSchedulerStartTime),
-				(unsigned)(resumeSchedulerEndTime-playerStopStartTime)
+				(unsigned)(suspendSchedulerEndTime - suspendSchedulerStartTime),
+				(unsigned)(resumeSchedulerEndTime - playerStopStartTime)
 			);
 	}
 }

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -312,6 +312,7 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 {
 	if (aamp)
 	{
+		auto playerStopStartTime=NOW_STEADY_TS_MS;
 		UsingPlayerId playerId(aamp->mPlayerId);
 		AAMPPlayerState state = aamp->GetState();
 
@@ -319,7 +320,9 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 		// 2. Check for state ,if already in Idle / Released , ignore stopInternal
 		// 3. Restart the scheduler , needed if same instance is used for tune again
 
+		auto suspendSchedulerStartTime=NOW_STEADY_TS_MS;
 		mScheduler.SuspendScheduler();
+		auto suspendSchedulerEndTime=NOW_STEADY_TS_MS;
 		mScheduler.RemoveAllTasks();
 
 		//state will be eSTATE_IDLE or eSTATE_RELEASED, right after an init or post-processing of a Stop call
@@ -338,6 +341,11 @@ void PlayerInstanceAAMP::Stop(bool sendStateChangeEvent, bool forceCleanup)
 		}
 		//Release lock
 		mScheduler.ResumeScheduler();
+		auto resumeSchedulerEndTime=NOW_STEADY_TS_MS;
+		AAMPLOG_WARN("-Stop (player) ; SuspendScheduler took %u ms, Total %u ms",
+				(unsigned)(suspendSchedulerEndTime-suspendSchedulerStartTime),
+				(unsigned)(resumeSchedulerEndTime-playerStopStartTime)
+			);
 	}
 }
 

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -12126,10 +12126,6 @@ void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 	else
 	{			
 		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
-		if (mApplyCachedCCStatus.load())
-		{
-			AAMPLOG_DEBUG("mApplyCachedCCStatus=true, setting CCStatus");
-		}
 		SetCCStatusInternal();
 	}
 }

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -1773,6 +1773,7 @@ PrivateInstanceAAMP::PrivateInstanceAAMP(AampConfig *config) : mReportProgressPo
 	, bitrateList()
 	, userProfileStatus(false)
 	, mApplyCachedVideoMute(false)
+	, mApplyCachedCCStatus(false)
 	, mFirstProgress(false)
 	, mTsbSessionRequestUrl()
 	, mcurrent_keyIdArray()
@@ -6479,6 +6480,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 					sink->SetVideoMute(video_muted.load());
 				}
 				SetCCStatusInternal();
+				mApplyCachedCCStatus = false;
 				sink->SetAudioVolume(volume);
 				if (mbPlayEnabled)
 				{
@@ -7097,11 +7099,17 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 				//These two fns are being called in PlayerInstanceAAMP::SetVideoMute
 				SetVideoMuteInternal(video_muted.load());
 				SetCCStatusInternal();
+				mApplyCachedCCStatus=false;
 			}
 			else
 			{
 				AAMPLOG_ERR("mpStreamAbstractionAAMP is NULL, cannot apply cached video mute");
 			}
+		}
+		else if (mApplyCachedCCStatus.load())
+		{
+			SetCCStatusInternal();
+			mApplyCachedCCStatus=false;
 		}
 	}
 
@@ -8539,6 +8547,7 @@ bool PrivateInstanceAAMP::IsLiveStream()
 void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 {
 	auto stopStartTime = NOW_STEADY_TS_MS;
+	mApplyCachedCCStatus = false;
 	// Clear all the player events in the queue and sets its state to RELEASED as everything is done
 	mEventManager->FlushPendingEvents();
 	// Set state to STOPPING irrespective of sending state change event or not
@@ -8588,9 +8597,14 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	// so downloads are disabled among other things
 	SetLocalAAMPTsb(false);
 	SetLocalAAMPTsbInjection(false);
+	auto streamLockStartTime = NOW_STEADY_TS_MS;
+	auto streamLockStopTime = NOW_STEADY_TS_MS;
+	auto licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
+	auto licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;
 	// Stopping the playback, release all DRM context
 	{
 		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
+		streamLockStopTime = NOW_STEADY_TS_MS;
 		if (mpStreamAbstractionAAMP)
 		{
 			if(DownloadsAreEnabled())
@@ -8608,7 +8622,9 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 				// StreamAbstractionAamp object from TeardownStream(). Otherwise it can
 				// lead to crash as PreFetchThread can call UpdateFailedDRMStatus
 				// of StreamAbstractionAamp.
+				licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
 				mDRMLicenseManager->SetLicenseFetcher(nullptr);
+				licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;
 			}
 			if (HasSidecarData())
 			{ // has sidecar data
@@ -8616,7 +8632,9 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 			}
 		}
 	}
+	auto tearDownStartTime = NOW_STEADY_TS_MS;
 	TeardownStream(true,true); //disable download as well
+	auto tearDownEndTime = NOW_STEADY_TS_MS;
 	
 	// Moved the tsb delete request from XRE to AAMP to avoid the HTTP-404 errors
 	// Moved the Fog TSB delete to avoid the delay in MPDDownloaderInstance release which results in HTTP-404
@@ -8761,7 +8779,11 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 
 	AampStreamSinkManager::GetInstance().DeactivatePlayer(this, true);
 	unsigned int mLastStopDurationMs = (unsigned)(NOW_STEADY_TS_MS - stopStartTime);
-	AAMPLOG_WARN("AAMP Stop took %u ms",mLastStopDurationMs);
+	AAMPLOG_WARN("AAMP Stop took %u ms; streamLock %u, SetLicenceFetcher %u, Teardown %u",
+		mLastStopDurationMs,
+		(unsigned int)(streamLockStopTime - streamLockStartTime),
+		(unsigned int)(licenseAquisitionLockStopTime- licenseAquisitionLockStartTime),
+		(unsigned int)(tearDownEndTime - tearDownStartTime)	);
 	profiler.mStopDurationMs = mLastStopDurationMs;
 
 }
@@ -12058,10 +12080,39 @@ int PrivateInstanceAAMP::GetTextTrack()
 void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 {
 	AAMPLOG_INFO("enabled %s", enabled?"true":"false");
-	{
+	auto playerState=GetState();
+	// This process will be blocking if we've already entered a playback state.
+	// This is a workaround where SetCCStatus is called whilst Tune is in progress (StreamLock held) from an EPG Stop call.
+	// Note: CC status can be changed at any time during playback and we do not want to ignore this if StreamLock is currently taken.
+	// The alternative would be to allow TryStreamLock() to have a timeout ~1s, but this might be less predictable.
+	bool allowDeferredApplication =	
+					((playerState == eSTATE_IDLE)         ||
+					(playerState == eSTATE_INITIALIZING) ||
+					(playerState == eSTATE_INITIALIZED)  ||
+					(playerState == eSTATE_PREPARING)    ||
+					(playerState == eSTATE_PREPARED)     ||
+					(playerState == eSTATE_STOPPING)     ||
+					(playerState == eSTATE_STOPPED)
+					);
+	// Set subtitles_muted flag to the value requested by the app
+	subtitles_muted = !enabled;
+
+	if(allowDeferredApplication)
+	{		
+		std::unique_lock<std::recursive_mutex> lock(mStreamLock, std::try_to_lock);
+		if( lock.owns_lock() )
+		{
+			SetCCStatusInternal();
+		}
+		else
+		{
+			AAMPLOG_WARN("CC status value has been cached, subtitles_muted = %d, playerState=%d", subtitles_muted.load(), playerState);
+			mApplyCachedCCStatus=true; // can't do it now, but remember that we want to apply this
+		}
+	}
+	else
+	{			
 		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
-		// Set subtitles_muted flag to the value requested by the app
-		subtitles_muted = !enabled;
 		SetCCStatusInternal();
 	}
 }

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6479,8 +6479,19 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 				{
 					sink->SetVideoMute(video_muted.load());
 				}
-				SetCCStatusInternal();
-				mApplyCachedCCStatus = false;
+				if (mApplyCachedCCStatus.load())
+				{
+					// clear the flag in a thread safe manner
+					while (mApplyCachedCCStatus.exchange(false))
+					{
+						AAMPLOG_DEBUG("mApplyCachedCCStatus=true, setting CCStatus");
+						SetCCStatusInternal();
+					}
+				}
+				else
+				{
+					SetCCStatusInternal();
+				}
 				sink->SetAudioVolume(volume);
 				if (mbPlayEnabled)
 				{
@@ -7099,7 +7110,6 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 				//These two fns are being called in PlayerInstanceAAMP::SetVideoMute
 				SetVideoMuteInternal(video_muted.load());
 				SetCCStatusInternal();
-				mApplyCachedCCStatus=false;
 			}
 			else
 			{
@@ -7108,8 +7118,11 @@ void PrivateInstanceAAMP::Tune(const char *mainManifestUrl,
 		}
 		else if (mApplyCachedCCStatus.load())
 		{
-			SetCCStatusInternal();
-			mApplyCachedCCStatus=false;
+			while (mApplyCachedCCStatus.exchange(false))
+			{
+				SetCCStatusInternal();
+				AAMPLOG_DEBUG("mApplyCachedCCStatus has been applied");
+			}
 		}
 	}
 
@@ -8599,8 +8612,8 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	SetLocalAAMPTsbInjection(false);
 	auto streamLockStartTime = NOW_STEADY_TS_MS;
 	auto streamLockStopTime = NOW_STEADY_TS_MS;
-	auto licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
-	auto licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;
+	auto licenseAcquisitionLockStartTime = NOW_STEADY_TS_MS;
+	auto licenseAcquisitionLockStopTime = NOW_STEADY_TS_MS;
 	// Stopping the playback, release all DRM context
 	{
 		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
@@ -8622,9 +8635,9 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 				// StreamAbstractionAamp object from TeardownStream(). Otherwise it can
 				// lead to crash as PreFetchThread can call UpdateFailedDRMStatus
 				// of StreamAbstractionAamp.
-				licenseAquisitionLockStartTime = NOW_STEADY_TS_MS;
+				licenseAcquisitionLockStartTime = NOW_STEADY_TS_MS;
 				mDRMLicenseManager->SetLicenseFetcher(nullptr);
-				licenseAquisitionLockStopTime = NOW_STEADY_TS_MS;
+				licenseAcquisitionLockStopTime = NOW_STEADY_TS_MS;
 			}
 			if (HasSidecarData())
 			{ // has sidecar data
@@ -8779,10 +8792,10 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 
 	AampStreamSinkManager::GetInstance().DeactivatePlayer(this, true);
 	unsigned int mLastStopDurationMs = (unsigned)(NOW_STEADY_TS_MS - stopStartTime);
-	AAMPLOG_WARN("AAMP Stop took %u ms; streamLock %u, SetLicenceFetcher %u, Teardown %u",
+	AAMPLOG_WARN("AAMP Stop took %u ms; streamLock %u, SetLicenseFetcher %u, Teardown %u",
 		mLastStopDurationMs,
 		(unsigned int)(streamLockStopTime - streamLockStartTime),
-		(unsigned int)(licenseAquisitionLockStopTime- licenseAquisitionLockStartTime),
+		(unsigned int)(licenseAcquisitionLockStopTime - licenseAcquisitionLockStartTime),
 		(unsigned int)(tearDownEndTime - tearDownStartTime)	);
 	profiler.mStopDurationMs = mLastStopDurationMs;
 
@@ -12113,6 +12126,10 @@ void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 	else
 	{			
 		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
+		if (mApplyCachedCCStatus.load())
+		{
+			AAMPLOG_DEBUG("mApplyCachedCCStatus=true, setting CCStatus");
+		}
 		SetCCStatusInternal();
 	}
 }

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -1185,6 +1185,7 @@ public:
 	bool playerStartedWithTrickPlay; 			/**< To indicate player switch happened in trickplay rate */
 	bool userProfileStatus; 				/**< Select profile based on user list*/
 	bool mApplyCachedVideoMute;				/**< To apply video mute() operations if it has been cached due to tune in progress */
+	std::atomic_bool mApplyCachedCCStatus;				/**< To apply cached subtitle/CC operations if cached due to tune in progress */
 	std::vector<uint8_t> mcurrent_keyIdArray;		/**< Current KeyID for DRM license */
 	DynamicDrmInfo mDynamicDrmDefaultconfig;		/**< Init drmConfig stored as default config */
 	std::vector<std::string> mDynamicDrmCache;


### PR DESCRIPTION
Reason for change: If Streamlock is not available, then apply this setting later. This is to reduce delays during channel zapping, reducing likelihood of EPG timeouts. Note: This still blocks on Streamlock if in a playing related state (e.g. user invoked subtitle change), since deferred settings are applied during tune.

This also includes some useful future debug for stop timings, since fixing this has pushed delays further into stop calls during channel zapping. E.g. Delays now seen acquiring the async task execution mutex during stop when an async task tune is still in progress, i.e. in SuspendScheduler.

Test Procedure: Check that the EPG stop sequence is not timing out. We still may see the occasional AS timeout in Stop (which includes _setClosedCaptionStatus & _stop calls).