### PR TITLE
SERXIONE-8808: Gst-Plugin-load scan crash fix

### DIFF
--- a/middleware/InterfacePlayerRDK.cpp
+++ b/middleware/InterfacePlayerRDK.cpp
@@ -5250,6 +5250,10 @@ void InterfacePlayerRDK::InitializePlayerGstreamerPlugins()
 	}
 	SocUtils::Init();
 
+	// Phase 2: Now that GStreamer is initialized, re-detect platform from plugin registry if needed
+	SocInterface::InitializePlatformFromPlugins();
+
+
 #define PLUGINS_TO_LOWER_RANK_MAX    2
 	static const char *plugins_to_lower_rank[PLUGINS_TO_LOWER_RANK_MAX] = {
 		"aacparse",

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -58,10 +58,15 @@ bool SocInterface::StartsWith( const char *inputStr, const char *prefix )
 SocPlatformType InferPlatformFromPluginScan()
 {
 	SocPlatformType platform = SOC_PLATFORM_DEFAULT;
+	const char *savedScanner = getenv("GST_PLUGIN_SCANNER");
+	setenv("GST_PLUGIN_SCANNER", "", 1);
 	// Ensure GST is initialized
 	if (!gst_init_check(nullptr, nullptr, nullptr)) {
 		MW_LOG_ERR("gst_init_check() failed");
 	}
+	// Restore original env var so we do not affect the rest of the process
+	if (savedScanner) { setenv("GST_PLUGIN_SCANNER", savedScanner, 1); }
+	else              { unsetenv("GST_PLUGIN_SCANNER"); }
 	static const std::pair<const char*, SocPlatformType> plugins[] = {
 		{"amlhalasink", SOC_PLATFORM_AMLOGIC},
 		{"omxeac3dec", SOC_PLATFORM_REALTEK},

--- a/middleware/vendor/SocInterface.cpp
+++ b/middleware/vendor/SocInterface.cpp
@@ -18,11 +18,15 @@
  */
 
 #include <assert.h>
+#include <mutex>
 #include "SocInterface.h"
 #include "vendor/amlogic/AmlogicSocInterface.h"
 #include "vendor/brcm/BrcmSocInterface.h"
 #include "vendor/realtek/RealtekSocInterface.h"
 #include "vendor/default/DefaultSocInterface.h"
+// Private singleton storage
+static std::shared_ptr<SocInterface> g_socInterface;
+static std::mutex g_socMutex;
 
 /**Initially re-sets the IsRialtoMode */
 bool SocInterface::mIsRialtoMode = false;
@@ -146,7 +150,33 @@ SocPlatformType SocInterface::InferPlatformFromDeviceProperties( void )
 
 
 /**
- * @brief Loads the instance with rialto mode or not 
+ * @brief Helper to create the right subclass based on platform type.
+ */
+static std::shared_ptr<SocInterface> CreateForPlatform(SocPlatformType platformType)
+{
+	switch (platformType)
+	{
+		case SOC_PLATFORM_AMLOGIC:
+			MW_LOG_MIL("Setting up SoC Interface for AMLOGIC");
+			return std::make_shared<AmlogicSocInterface>();
+		case SOC_PLATFORM_BROADCOM:
+			MW_LOG_MIL("Setting up SoC Interface for BROADCOM");
+			return std::make_shared<BrcmSocInterface>();
+		case SOC_PLATFORM_REALTEK:
+			MW_LOG_MIL("Setting up SoC Interface for REALTEK");
+			return std::make_shared<RealtekSocInterface>();
+		case SOC_PLATFORM_MEDIATEK:
+			MW_LOG_MIL("Setting up SoC Interface for MEDIATEK");
+			return std::make_shared<MtkSocInterface>();
+		default:
+			MW_LOG_MIL("Setting up SoC Interface for Default");
+			return std::make_shared<DefaultSocInterface>();
+	}
+}
+
+
+/**
+ * @brief Loads the instance with rialto mode or not
  *
  * @return A pointer to the created SocInterface object, or nullptr on failure.
  */
@@ -161,41 +191,48 @@ std::shared_ptr<SocInterface> SocInterface::CreateSocInterface(bool isRialto)
 }
 
 /**
- * @brief Creates an instance of the SoC-specific interface based on the detected platform.
+ * @brief Phase 1: Creates an instance of the SoC-specific interface.
+ *        Safe to call during dl_init — only reads /etc/device.properties, NO GStreamer calls.
  *
- * @return A pointer to the created SocInterface object, or nullptr on failure.
+ * @return A pointer to the created SocInterface object.
  */
 std::shared_ptr<SocInterface> SocInterface::CreateSocInterface()
 {
-	static std::shared_ptr<SocInterface> socInterface;
-	if( !socInterface)
+	std::lock_guard<std::mutex> lock(g_socMutex);
+	if (!g_socInterface)
 	{
+		// Only use device.properties at this stage — no GStreamer calls
 		SocPlatformType platformType = InferPlatformFromDeviceProperties();
-		if(platformType == SOC_PLATFORM_DEFAULT)
-		{
-			if(!mIsRialtoMode)
-			{
-				MW_LOG_MIL("Performing InterfacePluginScan| Rialto-Disabled");
-				platformType = InferPlatformFromPluginScan();
-                        }
-		}
-		switch (platformType)
-		{
-			case SOC_PLATFORM_AMLOGIC:
-				socInterface = std::make_shared<AmlogicSocInterface>();
-				break;
-			case SOC_PLATFORM_BROADCOM:
-				socInterface = std::make_shared<BrcmSocInterface>();
-				break;
-			case SOC_PLATFORM_REALTEK:
-				socInterface = std::make_shared<RealtekSocInterface>();
-				break;
-			default:
-				socInterface = std::make_shared<DefaultSocInterface>();
-				break;
-		}
+		g_socInterface = CreateForPlatform(platformType);
 	}
-	return socInterface;
+	return g_socInterface;
+}
+
+/**
+ * @brief Phase 2: Called after GStreamer is safely initialized to re-detect platform via plugin scan.
+ *        Must NOT be called during dl_init / library constructor.
+ *        Contains gst_init_check (via InferPlatformFromPluginScan).
+ */
+void SocInterface::InitializePlatformFromPlugins()
+{
+	std::lock_guard<std::mutex> lock(g_socMutex);
+	if (mIsRialtoMode) return;
+
+	// If device.properties already identified a specific platform, no need to scan plugins
+	SocPlatformType currentType = InferPlatformFromDeviceProperties();
+	if (currentType != SOC_PLATFORM_DEFAULT)
+	{
+		MW_LOG_MIL("Platform already identified from device.properties, skipping plugin scan");
+		return;
+	}
+
+	// This calls gst_init_check internally — safe here because we are NOT in dl_init
+	SocPlatformType platformType = InferPlatformFromPluginScan();
+	if (platformType != SOC_PLATFORM_DEFAULT)
+	{
+		MW_LOG_MIL("Plugin scan detected platform, replacing SoC interface");
+		g_socInterface = CreateForPlatform(platformType);
+	}
 }
 
 /**

--- a/middleware/vendor/SocInterface.h
+++ b/middleware/vendor/SocInterface.h
@@ -150,6 +150,12 @@ public:
 	 */
 	static std::shared_ptr<SocInterface> CreateSocInterface(bool isRialto);
 
+
+	/**
+	 * @brief Phase 2: Called after GStreamer is safely initialized to re-detect platform via plugin scan.
+	 *        Must NOT be called during dl_init / library constructor.
+	 */
+	static void InitializePlatformFromPlugins();
 	/**
 	 * @brief Configure the accept caps
 	 * @return void


### PR DESCRIPTION
Initially Gst-plugin-load scan can be called via createSocInterface via dl init .  Now addressed by removing the gst-plugin-load scan through dl-init path
