### PR TITLE
VPAAMP-839 intermittent AAMP_EVENT_TUNE_TIME_METRICS not reported L2 3001 fail

### DIFF
--- a/priv_aamp.cpp
+++ b/priv_aamp.cpp
@@ -42,7 +42,7 @@
 
 /**
  * @brief Network trace burst detection threshold (seconds)
- * 
+ *
  * Purpose: Minimum idle time in curl write callbacks to trigger burst splitting.
  * Value of 5ms chosen to distinguish network-level bursts from application buffering.
  * Bursts separated by gaps exceeding this threshold are recorded as separate entries.
@@ -51,7 +51,7 @@ static constexpr double kNetTraceBurstGapThresholdS = 0.005;  // 5 milliseconds
 
 /**
  * @brief Network trace late gap threshold (seconds)
- * 
+ *
  * Purpose: Gaps exceeding this threshold mark bursts as "late" for QoS analysis.
  * Value of 120ms chosen to identify bursts delayed beyond typical buffering jitter.
  * Late bursts indicate potential network congestion or server-side delays.
@@ -193,8 +193,8 @@ static TuneFailureMap tuneFailureMap[] =
 	{AAMP_TUNE_INIT_FAILED_PLAYLIST_VIDEO_DNLD_ERROR, 10, 5, "AAMP: init failed (unable to download video playlist)"},
 	{AAMP_TUNE_INIT_FAILED_PLAYLIST_AUDIO_DNLD_ERROR, 10, 6, "AAMP: init failed (unable to download audio playlist)"},
 	{AAMP_TUNE_INIT_FAILED_TRACK_SYNC_ERROR, 10, 7, "AAMP: init failed (unsynchronized tracks)"},
-	
-	
+
+
 	//Resource failure
 	{AAMP_TUNE_CONTENT_NOT_FOUND, 20, 1, "AAMP: Resource was not found at the URL(HTTP 404)"},
 
@@ -3164,14 +3164,22 @@ bool PrivateInstanceAAMP::PausePipeline(bool pause, bool forceStopPreBuffering)
  */
 void PrivateInstanceAAMP::SendTuneMetricsEvent()
 {
-	if (!mTuneTimeMetricData.empty() && mTuneMetricDataPending.load())
+	// Atomically consume the pending flag so that only the caller which
+	// observes it armed clears it and dispatches. MonitorProgress() can be
+	// entered concurrently from the gst first-frame thread and the async
+	// scheduler around tune completion; an unconditional clear here would let
+	// a no-send caller race ahead of LogTuneComplete() arming the flag and
+	// permanently drop the event.
+	if (mTuneMetricDataPending.exchange(false))
 	{
-		TuneTimeMetricsEventPtr e = std::make_shared<TuneTimeMetricsEvent>(std::move(mTuneTimeMetricData), GetSessionId());
+		if (!mTuneTimeMetricData.empty())
+		{
+			TuneTimeMetricsEventPtr e = std::make_shared<TuneTimeMetricsEvent>(std::move(mTuneTimeMetricData), GetSessionId());
 
-		AAMPLOG_TRACE("PrivateInstanceAAMP: Sending TuneTimeMetric event: %s", e->getTuneMetricsData().c_str());
-		SendEvent(e,AAMP_EVENT_ASYNC_MODE);
+			AAMPLOG_TRACE("PrivateInstanceAAMP: Sending TuneTimeMetric event: %s", e->getTuneMetricsData().c_str());
+			SendEvent(e,AAMP_EVENT_ASYNC_MODE);
+		}
 	}
-	mTuneMetricDataPending.store(false);
 }
 
 /**
@@ -4453,7 +4461,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 
 		AAMPLOG_INFO("aamp url:%d,%d,%d,%f,%s", mediaTypeTelemetry, mediaType, curlInstance, fragmentDurationS, remoteUrl.c_str());
 		CurlCallbackContext context(this, buffer);
-		
+
 		// ==== Begin additive instrumentation - no behavior change ====
 		// CSV path init: fires lazily on the first download where either the env
 		// override or netTraceCsvDump config is active. Double-checked locking
@@ -4513,7 +4521,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 		};
 		NetTraceGuard netGuard(&context.net, net_owner.get());
 		// ==== End additive instrumentation ====
-		
+
 		if (curl)
 		{
 			CURL_EASY_SETOPT_STRING(curl, CURLOPT_URL, remoteUrl.c_str());
@@ -4790,7 +4798,7 @@ bool PrivateInstanceAAMP::GetFile( std::string remoteUrl, AampMediaType mediaTyp
 												  size_download);
 					// Note: FlushCsv() is called outside the retry loop
 				}
-				
+
 				if(!mAampLLDashServiceData.lowLatencyMode)
 				{
 					int insertDownloadDelay = GETCONFIGVALUE_PRIV(eAAMPConfig_DownloadDelay);
@@ -6417,7 +6425,7 @@ void PrivateInstanceAAMP::TuneHelper(TuneType tuneType, bool seekWhilePaused)
 		mpStreamAbstractionAAMP->ResetESChangeStatus();
 		mpStreamAbstractionAAMP->ReSetPipelineFlushStatus();
 		mpStreamAbstractionAAMP->Start();
-		
+
 		// Start underflow monitor after successful initialization and Start()
 		if (mpStreamAbstractionAAMP && ISCONFIGSET_PRIV(eAAMPConfig_EnableAampUnderflowMonitor))
 		{
@@ -8382,8 +8390,8 @@ bool PrivateInstanceAAMP::SendStreamCopy(AampMediaType mediaType, const void *pt
 	StreamSink *sink = AampStreamSinkManager::GetInstance().GetStreamSink(this);
 	if (sink && ptr && len > 0)
 	{
-		return sink->SendCopy(mediaType, 
-							  std::vector<uint8_t>(static_cast<const uint8_t*>(ptr), 
+		return sink->SendCopy(mediaType,
+							  std::vector<uint8_t>(static_cast<const uint8_t*>(ptr),
 												   static_cast<const uint8_t*>(ptr) + len),
 							  fpts, fdts, fDuration);
 	}
@@ -8477,7 +8485,7 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 		mAutoResumeTaskPending = false;
 	}
 	DisableDownloads();
-	
+
 	UnblockWaitForDiscontinuityProcessToComplete();
 	if(mTelemetryInterval > 0)
 	{
@@ -8536,7 +8544,7 @@ void PrivateInstanceAAMP::Stop( bool sendStateChangeEvent )
 	auto tearDownStartTime = NOW_STEADY_TS_MS;
 	TeardownStream(true,true); //disable download as well
 	auto tearDownEndTime = NOW_STEADY_TS_MS;
-	
+
 	// Moved the tsb delete request from XRE to AAMP to avoid the HTTP-404 errors
 	// Moved the Fog TSB delete to avoid the delay in MPDDownloaderInstance release which results in HTTP-404
 	if(IsFogTSBSupported())
@@ -9224,7 +9232,7 @@ void PrivateInstanceAAMP::SetState(AAMPPlayerState state, bool sendStateChangeEv
 	// Atomically exchange the state and get the previous value in one operation
 	// This ensures only one thread observes each state transition, preventing duplicate events
 	AAMPPlayerState oldState = mState.exchange(state);
-	
+
 	// Early return if state hasn't changed
 	if (oldState == state)
 	{
@@ -12030,7 +12038,7 @@ void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 	// This is a workaround where SetCCStatus is called whilst Tune is in progress (StreamLock held) from an EPG Stop call.
 	// Note: CC status can be changed at any time during playback and we do not want to ignore this if StreamLock is currently taken.
 	// The alternative would be to allow TryStreamLock() to have a timeout ~1s, but this might be less predictable.
-	bool allowDeferredApplication =	
+	bool allowDeferredApplication =
 					((playerState == eSTATE_IDLE)         ||
 					(playerState == eSTATE_INITIALIZING) ||
 					(playerState == eSTATE_INITIALIZED)  ||
@@ -12043,7 +12051,7 @@ void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 	subtitles_muted = !enabled;
 
 	if(allowDeferredApplication)
-	{		
+	{
 		std::unique_lock<std::recursive_mutex> lock(mStreamLock, std::try_to_lock);
 		if( lock.owns_lock() )
 		{
@@ -12056,7 +12064,7 @@ void PrivateInstanceAAMP::SetCCStatus(bool enabled)
 		}
 	}
 	else
-	{			
+	{
 		std::lock_guard<std::recursive_mutex> lock(mStreamLock);
 		SetCCStatusInternal();
 	}
@@ -12453,7 +12461,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 	bool isJson = false;
 	bool isRetuneNeeded = false;
 	bool accessibilityPresent = false;
-	
+
 	try
 	{
 		jsObject = new AampJsonObject(languageList);
@@ -12478,7 +12486,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 	{
 		std::vector<std::string> inputLanguagesList;
 		std::string inputLanguagesString;
-		
+
 		/** Get language Properties*/
 		if (jsObject->isArray("languages"))
 		{
@@ -12505,10 +12513,10 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 		{
 			AAMPLOG_ERR("Preferred Audio Language Field Only support String or String Array");
 		}
-		
+
 		AAMPLOG_INFO("Number of preferred languages received: %zu", inputLanguagesList.size());
 		AAMPLOG_INFO("Preferred language string received: %s", inputLanguagesString.c_str());
-		
+
 		std::vector<std::string> inputLabelList;
 		std::string inputLabelsString;
 		/** Get Label Properties*/
@@ -12520,9 +12528,9 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				AAMPLOG_INFO("Preferred Label string: %s", inputLabelsString.c_str());
 			}
 		}
-		
+
 		string inputRenditionString;
-		
+
 		/** Get rendition or role Properties*/
 		if (jsObject->isString("rendition"))
 		{
@@ -12531,10 +12539,10 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				AAMPLOG_INFO("Preferred rendition string: %s", inputRenditionString.c_str());
 			}
 		}
-		
+
 		std::vector<std::string> inputCodecList;
 		std::string inputCodecString;
-		
+
 		/** Get Codec Properties*/
 		if (jsObject->isArray("codec"))
 		{
@@ -12562,7 +12570,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				AAMPLOG_INFO("Preferred codec string: %s", inputCodecString.c_str());
 			}
 		}
-		
+
 		Accessibility  inputAudioAccessibilityNode;
 		/** Get accessibility Properties*/
 		if (jsObject->isObject("accessibility"))
@@ -12579,7 +12587,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 			// Note: do NOT compare preferredAudioAccessibilityNode here; that
 			// preferred* read must happen under streamLock (see below).
 		}
-		
+
 		std::string inputNameString;
 		if (jsObject->isString("name"))
 		{
@@ -12588,7 +12596,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				AAMPLOG_INFO("Preferred name string: %s", inputNameString.c_str());
 			}
 		}
-		
+
 		/**< Release json object **/
 		SAFE_DELETE(jsObject);
 
@@ -12604,7 +12612,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 		{
 			isRetuneNeeded = true;
 		}
-		
+
 		/** Clear the cache **/
 		preferredAudioAccessibilityNode.clear();
 		preferredLabelsString.clear();
@@ -12615,7 +12623,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 		preferredCodecString.clear();
 		preferredCodecList.clear();
 		preferredNameString.clear();
-		
+
 		/** Reload the new values **/
 		preferredAudioAccessibilityNode = inputAudioAccessibilityNode;
 		preferredRenditionString = std::move(inputRenditionString);
@@ -12626,7 +12634,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 		preferredCodecString = std::move(inputCodecString);
 		preferredCodecList = std::move(inputCodecList);
 		preferredNameString = std::move(inputNameString);
-		
+
 		SETCONFIGVALUE_PRIV(AAMP_APPLICATION_SETTING,eAAMPConfig_PreferredAudioRendition,preferredRenditionString);
 		SETCONFIGVALUE_PRIV(AAMP_APPLICATION_SETTING,eAAMPConfig_PreferredAudioLabel,preferredLabelsString);
 		SETCONFIGVALUE_PRIV(AAMP_APPLICATION_SETTING,eAAMPConfig_PreferredAudioLanguage,preferredLanguagesString);
@@ -12659,9 +12667,9 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				}
 				SETCONFIGVALUE_PRIV(AAMP_APPLICATION_SETTING,eAAMPConfig_PreferredAudioLanguage,preferredLanguagesString);
 			}
-			
+
 			AAMPLOG_INFO("Number of preferred languages: %zu", preferredLanguagesList.size());
-			
+
 			if(labelList != NULL)
 			{
 				preferredLabelsString.clear();
@@ -12674,12 +12682,12 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 					preferredLabelList.push_back(lab);
 					AAMPLOG_INFO("Parsed preferred label: %s", lab.c_str());
 				}
-				
+
 				preferredLabelsString = std::string(labelList);
 				SETCONFIGVALUE_PRIV(AAMP_APPLICATION_SETTING,eAAMPConfig_PreferredAudioLabel,preferredLabelsString);
 				AAMPLOG_INFO("Number of preferred labels: %zu", preferredLabelList.size());
 			}
-			
+
 			if( preferredRendition )
 			{
 				AAMPLOG_INFO("Setting rendition %s", preferredRendition);
@@ -12690,7 +12698,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 			{
 				preferredRenditionString.clear();
 			}
-			
+
 			if( preferredType )
 			{
 				preferredTypeString = std::string(preferredType);
@@ -12708,7 +12716,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 			{
 				preferredTypeString.clear();
 			}
-			
+
 			if(codecList != NULL)
 			{
 				preferredCodecString.clear();
@@ -12725,7 +12733,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				SETCONFIGVALUE_PRIV(AAMP_APPLICATION_SETTING,eAAMPConfig_PreferredAudioCodec,preferredCodecString);
 			}
 			AAMPLOG_INFO("Number of preferred codecs: %zu", preferredCodecList.size());
-			
+
 			if(accessibilityItem && !accessibilityItem->getSchemeId().empty())
 			{
 				preferredAudioAccessibilityNode.clear();
@@ -12746,7 +12754,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 			{
 				preferredAudioAccessibilityNode.clear();
 			}
-			
+
 			if(preferredName)
 			{
 				AAMPLOG_INFO("Setting Name %s", preferredName);
@@ -12763,7 +12771,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 						 languageList?languageList:"", preferredRendition?preferredRendition:"", preferredType?preferredType:"");
 		}
 	}
-	
+
 	// streamLock (mStreamLock) was acquired in each branch above before any read
 	// or write of preferred* fields.  It remains held here to protect GetState(),
 	// mpStreamAbstractionAAMP, discardEnteringLiveEvt, and mLanguageChangeInProgress.
@@ -12780,7 +12788,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 			bool labelPresent = false;
 			bool namePresent = false;
 			int trackIndex = GetAudioTrack();
-			
+
 			bool languageAvailabilityInManifest = false;
 			bool renditionAvailabilityInManifest = false;
 			bool accessibilityAvailabilityInManifest = false;
@@ -12788,7 +12796,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 			bool nameAvailabilityInManifest = false;
 			std::string trackIndexStr;
 			bool codecChange = true;
-			
+
 			if (trackIndex >= 0)
 			{
 				std::vector<AudioTrackInfo> trackInfo = mpStreamAbstractionAAMP->GetAvailableAudioTracks();
@@ -12798,7 +12806,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				char *currentPrefCodec = const_cast<char*>(trackInfo[trackIndex].codec.c_str());
 				char *currentPrefLabel = const_cast<char*>(trackInfo[trackIndex].label.c_str());
 				char *currentPrefName = const_cast<char*>(trackInfo[trackIndex].name.c_str());
-				
+
 				//If codec is already set, check the new codec against the older and ensure any change. If not set, read through the audio track info and found the codec against the new language set
 				if(!preferredCodecString.empty())
 				{
@@ -12808,14 +12816,14 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 					}
 					AAMPLOG_WARN("PreferredCodecString %s existing Codec %s",preferredCodecString.c_str(),currentPrefCodec);
 				}
-				
+
 				// Logic to check whether the given language is present in the available tracks,
 				// if available, it should not match with current preferredLanguagesString, then call tune to reflect the language change.
 				// if not available, then avoid calling tune.
 				if(preferredLanguagesList.size() > 0)
 				{
 					std::string firstLanguage = preferredLanguagesList.at(0);
-					
+
 					// CID:280504 - Using invalid iterator
 					for (auto &temp : trackInfo)
 					{
@@ -12826,7 +12834,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 							{
 								trackIndexStr = temp.index;
 							}
-							
+
 							if (temp.isAvailable)
 							{
 								languageAvailabilityInManifest = true;
@@ -12834,14 +12842,14 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 							}
 						}
 					}
-					
+
 					if (preferredLanguagesList.size() > 1)
 					{
 						/* If multiple value of language is present then retune */
 						languagePresent = true;
 					}
 				}
-				
+
 				// Logic to check whether the given label is present in the available tracks,
 				// if available, it should not match with current preferredLabelsString, then call retune to reflect the language change.
 				// if not available, then avoid calling tune. Call retune if multiple labels is present
@@ -12860,15 +12868,15 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 							}
 						}
 					}
-					
+
 					if (preferredLabelList.size() > 1)
 					{
 						/* If multiple value of label is present then retune */
 						labelPresent = true;
 					}
 				}
-				
-				
+
+
 				// Logic to check whether the given rendition is present in the available tracks,
 				// if available, it should not match with current preferredRenditionString, then call tune to reflect the rendition change.
 				// if not available, then avoid calling tune.
@@ -12888,7 +12896,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 						}
 					}
 				}
-				
+
 				// Logic to check whether the given accessibility is present in the available tracks,
 				// if available, it should not match with current preferredTypeString, then call tune to reflect the accessibility change.
 				// if not available, then avoid calling tune.
@@ -12908,7 +12916,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 						}
 					}
 				}
-				
+
 				// Logic to check whether the given codec is present in the available tracks,
 				// if available, it should not match with current preferred codec, then call tune to reflect the codec change.
 				// if not available, then avoid calling tune.
@@ -12920,7 +12928,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				else if(preferredCodecList.size() > 0)
 				{
 					std::string firstCodec = preferredCodecList.at(0);
-					
+
 					for (auto &temp : trackInfo)
 					{
 						if ((temp.codec == firstCodec) && (temp.codec != currentPrefCodec) && (temp.isAvailable))
@@ -12929,13 +12937,13 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 							break;
 						}
 					}
-					
+
 				}
 				else
 				{
 					// Empty preferred codec list.
 				}
-				
+
 				// Logic to check whether the given name is present in the available tracks,
 				// if available, it should not match with current preferredNameString, then call tune to reflect the name change.
 				// if not available, then avoid calling tune.
@@ -12956,7 +12964,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 					}
 				}
 			}
-			
+
 			bool clearPreference = false;
 			if(isRetuneNeeded && preferredCodecList.size() == 0 && preferredTypeString.empty() && preferredRenditionString.empty() \
 			   && preferredLabelsString.empty() && preferredNameString.empty() && preferredLanguagesList.size() == 0)
@@ -12965,7 +12973,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 				AAMPLOG_INFO("API to clear all preferences; retune to make it affect");
 				clearPreference = true;
 			}
-			
+
 			if((mMediaFormat == eMEDIAFORMAT_OTA) || (mMediaFormat == eMEDIAFORMAT_RMF))
 			{
 				mpStreamAbstractionAAMP->SetPreferredAudioLanguages();
@@ -13007,7 +13015,7 @@ void PrivateInstanceAAMP::SetPreferredLanguages(const char *languageList, const 
 							{
 								ReloadTSB();
 							}
-							
+
 							/* If AAMP TSB is enabled, flush the TSB before seeking to live */
 							if(IsLocalAAMPTsb())
 							{
@@ -13441,9 +13449,9 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 	bool isSelectionChange = false;
 	bool isAvailableInManifest = false;
 	int closedCaptionTrackId = -1;
-	
+
 	SavePreferredTextLanguages(param, isSelectionChange);
-	
+
 	AAMPPlayerState state = GetState();
 	if (state != eSTATE_IDLE && state != eSTATE_RELEASED && state != eSTATE_ERROR)
 	{ // active playback session; apply immediately
@@ -13451,9 +13459,9 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 		if (mpStreamAbstractionAAMP)
 		{
 			std::vector<TextTrackInfo> trackInfo = mpStreamAbstractionAAMP->GetAvailableTextTracks();
-			
+
 			CheckPreferredTextLanguages(trackInfo, isAvailableInManifest, isSelectionChange, closedCaptionTrackId);
-			
+
 			if ((mMediaFormat == eMEDIAFORMAT_HDMI) || (mMediaFormat == eMEDIAFORMAT_COMPOSITE) || (mMediaFormat == eMEDIAFORMAT_OTA) ||
 				(mMediaFormat == eMEDIAFORMAT_RMF))
 			{
@@ -13478,7 +13486,7 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 						{
 							// Find the index of the selected track in the available tracks list
 							closedCaptionTrackId = FindTextTrackIndex(trackInfo, selectedTextTrack);
-							
+
 							AAMPLOG_INFO("Selected text track at index %d (lang=%s)",
 										 closedCaptionTrackId, selectedTextTrack.language.c_str());
 							SetPreferredTextTrack(std::move(selectedTextTrack));
@@ -13489,22 +13497,22 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 						}
 					}
 					seek_pos_seconds = GetPositionSeconds();
-					
+
 					if (IsLocalAAMPTsb())
 					{
 						mAampTsbLanguageChangeInProgress = true;
 					}
-					
+
 					TeardownStream(false);
 					if (IsFogTSBSupported() && (!isAvailableInManifest))
 					{
 						ReloadTSB();
 					}
-					
+
 					if (IsLocalAAMPTsb())
 					{
 						AAMPLOG_WARN("Flush the TSB before seeking to live");
-						
+
 						/* If AAMP TSB is enabled, flush the TSB before seeking to live */
 						if (mTSBSessionManager)
 						{
@@ -13522,7 +13530,7 @@ void PrivateInstanceAAMP::SetPreferredTextLanguages(const char *param)
 					{
 						TuneHelper(eTUNETYPE_SEEK);
 					}
-					
+
 					discardEnteringLiveEvt = false;
 				}
 			}


### PR DESCRIPTION
Reason for change: Race condition results in AAMP_EVENT_TUNE_TIME_METRICS not getting sent

Considering threads A: and B: and initial condition mTuneMetricDataPending=false

A: SendTuneMetricsEvent()
    if ( ... && mTuneMetricDataPending.load())
    {
      not executed
    } 
B: mTuneMetricDataPending.store(true)
A:   
    mTuneMetricDataPending.store(false);
    
   
So the setting mTuneMetricDataPending=true has been lost