### PR TITLE
Harmonise prompt feedback scoring: make Assumptions higher-is-better

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,7 +83,9 @@ Copilot must still follow these steps:
 - Always assess prompt quality for every prompt and emit scores unless the scoring thresholds for suppression are met.
 - When feedback is not suppressed, use the following format:
 - Format: `Scores: Completeness X/10, Assumptions X/10, Clarity X/10, CostRisk X/10 | Critique: <brief> | Improve: <specific edit>`.
-- Scoring: Completeness and Clarity are higher-is-better; Assumptions and CostRisk are lower-is-better.
+- Scoring: Completeness, Clarity, and Assumptions are higher-is-better; CostRisk is lower-is-better.
+- **Assumptions** is higher-is-better: a high score means little or no
+  inference is required, and a low score means many assumptions are needed.
 - **CostRisk** estimates likely token usage and repository traversal behaviour.
   - Score higher when the prompt involves: large logs, many files, broad repository
     requests, unrestricted agent instructions, repeated context, or exploratory prompting.
@@ -91,13 +93,13 @@ Copilot must still follow these steps:
     and targets a specific outcome.
 - Strict rubric for underspecified prompts:
   - If the prompt is extremely vague (for example: "build something"), score it harshly.
-  - For these prompts, use: Completeness 0-3/10, Clarity 0-3/10, Assumptions 7-10/10.
+  - For these prompts, use: Completeness 0-3/10, Clarity 0-3/10, Assumptions 0-3/10.
   - If target, scope, constraints, or success criteria are omitted,
-    cap Completeness and Clarity at 7/10 and set Assumptions to at least 3/10.
+    cap Completeness, Clarity, and Assumptions at 7/10.
 - Keep it short and specific; avoid generic advice.
 - Never suppress scored feedback for underspecified prompts (including
   prompts that fall under the strict rubric above).
-- Suppress displayed feedback when Completeness >= 8, Assumptions <= 2,
+- Suppress displayed feedback when Completeness >= 8, Assumptions >= 8,
   Clarity >= 8, and CostRisk <= 3,
   unless the user explicitly asks to apply feedback to the current prompt.
 - Determine suppression from the current user prompt only; retrospective analysis of earlier prompts should be provided only when explicitly requested.

--- a/docs/GithubCopilot/CopilotGeneralUseGuidelines.md
+++ b/docs/GithubCopilot/CopilotGeneralUseGuidelines.md
@@ -469,7 +469,7 @@ The following factors increase CostRisk:
 ### Example Feedback Line
 
 ```text
-Scores: Completeness 7/10, Assumptions 3/10, Clarity 7/10, CostRisk 6/10
+Scores: Completeness 7/10, Assumptions 7/10, Clarity 7/10, CostRisk 6/10
 | Critique: Prompt includes a 1500-line log and asks for broad analysis
   without isolating the failure.
 | Improve: Extract the 30-50 lines around the DRM renewal failure and

--- a/docs/GithubCopilot/CopilotPromptGuidelines.md
+++ b/docs/GithubCopilot/CopilotPromptGuidelines.md
@@ -65,13 +65,13 @@ Scoring is interpreted as follows:
 | Score | Meaning |
 |---|---|
 | Completeness | Higher is better. Measures whether the prompt includes the goal, context, scope, constraints, evidence, and success criteria. |
-| Assumptions  | Lower is better. Measures how much Copilot must infer or guess. |
+| Assumptions  | Higher is better. Measures how few inferences or guesses Copilot must make; a high score means little or no guessing is required. |
 | Clarity      | Higher is better. Measures whether the request is specific, understandable, and actionable. |
 
 Developers should pay particular attention to feedback when:
 
 - Completeness is below 8
-- Assumptions is above 2
+- Assumptions is below 8
 - Clarity is below 8
 - Copilot suggests a more specific prompt wording
 - the critique says the prompt is too broad, underspecified, or likely to require unnecessary context
@@ -97,7 +97,7 @@ or:
 Fix playback.
 ```
 
-should be expected to receive low Completeness and Clarity scores, and a high Assumptions score.
+should be expected to receive low Completeness, Clarity, and Assumptions scores.
 
 Do not ignore this feedback. It is there to prevent common failure modes:
 


### PR DESCRIPTION
Invert the Assumptions metric so a high score means few/no assumptions are needed and a low score means many are required, removing the confusing high-low-high pattern. CostRisk remains lower-is-better.

Updated copilot-instructions.md and both CopilotGeneralUseGuidelines.md and CopilotPromptGuidelines.md (scale, rubric, thresholds, examples).