### PR TITLE
VPAAMP-738 Enable GH actions L1s as part of PRs with support branches as base

### DIFF
--- a/.github/workflows/L1-tests.yml
+++ b/.github/workflows/L1-tests.yml
@@ -2,7 +2,10 @@ name: L1 tests
 
 on:
   pull_request:
-    branches: [ develop, dev_sprint_25_2 ]
+    branches:
+      - develop
+      - dev_sprint_25_2
+      - 'support/**'
 
 jobs:
   execute-unit-tests-on-pr:


### PR DESCRIPTION
Reason for change: To add L1 test run to support branches
Risks: Low
Priority: P1