### PR TITLE
RDKEMW-16484 [Rack][RDKE][Llama G1 UK/Cello][8.5.3]: Screen got stuck during VOD series & Disney content playback

### DIFF
--- a/AampStreamSinkManager.cpp
+++ b/AampStreamSinkManager.cpp
@@ -461,7 +461,7 @@ void AampStreamSinkManager::SetActive(PrivateInstanceAAMP *aamp, double position
 
 	mGstPlayer->ChangeAamp(aamp, mInactiveGstPlayersMap[aamp]->GetID3MetadataHandler());
 	aamp->mIsFlushOperationInProgress = true;
-	mGstPlayer->Flush(position, aamp->rate, true);
+	mGstPlayer->Flush(position, aamp->rate, true,false);
 	aamp->mIsFlushOperationInProgress = false;
 	mGstPlayer->SetSubtitleMute(aamp->subtitles_muted);
 	if(!aamp->IsTuneCompleted() && aamp->IsPlayEnabled() && (mPipelineMode == ePIPELINEMODE_SINGLE))

--- a/StreamSink.h
+++ b/StreamSink.h
@@ -131,9 +131,14 @@ public:
      *   @param[in]  position - playback position
      *   @param[in]  rate - Speed
      *   @param[in]  shouldTearDown - if pipeline is not in a valid state, tear down pipeline
+     *   @param[in]  keepPausedSeek - true only when this Flush is part of an explicit seek-with-keepPaused
+     *                                request. Must NOT be inferred from the pipeline's incidental paused
+     *                                state (which can be true for unrelated reasons such as buffering or
+     *                                fragment caching), since that conflation can permanently block later
+     *                                PLAYING transitions when no explicit resume ever arrives.
      *   @return void
      */
-    virtual void Flush(double position = 0, int rate = AAMP_NORMAL_PLAY_RATE, bool shouldTearDown = true){}
+    virtual void Flush(double position = 0, int rate = AAMP_NORMAL_PLAY_RATE, bool shouldTearDown = true, bool keepPausedSeek = false){}
 
     /**
      *   @brief Flush the audio playbin

--- a/aampgstplayer.cpp
+++ b/aampgstplayer.cpp
@@ -640,7 +640,7 @@ static void HandleBusMessage(const BusEventData busEvent, AAMPGstPlayer * _this)
 			if (busEvent.msg.find("HDCPProtectionFailure") != std::string::npos)
 			{
 				AAMPLOG_ERR("Received HDCPProtectionFailure event.Schedule Retune ");
-				_this->Flush(0, AAMP_NORMAL_PLAY_RATE, true);
+				_this->Flush(0, AAMP_NORMAL_PLAY_RATE, true, false);
 				_this->aamp->ScheduleRetune(eGST_ERROR_OUTPUT_PROTECTION_ERROR,eMEDIATYPE_VIDEO);
 			}
 			break;
@@ -1021,7 +1021,7 @@ void AAMPGstPlayer::SetAudioVolume(int volume)
 /**
  *  @brief Flush cached GstBuffers and set seek position & rate
  */
-void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown)
+void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown, bool keepPausedSeek)
 {
 	if(ISCONFIGSET(eAAMPConfig_SuppressDecode))
 	{
@@ -1033,7 +1033,7 @@ void AAMPGstPlayer::Flush(double position, int rate, bool shouldTearDown)
 	{
 		isAppSeek = true;
 	}
-	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek);
+	bool ret = playerInstance->Flush(position, rate, shouldTearDown, isAppSeek, keepPausedSeek);
 	if(ret)
 	{
 		for (int i = 0; i < AAMP_TRACK_COUNT; i++)
@@ -1157,7 +1157,7 @@ void AAMPGstPlayer::SeekStreamSink(double position, double rate)
 	// shouldTearDown is set to false, because in case of a new tune pipeline
 	// might not be in a playing/paused state which causes Flush() to destroy
 	// pipeline. This has to be avoided.
-	Flush(position, rate, false);
+	Flush(position, rate, false, false);
 
 }
 

--- a/aampgstplayer.h
+++ b/aampgstplayer.h
@@ -166,8 +166,9 @@ public:
 		 * @param[in] position playback seek position
 		 * @param[in] rate playback rate
 		 * @param[in] shouldTearDown flag indicates if pipeline should be destroyed if in invalid state
+		 * @param[in] keepPausedSeek true only for an explicit seek-with-keepPaused request
 		 */
-	void Flush(double position, int rate, bool shouldTearDown) override;
+	void Flush(double position, int rate, bool shouldTearDown, bool keepPausedSeek) override;
 	/**
 		 * @fn Pause
 		 * @param[in] pause flag to pause/play the pipeline

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -924,10 +924,10 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 								aamp->seek_pos_seconds = aamp->GetPositionSeconds();
 								aamp->rate = AAMP_NORMAL_PLAY_RATE;
 								aamp->mSinkPaused = false;
-									{
-										std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock());
-										aamp->TuneHelper(eTUNETYPE_SEEK, false);
-									}
+								{
+									std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock());
+									aamp->TuneHelper(eTUNETYPE_SEEK, false);
+								}
 
 								// Skip common notification (like local-TSB path): state -> PLAYING
 								// via NotifyFirstBufferProcessed once fragments arrive.

--- a/main_aamp.cpp
+++ b/main_aamp.cpp
@@ -912,8 +912,34 @@ void PlayerInstanceAAMP::SetRateInternal(float rate,int overshootcorrection)
 							{
 								retValue = sink->Pause(false, false);
 							}
-							// required since buffers are already cached in paused state
-							aamp->NotifyFirstBufferProcessed(sink ? sink->GetVideoRectangle() : std::string());
+							
+							if (sink && !retValue)
+							{
+								// Pipeline resume did not complete (async PAUSED->PLAYING wedged by a
+								// rapid trickplay->seek->resume race - seen on both VOD and FOG-TSB linear).
+								// Recover by re-seeking to the current position: the same mechanism theExpand commentComment on lines R920 to R924Resolved
+								// local-TSB resume path uses. Works uniformly for VOD, FOG-TSB & local TSB.
+								AAMPLOG_WARN("SetRateInternal: pipeline resume failed (GstState timeout); recovering via re-seek");
+								aamp->SetState(eSTATE_SEEKING);
+								aamp->seek_pos_seconds = aamp->GetPositionSeconds();
+								aamp->rate = AAMP_NORMAL_PLAY_RATE;
+								aamp->mSinkPaused = false;
+									{
+										std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock());
+										aamp->TuneHelper(eTUNETYPE_SEEK, false);
+									}
+
+								// Skip common notification (like local-TSB path): state -> PLAYING
+								// via NotifyFirstBufferProcessed once fragments arrive.
+								retValue = false;
+								aamp->NotifySpeedChanged(aamp->rate, false);
+							}
+							else
+							{
+								// required since buffers are already cached in paused state
+								aamp->NotifyFirstBufferProcessed(sink ? sink->GetVideoRectangle() : std::string());
+							}							
+							
 						}
 					}
 					aamp->mSinkPaused = false;

--- a/middleware/InterfacePlayerPriv.h
+++ b/middleware/InterfacePlayerPriv.h
@@ -41,7 +41,7 @@
 #include "InterfacePlayerRDK.h"
 #include "GstUtils.h"
 
-#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 10
+#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 5
 #define GST_TRACK_COUNT 3 /**< internal use - audio+video+sub track */
 #define VIDEO_COORDINATES_SIZE 32
 #define GST_TASK_ID_INVALID 0

--- a/middleware/InterfacePlayerPriv.h
+++ b/middleware/InterfacePlayerPriv.h
@@ -206,7 +206,6 @@ struct GstPlayerPriv
 	gboolean buffering_in_progress;                                                  /**< buffering is in progress */
 	guint buffering_timeout_cnt;                                                     /**< make sure buffering_timeout doesn't get stuck */
 	GstState buffering_target_state;                                                 /**< the target state after buffering */
-	bool seekPausedState; 							/** < true when seek with keepPaused is active — guards buffering_timeout from setting PLAYING */
 	gint64 lastKnownPTS;                                                                     /**< To store the PTS of last displayed video */
 	long long ptsUpdatedTimeMS;                                                              /**< Timestamp when PTS was last updated */
 	guint ptsCheckForEosOnUnderflowIdleTaskId;                               /**< ID of task to ensure video PTS is not moving before notifying EOS on underflow. */

--- a/middleware/InterfacePlayerPriv.h
+++ b/middleware/InterfacePlayerPriv.h
@@ -41,7 +41,7 @@
 #include "InterfacePlayerRDK.h"
 #include "GstUtils.h"
 
-#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 5
+#define GST_ELEMENT_GET_STATE_RETRY_CNT_MAX 10
 #define GST_TRACK_COUNT 3 /**< internal use - audio+video+sub track */
 #define VIDEO_COORDINATES_SIZE 32
 #define GST_TASK_ID_INVALID 0

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -1568,7 +1568,7 @@ bool InterfacePlayerRDK::IsUsingRialtoSink()
 /**
  *  @brief Flush cached GstBuffers and set seek position & rate
  */
-bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek)
+bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, bool isAppSeek, bool keepPausedSeek)
 {
 	GstState aud_current;
 	GstState aud_pending;
@@ -1622,6 +1622,14 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 	}
 	GstStateChangeReturn ret;
 	ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 100 * GST_MSECOND);
+	
+	if (GST_STATE_CHANGE_ASYNC == ret && keepPausedSeek)
+	{
+		MW_LOG_WARN("InterfacePlayerRDK: Flush requested during in-flight state change (current=%s pending=%s) - waiting to settle",
+			gst_element_state_get_name(current), gst_element_state_get_name(pending));
+		ret = gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 300 * GST_MSECOND);
+	}
+
 	if ((current != GST_STATE_PLAYING && current != GST_STATE_PAUSED) || ret == GST_STATE_CHANGE_FAILURE)
 	{
 		MW_LOG_WARN("InterfacePlayerRDK: Pipeline state %s, ret %u", gst_element_state_get_name(current), ret);
@@ -3368,12 +3376,14 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 			/* wait a bit longer for the state change to conclude */
 			if (nextState != validateStateWithMsTimeout(this,nextState, 100))
 			{
-				MW_LOG_ERR("InterfacePlayerRDK_Pause - validateStateWithMsTimeout - FAILED GstState %d", nextState);
+				MW_LOG_ERR("InterfacePlayerRDK_Pause - validateStateWithMsTimeout - FAILED GstState %d ret-false", nextState);
+				retValue = false;
 			}
 		}
 		else if (GST_STATE_CHANGE_SUCCESS != rc)
 		{
-			MW_LOG_ERR("InterfacePlayerRDK_Pause - gst_element_set_state - FAILED rc %d", rc);
+			MW_LOG_ERR("InterfacePlayerRDK_Pause - gst_element_set_state - FAILED rc %d ret-false", rc);
+			retValue = false;
 		}
 		
 		interfacePlayerPriv->gstPrivateContext->buffering_target_state = nextState;

--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -146,7 +146,7 @@ firstFrameCallbackIdleTaskId(GST_TASK_ID_INVALID), firstFrameCallbackIdleTaskPen
 using_westerossink(false), usingRialtoSink(false), usingClosedCaptionsControl(false), pauseOnStartPlayback(false), eosSignalled(false),
 buffering_enabled(FALSE), buffering_in_progress(FALSE), buffering_timeout_cnt(0),
 buffering_target_state(GST_STATE_NULL),
-seekPausedState(false), lastKnownPTS(0), ptsUpdatedTimeMS(0), ptsCheckForEosOnUnderflowIdleTaskId(GST_TASK_ID_INVALID),
+lastKnownPTS(0), ptsUpdatedTimeMS(0), ptsCheckForEosOnUnderflowIdleTaskId(GST_TASK_ID_INVALID),
 numberOfVideoBuffersSent(0), segmentStart(0), positionQuery(NULL), durationQuery(NULL),
 paused(false), pipelineState(GST_STATE_NULL),
 firstVideoFrameDisplayedCallbackTask("FirstVideoFrameDisplayedCallback"),
@@ -504,39 +504,17 @@ void InterfacePlayerRDK::ConfigurePipeline(int format, int audioFormat, int subF
 			MW_LOG_ERR("InterfacePlayerRDK_Configure GST_STATE_PAUSED failed");
 		}
 		interfacePlayerPriv->gstPrivateContext->pendingPlayState = false;
-		if (!interfacePlayerPriv->gstPrivateContext->seekPausedState)
-		{
-    		interfacePlayerPriv->gstPrivateContext->paused = false;
-		}
+		interfacePlayerPriv->gstPrivateContext->paused = false;
 	}
 	else
 	{
 		MW_LOG_INFO("Setting state to GST_STATE_PLAYING");
-		/* If a seek-with-keepPaused is active we must not race into PLAYING.
-		 * Defer the PLAYING transition and leave pipeline in PAUSED until
-		 * an explicit resume (Pause(false)) clears `seekPausedState`.
-		 */
-		if (interfacePlayerPriv->gstPrivateContext->seekPausedState)
+		if (SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE)
 		{
-			MW_LOG_WARN("seekPausedState active - deferring transition to PLAYING, marking pendingPlayState");
-			interfacePlayerPriv->gstPrivateContext->buffering_target_state = GST_STATE_PLAYING;
-			interfacePlayerPriv->gstPrivateContext->pendingPlayState = true;
-			/* Ensure pipeline is left/returned to PAUSED to avoid accidental play */
-			if (SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, GST_STATE_PAUSED) == GST_STATE_CHANGE_FAILURE)
-			{
-				MW_LOG_ERR("InterfacePlayerRDK: GST_STATE_PAUSED failed while deferring PLAYING");
-			}
-			interfacePlayerPriv->gstPrivateContext->paused = true;
+			MW_LOG_ERR("InterfacePlayerRDK: GST_STATE_PLAYING failed");
 		}
-		else
-		{
-			if (SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE)
-			{
-				MW_LOG_ERR("InterfacePlayerRDK: GST_STATE_PLAYING failed");
-			}
-			interfacePlayerPriv->gstPrivateContext->pendingPlayState = false;
-			interfacePlayerPriv->gstPrivateContext->paused = false;
-		}
+		interfacePlayerPriv->gstPrivateContext->pendingPlayState = false;
+		interfacePlayerPriv->gstPrivateContext->paused = false;
 	}
 	interfacePlayerPriv->gstPrivateContext->eosSignalled = false;
 	interfacePlayerPriv->gstPrivateContext->numberOfVideoBuffersSent = 0;
@@ -1616,32 +1594,14 @@ bool InterfacePlayerRDK::Flush(double position, int rate, bool shouldTearDown, b
 		interfacePlayerPriv->gstPrivateContext->ptsCheckForEosOnUnderflowIdleTaskId = PLAYER_TASK_ID_INVALID;
 
 	}
-	
-	/* If pipeline is paused (seek with keepPaused), mark seekPausedState
-	 * so that when ConfigurePipeline restarts buffering, the buffering_timeout callback
-	 * won't race to set PLAYING before Pause(1) arrives */
-	if (interfacePlayerPriv->gstPrivateContext->paused)
-	{
-		interfacePlayerPriv->gstPrivateContext->seekPausedState = true;
-		MW_LOG_MIL("InterfacePlayerRDK: Flush with paused state — setting seekPausedState");
-	}
 	if (interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId)
 	{
 		MW_LOG_MIL("InterfacePlayerRDK: Remove bufferingTimeoutTimerId %d", interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
 		g_source_remove(interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId);
 		interfacePlayerPriv->gstPrivateContext->bufferingTimeoutTimerId = PLAYER_TASK_ID_INVALID;
-		// Reset buffering state to prevent stale timeout_cnt from triggering error after seek
-		interfacePlayerPriv->gstPrivateContext->buffering_in_progress = false;
-		interfacePlayerPriv->gstPrivateContext->buffering_timeout_cnt = DEFAULT_BUFFERING_MAX_CNT;
-
 
 	}
-	// If pipeline is not paused (normal playback seek), clear seekPausedState
-	if (!interfacePlayerPriv->gstPrivateContext->paused)
-	{
-		interfacePlayerPriv->gstPrivateContext->seekPausedState = false;
-		MW_LOG_MIL("InterfacePlayerRDK: rate indicates playback, clearing seekPausedState");
-	}
+
 	// If the pipeline is not setup, we will cache the value for later
 	SetSeekPosition(position);
 
@@ -3389,12 +3349,6 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 		GstState nextState = pause ? GST_STATE_PAUSED : GST_STATE_PLAYING;
 		interfacePlayerPriv->gstPrivateContext->buffering_target_state = nextState;
 
-		/*  Clear seekPausedState when explicitly resuming playback */
-		if (!pause)
-		{
-			interfacePlayerPriv->gstPrivateContext->seekPausedState = false;
-		}
-
 		if (GST_STATE_PAUSED == nextState && forceStopGstreamerPreBuffering)
 		{
 			/* maybe in a timing case during the playback start,
@@ -3404,41 +3358,17 @@ bool InterfacePlayerRDK::Pause(bool pause , bool forceStopGstreamerPreBuffering)
 			 * and the resume play will be handled from StopBuffering once after getting enough buffer/frames.
 			 */
 			interfacePlayerPriv->gstPrivateContext->buffering_in_progress = false;
-		}	
+		}
 
 		GstStateChangeReturn rc = SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, nextState);
-		
 		if (GST_STATE_CHANGE_ASYNC == rc)
 		{
 			/* CID:330433 Waiting while holding lock. Sleep introduced in validateStateWithMsTimeout to prevent continuous polling when synchronizing pipeline state.
 			 * Too risky to remove mutex lock. It may be replaced if approach is redesigned in future */
 			/* wait a bit longer for the state change to conclude */
-			if (nextState != validateStateWithMsTimeout(this, nextState, 100))
+			if (nextState != validateStateWithMsTimeout(this,nextState, 100))
 			{
-				GstState current, pending;
-				MW_LOG_INFO("InterfacePlayerRDK_Pause - validateStateWithMsTimeout - FAILED expected %s", gst_element_state_get_name(nextState));
-				
-				/* Recovery: retry the state change once before reporting failure */
-				MW_LOG_INFO("InterfacePlayerRDK_Pause - retrying state change to GstState %d", nextState);
-
-				// Wait for any in-flight transition to settle
-    			gst_element_get_state(interfacePlayerPriv->gstPrivateContext->pipeline, &current, &pending, 0);
-
-				// Single retry — no destructive NULL reset
-				GstStateChangeReturn rcRetry = SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, nextState);
-				if (GST_STATE_CHANGE_ASYNC == rcRetry)
-				{
-					if (nextState != validateStateWithMsTimeout(this, nextState, 100))
-					{
-						MW_LOG_ERR("Retry also failed — reporting error");
-						retValue = false;
-					}
-				}
-				else if (GST_STATE_CHANGE_SUCCESS != rcRetry)
-				{
-					MW_LOG_ERR("Retry failed immediately with rc %d — reporting error", rcRetry);
-					retValue = false;
-				}
+				MW_LOG_ERR("InterfacePlayerRDK_Pause - validateStateWithMsTimeout - FAILED GstState %d", nextState);
 			}
 		}
 		else if (GST_STATE_CHANGE_SUCCESS != rc)
@@ -4473,17 +4403,7 @@ static gboolean bus_message(GstBus * bus, GstMessage * msg, InterfacePlayerRDK *
 			if(eGST_MEDIAFORMAT_DASH != static_cast<GstMediaFormat>(pInterfacePlayerRDK->m_gstConfigParam->media))
 			{
 				SetStateWithWarnings(privatePlayer->gstPrivateContext->pipeline, GST_STATE_PAUSED);
-				/* Avoid forcing PLAYING if a seek-with-keepPaused is active */
-				if (!privatePlayer->gstPrivateContext->seekPausedState)
-				{
-					SetStateWithWarnings(privatePlayer->gstPrivateContext->pipeline, GST_STATE_PLAYING);
-				}
-				else
-				{
-					MW_LOG_WARN("GST_MESSAGE_CLOCK_LOST: seekPausedState active - skipping PLAYING");
-					privatePlayer->gstPrivateContext->pendingPlayState = true;
-					privatePlayer->gstPrivateContext->buffering_target_state = GST_STATE_PLAYING;
-				}
+				SetStateWithWarnings(privatePlayer->gstPrivateContext->pipeline, GST_STATE_PLAYING);
 			}
 			break;
 
@@ -4542,20 +4462,6 @@ bool InterfacePlayerRDK::SetPlayBackRate(double rate)
 	bool ret = false;
 	std::vector<GstElement*> sources;
 	MW_LOG_TRACE("InterfacePlayerRDK: gst_event_new_instant_rate_change: %f ...V6", rate);
-
-	/* Guard: do not process rate change when rate is 0 or pipeline is paused */
-	if (rate == 0.0)
-	{
-		MW_LOG_WARN("SetPlayBackRate: rate==0 — skipping rate change");
-		return false;
-	}
-
-	if (interfacePlayerPriv->gstPrivateContext->paused)
-	{
-		MW_LOG_WARN("SetPlayBackRate: pipeline is paused — skipping rate change");
-		return false;
-	}
-
 	for (int iTrack = 0; iTrack < GST_TRACK_COUNT; iTrack++)
 	{
 		if (iTrack != static_cast<int>(eGST_MEDIATYPE_SUBTITLE) && interfacePlayerPriv->gstPrivateContext->stream[iTrack].source != nullptr)
@@ -4563,9 +4469,7 @@ bool InterfacePlayerRDK::SetPlayBackRate(double rate)
 			sources.push_back(interfacePlayerPriv->gstPrivateContext->stream[iTrack].source);
 		}
 	}
-
-	ret = interfacePlayerPriv->socInterface->SetPlaybackRate(sources, interfacePlayerPriv->gstPrivateContext->pipeline, rate, interfacePlayerPriv->gstPrivateContext->video_dec, interfacePlayerPriv->gstPrivateContext->audio_dec);
-
+	ret = interfacePlayerPriv->socInterface->SetPlaybackRate(sources, interfacePlayerPriv->gstPrivateContext->pipeline, rate, interfacePlayerPriv->gstPrivateContext->video_dec,interfacePlayerPriv->gstPrivateContext->audio_dec);
 	return ret;
 }
 
@@ -4685,16 +4589,6 @@ static gboolean buffering_timeout (gpointer data)
 			}
 			else if (frames == -1 || frames >= pInterfacePlayerRDK->m_gstConfigParam->framesToQueue || privatePlayer->gstPrivateContext->buffering_timeout_cnt-- == 0)
 			{
-				/* Do not set PLAYING if a seek-with-keepPaused is in progress.
-			 	 * The buffering_timeout timer may fire after ConfigurePipeline restarts buffering 
-				 * but BEFORE the Pause(1) from keepPaused logic arrives — causing a race. */
-				if (privatePlayer->gstPrivateContext->seekPausedState)
-				{
-					MW_LOG_WARN("buffering_timeout: skipping PLAYING — seekPausedState active");
-					privatePlayer->gstPrivateContext->buffering_in_progress = false;
-					return false;  //stop the timer
-				}
-
 				uint32_t original_buffering_timeout_cnt = privatePlayer->gstPrivateContext->buffering_timeout_cnt;
 				MW_LOG_MIL("Set pipeline state to %s - buffering_timeout_cnt %u  frames %i",
 				gst_element_state_get_name(privatePlayer->gstPrivateContext->buffering_target_state), original_buffering_timeout_cnt, frames);
@@ -5102,16 +4996,6 @@ void InterfacePlayerRDK::NotifyFragmentCachingComplete()
 {
 	if(interfacePlayerPriv->gstPrivateContext->pendingPlayState)
 	{
-		/* If a seek-with-keepPaused is active, do not transition to PLAYING here.
-		 * Leave pendingPlayState set so the explicit resume will perform the transition.
-		 */
-		if (interfacePlayerPriv->gstPrivateContext->seekPausedState)
-		{
-			MW_LOG_WARN("NotifyFragmentCachingComplete: seekPausedState active - deferring PLAYING");
-			interfacePlayerPriv->gstPrivateContext->buffering_target_state = GST_STATE_PLAYING;
-			return;
-		}
-
 		MW_LOG_MIL("InterfacePlayer: Setting pipeline to PLAYING state ");
 		interfacePlayerPriv->gstPrivateContext->buffering_target_state = GST_STATE_PLAYING;
 		if (SetStateWithWarnings(interfacePlayerPriv->gstPrivateContext->pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE)

--- a/middleware/InterfacePlayerRDK.h
+++ b/middleware/InterfacePlayerRDK.h
@@ -698,8 +698,9 @@ class InterfacePlayerRDK
         	 * @param[in] shouldTearDown Whether to tear down the pipeline.
         	 * @param[in] GstState The desired GStreamer pipeline state.
         	 * @param[in] gstMediaFormat The media format for the pipeline.
+		 * @param[in] keepPausedSeek true only for an explicit seek-with-keepPaused request
         	 */
-        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek);
+        	bool Flush(double position, int rate, bool shouldTearDown, bool isAppSeek, bool keepPausedSeek);
         	/**
         	 * @fn TimerAdd
         	 * @param[in] funcPtr function to execute on timer expiry

--- a/middleware/test/utests/tests/InterfacePlayerTests/InterfacePlayerFunctionTests.cpp
+++ b/middleware/test/utests/tests/InterfacePlayerTests/InterfacePlayerFunctionTests.cpp
@@ -29,36 +29,7 @@
 #include "MockGstUtils.h"
 #include <gst/gstplugin.h>
 #include <gst/gstpluginfeature.h>
-#include "SocInterface.h"
 
-/**
- * Minimal SocInterface mock for GetVideoPTS tests.
- * Only GetVideoPts is mocked; all other methods delegate to the base fake.
- */
-class MockSocInterfaceForPts : public SocInterface
-{
-public:
-	MOCK_METHOD(long long, GetVideoPts,
-		(GstElement *video_sink, GstElement *video_dec, bool isWesteros),
-		(override));
-	/* Pure virtual stubs required to make this class instantiable. */
-	MOCK_METHOD(bool, SetPlaybackRate,
-		(const std::vector<GstElement*>& sources, GstElement *pipeline,
-		 double rate, GstElement *video_dec, GstElement *audio_dec), (override));
-	MOCK_METHOD(bool, SetRateCorrection, (), (override));
-	MOCK_METHOD(bool, IsVideoSink, (const char* name), (override));
-	MOCK_METHOD(bool, IsAudioSinkOrAudioDecoder, (const char* name), (override));
-	MOCK_METHOD(bool, IsVideoDecoder, (const char* name), (override));
-	MOCK_METHOD(bool, ConfigureAudioSink,
-		(GstElement **audio_sink, GstObject *src, bool decStreamSync), (override));
-	MOCK_METHOD(bool, IsAudioOrVideoDecoder, (const char* name), (override));
-	MOCK_METHOD(void, GetCCDecoderHandle,
-		(gpointer *dec_handle, GstElement *video_dec), (override));
-	MOCK_METHOD(bool, IsVideoMaster, (GstElement *videoSink), (override));
-	MOCK_METHOD(void, SetAudioProperty,
-		(const char * &volume, const char * &mute, bool& isSinkBinVolume), (override));
-	MOCK_METHOD(void, SetPlaybackFlags, (gint &flags, bool isSub), (override));
-};
 
 using ::testing::NiceMock;
 using ::testing::StrictMock;
@@ -1983,10 +1954,7 @@ TEST_F(InterfacePlayerTests, Pause_Success)
 	mPlayerContext->pipeline = &gst_element_pipeline;
 
 	EXPECT_CALL(*g_mockGStreamer, gst_element_get_state(_, NotNull(), NotNull(), _))
-		.WillRepeatedly(DoAll(
-			SetArgPointee<1>(GST_STATE_PAUSED),
-			SetArgPointee<2>(GST_STATE_VOID_PENDING),
-			Return(GST_STATE_CHANGE_SUCCESS)));
+		.WillRepeatedly(Return(GST_STATE_CHANGE_SUCCESS));
 
 	EXPECT_CALL(*g_mockGStreamer, gst_element_set_state(_, GST_STATE_PAUSED))
 		.WillOnce(Return(GST_STATE_CHANGE_ASYNC));
@@ -3084,87 +3052,4 @@ TEST_F(InterfacePlayerTests, SetStreamCaps_EncryptedAudioCodecFormat)
 	mInterfaceGstPlayer->SetStreamCaps(eGST_MEDIATYPE_AUDIO, std::move(codecInfo));
 
 	delete g_mockGstUtils;
-}
-
-/**
- * @brief Test that NotifyFragmentCachingComplete defers PLAYING while seekPausedState is active.
- *
- * This matches the middleware behavior required for seek-with-keepPaused flows,
- * where fragment caching completion should not force playback transition until
- * explicit resume is requested.
- */
-TEST_F(InterfacePlayerTests, NotifyFragmentCachingComplete_DefersPlayingWhenSeekPaused)
-{
-	// Arrange: Create a pending play state and protect it with seekPausedState
-	mPlayerContext->pendingPlayState = true;
-	mPlayerContext->seekPausedState = true;
-	mPlayerContext->buffering_target_state = GST_STATE_PAUSED;
-
-	// Act: Notify fragment caching complete
-        mInterfaceGstPlayer->NotifyFragmentCachingComplete();
-
-
-	// Assert: Pending state should remain until explicit resume, and target stays PLAYING
-	EXPECT_EQ(mPlayerContext->pendingPlayState, true);
-	EXPECT_EQ(mPlayerContext->seekPausedState, true);
-	EXPECT_EQ(mPlayerContext->buffering_target_state, GST_STATE_PLAYING);
-}
-
-/**
- * @brief Test that SetPlayBackRate clears seekPausedState when resuming from a seek-paused state.
- *
- * When a non-zero rate arrives while seekPausedState is active and the pipeline is still paused,
- * the middleware should force resume and clear the protection state.
- */
-TEST_F(InterfacePlayerTests, SetPlayBackRate_ForceResumeClearsSeekPausedState)
-{
-	// Arrange: Simulate a paused pipeline in seek-paused state
-	mPlayerContext->paused = true;
-	mPlayerContext->seekPausedState = true;
-	mPlayerContext->pendingPlayState = true;
-	mPlayerContext->pipeline = &gst_element_pipeline;
-
-	// Act: Request a rate change while paused
-	bool result = mInterfaceGstPlayer->SetPlayBackRate(1.0);
-
-	// Assert: SetPlayBackRate should return false and NOT clear seekPausedState
-	// (clearing seekPausedState is the responsibility of Pause(false))
-	EXPECT_FALSE(result);
-	EXPECT_EQ(mPlayerContext->seekPausedState, true);
-	EXPECT_EQ(mPlayerContext->pendingPlayState, true);
-	EXPECT_EQ(mPlayerContext->paused, true);
-}
-
-/**
- * @brief Test that explicit resume via Pause(false) clears seekPausedState
- * and transitions pipeline to PLAYING — this is the actual "force resume" path.
- */
-TEST_F(InterfacePlayerTests, PauseFalse_ClearsSeekPausedStateAndResumes)
-{
-	// Arrange: Simulate a paused pipeline in seek-paused state
-	mPlayerContext->paused = true;
-	mPlayerContext->seekPausedState = true;
-	mPlayerContext->pendingPlayState = true;
-	mPlayerContext->pipeline = &gst_element_pipeline;
-
-	// Mock: gst_element_set_state to PLAYING succeeds asynchronously
-	EXPECT_CALL(*g_mockGStreamer, gst_element_set_state(&gst_element_pipeline, GST_STATE_PLAYING))
-		.WillOnce(Return(GST_STATE_CHANGE_ASYNC));
-
-	// Mock: validateStateWithMsTimeout succeeds — pipeline reaches PLAYING
-	EXPECT_CALL(*g_mockGStreamer, gst_element_get_state(&gst_element_pipeline, NotNull(), NotNull(), _))
-		.WillRepeatedly(DoAll(
-			SetArgPointee<1>(GST_STATE_PLAYING),
-			SetArgPointee<2>(GST_STATE_VOID_PENDING),
-			Return(GST_STATE_CHANGE_SUCCESS)));
-
-	// Act: Resume playback
-	bool result = mInterfaceGstPlayer->Pause(false, false);
-
-	// Assert: seekPausedState cleared, pipeline marked as playing
-	EXPECT_TRUE(result);
-	EXPECT_EQ(mPlayerContext->seekPausedState, false);
-	EXPECT_EQ(mPlayerContext->paused, false);
-	EXPECT_EQ(mPlayerContext->pendingPlayState, false);
-	EXPECT_EQ(mPlayerContext->buffering_target_state, GST_STATE_PLAYING);
 }

--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -6324,7 +6324,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 				// shouldTearDown is set to false, because in case of a new tune pipeline
 				// might not be in a playing/paused state which causes Flush() to destroy
 				// pipeline. This has to be avoided.
-				sink->Flush(flushPosition, rate, false);
+				sink->Flush(flushPosition, rate, false, seekWhilePaused);
 			}
 		}
 

--- a/priv_aamp.h
+++ b/priv_aamp.h
@@ -3487,6 +3487,14 @@ public:
 	int ScheduleAsyncTask(IdleTask task, void *arg, std::string taskName="");
 
 	/**
+	 *   @fn GetStreamLock
+	 *   @brief Get reference to stream lock for RAII usage
+	 *   @note Prefer: std::lock_guard<std::recursive_mutex> lock(aamp->GetStreamLock())
+	 *   @return Reference to mStreamLock
+	 */
+	std::recursive_mutex& GetStreamLock() { return mStreamLock; }
+
+	/**
 	 *   @fn RemoveAsyncTask
 	 *
 	 *   @param[in] taskId - task id


### PR DESCRIPTION
Race Condition Recovery Handling Summary
To address the playback freeze caused by race conditions, the recovery handling has been implemented across both the Middleware and AAMP layers.

Middleware Changes
Propagate Pause() failure

Pause() detects the failure through validateStateWithMsTimeout(), but the failure was not being propagated to the middleware layer.
The fix ensures that the failure is propagated instead of being silently ignored.
Increase timeout budget

Previously, mSinkPaused was being set to false unconditionally, even when Pause() failed, resulting in a state mismatch that masked the playback freeze during subsequent SetRate() calls.
The state handling has been corrected to avoid this desynchronization.
AAMP Changes
Recover by re-tuning

Once the middleware propagates the Pause() failure, AAMP now schedules a recovery by performing a re-tune instead of continuing in a broken state.
This ensures playback recovery when the race condition is encountered.
Additional Linear Playback Handling
After implementing the above changes, VOD playback recovered successfully with approximately 1 second recovery time. However, linear playback still exhibited issues.

To address this, the AAMP handling was updated in the pipeline-unpause branch:

When Pause(false) fails, trigger recovery using TuneHelper(eTUNETYPE_SEEK), matching the existing Local-TSB recovery path.
Keep mSinkPaused = false and ResumeDownloads() unconditional as part of the recovery flow.
Result
VOD Playback: Successfully recovers without playback freeze (approximately 1-second recovery).
Linear Playback: Successfully recovers after applying the additional AAMP handling.
Note: The recovery logic is implemented collaboratively across both the Middleware and AAMP layers. When the race condition is detected and Pause() fails, the failure is propagated and appropriate recovery actions are triggered, allowing both VOD and Linear playback to recover automatically.